### PR TITLE
docs(patterns): add Track J prerequisite contract (v0.9)

### DIFF
--- a/docs/reference/patterns-contract.md
+++ b/docs/reference/patterns-contract.md
@@ -3,6 +3,8 @@
 This document defines the contract for the patterns command surface.
 
 > **v0.7+ contract surface.** Does not modify any v0.5 or v0.6 contracts.
+>
+> **v0.9 additions (Track J).** Pattern prerequisites and skip reasons (additive, backwards-compatible).
 
 ## Overview
 
@@ -66,6 +68,7 @@ Schema: patterns.v1
 
 [<STATUS>] <pattern-id>
   <pattern-name>
+  skip_reason: <reason>  (v0.9+, only when status=SKIP and prereqs unmet)
   findings (<count>):
     - [<severity>] <message>
       resource: <resource-id>  (if applicable)
@@ -116,6 +119,7 @@ Rules for remediation rendering:
       "id": "<pattern-id>",
       "name": "<pattern-name>",
       "status": "pass|fail|skip",
+      "skip_reason": "<reason>",  // v0.9+, optional, only when status=skip
       "findings": [
         {
           "pattern": "<pattern-id>",
@@ -175,6 +179,7 @@ Description:
   <description>
 
 Result: [<STATUS>]
+  skip_reason: <reason>  (v0.9+, only when status=SKIP and prereqs unmet)
   findings (<count>):
     - [<severity>] <message>
       ...
@@ -275,6 +280,49 @@ These fields are **additive** — consumers that only understand v0.7 fields may
 
 ---
 
+## Pattern Prerequisites (v0.9+)
+
+Patterns may declare prerequisites that must be satisfied before detection runs.
+If prerequisites are not met, the pattern result is `skip` with a structured reason.
+
+### Prerequisite Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `requires_node_kind` | Graph must contain at least one node of this kind | `Deployment` |
+| `requires_any_of_kinds` | Graph must contain at least one node of any listed kind | `["Deployment", "ReplicaSet"]` |
+
+Prerequisites are evaluated in declared order. The first unmet prerequisite determines the skip reason.
+
+### Skip Reason (v0.9+)
+
+When a pattern is skipped due to unmet prerequisites, the result includes a `skip_reason`:
+
+**Text output:**
+```
+[SKIP] <pattern-id>
+  <pattern-name>
+  skip_reason: <reason>
+```
+
+**JSON output:**
+```json
+{
+  "id": "<pattern-id>",
+  "name": "<pattern-name>",
+  "status": "skip",
+  "skip_reason": "<reason>",
+  "findings": []
+}
+```
+
+The `skip_reason` field:
+- Is only present when `status` is `skip` and prerequisites were unmet
+- Is a deterministic, human-readable string
+- Does not include timestamps or variable data
+
+---
+
 ## Registered Patterns (v0.7+)
 
 ### k8s.ownership_chain_complete
@@ -284,10 +332,13 @@ These fields are **additive** — consumers that only understand v0.7 fields may
 Checks that Deployment → ReplicaSet → Pod ownership chains are complete.
 Incomplete chains may indicate orphaned resources or missing links.
 
+**Prerequisites (v0.9+):**
+- `requires_any_of_kinds`: `["Deployment", "ReplicaSet", "Pod"]`
+
 **Status logic:**
 - `pass`: All ownership chains are complete
 - `fail`: Orphaned ReplicaSets or Deployments without ReplicaSets detected
-- `skip`: No Deployments in graph
+- `skip`: Prerequisites not met (no Deployment/ReplicaSet/Pod nodes in graph)
 
 **Findings:**
 - Warning: ReplicaSet has no owning Deployment


### PR DESCRIPTION
## Summary

Establishes Track J (v0.9) contract additions for pattern prerequisites (additive, no code changes).

- Pattern prerequisites: `requires_node_kind`, `requires_any_of_kinds`
- Skip reason: structured reason when prereqs unmet
- Output format updates for text and JSON

## Test plan

- [x] No code changes, docs-only PR
- [x] Contract documented in `docs/reference/patterns-contract.md`

🤖 Generated with [Claude Code](https://claude.ai/code)