### PR TITLE
test: Add doc reference to ownership tests (closes #43)

### DIFF
--- a/pkg/agent/ownership_test.go
+++ b/pkg/agent/ownership_test.go
@@ -1,6 +1,19 @@
 // Copyright (C) ConfigHub, Inc.
 // SPDX-License-Identifier: MIT
 
+// Ownership detection tests - deterministic tests for v0.5 (#43)
+//
+// These tests verify ownership detection behavior as documented in:
+// docs/reference/ownership-precedence.md
+//
+// Tests cover:
+// - Individual owner types (Flux, ArgoCD, Helm, Terraform, ConfigHub, Crossplane, K8s)
+// - Precedence rules when multiple signals are present
+// - Unknown/ambiguous cases returning "unknown"
+// - Edge cases (empty values, malformed annotations)
+//
+// See TestDetectOwnership_Priority for precedence verification.
+
 package agent
 
 import (


### PR DESCRIPTION
## Summary

Adds documentation header to `pkg/agent/ownership_test.go` linking it to the authoritative ownership precedence specification.

## Changes

- Added doc reference header to ownership_test.go pointing to docs/reference/ownership-precedence.md
- Documents what the existing tests cover (all owner types, precedence, unknown cases, edge cases)

## Why

Issue #43 requires deterministic ownership tests. Upon investigation, comprehensive tests already exist. This PR adds the documentation link to connect tests to the spec.

## Review-by-Evidence

### What changed (1-3 bullets)

- Added header comment to pkg/agent/ownership_test.go linking to docs/reference/ownership-precedence.md

### Why (1 bullet)

- Connects existing ownership tests to the authoritative v0.5 specification document

### Tests added/updated

- None - this PR adds documentation to existing tests
- Existing tests cover: Flux, ArgoCD, Helm, Terraform, ConfigHub, Crossplane, K8s native, precedence, unknown cases

### Golden diffs?

- [x] No golden file changes

### Cluster proof required?

- [x] Not required (change does not affect risky areas - documentation only)

### Risk assessment

**Could this create false certainty (false ownership claims, misleading health status)?**

- [x] No - change does not affect ownership or health logic

## Checklist

- [x] CI passes
- [x] No false ownership/health claims introduced
- [x] Documentation updated if needed
- [x] Review-by-evidence section complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)