### PR TITLE
feat(patterns): add prerequisite evaluation engine (v0.9)

### DIFF
--- a/internal/patterns/detect.go
+++ b/internal/patterns/detect.go
@@ -16,6 +16,18 @@ func DetectAll(g *graph.Graph) Result {
 	results := make([]PatternResult, 0, len(patterns))
 
 	for _, p := range patterns {
+		// Check prerequisites first (v0.9+)
+		if skipReason := checkPrerequisites(p, g); skipReason != "" {
+			results = append(results, PatternResult{
+				ID:         p.ID,
+				Name:       p.Name,
+				Status:     StatusSkip,
+				SkipReason: skipReason,
+				Findings:   []Finding{},
+			})
+			continue
+		}
+
 		findings, status := p.Detect(g)
 
 		// Sort findings for deterministic output
@@ -43,6 +55,17 @@ func DetectOne(g *graph.Graph, patternID string) *PatternResult {
 		return nil
 	}
 
+	// Check prerequisites first (v0.9+)
+	if skipReason := checkPrerequisites(*p, g); skipReason != "" {
+		return &PatternResult{
+			ID:         p.ID,
+			Name:       p.Name,
+			Status:     StatusSkip,
+			SkipReason: skipReason,
+			Findings:   []Finding{},
+		}
+	}
+
 	findings, status := p.Detect(g)
 	sortFindings(findings)
 
@@ -62,6 +85,47 @@ func AnyFail(r Result) bool {
 		}
 	}
 	return false
+}
+
+// checkPrerequisites evaluates pattern prerequisites against the graph.
+// Returns empty string if all prerequisites are met, or a skip reason if not.
+func checkPrerequisites(p Pattern, g *graph.Graph) string {
+	if len(p.Prerequisites) == 0 {
+		return ""
+	}
+
+	// Build a set of node kinds present in the graph
+	presentKinds := make(map[string]bool)
+	for _, node := range g.Nodes {
+		presentKinds[node.Kind] = true
+	}
+
+	// Evaluate prerequisites in declared order
+	for _, prereq := range p.Prerequisites {
+		switch prereq.Type {
+		case "requires_node_kind":
+			// All listed kinds must be present
+			for _, kind := range prereq.Kinds {
+				if !presentKinds[kind] {
+					return fmt.Sprintf("no %s nodes in graph", kind)
+				}
+			}
+		case "requires_any_of_kinds":
+			// At least one of the listed kinds must be present
+			found := false
+			for _, kind := range prereq.Kinds {
+				if presentKinds[kind] {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Sprintf("no %s nodes in graph", strings.Join(prereq.Kinds, "/"))
+			}
+		}
+	}
+
+	return ""
 }
 
 // sortFindings sorts findings by (severity, resource, message) for deterministic output.
@@ -111,6 +175,11 @@ func RenderText(r Result) string {
 
 		sb.WriteString(fmt.Sprintf("%s %s\n", indicator, pr.ID))
 		sb.WriteString(fmt.Sprintf("  %s\n", pr.Name))
+
+		// Skip reason (v0.9+) - only when status=skip and prereqs unmet
+		if pr.SkipReason != "" {
+			sb.WriteString(fmt.Sprintf("  skip_reason: %s\n", pr.SkipReason))
+		}
 
 		// Always print findings block
 		sb.WriteString(fmt.Sprintf("  findings (%d):\n", len(pr.Findings)))
@@ -169,6 +238,12 @@ func RenderExplain(p *Pattern, pr *PatternResult) string {
 		}
 
 		sb.WriteString(fmt.Sprintf("Result: %s\n", indicator))
+
+		// Skip reason (v0.9+) - only when status=skip and prereqs unmet
+		if pr.SkipReason != "" {
+			sb.WriteString(fmt.Sprintf("  skip_reason: %s\n", pr.SkipReason))
+		}
+
 		sb.WriteString(fmt.Sprintf("  findings (%d):\n", len(pr.Findings)))
 		if len(pr.Findings) == 0 {
 			sb.WriteString("    (none)\n")

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -406,3 +406,238 @@ func TestSortFindings(t *testing.T) {
 		t.Errorf("expected info last, got %s", findings[2].Severity)
 	}
 }
+
+// Tests for Track J prerequisites (v0.9+)
+
+func TestCheckPrerequisites_NoPrereqs(t *testing.T) {
+	g := graph.NewGraph("test")
+	p := Pattern{
+		ID:            "test.pattern",
+		Prerequisites: nil, // No prerequisites
+	}
+
+	reason := checkPrerequisites(p, g)
+	if reason != "" {
+		t.Errorf("expected empty skip reason for pattern without prereqs, got %s", reason)
+	}
+}
+
+func TestCheckPrerequisites_RequiresNodeKind_Met(t *testing.T) {
+	g := graph.NewGraph("test")
+	g.AddNode(graph.Node{Kind: "Deployment", ID: "test/default/Deployment/foo"})
+
+	p := Pattern{
+		ID: "test.pattern",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_node_kind", Kinds: []string{"Deployment"}},
+		},
+	}
+
+	reason := checkPrerequisites(p, g)
+	if reason != "" {
+		t.Errorf("expected empty skip reason when prereq met, got %s", reason)
+	}
+}
+
+func TestCheckPrerequisites_RequiresNodeKind_Unmet(t *testing.T) {
+	g := graph.NewGraph("test")
+	// Empty graph - no Deployment
+
+	p := Pattern{
+		ID: "test.pattern",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_node_kind", Kinds: []string{"Deployment"}},
+		},
+	}
+
+	reason := checkPrerequisites(p, g)
+	if reason == "" {
+		t.Error("expected skip reason when prereq not met")
+	}
+	if !strings.Contains(reason, "Deployment") {
+		t.Errorf("expected reason to mention Deployment, got %s", reason)
+	}
+}
+
+func TestCheckPrerequisites_RequiresAnyOfKinds_Met(t *testing.T) {
+	g := graph.NewGraph("test")
+	g.AddNode(graph.Node{Kind: "Pod", ID: "test/default/Pod/foo"})
+
+	p := Pattern{
+		ID: "test.pattern",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_any_of_kinds", Kinds: []string{"Deployment", "ReplicaSet", "Pod"}},
+		},
+	}
+
+	reason := checkPrerequisites(p, g)
+	if reason != "" {
+		t.Errorf("expected empty skip reason when any-of prereq met, got %s", reason)
+	}
+}
+
+func TestCheckPrerequisites_RequiresAnyOfKinds_Unmet(t *testing.T) {
+	g := graph.NewGraph("test")
+	g.AddNode(graph.Node{Kind: "ConfigMap", ID: "test/default/ConfigMap/foo"})
+
+	p := Pattern{
+		ID: "test.pattern",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_any_of_kinds", Kinds: []string{"Deployment", "ReplicaSet", "Pod"}},
+		},
+	}
+
+	reason := checkPrerequisites(p, g)
+	if reason == "" {
+		t.Error("expected skip reason when any-of prereq not met")
+	}
+	if !strings.Contains(reason, "Deployment") || !strings.Contains(reason, "ReplicaSet") || !strings.Contains(reason, "Pod") {
+		t.Errorf("expected reason to mention all required kinds, got %s", reason)
+	}
+}
+
+func TestCheckPrerequisites_MultiplePrereqs_FirstUnmet(t *testing.T) {
+	g := graph.NewGraph("test")
+	g.AddNode(graph.Node{Kind: "Pod", ID: "test/default/Pod/foo"})
+
+	p := Pattern{
+		ID: "test.pattern",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_node_kind", Kinds: []string{"Deployment"}}, // Will fail
+			{Type: "requires_node_kind", Kinds: []string{"Pod"}},        // Would pass
+		},
+	}
+
+	reason := checkPrerequisites(p, g)
+	if reason == "" {
+		t.Error("expected skip reason when first prereq not met")
+	}
+	if !strings.Contains(reason, "Deployment") {
+		t.Errorf("expected reason to mention Deployment (first unmet), got %s", reason)
+	}
+}
+
+func TestDetectAll_WithPrereqs_Skipped(t *testing.T) {
+	// Temporarily register a test pattern with prerequisites
+	testPattern := Pattern{
+		ID:          "test.prereq_pattern",
+		Name:        "Test Prereq Pattern",
+		Description: "Test pattern with prerequisites",
+		Category:    "test",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_node_kind", Kinds: []string{"NonexistentKind"}},
+		},
+		Detect: func(g *graph.Graph) ([]Finding, Status) {
+			// This should never be called
+			t.Error("Detect should not be called when prereqs unmet")
+			return nil, StatusPass
+		},
+	}
+
+	// Register and defer cleanup
+	Register(testPattern)
+	defer func() {
+		// Clean up by removing from registry
+		delete(registry, testPattern.ID)
+	}()
+
+	g := graph.NewGraph("test")
+	result := DetectAll(g)
+
+	// Find our test pattern result
+	var testResult *PatternResult
+	for i := range result.Patterns {
+		if result.Patterns[i].ID == "test.prereq_pattern" {
+			testResult = &result.Patterns[i]
+			break
+		}
+	}
+
+	if testResult == nil {
+		t.Fatal("expected test pattern in results")
+	}
+
+	if testResult.Status != StatusSkip {
+		t.Errorf("expected skip status, got %s", testResult.Status)
+	}
+
+	if testResult.SkipReason == "" {
+		t.Error("expected skip_reason to be set")
+	}
+
+	if len(testResult.Findings) != 0 {
+		t.Errorf("expected empty findings when skipped, got %d", len(testResult.Findings))
+	}
+}
+
+func TestRenderText_WithSkipReason(t *testing.T) {
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		Patterns: []PatternResult{
+			{
+				ID:         "test.pattern",
+				Name:       "Test Pattern",
+				Status:     StatusSkip,
+				SkipReason: "no Deployment nodes in graph",
+				Findings:   []Finding{},
+			},
+		},
+	}
+
+	output := RenderText(result)
+
+	if !strings.Contains(output, "[SKIP]") {
+		t.Error("expected [SKIP] in output")
+	}
+
+	if !strings.Contains(output, "skip_reason: no Deployment nodes in graph") {
+		t.Error("expected skip_reason in output")
+	}
+}
+
+func TestRenderJSON_WithSkipReason(t *testing.T) {
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		Patterns: []PatternResult{
+			{
+				ID:         "test.pattern",
+				Name:       "Test Pattern",
+				Status:     StatusSkip,
+				SkipReason: "no Deployment nodes in graph",
+				Findings:   []Finding{},
+			},
+		},
+	}
+
+	output, err := RenderJSON(result)
+	if err != nil {
+		t.Fatalf("RenderJSON error: %v", err)
+	}
+
+	if !strings.Contains(output, `"skip_reason": "no Deployment nodes in graph"`) {
+		t.Error("expected skip_reason in JSON output")
+	}
+}
+
+func TestRenderJSON_OmitsEmptySkipReason(t *testing.T) {
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		Patterns: []PatternResult{
+			{
+				ID:       "test.pattern",
+				Name:     "Test Pattern",
+				Status:   StatusPass,
+				Findings: []Finding{},
+			},
+		},
+	}
+
+	output, err := RenderJSON(result)
+	if err != nil {
+		t.Fatalf("RenderJSON error: %v", err)
+	}
+
+	if strings.Contains(output, "skip_reason") {
+		t.Error("expected skip_reason to be omitted when empty")
+	}
+}

