### PR TITLE
feat(graph): add GitOps CRDs as nodes (best-effort)

### DIFF
--- a/internal/graph/collector_gitops.go
+++ b/internal/graph/collector_gitops.go
@@ -1,0 +1,132 @@
+package graph
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// GitOpsCRD defines a GitOps CRD to collect.
+type GitOpsCRD struct {
+	GVR        schema.GroupVersionResource
+	Kind       string
+	APIVersion string
+}
+
+// ArgoCDCRDs lists the Argo CD CRDs to collect.
+var ArgoCDCRDs = []GitOpsCRD{
+	{
+		GVR:        schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"},
+		Kind:       "Application",
+		APIVersion: "argoproj.io/v1alpha1",
+	},
+	{
+		GVR:        schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applicationsets"},
+		Kind:       "ApplicationSet",
+		APIVersion: "argoproj.io/v1alpha1",
+	},
+}
+
+// FluxCRDs lists the Flux CRDs to collect.
+var FluxCRDs = []GitOpsCRD{
+	{
+		GVR:        schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
+		Kind:       "Kustomization",
+		APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+	},
+	{
+		GVR:        schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
+		Kind:       "HelmRelease",
+		APIVersion: "helm.toolkit.fluxcd.io/v2",
+	},
+	{
+		GVR:        schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+		Kind:       "GitRepository",
+		APIVersion: "source.toolkit.fluxcd.io/v1",
+	},
+}
+
+// GitOpsCollector collects GitOps CRDs into the graph.
+type GitOpsCollector struct {
+	client  dynamic.Interface
+	cluster string
+}
+
+// NewGitOpsCollector creates a new GitOps collector.
+func NewGitOpsCollector(client dynamic.Interface, cluster string) *GitOpsCollector {
+	return &GitOpsCollector{
+		client:  client,
+		cluster: cluster,
+	}
+}
+
+// CollectGitOpsCRDs collects Argo CD and Flux CRDs as nodes.
+// This is best-effort: missing CRDs are silently skipped.
+func (c *GitOpsCollector) CollectGitOpsCRDs(ctx context.Context, g *Graph, namespace string) error {
+	// Collect Argo CD CRDs
+	for _, crd := range ArgoCDCRDs {
+		if err := c.collectCRD(ctx, g, crd, namespace); err != nil {
+			// Best-effort: skip on any error (missing CRD, RBAC forbidden, etc.)
+			continue
+		}
+	}
+
+	// Collect Flux CRDs
+	for _, crd := range FluxCRDs {
+		if err := c.collectCRD(ctx, g, crd, namespace); err != nil {
+			// Best-effort: skip on any error (missing CRD, RBAC forbidden, etc.)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// collectCRD collects a single CRD type into the graph.
+func (c *GitOpsCollector) collectCRD(ctx context.Context, g *Graph, crd GitOpsCRD, namespace string) error {
+	var resourceInterface dynamic.ResourceInterface
+	if namespace == "" {
+		resourceInterface = c.client.Resource(crd.GVR)
+	} else {
+		resourceInterface = c.client.Resource(crd.GVR).Namespace(namespace)
+	}
+
+	list, err := resourceInterface.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, item := range list.Items {
+		node := c.unstructuredToNode(item, crd)
+		g.AddNode(node)
+	}
+
+	return nil
+}
+
+// unstructuredToNode converts an unstructured resource to a graph node.
+func (c *GitOpsCollector) unstructuredToNode(u unstructured.Unstructured, crd GitOpsCRD) Node {
+	labels := u.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	// Only include labels if non-empty
+	var nodeLabels map[string]string
+	if len(labels) > 0 {
+		nodeLabels = labels
+	}
+
+	return Node{
+		ID:         NodeID(c.cluster, u.GetNamespace(), crd.Kind, u.GetName()),
+		Cluster:    c.cluster,
+		Namespace:  u.GetNamespace(),
+		Kind:       crd.Kind,
+		Name:       u.GetName(),
+		APIVersion: crd.APIVersion,
+		Labels:     nodeLabels,
+	}
+}

--- a/internal/graph/collector_gitops_test.go
+++ b/internal/graph/collector_gitops_test.go
@@ -1,0 +1,321 @@
+package graph
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// allGitOpsGVRs returns all GitOps GVRs for fake client registration.
+func allGitOpsGVRs() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}:             "ApplicationList",
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applicationsets"}:          "ApplicationSetList",
+		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}: "KustomizationList",
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}:        "HelmReleaseList",
+		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"}:   "GitRepositoryList",
+	}
+}
+
+func TestCollectGitOpsCRDs_Empty(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, allGitOpsGVRs())
+
+	collector := NewGitOpsCollector(client, "test-cluster")
+	g := NewGraph("test-cluster")
+
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	// No objects, so no nodes
+	if len(g.Nodes) != 0 {
+		t.Errorf("expected 0 nodes, got %d", len(g.Nodes))
+	}
+}
+
+func TestCollectGitOpsCRDs_ArgoApplication(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "my-app",
+				"namespace": "argocd",
+				"labels": map[string]interface{}{
+					"app.kubernetes.io/name": "my-app",
+				},
+			},
+			"spec": map[string]interface{}{
+				"project": "default",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, allGitOpsGVRs(), app)
+
+	collector := NewGitOpsCollector(client, "test-cluster")
+	g := NewGraph("test-cluster")
+
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	// Should have 1 node for the Application
+	if len(g.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(g.Nodes))
+	}
+
+	node := g.Nodes[0]
+	if node.Kind != "Application" {
+		t.Errorf("expected kind Application, got %s", node.Kind)
+	}
+	if node.Name != "my-app" {
+		t.Errorf("expected name my-app, got %s", node.Name)
+	}
+	if node.Namespace != "argocd" {
+		t.Errorf("expected namespace argocd, got %s", node.Namespace)
+	}
+	if node.APIVersion != "argoproj.io/v1alpha1" {
+		t.Errorf("expected api_version argoproj.io/v1alpha1, got %s", node.APIVersion)
+	}
+	if node.ID != "test-cluster/argocd/Application/my-app" {
+		t.Errorf("expected ID test-cluster/argocd/Application/my-app, got %s", node.ID)
+	}
+	if node.Labels["app.kubernetes.io/name"] != "my-app" {
+		t.Errorf("expected label app.kubernetes.io/name=my-app, got %v", node.Labels)
+	}
+}
+
+func TestCollectGitOpsCRDs_FluxKustomization(t *testing.T) {
+	ks := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]interface{}{
+				"name":      "my-ks",
+				"namespace": "flux-system",
+			},
+			"spec": map[string]interface{}{
+				"interval": "10m",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, allGitOpsGVRs(), ks)
+
+	collector := NewGitOpsCollector(client, "test-cluster")
+	g := NewGraph("test-cluster")
+
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	if len(g.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(g.Nodes))
+	}
+
+	node := g.Nodes[0]
+	if node.Kind != "Kustomization" {
+		t.Errorf("expected kind Kustomization, got %s", node.Kind)
+	}
+	if node.APIVersion != "kustomize.toolkit.fluxcd.io/v1" {
+		t.Errorf("expected api_version kustomize.toolkit.fluxcd.io/v1, got %s", node.APIVersion)
+	}
+}
+
+func TestCollectGitOpsCRDs_MultipleTypes(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "app1",
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	appSet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "ApplicationSet",
+			"metadata": map[string]interface{}{
+				"name":      "appset1",
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, allGitOpsGVRs(), app, appSet)
+
+	collector := NewGitOpsCollector(client, "test-cluster")
+	g := NewGraph("test-cluster")
+
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	if len(g.Nodes) != 2 {
+		t.Errorf("expected 2 nodes, got %d", len(g.Nodes))
+	}
+
+	// Verify we have both kinds
+	kinds := make(map[string]bool)
+	for _, node := range g.Nodes {
+		kinds[node.Kind] = true
+	}
+	if !kinds["Application"] {
+		t.Error("missing Application node")
+	}
+	if !kinds["ApplicationSet"] {
+		t.Error("missing ApplicationSet node")
+	}
+}
+
+func TestCollectGitOpsCRDs_NamespaceFilter(t *testing.T) {
+	app1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "app1",
+				"namespace": "argocd",
+			},
+		},
+	}
+	app2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "app2",
+				"namespace": "other-ns",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, allGitOpsGVRs(), app1, app2)
+
+	collector := NewGitOpsCollector(client, "test-cluster")
+
+	// Collect only from argocd namespace
+	g := NewGraph("test-cluster")
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "argocd")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	if len(g.Nodes) != 1 {
+		t.Errorf("expected 1 node (argocd namespace only), got %d", len(g.Nodes))
+	}
+	if g.Nodes[0].Name != "app1" {
+		t.Errorf("expected app1, got %s", g.Nodes[0].Name)
+	}
+}
+
+func TestCollectGitOpsCRDs_NoEdges(t *testing.T) {
+	// Per design: #61 adds nodes only, no edges
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "my-app",
+				"namespace": "argocd",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, allGitOpsGVRs(), app)
+
+	collector := NewGitOpsCollector(client, "test-cluster")
+	g := NewGraph("test-cluster")
+
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	// Should have no edges (nodes only for Phase 2)
+	if len(g.Edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(g.Edges))
+	}
+}
+
+func TestCollectGitOpsCRDs_AllFluxTypes(t *testing.T) {
+	ks := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]interface{}{
+				"name":      "my-ks",
+				"namespace": "flux-system",
+			},
+		},
+	}
+
+	hr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata": map[string]interface{}{
+				"name":      "my-hr",
+				"namespace": "flux-system",
+			},
+		},
+	}
+
+	gr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "GitRepository",
+			"metadata": map[string]interface{}{
+				"name":      "my-repo",
+				"namespace": "flux-system",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, allGitOpsGVRs(), ks, hr, gr)
+
+	collector := NewGitOpsCollector(client, "test-cluster")
+	g := NewGraph("test-cluster")
+
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	if len(g.Nodes) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(g.Nodes))
+	}
+
+	kinds := make(map[string]bool)
+	for _, node := range g.Nodes {
+		kinds[node.Kind] = true
+	}
+	if !kinds["Kustomization"] {
+		t.Error("missing Kustomization node")
+	}
+	if !kinds["HelmRelease"] {
+		t.Error("missing HelmRelease node")
+	}
+	if !kinds["GitRepository"] {
+		t.Error("missing GitRepository node")
+	}
+}

