### PR TITLE
feat(graph): add graph explain + goldens (v0.6 contract)

### DIFF
--- a/cmd/cub-scout/graph_explain.go
+++ b/cmd/cub-scout/graph_explain.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/internal/graph"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+)
+
+var graphExplainCmd = &cobra.Command{
+	Use:   "explain <kind>/<name>",
+	Short: "Explain a resource's graph relationships",
+	Long: `Explain a resource's relationships in the graph.
+
+Shows the resource's details and all incoming/outgoing edges with evidence.
+
+Output is deterministic: same graph produces identical output.
+
+Example:
+  cub-scout graph explain Deployment/nginx -n default
+  cub-scout graph explain Pod/nginx-abc123-xyz -n default`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			fmt.Fprintln(os.Stderr, "Error: requires exactly 1 argument: <kind>/<name>")
+			os.Exit(2)
+		}
+		return nil
+	},
+	RunE:              runGraphExplain,
+	SilenceUsage:      true, // Don't print usage on error
+	SilenceErrors:     true, // We handle errors ourselves
+	DisableFlagsInUseLine: true,
+}
+
+var (
+	graphExplainNamespace string
+)
+
+func init() {
+	graphCmd.AddCommand(graphExplainCmd)
+
+	graphExplainCmd.Flags().StringVarP(&graphExplainNamespace, "namespace", "n", "", "Namespace of the resource (required)")
+	// Don't use MarkFlagRequired - we handle it ourselves for deterministic error output
+}
+
+func runGraphExplain(cmd *cobra.Command, args []string) error {
+	// Parse kind/name argument
+	kindName := args[0]
+	parts := strings.SplitN(kindName, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		fmt.Fprintln(os.Stderr, "Error: invalid argument format, expected <kind>/<name>")
+		os.Exit(2)
+	}
+	kind := parts[0]
+	name := parts[1]
+
+	// Check namespace flag
+	if graphExplainNamespace == "" {
+		fmt.Fprintln(os.Stderr, "Error: --namespace is required")
+		os.Exit(2)
+	}
+
+	// Get cluster name
+	cluster := os.Getenv("CUB_SCOUT_TEST_CLUSTER")
+	if cluster == "" {
+		cluster = getCurrentContext()
+	}
+
+	// Build graph
+	g := graph.NewGraph(cluster)
+
+	// Collect from cluster unless we're in test mode
+	if os.Getenv("CUB_SCOUT_TEST_TIME") == "" {
+		cfg, err := buildConfig()
+		if err != nil {
+			// If no cluster access, proceed with empty graph
+			// Target won't be found, which is correct
+		} else {
+			client, err := kubernetes.NewForConfig(cfg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to create kubernetes client: %v\n", err)
+				os.Exit(1)
+			}
+
+			collector := graph.NewCollector(client, cluster)
+			ctx := context.Background()
+
+			// Collect ownership chain (ignore errors for best-effort)
+			_ = collector.CollectOwnershipChain(ctx, g, "")
+		}
+	}
+
+	// Override GeneratedAt for deterministic testing
+	if testTime := os.Getenv("CUB_SCOUT_TEST_TIME"); testTime != "" {
+		if t, err := time.Parse(time.RFC3339, testTime); err == nil {
+			g.GeneratedAt = t
+		}
+	}
+
+	// Explain the target
+	output, exitCode := graph.Explain(g, cluster, graphExplainNamespace, kind, name)
+	fmt.Print(output)
+
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
+
+	return nil
+}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -20,6 +20,7 @@ Complete reference for all cub-scout commands.
 | `health` | Scout-style health check |
 | `setup` | Set up shell completions |
 | `graph export` | Export resource graph as JSON (v0.6) |
+| `graph explain` | Explain a resource's graph relationships (v0.6) |
 
 ---
 
