### PR TITLE
feat(patterns): support remediation, refs, confidence fields

### DIFF
--- a/internal/patterns/detect.go
+++ b/internal/patterns/detect.go
@@ -86,9 +86,43 @@ func sortFindings(findings []Finding) {
 		return findings[i].Message < findings[j].Message
 	})
 
-	// Also sort evidence within each finding
+	// Sort arrays within each finding for deterministic output
 	for i := range findings {
 		sort.Strings(findings[i].Evidence)
+		sort.Strings(findings[i].Refs)
+		// Sort remediation.links (steps maintain pattern-defined order)
+		if findings[i].Remediation != nil {
+			sort.Strings(findings[i].Remediation.Links)
+		}
+	}
+}
+
+// renderFinding renders a single finding to the string builder.
+func renderFinding(sb *strings.Builder, f Finding, indent string) {
+	sb.WriteString(fmt.Sprintf("%s- [%s] %s\n", indent, f.Severity, f.Message))
+	if f.Resource != "" {
+		sb.WriteString(fmt.Sprintf("%s  resource: %s\n", indent, f.Resource))
+	}
+	if len(f.Evidence) > 0 {
+		sb.WriteString(fmt.Sprintf("%s  evidence (%d):\n", indent, len(f.Evidence)))
+		for _, e := range f.Evidence {
+			sb.WriteString(fmt.Sprintf("%s    - %s\n", indent, e))
+		}
+	}
+	// Render remediation block only if present (v0.8+)
+	if f.Remediation != nil && f.Remediation.Summary != "" {
+		sb.WriteString(fmt.Sprintf("%s  Remediation: %s\n", indent, f.Remediation.Summary))
+		if len(f.Remediation.Steps) > 0 {
+			for _, step := range f.Remediation.Steps {
+				sb.WriteString(fmt.Sprintf("%s    - %s\n", indent, step))
+			}
+		}
+		if len(f.Remediation.Links) > 0 {
+			sb.WriteString(fmt.Sprintf("%s  Links:\n", indent))
+			for _, link := range f.Remediation.Links {
+				sb.WriteString(fmt.Sprintf("%s    - %s\n", indent, link))
+			}
+		}
 	}
 }
 
@@ -118,16 +152,7 @@ func RenderText(r Result) string {
 			sb.WriteString("    (none)\n")
 		} else {
 			for _, f := range pr.Findings {
-				sb.WriteString(fmt.Sprintf("    - [%s] %s\n", f.Severity, f.Message))
-				if f.Resource != "" {
-					sb.WriteString(fmt.Sprintf("      resource: %s\n", f.Resource))
-				}
-				if len(f.Evidence) > 0 {
-					sb.WriteString(fmt.Sprintf("      evidence (%d):\n", len(f.Evidence)))
-					for _, e := range f.Evidence {
-						sb.WriteString(fmt.Sprintf("        - %s\n", e))
-					}
-				}
+				renderFinding(&sb, f, "    ")
 			}
 		}
 		sb.WriteString("\n")
@@ -174,16 +199,7 @@ func RenderExplain(p *Pattern, pr *PatternResult) string {
 			sb.WriteString("    (none)\n")
 		} else {
 			for _, f := range pr.Findings {
-				sb.WriteString(fmt.Sprintf("    - [%s] %s\n", f.Severity, f.Message))
-				if f.Resource != "" {
-					sb.WriteString(fmt.Sprintf("      resource: %s\n", f.Resource))
-				}
-				if len(f.Evidence) > 0 {
-					sb.WriteString(fmt.Sprintf("      evidence (%d):\n", len(f.Evidence)))
-					for _, e := range f.Evidence {
-						sb.WriteString(fmt.Sprintf("        - %s\n", e))
-					}
-				}
+				renderFinding(&sb, f, "    ")
 			}
 		}
 	}

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -406,3 +406,225 @@ func TestSortFindings(t *testing.T) {
 		t.Errorf("expected info last, got %s", findings[2].Severity)
 	}
 }