--- a/internal/graph/export_test.go
+++ b/internal/graph/export_test.go
@@ -11,6 +11,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -160,5 +164,89 @@ func TestExport_ValidJSON(t *testing.T) {
 	// Verify schema version
 	if parsed.SchemaVersion != SchemaVersion {
 		t.Errorf("expected schema version %q, got %q", SchemaVersion, parsed.SchemaVersion)
+	}
+}
+
+// TestExport_GitOpsCRDs_Golden is a golden test that verifies the JSON export
+// format for GitOps CRDs (Argo CD Application, Flux Kustomization).
+func TestExport_GitOpsCRDs_Golden(t *testing.T) {
+	fixedTime, _ := time.Parse(time.RFC3339, "2026-01-01T00:00:00Z")
+
+	// Create GitOps fixtures
+	argoApp := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "my-app",
+				"namespace": "argocd",
+				"labels": map[string]interface{}{
+					"app.kubernetes.io/name": "my-app",
+				},
+			},
+		},
+	}
+
+	fluxKs := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]interface{}{
+				"name":      "infra",
+				"namespace": "flux-system",
+			},
+		},
+	}
+
+	// Create fake dynamic client with all GitOps GVRs
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}:             "ApplicationList",
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applicationsets"}:          "ApplicationSetList",
+		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}: "KustomizationList",
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}:        "HelmReleaseList",
+		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"}:   "GitRepositoryList",
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, argoApp, fluxKs)
+
+	// Build graph
+	collector := NewGitOpsCollector(client, "test-cluster")
+	g := NewGraph("test-cluster")
+	g.GeneratedAt = fixedTime
+
+	err := collector.CollectGitOpsCRDs(context.Background(), g, "")
+	if err != nil {
+		t.Fatalf("CollectGitOpsCRDs failed: %v", err)
+	}
+
+	// Export
+	output, err := g.Export()
+	if err != nil {
+		t.Fatalf("Export failed: %v", err)
+	}
+
+	// Golden file path
+	goldenPath := filepath.Join("testdata", "gitops-crds.golden.json")
+
+	// Update golden file if -update flag is set
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll("testdata", 0755); err != nil {
+			t.Fatalf("failed to create testdata dir: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, output, 0644); err != nil {
+			t.Fatalf("failed to write golden file: %v", err)
+		}
+		t.Log("Updated golden file")
+		return
+	}
+
+	// Load and compare
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file %s: %v\nRun with UPDATE_GOLDEN=1 to create it", goldenPath, err)
+	}
+
+	if string(output) != string(golden) {
+		t.Errorf("output mismatch\ngot:\n%s\n\nwant:\n%s", output, golden)
 	}
 }

