### PR TITLE
feat: Add Crossplane lineage to trace output (Issue #12)

### DIFF
--- a/cmd/cub-scout/trace.go
+++ b/cmd/cub-scout/trace.go
@@ -766,6 +766,15 @@ func outputReverseTraceHuman(result *agent.ReverseTraceResult) error {
 		fmt.Printf("\n")
 	}
 
+	// If this looks Crossplane-managed, show XR-first lineage (Managed → XR → optional Claim).
+	// This does not alter ownership detection; it only surfaces what the resolver can infer
+	// from already-fetched objects.
+	if len(result.Objects) > 0 {
+		if lineage, ok := agent.ResolveCrossplaneLineage(result.Objects[0], result.Objects); ok {
+			fmt.Print(renderCrossplaneLineageHuman(lineage))
+		}
+	}
+
 	// Print ownership detection result
 	fmt.Printf("\n")
 	fmt.Printf("%s%sDetected Owner:%s ", colorBold, colorWhite, colorReset)

--- a/cmd/cub-scout/trace_crossplane.go
+++ b/cmd/cub-scout/trace_crossplane.go
@@ -1,0 +1,51 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+// renderCrossplaneLineageHuman renders a compact XR-first Crossplane lineage section.
+// It is intended for the reverse trace UX where we already have a small local object set.
+func renderCrossplaneLineageHuman(lineage *agent.CrossplaneLineage) string {
+	if lineage == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("%s%sCrossplane lineage:%s\n", colorBold, colorWhite, colorReset))
+
+	// Managed resource (always present)
+	b.WriteString(fmt.Sprintf("  %smanaged:%s   %s\n", colorDim, colorReset, lineage.Managed.Ref.String()))
+
+	// XR-first platform owner (Composite/XR)
+	if lineage.Composite.Ref.Name != "" {
+		label := lineage.Composite.Ref.String()
+		if !lineage.Composite.Present {
+			label += fmt.Sprintf(" %s(partial lineage)%s", colorDim, colorReset)
+		}
+		b.WriteString(fmt.Sprintf("  %sxr:%s       %s\n", colorDim, colorReset, label))
+	}
+
+	// Optional claim (enrichment)
+	if lineage.Claim != nil && lineage.Claim.Ref.Name != "" {
+		label := lineage.Claim.Ref.String()
+		if !lineage.Claim.Present {
+			label += fmt.Sprintf(" %s(partial lineage)%s", colorDim, colorReset)
+		}
+		b.WriteString(fmt.Sprintf("  %sclaim:%s    %s\n", colorDim, colorReset, label))
+	}
+
+	if len(lineage.Evidence) > 0 {
+		b.WriteString(fmt.Sprintf("  %sevidence:%s %s\n", colorDim, colorReset, strings.Join(lineage.Evidence, ", ")))
+	}
+
+	b.WriteString("\n")
+	return b.String()
+}