+
+// Track I (v0.8+) tests for enrichment fields
+
+func TestSortFindings_SortsRefs(t *testing.T) {
+	findings := []Finding{
+		{
+			Severity: SeverityWarning,
+			Message:  "test",
+			Refs:     []string{"z-ref", "a-ref", "m-ref"},
+		},
+	}
+
+	sortFindings(findings)
+
+	// Refs should be sorted alphabetically
+	if findings[0].Refs[0] != "a-ref" {
+		t.Errorf("expected refs sorted, got %v", findings[0].Refs)
+	}
+	if findings[0].Refs[1] != "m-ref" {
+		t.Errorf("expected refs sorted, got %v", findings[0].Refs)
+	}
+	if findings[0].Refs[2] != "z-ref" {
+		t.Errorf("expected refs sorted, got %v", findings[0].Refs)
+	}
+}
+
+func TestSortFindings_SortsRemediationLinks(t *testing.T) {
+	findings := []Finding{
+		{
+			Severity: SeverityWarning,
+			Message:  "test",
+			Remediation: &Remediation{
+				Summary: "Fix it",
+				Links:   []string{"https://z.com", "https://a.com"},
+			},
+		},
+	}
+
+	sortFindings(findings)
+
+	// Links should be sorted alphabetically
+	if findings[0].Remediation.Links[0] != "https://a.com" {
+		t.Errorf("expected links sorted, got %v", findings[0].Remediation.Links)
+	}
+}
+
+func TestSortFindings_PreservesStepsOrder(t *testing.T) {
+	findings := []Finding{
+		{
+			Severity: SeverityWarning,
+			Message:  "test",
+			Remediation: &Remediation{
+				Summary: "Fix it",
+				Steps:   []string{"step 2", "step 1", "step 3"},
+			},
+		},
+	}
+
+	sortFindings(findings)
+
+	// Steps should NOT be re-sorted (pattern-defined order)
+	if findings[0].Remediation.Steps[0] != "step 2" {
+		t.Errorf("expected steps order preserved, got %v", findings[0].Remediation.Steps)
+	}
+}
+
+func TestRenderText_WithRemediation(t *testing.T) {
+	confidence := 0.9
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		Patterns: []PatternResult{
+			{
+				ID:     "test.pattern",
+				Name:   "Test Pattern",
+				Status: StatusFail,
+				Findings: []Finding{
+					{
+						Pattern:    "test.pattern",
+						Severity:   SeverityWarning,
+						Message:    "Something is wrong",
+						Confidence: &confidence,
+						Refs:       []string{"k8s:Pod/default/test"},
+						Remediation: &Remediation{
+							Summary: "Fix the thing",
+							Steps:   []string{"Do step 1", "Do step 2"},
+							Links:   []string{"https://example.com/docs"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	output := RenderText(result)
+
+	// Should contain remediation block
+	if !strings.Contains(output, "Remediation: Fix the thing") {
+		t.Error("expected remediation summary in output")
+	}
+	if !strings.Contains(output, "- Do step 1") {
+		t.Error("expected remediation steps in output")
+	}
+	if !strings.Contains(output, "Links:") {
+		t.Error("expected Links section in output")
+	}
+	if !strings.Contains(output, "- https://example.com/docs") {
+		t.Error("expected remediation link in output")
+	}
+}
+
+func TestRenderText_WithoutRemediation(t *testing.T) {
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		Patterns: []PatternResult{
+			{
+				ID:     "test.pattern",
+				Name:   "Test Pattern",
+				Status: StatusFail,
+				Findings: []Finding{
+					{
+						Pattern:  "test.pattern",
+						Severity: SeverityWarning,
+						Message:  "Something is wrong",
+					},
+				},
+			},
+		},
+	}
+
+	output := RenderText(result)
+
+	// Should NOT contain remediation block
+	if strings.Contains(output, "Remediation:") {
+		t.Error("should not print remediation when absent")
+	}
+	if strings.Contains(output, "Links:") {
+		t.Error("should not print Links when remediation absent")
+	}
+}
+
+func TestRenderJSON_WithEnrichmentFields(t *testing.T) {
+	confidence := 0.85
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		Patterns: []PatternResult{
+			{
+				ID:     "test.pattern",
+				Name:   "Test Pattern",
+				Status: StatusFail,
+				Findings: []Finding{
+					{
+						Pattern:    "test.pattern",
+						Severity:   SeverityWarning,
+						Message:    "Test message",
+						Confidence: &confidence,
+						Refs:       []string{"k8s:Pod/default/test"},
+						Remediation: &Remediation{
+							Summary: "Fix it",
+							Steps:   []string{"Step 1"},
+							Links:   []string{"https://example.com"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	output, err := RenderJSON(result)
+	if err != nil {
+		t.Fatalf("RenderJSON error: %v", err)
+	}
+
+	// Should contain new fields
+	if !strings.Contains(output, `"confidence": 0.85`) {
+		t.Error("expected confidence in JSON output")
+	}
+	if !strings.Contains(output, `"refs"`) {
+		t.Error("expected refs in JSON output")
+	}
+	if !strings.Contains(output, `"remediation"`) {
+		t.Error("expected remediation in JSON output")
+	}
+	if !strings.Contains(output, `"summary": "Fix it"`) {
+		t.Error("expected remediation summary in JSON output")
+	}
+}
+
+func TestRenderJSON_OmitsAbsentFields(t *testing.T) {
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		Patterns: []PatternResult{
+			{
+				ID:     "test.pattern",
+				Name:   "Test Pattern",
+				Status: StatusPass,
+				Findings: []Finding{
+					{
+						Pattern:  "test.pattern",
+						Severity: SeverityInfo,
+						Message:  "All good",
+					},
+				},
+			},
+		},
+	}
+
+	output, err := RenderJSON(result)
+	if err != nil {
+		t.Fatalf("RenderJSON error: %v", err)
+	}
+
+	// Should NOT contain new optional fields when absent
+	if strings.Contains(output, `"confidence"`) {
+		t.Error("should not include confidence when nil")
+	}
+	if strings.Contains(output, `"refs"`) {
+		t.Error("should not include refs when nil/empty")
+	}
+	if strings.Contains(output, `"remediation"`) {
+		t.Error("should not include remediation when nil")
+	}
+}

--- a/internal/patterns/types.go
+++ b/internal/patterns/types.go
@@ -60,6 +60,27 @@ type Finding struct {
 
 	// Evidence provides supporting details.
 	Evidence []string `json:"evidence,omitempty"`
+
+	// Confidence is a deterministic score (0.0-1.0) for the finding (v0.8+, optional).
+	Confidence *float64 `json:"confidence,omitempty"`
+
+	// Refs are stable identifiers for correlation across runs (v0.8+, optional).
+	Refs []string `json:"refs,omitempty"`
+
+	// Remediation provides actionable guidance (v0.8+, optional).
+	Remediation *Remediation `json:"remediation,omitempty"`
+}
+
+// Remediation provides structured guidance for resolving a finding.
+type Remediation struct {
+	// Summary is a brief description of the fix (required if Remediation is present).
+	Summary string `json:"summary"`
+
+	// Steps are ordered action steps (optional).
+	Steps []string `json:"steps,omitempty"`
+
+	// Links are canonical documentation URLs (optional).
+	Links []string `json:"links,omitempty"`
 }
 
 // Severity indicates the importance of a finding.


### PR DESCRIPTION
## Summary

Implements Track I finding fields and rendering; depends on PR #66.

- Adds `Confidence`, `Refs`, `Remediation` fields to `Finding` struct
- Adds `Remediation` struct with `Summary`, `Steps`, `Links`
- Updates text renderer to display remediation blocks when present
- Sorts `refs` and `links` for deterministic output; preserves `steps` order
- All fields omit from JSON when empty (`omitempty`)

## Test plan

- [x] Unit tests for sorting logic (`TestSortFindings_*`)
- [x] Unit tests for rendering with/without remediation
- [x] JSON omitempty verified (absent fields don't appear)
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)