--- a/internal/graph/testdata/gitops-crds.golden.json
+++ b/internal/graph/testdata/gitops-crds.golden.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "graph.v1",
+  "generated_at": "2026-01-01T00:00:00Z",
+  "cluster": "test-cluster",
+  "nodes": [
+    {
+      "id": "test-cluster/argocd/Application/my-app",
+      "cluster": "test-cluster",
+      "namespace": "argocd",
+      "kind": "Application",
+      "name": "my-app",
+      "api_version": "argoproj.io/v1alpha1",
+      "labels": {
+        "app.kubernetes.io/name": "my-app"
+      }
+    },
+    {
+      "id": "test-cluster/flux-system/Kustomization/infra",
+      "cluster": "test-cluster",
+      "namespace": "flux-system",
+      "kind": "Kustomization",
+      "name": "infra",
+      "api_version": "kustomize.toolkit.fluxcd.io/v1"
+    }
+  ],
+  "edges": []
+}


### PR DESCRIPTION
## Summary
Add graph collectors for GitOps CRDs when present in the cluster (best-effort ingestion).

Closes #61

## GitOps CRDs Supported

### Argo CD
- `Application` (argoproj.io/v1alpha1)
- `ApplicationSet` (argoproj.io/v1alpha1)

### Flux
- `Kustomization` (kustomize.toolkit.fluxcd.io/v1)
- `HelmRelease` (helm.toolkit.fluxcd.io/v2)
- `GitRepository` (source.toolkit.fluxcd.io/v1)

## Features
- **Best-effort**: Missing CRDs are silently skipped (no errors)
- **Dynamic client**: Uses Kubernetes dynamic client for CRD discovery
- **Nodes only**: No edges in this PR (future work)
- **Labels preserved**: Node labels included when present

## Files Added
- `internal/graph/collector_gitops.go` - GitOps collector implementation
- `internal/graph/collector_gitops_test.go` - 7 unit tests
- `internal/graph/testdata/gitops-crds.golden.json` - Locked export format

## Acceptance Criteria
- [x] Nodes created for Argo CD CRDs when present
- [x] Nodes created for Flux CRDs when present
- [x] Graceful skip when CRD not installed
- [x] `api_version` correctly set
- [x] Labels included if present
- [x] No edges (per Phase 2 scope)
- [x] Golden tests with fake dynamic client
- [x] `go test ./...` passes

## Test plan
- [x] `go test ./internal/graph/...` - All tests pass
- [x] `go test ./...` - Full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)