@@ -387,6 +388,59 @@ cub-scout graph export [flags]
 ```
 
 See [Graph Contract Reference](graph-contract.md) for full schema documentation.
+
+### graph explain
+
+Explain a resource's relationships in the graph.
+
+```bash
+cub-scout graph explain <kind>/<name> -n <namespace>
+```
+
+Shows the resource's details and all incoming/outgoing edges with evidence.
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-n, --namespace` | Namespace of the resource (required) |
+
+#### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (missing args / missing namespace) |
+| 3 | Target not found |
+
+#### Example Output
+
+```
+GRAPH EXPLAIN
+Target: cluster/default/Deployment/nginx
+Schema: graph.v1
+
+Node:
+  kind: Deployment
+  name: nginx
+  namespace: default
+  api_version: apps/v1
+  id: cluster/default/Deployment/nginx
+  labels:
+    app=nginx
+
+Relationships:
+  outgoing (1):
+    - owns -> cluster/default/ReplicaSet/nginx-abc123
+      evidence (1):
+        - field: metadata.ownerReferences
+          reason: ReplicaSet nginx-abc123 has ownerReference to Deployment nginx
+  incoming (0):
+
+Hint: Use 'cub-scout graph export --json' for the full graph.
+```
+
+See [Graph Explain Contract](graph-explain-contract.md) for full output format documentation.
 
 ---
 

