### PR TITLE
Add Crossplane XR-first detection contract tests + fixtures

### DIFF
--- a/examples/crossplane-system/README.md
+++ b/examples/crossplane-system/README.md
@@ -1,0 +1,9 @@
+# Crossplane system ownership example
+
+This directory contains a small set of **Crossplane control-plane** resources (package manager + API extension resources).
+
+Expected behavior:
+- `DetectOwnership` returns `type=crossplane, subType=system` for these resources.
+- They do **not** show up as "unmanaged" / "orphan" in summaries.
+
+See `crossplane-system.yaml`.

--- a/examples/crossplane-system/crossplane-system.yaml
+++ b/examples/crossplane-system/crossplane-system.yaml
@@ -1,0 +1,49 @@
+# NOTE: This file is intended for testing and demos. It may not be directly apply-able
+# unless Crossplane CRDs are installed in the cluster.
+
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws
+  namespace: crossplane-system
+---
+apiVersion: pkg.crossplane.io/v1
+kind: ProviderRevision
+metadata:
+  name: provider-aws-1234abcd
+  namespace: crossplane-system
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: platform-config
+  namespace: crossplane-system
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.database.example.org
+spec:
+  group: database.example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    size:
+                      type: string

--- a/test/fixtures/crossplane/managed-ownerref.yaml
+++ b/test/fixtures/crossplane/managed-ownerref.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-credentials
+  namespace: crossplane-system
+  ownerReferences:
+    - apiVersion: rds.aws.upbound.io/v1beta1
+      kind: Instance
+      name: staging-db
+      uid: 00000000-0000-0000-0000-000000000000
+type: Opaque

--- a/test/fixtures/crossplane/managed-with-claim.yaml
+++ b/test/fixtures/crossplane/managed-with-claim.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticache-proxy
+  namespace: crossplane-system
+  labels:
+    crossplane.io/claim-name: ecommerce-cache
+    crossplane.io/claim-namespace: ecommerce
+    crossplane.io/composite: xredisinstance-def456

--- a/test/fixtures/crossplane/managed-xr-only.yaml
+++ b/test/fixtures/crossplane/managed-xr-only.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rds-proxy
+  namespace: crossplane-system
+  labels:
+    crossplane.io/composite: xpostgresqlinstance-abc123

--- a/test/unit/crossplane_contract_test.go
+++ b/test/unit/crossplane_contract_test.go
@@ -1,0 +1,58 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// loadFixtureUnstructured loads a single YAML document into an Unstructured object.
+func loadFixtureUnstructured(t *testing.T, relPath string) *unstructured.Unstructured {
+	t.Helper()
+	path := filepath.Join(FixturesDir, relPath)
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(b, &obj))
+
+	u := &unstructured.Unstructured{Object: obj}
+	return u
+}
+
+// TestCrossplaneDetectionContract codifies the XR-first ownership rules:
+// - Composite label or XR ownerRef is sufficient for Crossplane ownership.
+// - Claim labels enrich but are not required.
+// - Claim takes precedence over composite when both are present.
+func TestCrossplaneDetectionContract(t *testing.T) {
+	t.Run("XR-first: composite label implies Crossplane ownership even without claim", func(t *testing.T) {
+		u := loadFixtureUnstructured(t, "crossplane/managed-xr-only.yaml")
+		own := agent.DetectOwnership(u)
+		assert.Equal(t, agent.OwnerCrossplane, own.Type)
+		assert.Equal(t, "composite", own.SubType)
+		assert.Equal(t, "xpostgresqlinstance-abc123", own.Name)
+	})
+
+	t.Run("Claim labels enrich: claim takes precedence over composite", func(t *testing.T) {
+		u := loadFixtureUnstructured(t, "crossplane/managed-with-claim.yaml")
+		own := agent.DetectOwnership(u)
+		assert.Equal(t, agent.OwnerCrossplane, own.Type)
+		assert.Equal(t, "claim", own.SubType)
+		assert.Equal(t, "ecommerce-cache", own.Name)
+		assert.Equal(t, "ecommerce", own.Namespace)
+	})
+
+	t.Run("OwnerRef: upbound.io group implies Crossplane ownership", func(t *testing.T) {
+		u := loadFixtureUnstructured(t, "crossplane/managed-ownerref.yaml")
+		own := agent.DetectOwnership(u)
+		assert.Equal(t, agent.OwnerCrossplane, own.Type)
+		assert.Equal(t, "instance", own.SubType)
+		assert.Equal(t, "staging-db", own.Name)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds contract tests codifying XR-first Crossplane ownership rules
- XR-first: Composite label implies Crossplane ownership even without claim
- Claim labels enrich and take precedence over composite when present
- OwnerRef with upbound.io group implies Crossplane ownership

Fixes #10

## Files Added

- `test/fixtures/crossplane/` - YAML fixtures for each scenario
- `test/unit/crossplane_contract_test.go` - Contract tests
- `examples/crossplane-system/` - Example Crossplane system resources

## Test plan

- [x] XR-first: composite label without claim → Crossplane ownership
- [x] Claim takes precedence over composite when both present
- [x] OwnerRef with upbound.io group → Crossplane ownership
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)