### PR TITLE
feat(patterns): wire prerequisites into ownership_chain pattern

### DIFF
--- a/internal/patterns/pattern_ownership_chain.go
+++ b/internal/patterns/pattern_ownership_chain.go
@@ -12,7 +12,10 @@ func init() {
 		Name:        "Kubernetes Ownership Chain Complete",
 		Description: "Checks that Deployment → ReplicaSet → Pod ownership chains are complete. Incomplete chains may indicate orphaned resources or missing links.",
 		Category:    "k8s",
-		Detect:      detectOwnershipChainComplete,
+		Prerequisites: []Prerequisite{
+			{Type: "requires_any_of_kinds", Kinds: []string{"Deployment", "ReplicaSet", "Pod"}},
+		},
+		Detect: detectOwnershipChainComplete,
 	})
 }
 
@@ -35,15 +38,6 @@ func detectOwnershipChainComplete(g *graph.Graph) ([]Finding, Status) {
 		case "Pod":
 			pods[node.ID] = node
 		}
-	}
-
-	// Skip pattern if no deployments exist
-	if len(deployments) == 0 {
-		return []Finding{{
-			Pattern:  "k8s.ownership_chain_complete",
-			Severity: SeverityInfo,
-			Message:  "No Deployments found in graph",
-		}}, StatusSkip
 	}
 
 	// Build edge maps: parent -> children

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.json
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.json
@@ -22,13 +22,8 @@
       "id": "k8s.ownership_chain_complete",
       "name": "Kubernetes Ownership Chain Complete",
       "status": "skip",
-      "findings": [
-        {
-          "pattern": "k8s.ownership_chain_complete",
-          "severity": "info",
-          "message": "No Deployments found in graph"
-        }
-      ]
+      "skip_reason": "no Deployment/ReplicaSet/Pod nodes in graph",
+      "findings": []
     }
   ]
 }

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.txt
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.txt
@@ -12,5 +12,6 @@ Schema: patterns.v1
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete
-  findings (1):
-    - [info] No Deployments found in graph
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)

--- a/test/golden/patterns-explain/testdata/explain-ownership-chain.golden.txt
+++ b/test/golden/patterns-explain/testdata/explain-ownership-chain.golden.txt
@@ -7,5 +7,6 @@ Description:
   Checks that Deployment → ReplicaSet → Pod ownership chains are complete. Incomplete chains may indicate orphaned resources or missing links.
 
 Result: [SKIP]
-  findings (1):
-    - [info] No Deployments found in graph
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)


### PR DESCRIPTION
## Summary

Wires prerequisites into MVP patterns.

### `k8s.ownership_chain_complete`
- Prerequisite: `requires_any_of_kinds: ["Deployment", "ReplicaSet", "Pod"]`
- Removes internal skip logic in favor of engine-level prereq checking
- Skip reason now provided by prerequisite system

### `gitops.controller_presence`
- No prerequisites (handles empty case with a finding)

## Test plan

- [x] Golden tests updated for new skip_reason output
- [x] Unit tests pass
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)