--- a/docs/reference/graph-explain-contract.md
+++ b/docs/reference/graph-explain-contract.md
@@ -1,0 +1,265 @@
+# Graph Explain Contract (v0.6)
+
+This document defines the `graph explain` command contract for cub-scout v0.6+.
+
+> **v0.6 contract surface.** This does not modify any v0.5 contracts.
+
+---
+
+## Command
+
+```bash
+cub-scout graph explain <kind>/<name> -n <namespace>
+```
+
+### Inputs
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<kind>/<name>` | yes | Target resource selector (case-sensitive Kind as shown in graph export) |
+| `-n, --namespace` | yes | Namespace of the resource |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (missing args / missing namespace) |
+| 3 | Target not found |
+
+---
+
+## Output Format (Deterministic Text)
+
+### Header
+
+```
+GRAPH EXPLAIN
+Target: <cluster>/<namespace>/<kind>/<name>
+Schema: graph.v1
+```
+
+### Node Details Section
+
+Always shown:
+
+```
+Node:
+  kind: <Kind>
+  name: <name>
+  namespace: <namespace>        # omit line entirely for cluster-scoped
+  api_version: <api_version>
+  id: <id>
+  labels:
+    <k1>=<v1>
+    <k2>=<v2>
+```
+
+Rules:
+- `labels:` block:
+  - If no labels: show `labels: (none)`
+  - Otherwise sort keys lexicographically
+- Field names are lowercase with underscores exactly as above
+
+### Relationships Section
+
+Always shown:
+
+```
+Relationships:
+  outgoing (<N>):
+    - <type> -> <to_id>
+      evidence (<M>):
+        - field: <field>
+          reason: <reason>
+  incoming (<N>):
+    - <type> <- <from_id>
+      evidence (<M>):
+        - field: <field>
+          reason: <reason>
+```
+
+Rules:
+- Show both `outgoing` and `incoming` blocks even if count is 0
+- Ordering:
+  - Outgoing edges sorted by `(type, to_id)` lexicographically
+  - Incoming edges sorted by `(type, from_id)` lexicographically
+  - Evidence entries sorted by `(field, reason)` lexicographically
+- Evidence formatting:
+  - Always print `evidence (<M>):`
+  - For each evidence entry print two lines as shown
+- If an edge refers to a node ID that isn't present in the graph, still print the ID (don't error)
+
+### Footer
+
+```
+Hint: Use 'cub-scout graph export --json' for the full graph.
+```
+
+---
+
+## Determinism Requirements
+
+- No timestamps in output
+- Output must be byte-identical for the same underlying graph
+- Sorting rules above are mandatory
+
+---
+
+## Error Behavior
+
+If node not found, exit code 3 with a one-line message:
+
+```
+Error: target not found: <cluster>/<ns>/<kind>/<name>
+```
+
+Keep error line deterministic.
+
+---
+
+## Golden Examples
+
+### Golden 1: Deployment with outgoing owns edge
+
+**File:** `test/golden/graph-explain/testdata/deployment.golden.txt`
+
+```
+GRAPH EXPLAIN
+Target: test-cluster/default/Deployment/nginx
+Schema: graph.v1
+
+Node:
+  kind: Deployment
+  name: nginx
+  namespace: default
+  api_version: apps/v1
+  id: test-cluster/default/Deployment/nginx
+  labels:
+    app=nginx
+
+Relationships:
+  outgoing (1):
+    - owns -> test-cluster/default/ReplicaSet/nginx-abc123
+      evidence (1):
+        - field: metadata.ownerReferences
+          reason: ReplicaSet nginx-abc123 has ownerReference to Deployment nginx
+  incoming (0):
+
+Hint: Use 'cub-scout graph export --json' for the full graph.
+```
+
+### Golden 2: Pod with incoming owns edge
+
+**File:** `test/golden/graph-explain/testdata/pod.golden.txt`
+
+```
+GRAPH EXPLAIN
+Target: test-cluster/default/Pod/nginx-abc123-xyz789
+Schema: graph.v1
+
+Node:
+  kind: Pod
+  name: nginx-abc123-xyz789
+  namespace: default
+  api_version: v1
+  id: test-cluster/default/Pod/nginx-abc123-xyz789
+  labels:
+    app=nginx
+
+Relationships:
+  outgoing (0):
+  incoming (1):
+    - owns <- test-cluster/default/ReplicaSet/nginx-abc123
+      evidence (1):
+        - field: metadata.ownerReferences
+          reason: Pod nginx-abc123-xyz789 has ownerReference to ReplicaSet nginx-abc123
+
+Hint: Use 'cub-scout graph export --json' for the full graph.
+```
+
+### Golden 3: GitOps CRD node with no edges
+
+**File:** `test/golden/graph-explain/testdata/crd-no-edges.golden.txt`
+
+```
+GRAPH EXPLAIN
+Target: test-cluster/argocd/Application/my-app
+Schema: graph.v1
+
+Node:
+  kind: Application
+  name: my-app
+  namespace: argocd
+  api_version: argoproj.io/v1alpha1
+  id: test-cluster/argocd/Application/my-app
+  labels:
+    app.kubernetes.io/name=my-app
+
+Relationships:
+  outgoing (0):
+  incoming (0):
+
+Hint: Use 'cub-scout graph export --json' for the full graph.
+```
+
+---
+
+## Implementation Notes
+
+### Suggested Code Flow
+
+1. Build graph using existing collectors (same as export)
+2. Resolve target node ID from args (`cluster`, `namespace`, `kind`, `name`)
+3. Find node in `g.Nodes` (map by ID)
+4. Filter edges into:
+   - outgoing: `edge.From == targetID`
+   - incoming: `edge.To == targetID`
+5. Sort outgoing/incoming as specified
+6. Render using `strings.Builder`
+
+### Suggested File Structure
+
+```
+cmd/cub-scout/graph_explain.go          # CLI command
+internal/graph/explain.go               # Core explain logic
+internal/graph/explain_test.go          # Unit tests
+test/golden/graph-explain/              # Golden tests
+  graph_explain_test.go
+  testdata/
+    deployment.golden.txt
+    pod.golden.txt
+    crd-no-edges.golden.txt
+    not-found.golden.txt
+```
+
+### Core Types
+
+```go
+// Explanation holds the explain output for a resource.
+type Explanation struct {
+    Node     Node
+    Outgoing []RelatedEdge
+    Incoming []RelatedEdge
+}
+
+// RelatedEdge represents an edge in the explain output.
+type RelatedEdge struct {
+    Type     EdgeType
+    Target   string     // node ID (to_id for outgoing, from_id for incoming)
+    Evidence []Evidence
+}
+
+// Explain returns explanation for a resource in the graph.
+func (g *Graph) Explain(nodeID string) (*Explanation, error)
+
+// Render formats the explanation as deterministic text.
+func (e *Explanation) Render(cluster string) string
+```
+
+---
+
+## See Also
+
+- [graph-contract.md](graph-contract.md) — Graph export contract
+- [commands.md](commands.md) — CLI reference

--- a/internal/graph/explain.go
+++ b/internal/graph/explain.go
@@ -1,0 +1,166 @@
+package graph
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RelatedEdge represents an edge in the explain output.
+type RelatedEdge struct {
+	Type     EdgeType
+	Target   string // node ID (to_id for outgoing, from_id for incoming)
+	Evidence []Evidence
+}
+
+// Explanation holds the explain output for a resource.
+type Explanation struct {
+	Node     Node
+	Outgoing []RelatedEdge
+	Incoming []RelatedEdge
+}
+
+// Explain returns explanation for a resource in the graph.
+// Returns the rendered output string and an exit code (0=success, 3=not found).
+func Explain(g *Graph, cluster, namespace, kind, name string) (string, int) {
+	targetID := NodeID(cluster, namespace, kind, name)
+
+	// Build node lookup map
+	nodeMap := make(map[string]Node)
+	for _, node := range g.Nodes {
+		nodeMap[node.ID] = node
+	}
+
+	// Find target node
+	node, found := nodeMap[targetID]
+	if !found {
+		return fmt.Sprintf("Error: target not found: %s\n", targetID), 3
+	}
+
+	// Filter and collect edges
+	var outgoing, incoming []RelatedEdge
+
+	for _, edge := range g.Edges {
+		if edge.From == targetID {
+			outgoing = append(outgoing, RelatedEdge{
+				Type:     edge.Type,
+				Target:   edge.To,
+				Evidence: edge.Evidence,
+			})
+		}
+		if edge.To == targetID {
+			incoming = append(incoming, RelatedEdge{
+				Type:     edge.Type,
+				Target:   edge.From,
+				Evidence: edge.Evidence,
+			})
+		}
+	}
+
+	// Sort edges deterministically
+	sortRelatedEdges(outgoing)
+	sortRelatedEdges(incoming)
+
+	// Build explanation
+	exp := Explanation{
+		Node:     node,
+		Outgoing: outgoing,
+		Incoming: incoming,
+	}
+
+	return exp.Render(cluster), 0
+}
+
+// sortRelatedEdges sorts edges by (type, target) lexicographically.
+func sortRelatedEdges(edges []RelatedEdge) {
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Type != edges[j].Type {
+			return edges[i].Type < edges[j].Type
+		}
+		return edges[i].Target < edges[j].Target
+	})
+
+	// Also sort evidence within each edge
+	for i := range edges {
+		sortEvidence(edges[i].Evidence)
+	}
+}
+
+// sortEvidence sorts evidence by (field, reason) lexicographically.
+func sortEvidence(evidence []Evidence) {
+	sort.Slice(evidence, func(i, j int) bool {
+		if evidence[i].Field != evidence[j].Field {
+			return evidence[i].Field < evidence[j].Field
+		}
+		return evidence[i].Reason < evidence[j].Reason
+	})
+}
+
+// Render formats the explanation as deterministic text.
+func (e *Explanation) Render(cluster string) string {
+	var sb strings.Builder
+
+	// Header
+	sb.WriteString("GRAPH EXPLAIN\n")
+	sb.WriteString(fmt.Sprintf("Target: %s\n", e.Node.ID))
+	sb.WriteString(fmt.Sprintf("Schema: %s\n", SchemaVersion))
+	sb.WriteString("\n")
+
+	// Node details
+	sb.WriteString("Node:\n")
+	sb.WriteString(fmt.Sprintf("  kind: %s\n", e.Node.Kind))
+	sb.WriteString(fmt.Sprintf("  name: %s\n", e.Node.Name))
+	if e.Node.Namespace != "" {
+		sb.WriteString(fmt.Sprintf("  namespace: %s\n", e.Node.Namespace))
+	}
+	sb.WriteString(fmt.Sprintf("  api_version: %s\n", e.Node.APIVersion))
+	sb.WriteString(fmt.Sprintf("  id: %s\n", e.Node.ID))
+
+	// Labels
+	sb.WriteString("  labels:\n")
+	if len(e.Node.Labels) == 0 {
+		sb.WriteString("    (none)\n")
+	} else {
+		// Sort labels by key
+		keys := make([]string, 0, len(e.Node.Labels))
+		for k := range e.Node.Labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			sb.WriteString(fmt.Sprintf("    %s=%s\n", k, e.Node.Labels[k]))
+		}
+	}
+	sb.WriteString("\n")
+
+	// Relationships
+	sb.WriteString("Relationships:\n")
+
+	// Outgoing
+	sb.WriteString(fmt.Sprintf("  outgoing (%d):\n", len(e.Outgoing)))
+	for _, edge := range e.Outgoing {
+		sb.WriteString(fmt.Sprintf("    - %s -> %s\n", edge.Type, edge.Target))
+		sb.WriteString(fmt.Sprintf("      evidence (%d):\n", len(edge.Evidence)))
+		for _, ev := range edge.Evidence {
+			sb.WriteString(fmt.Sprintf("        - field: %s\n", ev.Field))
+			sb.WriteString(fmt.Sprintf("          reason: %s\n", ev.Reason))
+		}
+	}
+
+	// Incoming
+	sb.WriteString(fmt.Sprintf("  incoming (%d):\n", len(e.Incoming)))
+	for _, edge := range e.Incoming {
+		sb.WriteString(fmt.Sprintf("    - %s <- %s\n", edge.Type, edge.Target))
+		sb.WriteString(fmt.Sprintf("      evidence (%d):\n", len(edge.Evidence)))
+		for _, ev := range edge.Evidence {
+			sb.WriteString(fmt.Sprintf("        - field: %s\n", ev.Field))
+			sb.WriteString(fmt.Sprintf("          reason: %s\n", ev.Reason))
+		}
+	}
+	sb.WriteString("\n")
+
+	// Footer
+	sb.WriteString("Hint: Use 'cub-scout graph export --json' for the full graph.\n")
+
+	return sb.String()
+}

--- a/internal/graph/explain_test.go
+++ b/internal/graph/explain_test.go
@@ -1,0 +1,260 @@
+package graph
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildTestGraph creates a graph with Deployment → ReplicaSet → Pod chain
+// plus an Argo Application for testing.
+func buildTestGraph() *Graph {
+	g := NewGraph("test-cluster")
+
+	// Deployment
+	g.AddNode(Node{
+		ID:         "test-cluster/default/Deployment/nginx",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "Deployment",
+		Name:       "nginx",
+		APIVersion: "apps/v1",
+		Labels:     map[string]string{"app": "nginx"},
+	})
+
+	// ReplicaSet
+	g.AddNode(Node{
+		ID:         "test-cluster/default/ReplicaSet/nginx-abc123",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "ReplicaSet",
+		Name:       "nginx-abc123",
+		APIVersion: "apps/v1",
+		Labels:     map[string]string{"app": "nginx", "pod-template-hash": "abc123"},
+	})
+
+	// Pod
+	g.AddNode(Node{
+		ID:         "test-cluster/default/Pod/nginx-abc123-xyz789",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "Pod",
+		Name:       "nginx-abc123-xyz789",
+		APIVersion: "v1",
+		Labels:     map[string]string{"app": "nginx"},
+	})
+
+	// Argo Application (no edges)
+	g.AddNode(Node{
+		ID:         "test-cluster/argocd/Application/my-app",
+		Cluster:    "test-cluster",
+		Namespace:  "argocd",
+		Kind:       "Application",
+		Name:       "my-app",
+		APIVersion: "argoproj.io/v1alpha1",
+		Labels:     map[string]string{"app.kubernetes.io/name": "my-app"},
+	})
+
+	// Deployment → ReplicaSet edge
+	g.AddEdge(Edge{
+		From: "test-cluster/default/Deployment/nginx",
+		To:   "test-cluster/default/ReplicaSet/nginx-abc123",
+		Type: EdgeTypeOwns,
+		Evidence: []Evidence{{
+			Field:  "metadata.ownerReferences",
+			Reason: "ReplicaSet nginx-abc123 has ownerReference to Deployment nginx",
+		}},
+	})
+
+	// ReplicaSet → Pod edge
+	g.AddEdge(Edge{
+		From: "test-cluster/default/ReplicaSet/nginx-abc123",
+		To:   "test-cluster/default/Pod/nginx-abc123-xyz789",
+		Type: EdgeTypeOwns,
+		Evidence: []Evidence{{
+			Field:  "metadata.ownerReferences",
+			Reason: "Pod nginx-abc123-xyz789 has ownerReference to ReplicaSet nginx-abc123",
+		}},
+	})
+
+	return g
+}
+
+func TestExplain_Deployment_Golden(t *testing.T) {
+	g := buildTestGraph()
+
+	output, exitCode := Explain(g, "test-cluster", "default", "Deployment", "nginx")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	goldenPath := filepath.Join("..", "..", "test", "golden", "graph-explain", "testdata", "deployment.golden.txt")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if output != string(golden) {
+		t.Errorf("output mismatch\ngot:\n%s\n\nwant:\n%s", output, string(golden))
+	}
+}
+
+func TestExplain_Pod_Golden(t *testing.T) {
+	g := buildTestGraph()
+
+	output, exitCode := Explain(g, "test-cluster", "default", "Pod", "nginx-abc123-xyz789")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	goldenPath := filepath.Join("..", "..", "test", "golden", "graph-explain", "testdata", "pod.golden.txt")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if output != string(golden) {
+		t.Errorf("output mismatch\ngot:\n%s\n\nwant:\n%s", output, string(golden))
+	}
+}
+
+func TestExplain_CRDNoEdges_Golden(t *testing.T) {
+	g := buildTestGraph()
+
+	output, exitCode := Explain(g, "test-cluster", "argocd", "Application", "my-app")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	goldenPath := filepath.Join("..", "..", "test", "golden", "graph-explain", "testdata", "crd-no-edges.golden.txt")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if output != string(golden) {
+		t.Errorf("output mismatch\ngot:\n%s\n\nwant:\n%s", output, string(golden))
+	}
+}
+
+func TestExplain_NotFound_Golden(t *testing.T) {
+	g := buildTestGraph()
+
+	output, exitCode := Explain(g, "test-cluster", "default", "Deployment", "nonexistent")
+
+	if exitCode != 3 {
+		t.Fatalf("expected exit code 3, got %d", exitCode)
+	}
+
+	goldenPath := filepath.Join("..", "..", "test", "golden", "graph-explain", "testdata", "not-found.golden.txt")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if output != string(golden) {
+		t.Errorf("output mismatch\ngot:\n%s\n\nwant:\n%s", output, string(golden))
+	}
+}
+
+func TestExplain_Deterministic(t *testing.T) {
+	g := buildTestGraph()
+
+	output1, _ := Explain(g, "test-cluster", "default", "Deployment", "nginx")
+	output2, _ := Explain(g, "test-cluster", "default", "Deployment", "nginx")
+
+	if output1 != output2 {
+		t.Error("Explain is not deterministic")
+	}
+}
+
+func TestExplain_NoLabels(t *testing.T) {
+	g := NewGraph("test-cluster")
+	g.AddNode(Node{
+		ID:         "test-cluster/default/Pod/orphan",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "Pod",
+		Name:       "orphan",
+		APIVersion: "v1",
+		Labels:     nil, // No labels
+	})
+
+	output, exitCode := Explain(g, "test-cluster", "default", "Pod", "orphan")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	// Should contain "(none)" for labels
+	if !strings.Contains(output, "labels:\n    (none)") {
+		t.Errorf("expected '(none)' for empty labels, got:\n%s", output)
+	}
+}
+
+func TestExplain_MultipleOutgoingEdges(t *testing.T) {
+	g := NewGraph("test-cluster")
+
+	// Deployment that owns two ReplicaSets
+	g.AddNode(Node{
+		ID:         "test-cluster/default/Deployment/app",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "Deployment",
+		Name:       "app",
+		APIVersion: "apps/v1",
+		Labels:     map[string]string{"app": "test"},
+	})
+	g.AddNode(Node{
+		ID:         "test-cluster/default/ReplicaSet/app-v1",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "ReplicaSet",
+		Name:       "app-v1",
+		APIVersion: "apps/v1",
+	})
+	g.AddNode(Node{
+		ID:         "test-cluster/default/ReplicaSet/app-v2",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "ReplicaSet",
+		Name:       "app-v2",
+		APIVersion: "apps/v1",
+	})
+
+	// Add edges in reverse order to test sorting
+	g.AddEdge(Edge{
+		From:     "test-cluster/default/Deployment/app",
+		To:       "test-cluster/default/ReplicaSet/app-v2",
+		Type:     EdgeTypeOwns,
+		Evidence: []Evidence{{Field: "metadata.ownerReferences", Reason: "RS v2"}},
+	})
+	g.AddEdge(Edge{
+		From:     "test-cluster/default/Deployment/app",
+		To:       "test-cluster/default/ReplicaSet/app-v1",
+		Type:     EdgeTypeOwns,
+		Evidence: []Evidence{{Field: "metadata.ownerReferences", Reason: "RS v1"}},
+	})
+
+	output, exitCode := Explain(g, "test-cluster", "default", "Deployment", "app")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	// Should show outgoing (2)
+	if !strings.Contains(output, "outgoing (2):") {
+		t.Errorf("expected 'outgoing (2):', got:\n%s", output)
+	}
+
+	// v1 should come before v2 (sorted by target)
+	v1Idx := strings.Index(output, "app-v1")
+	v2Idx := strings.Index(output, "app-v2")
+	if v1Idx > v2Idx {
+		t.Errorf("expected app-v1 before app-v2 (sorted), got:\n%s", output)
+	}
+}

--- a/test/golden/graph-explain/testdata/crd-no-edges.golden.txt
+++ b/test/golden/graph-explain/testdata/crd-no-edges.golden.txt
@@ -1,0 +1,18 @@
+GRAPH EXPLAIN
+Target: test-cluster/argocd/Application/my-app
+Schema: graph.v1
+
+Node:
+  kind: Application
+  name: my-app
+  namespace: argocd
+  api_version: argoproj.io/v1alpha1
+  id: test-cluster/argocd/Application/my-app
+  labels:
+    app.kubernetes.io/name=my-app
+
+Relationships:
+  outgoing (0):
+  incoming (0):
+
+Hint: Use 'cub-scout graph export --json' for the full graph.

--- a/test/golden/graph-explain/testdata/deployment.golden.txt
+++ b/test/golden/graph-explain/testdata/deployment.golden.txt
@@ -1,0 +1,22 @@
+GRAPH EXPLAIN
+Target: test-cluster/default/Deployment/nginx
+Schema: graph.v1
+
+Node:
+  kind: Deployment
+  name: nginx
+  namespace: default
+  api_version: apps/v1
+  id: test-cluster/default/Deployment/nginx
+  labels:
+    app=nginx
+
+Relationships:
+  outgoing (1):
+    - owns -> test-cluster/default/ReplicaSet/nginx-abc123
+      evidence (1):
+        - field: metadata.ownerReferences
+          reason: ReplicaSet nginx-abc123 has ownerReference to Deployment nginx
+  incoming (0):
+
+Hint: Use 'cub-scout graph export --json' for the full graph.

--- a/test/golden/graph-explain/testdata/not-found.golden.txt
+++ b/test/golden/graph-explain/testdata/not-found.golden.txt
@@ -1,0 +1,1 @@
+Error: target not found: test-cluster/default/Deployment/nonexistent

--- a/test/golden/graph-explain/testdata/pod.golden.txt
+++ b/test/golden/graph-explain/testdata/pod.golden.txt
@@ -1,0 +1,22 @@
+GRAPH EXPLAIN
+Target: test-cluster/default/Pod/nginx-abc123-xyz789
+Schema: graph.v1
+
+Node:
+  kind: Pod
+  name: nginx-abc123-xyz789
+  namespace: default
+  api_version: v1
+  id: test-cluster/default/Pod/nginx-abc123-xyz789
+  labels:
+    app=nginx
+
+Relationships:
+  outgoing (0):
+  incoming (1):
+    - owns <- test-cluster/default/ReplicaSet/nginx-abc123
+      evidence (1):
+        - field: metadata.ownerReferences
+          reason: Pod nginx-abc123-xyz789 has ownerReference to ReplicaSet nginx-abc123
+
+Hint: Use 'cub-scout graph export --json' for the full graph.


### PR DESCRIPTION
## Summary
- Adds `cub-scout graph explain <kind>/<name> -n <namespace>` command
- Deterministic text output showing node details and relationships
- Golden tests for Deployment, Pod, CRD, and not-found scenarios
- Exit codes: 0=success, 2=usage error, 3=not found

Closes #62

## Files
- `cmd/cub-scout/graph_explain.go` - CLI command
- `internal/graph/explain.go` - Renderer
- `internal/graph/explain_test.go` - 7 tests (golden + unit)
- `test/golden/graph-explain/testdata/*.golden.txt` - 4 golden files
- `docs/reference/graph-explain-contract.md` - Contract spec
- `docs/reference/commands.md` - Updated with graph explain section

## Test plan
- [x] `go test ./internal/graph/...` passes (all 7 explain tests)
- [x] Exit code 2 verified for missing args and missing namespace
- [x] Exit code 3 verified for not-found target
- [x] Output is deterministic (TestExplain_Deterministic)
- [x] Golden tests lock output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)