--- a/internal/patterns/types.go
+++ b/internal/patterns/types.go
@@ -39,9 +39,22 @@ type Pattern struct {
 	// Category groups related patterns (e.g., "k8s", "gitops").
 	Category string `json:"category"`
 
+	// Prerequisites are conditions that must be met before detection runs (v0.9+).
+	// If any prerequisite is unmet, the pattern is skipped with a reason.
+	Prerequisites []Prerequisite `json:"-"`
+
 	// Detect runs the pattern detection against a graph.
 	// Returns findings and status. Errors are returned as findings with error severity.
 	Detect func(g *graph.Graph) ([]Finding, Status) `json:"-"`
+}
+
+// Prerequisite defines a condition that must be met before a pattern runs.
+type Prerequisite struct {
+	// Type is the prerequisite type (e.g., "requires_node_kind", "requires_any_of_kinds").
+	Type string
+
+	// Kinds is the list of node kinds required (for requires_node_kind or requires_any_of_kinds).
+	Kinds []string
 }
 
 // Finding represents a single detection result from a pattern.
@@ -95,6 +108,10 @@ type PatternResult struct {
 
 	// Status is the pattern result status.
 	Status Status `json:"status"`
+
+	// SkipReason explains why a pattern was skipped (v0.9+, optional).
+	// Only present when status is "skip" and prerequisites were unmet.
+	SkipReason string `json:"skip_reason,omitempty"`
 
 	// Findings lists all findings from this pattern.
 	Findings []Finding `json:"findings"`


### PR DESCRIPTION
## Summary

Implements Track J prerequisite engine.

- `Prerequisite` type with `requires_node_kind` and `requires_any_of_kinds`
- `checkPrerequisites()` evaluates prereqs before detection runs
- `SkipReason` field in `PatternResult` for structured skip reporting
- Updated renderers to display skip_reason
- JSON omitempty for skip_reason when empty

## Test plan

- [x] Unit tests for prerequisite evaluation
- [x] Unit tests for skip_reason rendering (text and JSON)
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)