### PR TITLE
feat(patterns): add remediation hints to MVP patterns

### DIFF
--- a/internal/patterns/pattern_gitops_presence.go
+++ b/internal/patterns/pattern_gitops_presence.go
@@ -98,14 +98,28 @@ func detectGitOpsControllerPresence(g *graph.Graph) ([]Finding, Status) {
 	}
 
 	if !hasArgoCD && !hasFlux {
+		confidenceNoGitOps := 0.8
 		findings = append(findings, Finding{
-			Pattern:  "gitops.controller_presence",
-			Severity: SeverityWarning,
-			Message:  "No GitOps controllers detected",
+			Pattern:    "gitops.controller_presence",
+			Severity:   SeverityWarning,
+			Message:    "No GitOps controllers detected",
+			Confidence: &confidenceNoGitOps,
 			Evidence: []string{
 				"No Argo CD Applications or ApplicationSets found",
 				"No Flux Kustomizations, HelmReleases, or GitRepositories found",
 				"This may indicate GitOps is not deployed, or CRDs are in namespaces not collected",
+			},
+			Remediation: &Remediation{
+				Summary: "Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.",
+				Steps: []string{
+					"Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.",
+					"Install the controller following the official documentation.",
+					"Create Application or Kustomization resources to manage your workloads.",
+				},
+				Links: []string{
+					"https://argo-cd.readthedocs.io/en/stable/getting_started/",
+					"https://fluxcd.io/flux/get-started/",
+				},
 			},
 		})
 		return findings, StatusFail

--- a/internal/patterns/pattern_gitops_presence.go
+++ b/internal/patterns/pattern_gitops_presence.go
@@ -110,11 +110,11 @@ func detectGitOpsControllerPresence(g *graph.Graph) ([]Finding, Status) {
 				"This may indicate GitOps is not deployed, or CRDs are in namespaces not collected",
 			},
 			Remediation: &Remediation{
-				Summary: "Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.",
+				Summary: "Install a GitOps controller (Argo CD or Flux) if you intend to manage cluster resources declaratively from Git.",
 				Steps: []string{
-					"Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.",
-					"Install the controller following the official documentation.",
-					"Create Application or Kustomization resources to manage your workloads.",
+					"Choose a controller: Argo CD for application-centric workflows, Flux for Git-native automation.",
+					"Install it using the official documentation.",
+					"Define GitOps resources (e.g., Argo CD Application/ApplicationSet or Flux Kustomization/HelmRelease) for your workloads.",
 				},
 				Links: []string{
 					"https://argo-cd.readthedocs.io/en/stable/getting_started/",

--- a/internal/patterns/pattern_ownership_chain.go
+++ b/internal/patterns/pattern_ownership_chain.go
@@ -75,15 +75,29 @@ func detectOwnershipChainComplete(g *graph.Graph) ([]Finding, Status) {
 	}
 
 	// Check for orphaned ReplicaSets (RS without owning Deployment)
+	confidenceOrphanedRS := 0.9
 	for rsID, rs := range replicasets {
 		if _, hasOwner := rsToDeployment[rsID]; !hasOwner {
 			findings = append(findings, Finding{
-				Pattern:  "k8s.ownership_chain_complete",
-				Severity: SeverityWarning,
-				Message:  fmt.Sprintf("ReplicaSet %q has no owning Deployment in graph", rs.Name),
-				Resource: rsID,
+				Pattern:    "k8s.ownership_chain_complete",
+				Severity:   SeverityWarning,
+				Message:    fmt.Sprintf("ReplicaSet %q has no owning Deployment in graph", rs.Name),
+				Resource:   rsID,
+				Confidence: &confidenceOrphanedRS,
+				Refs:       []string{fmt.Sprintf("k8s:ReplicaSet/%s/%s", rs.Namespace, rs.Name)},
 				Evidence: []string{
 					"No 'owns' edge from any Deployment to this ReplicaSet",
+				},
+				Remediation: &Remediation{
+					Summary: "Verify the ReplicaSet was created by a Deployment or is intentionally standalone.",
+					Steps: []string{
+						"Check if a Deployment with matching selector exists in the namespace.",
+						"Verify the ReplicaSet's metadata.ownerReferences field.",
+						"If orphaned after Deployment deletion, consider cleaning up the ReplicaSet.",
+					},
+					Links: []string{
+						"https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/",
+					},
 				},
 			})
 		}
@@ -108,16 +122,30 @@ func detectOwnershipChainComplete(g *graph.Graph) ([]Finding, Status) {
 	}
 
 	// Check for Deployments without ReplicaSets
+	confidenceNoRS := 0.85
 	for deployID, deploy := range deployments {
 		if rsIDs, hasRS := deploymentToRS[deployID]; !hasRS || len(rsIDs) == 0 {
 			findings = append(findings, Finding{
-				Pattern:  "k8s.ownership_chain_complete",
-				Severity: SeverityWarning,
-				Message:  fmt.Sprintf("Deployment %q has no ReplicaSets in graph", deploy.Name),
-				Resource: deployID,
+				Pattern:    "k8s.ownership_chain_complete",
+				Severity:   SeverityWarning,
+				Message:    fmt.Sprintf("Deployment %q has no ReplicaSets in graph", deploy.Name),
+				Resource:   deployID,
+				Confidence: &confidenceNoRS,
+				Refs:       []string{fmt.Sprintf("k8s:Deployment/%s/%s", deploy.Namespace, deploy.Name)},
 				Evidence: []string{
 					"No 'owns' edge from this Deployment to any ReplicaSet",
 					"This may indicate the Deployment has not created any replicas yet",
+				},
+				Remediation: &Remediation{
+					Summary: "Check if the Deployment controller is healthy and has created ReplicaSets.",
+					Steps: []string{
+						"Run 'kubectl get rs -n <namespace>' to check for ReplicaSets.",
+						"Check Deployment status with 'kubectl describe deployment <name>'.",
+						"Verify the Deployment is not paused or scaled to zero.",
+					},
+					Links: []string{
+						"https://kubernetes.io/docs/concepts/workloads/controllers/deployment/",
+					},
 				},
 			})
 		}

--- a/internal/patterns/pattern_ownership_chain.go
+++ b/internal/patterns/pattern_ownership_chain.go
@@ -89,11 +89,11 @@ func detectOwnershipChainComplete(g *graph.Graph) ([]Finding, Status) {
 					"No 'owns' edge from any Deployment to this ReplicaSet",
 				},
 				Remediation: &Remediation{
-					Summary: "Verify the ReplicaSet was created by a Deployment or is intentionally standalone.",
+					Summary: "Verify the ReplicaSet is owned by a Deployment, or confirm it is intentionally standalone.",
 					Steps: []string{
-						"Check if a Deployment with matching selector exists in the namespace.",
-						"Verify the ReplicaSet's metadata.ownerReferences field.",
-						"If orphaned after Deployment deletion, consider cleaning up the ReplicaSet.",
+						"Check for a Deployment in the namespace with a matching selector/labels.",
+						"Inspect the ReplicaSet metadata.ownerReferences.",
+						"If it's orphaned and not serving pods, consider cleaning it up.",
 					},
 					Links: []string{
 						"https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/",
@@ -137,11 +137,11 @@ func detectOwnershipChainComplete(g *graph.Graph) ([]Finding, Status) {
 					"This may indicate the Deployment has not created any replicas yet",
 				},
 				Remediation: &Remediation{
-					Summary: "Check if the Deployment controller is healthy and has created ReplicaSets.",
+					Summary: "Check whether the Deployment controller is healthy and has created ReplicaSets.",
 					Steps: []string{
-						"Run 'kubectl get rs -n <namespace>' to check for ReplicaSets.",
-						"Check Deployment status with 'kubectl describe deployment <name>'.",
-						"Verify the Deployment is not paused or scaled to zero.",
+						"Run `kubectl get rs -n <namespace>` and look for ReplicaSets owned by this Deployment.",
+						"Check status/events with `kubectl describe deployment <name> -n <namespace>`.",
+						"Verify the Deployment is not paused and is not scaled to zero.",
 					},
 					Links: []string{
 						"https://kubernetes.io/docs/concepts/workloads/controllers/deployment/",

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.json
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.json
@@ -17,11 +17,11 @@
           ],
           "confidence": 0.8,
           "remediation": {
-            "summary": "Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.",
+            "summary": "Install a GitOps controller (Argo CD or Flux) if you intend to manage cluster resources declaratively from Git.",
             "steps": [
-              "Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.",
-              "Install the controller following the official documentation.",
-              "Create Application or Kustomization resources to manage your workloads."
+              "Choose a controller: Argo CD for application-centric workflows, Flux for Git-native automation.",
+              "Install it using the official documentation.",
+              "Define GitOps resources (e.g., Argo CD Application/ApplicationSet or Flux Kustomization/HelmRelease) for your workloads."
             ],
             "links": [
               "https://argo-cd.readthedocs.io/en/stable/getting_started/",

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.json
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.json
@@ -14,7 +14,20 @@
             "No Argo CD Applications or ApplicationSets found",
             "No Flux Kustomizations, HelmReleases, or GitRepositories found",
             "This may indicate GitOps is not deployed, or CRDs are in namespaces not collected"
-          ]
+          ],
+          "confidence": 0.8,
+          "remediation": {
+            "summary": "Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.",
+            "steps": [
+              "Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.",
+              "Install the controller following the official documentation.",
+              "Create Application or Kustomization resources to manage your workloads."
+            ],
+            "links": [
+              "https://argo-cd.readthedocs.io/en/stable/getting_started/",
+              "https://fluxcd.io/flux/get-started/"
+            ]
+          }
         }
       ]
     },

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.txt
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.txt
@@ -9,6 +9,13 @@ Schema: patterns.v1
         - No Argo CD Applications or ApplicationSets found
         - No Flux Kustomizations, HelmReleases, or GitRepositories found
         - This may indicate GitOps is not deployed, or CRDs are in namespaces not collected
+      Remediation: Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.
+        - Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.
+        - Install the controller following the official documentation.
+        - Create Application or Kustomization resources to manage your workloads.
+      Links:
+        - https://argo-cd.readthedocs.io/en/stable/getting_started/
+        - https://fluxcd.io/flux/get-started/
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.txt
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.txt
@@ -9,10 +9,10 @@ Schema: patterns.v1
         - No Argo CD Applications or ApplicationSets found
         - No Flux Kustomizations, HelmReleases, or GitRepositories found
         - This may indicate GitOps is not deployed, or CRDs are in namespaces not collected
-      Remediation: Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.
-        - Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.
-        - Install the controller following the official documentation.
-        - Create Application or Kustomization resources to manage your workloads.
+      Remediation: Install a GitOps controller (Argo CD or Flux) if you intend to manage cluster resources declaratively from Git.
+        - Choose a controller: Argo CD for application-centric workflows, Flux for Git-native automation.
+        - Install it using the official documentation.
+        - Define GitOps resources (e.g., Argo CD Application/ApplicationSet or Flux Kustomization/HelmRelease) for your workloads.
       Links:
         - https://argo-cd.readthedocs.io/en/stable/getting_started/
         - https://fluxcd.io/flux/get-started/

--- a/test/golden/patterns-explain/testdata/explain-gitops-presence.golden.txt
+++ b/test/golden/patterns-explain/testdata/explain-gitops-presence.golden.txt
@@ -13,10 +13,10 @@ Result: [FAIL]
         - No Argo CD Applications or ApplicationSets found
         - No Flux Kustomizations, HelmReleases, or GitRepositories found
         - This may indicate GitOps is not deployed, or CRDs are in namespaces not collected
-      Remediation: Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.
-        - Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.
-        - Install the controller following the official documentation.
-        - Create Application or Kustomization resources to manage your workloads.
+      Remediation: Install a GitOps controller (Argo CD or Flux) if you intend to manage cluster resources declaratively from Git.
+        - Choose a controller: Argo CD for application-centric workflows, Flux for Git-native automation.
+        - Install it using the official documentation.
+        - Define GitOps resources (e.g., Argo CD Application/ApplicationSet or Flux Kustomization/HelmRelease) for your workloads.
       Links:
         - https://argo-cd.readthedocs.io/en/stable/getting_started/
         - https://fluxcd.io/flux/get-started/

--- a/test/golden/patterns-explain/testdata/explain-gitops-presence.golden.txt
+++ b/test/golden/patterns-explain/testdata/explain-gitops-presence.golden.txt
@@ -13,3 +13,10 @@ Result: [FAIL]
         - No Argo CD Applications or ApplicationSets found
         - No Flux Kustomizations, HelmReleases, or GitRepositories found
         - This may indicate GitOps is not deployed, or CRDs are in namespaces not collected
+      Remediation: Install a GitOps controller (Argo CD or Flux) to manage cluster resources declaratively.
+        - Choose a GitOps tool: Argo CD for application-centric workflows, Flux for Git-native automation.
+        - Install the controller following the official documentation.
+        - Create Application or Kustomization resources to manage your workloads.
+      Links:
+        - https://argo-cd.readthedocs.io/en/stable/getting_started/
+        - https://fluxcd.io/flux/get-started/


### PR DESCRIPTION
## Summary

Populates remediation and confidence for MVP patterns; depends on PR #67.

Adds Track I enrichment fields to both MVP patterns:

### `gitops.controller_presence` (confidence: 0.8)
- Remediation when no controllers detected
- Steps guide installation of Argo CD or Flux
- Links to official getting-started docs

### `k8s.ownership_chain_complete`
- Orphaned ReplicaSet (confidence: 0.9): verify ownership or cleanup
- Deployment without ReplicaSets (confidence: 0.85): check controller health

## Design notes

- **Steps preserve defined order** (not sorted) — intentional for sequential guidance
- Links and refs are sorted lexicographically for determinism
- Text is operator-grade: concise, actionable, non-marketing

## Test plan

- [x] Golden tests updated for new output format
- [x] `go test ./...` passes
- [x] No changes to exit codes, pattern IDs, or detection semantics

🤖 Generated with [Claude Code](https://claude.ai/code)