--- a/cmd/cub-scout/trace_crossplane_test.go
+++ b/cmd/cub-scout/trace_crossplane_test.go
@@ -1,0 +1,174 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestRenderCrossplaneLineageHuman(t *testing.T) {
+	t.Run("nil lineage returns empty string", func(t *testing.T) {
+		result := renderCrossplaneLineageHuman(nil)
+		if result != "" {
+			t.Errorf("expected empty string for nil lineage, got %q", result)
+		}
+	})
+
+	t.Run("XR-only (no claim)", func(t *testing.T) {
+		lineage := &agent.CrossplaneLineage{
+			Managed: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "RDSInstance", Name: "mydb", Namespace: "prod"},
+				Present: true,
+			},
+			Composite: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "XPostgreSQLInstance", Name: "mydb-xr"},
+				Present: true,
+			},
+			Claim:    nil,
+			Evidence: []string{"label:crossplane.io/composite"},
+		}
+
+		result := renderCrossplaneLineageHuman(lineage)
+
+		// Should contain header
+		if !strings.Contains(result, "Crossplane lineage:") {
+			t.Error("expected output to contain 'Crossplane lineage:'")
+		}
+
+		// Should contain managed
+		if !strings.Contains(result, "managed:") {
+			t.Error("expected output to contain 'managed:'")
+		}
+
+		// Should contain xr
+		if !strings.Contains(result, "xr:") {
+			t.Error("expected output to contain 'xr:'")
+		}
+
+		// Should NOT contain claim
+		if strings.Contains(result, "claim:") {
+			t.Error("expected output NOT to contain 'claim:' when Claim is nil")
+		}
+
+		// Should contain evidence
+		if !strings.Contains(result, "evidence:") {
+			t.Error("expected output to contain 'evidence:'")
+		}
+	})
+
+	t.Run("XR + Claim present", func(t *testing.T) {
+		lineage := &agent.CrossplaneLineage{
+			Managed: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "RDSInstance", Name: "mydb", Namespace: "prod"},
+				Present: true,
+			},
+			Composite: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "XPostgreSQLInstance", Name: "mydb-xr"},
+				Present: true,
+			},
+			Claim: &agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "PostgreSQLInstance", Name: "mydb", Namespace: "prod"},
+				Present: true,
+			},
+			Evidence: []string{"label:crossplane.io/composite", "label:crossplane.io/claim-name"},
+		}
+
+		result := renderCrossplaneLineageHuman(lineage)
+
+		// Should contain claim line
+		if !strings.Contains(result, "claim:") {
+			t.Error("expected output to contain 'claim:' when Claim is present")
+		}
+
+		// Should NOT contain partial lineage (all present)
+		if strings.Contains(result, "(partial lineage)") {
+			t.Error("expected output NOT to contain '(partial lineage)' when all nodes are present")
+		}
+	})
+
+	t.Run("partial chain - XR and Claim not present", func(t *testing.T) {
+		lineage := &agent.CrossplaneLineage{
+			Managed: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "RDSInstance", Name: "mydb", Namespace: "prod"},
+				Present: true,
+			},
+			Composite: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "CompositeResource", Name: "mydb-xr"},
+				Present: false, // XR object not found
+			},
+			Claim: &agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "Claim", Name: "mydb", Namespace: "prod"},
+				Present: false, // Claim object not found
+			},
+			Evidence: []string{"label:crossplane.io/composite"},
+		}
+
+		result := renderCrossplaneLineageHuman(lineage)
+
+		// Should contain partial lineage at least once (ideally twice)
+		if !strings.Contains(result, "(partial lineage)") {
+			t.Error("expected output to contain '(partial lineage)' when nodes are not present")
+		}
+
+		// Count occurrences of "(partial lineage)"
+		count := strings.Count(result, "(partial lineage)")
+		if count < 1 {
+			t.Errorf("expected at least 1 '(partial lineage)', got %d", count)
+		}
+	})
+
+	t.Run("evidence formatting with multiple items", func(t *testing.T) {
+		lineage := &agent.CrossplaneLineage{
+			Managed: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "RDSInstance", Name: "mydb"},
+				Present: true,
+			},
+			Composite: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "XPostgreSQLInstance", Name: "mydb-xr"},
+				Present: true,
+			},
+			Evidence: []string{"label:crossplane.io/composite", "label:crossplane.io/claim-name"},
+		}
+
+		result := renderCrossplaneLineageHuman(lineage)
+
+		// Should contain both evidence items
+		if !strings.Contains(result, "label:crossplane.io/composite") {
+			t.Error("expected output to contain 'label:crossplane.io/composite'")
+		}
+		if !strings.Contains(result, "label:crossplane.io/claim-name") {
+			t.Error("expected output to contain 'label:crossplane.io/claim-name'")
+		}
+
+		// Should contain comma separator
+		if !strings.Contains(result, ", ") {
+			t.Error("expected evidence items to be comma-separated")
+		}
+	})
+
+	t.Run("empty XR name does not print xr line", func(t *testing.T) {
+		lineage := &agent.CrossplaneLineage{
+			Managed: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "RDSInstance", Name: "mydb"},
+				Present: true,
+			},
+			Composite: agent.CrossplaneLineageNode{
+				Ref:     agent.ResourceRef{Kind: "CompositeResource", Name: ""}, // Empty name
+				Present: false,
+			},
+			Evidence: []string{"unresolved"},
+		}
+
+		result := renderCrossplaneLineageHuman(lineage)
+
+		// Should NOT contain "xr:" followed by space (the label line)
+		// Note: evidence may contain "xr:" as a value, so we check for the specific label format
+		if strings.Contains(result, "xr:       ") {
+			t.Error("expected output NOT to contain xr label line when XR name is empty")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Shows XR-first Crossplane lineage in reverse trace output when tracing Crossplane-managed resources:

```
Crossplane lineage:
  managed:   RDSInstance/mydb in prod
  xr:       XPostgreSQLInstance/mydb-xr
  claim:    PostgreSQLInstance/mydb in prod
  evidence: label:crossplane.io/composite, label:crossplane.io/claim-name
```

- **Managed resource** - the thing you traced
- **Composite Resource (XR)** - the real platform owner (XR-first)
- **Claim** - only shown when resolvable
- **Evidence** - which signals were used to build the lineage

When objects cannot be resolved, shows `(partial lineage)` instead of misleading "unmanaged" language.

Fixes #12

## Implementation

| File | Change |
|------|--------|
| `pkg/agent/reverse_trace.go` | Added `Objects` field (`json:"-"`) to store fetched resources for local analysis |
| `cmd/cub-scout/trace.go` | Call resolver after K8s chain is printed |
| `cmd/cub-scout/trace_crossplane.go` | Render helper for lineage output |
| `cmd/cub-scout/trace_crossplane_test.go` | Unit tests for renderer |

## Design notes

- **No new detection logic** - just consumes resolver output
- **JSON output unchanged** - Objects field has `json:"-"`
- **Presentation only** - resolver untouched

## Test plan

- [x] Unit tests for renderer: nil input, XR-only, XR+Claim, partial chain, evidence formatting
- [x] Full test suite passes
- [ ] Manual: `cub-scout trace <crossplane-resource> --reverse` shows lineage section

🤖 Generated with [Claude Code](https://claude.com/claude-code)