### PR TITLE
docs: v0.9.1 polish - roadmap alignment and release notes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,32 +76,67 @@ Introduce a first-class **resource graph** that captures cluster-visible relatio
 
 ---
 
-## v0.8 — Finding Enrichment (Active)
+## v0.8 — Finding Enrichment (Released)
 
-**Status:** In progress (Track I)
+**Status:** Released (`v0.8.0` content in `v0.9.0`) (Track I)
 
-### Goal
+### Completed
 
-Enrich pattern findings with actionability metadata without changing detection logic or breaking existing consumers.
-
-### Scope
-
-* Additive optional fields on findings:
+- Additive optional fields on findings:
   - `confidence`: deterministic score (0.0–1.0)
   - `refs`: stable resource identifiers for correlation
   - `remediation`: structured guidance (summary, steps, links)
-* Text rendering of remediation blocks
-* Backwards-compatible JSON (omitempty)
+- Text rendering of remediation blocks
+- Backwards-compatible JSON (omitempty)
+- Remediation wired to MVP patterns:
+  - `gitops.controller_presence`: Guidance for installing Argo CD or Flux
+  - `k8s.ownership_chain_complete`: Steps for investigating orphaned resources
+
+> v0.8 features shipped as part of v0.9.0 release due to combined merge.
+
+---
+
+## v0.9 — Pattern Prerequisites (Released)
+
+**Status:** Released (`v0.9.0`) (Track J)
+
+### Completed
+
+- Pattern prerequisite system:
+  - `requires_node_kind`: Graph must contain specific node kind
+  - `requires_any_of_kinds`: Graph must contain any of listed kinds
+  - `skip_reason`: Structured reason when prerequisites unmet
+- Prerequisites wired to `k8s.ownership_chain_complete` pattern
+- Contract documentation updated
+
+> v0.9 pattern prerequisites are stable. Additive prerequisite types may be added in future versions.
+
+---
+
+## v0.9.x — Stabilization Window (Active)
+
+**Status:** In progress
+
+### Goal
+
+Polish and harden v0.9 before expanding scope. No new features beyond minor pattern coverage gaps.
+
+### Scope
+
+* Wording polish and documentation alignment
+* Pattern coverage gaps (1–2 GitOps interpretive patterns)
+* Contract clarity improvements
+* Release notes cleanup
 
 ### Non-goals
 
-* No changes to pattern IDs or detection semantics
-* No changes to exit codes
+* No new prerequisite types
+* No hierarchical GitOps patterns
 * No Git parsing or external service integration
 
 ---
 
-## v0.9 — Git-Aware Inference
+## v0.10 — Git-Aware Inference
 
 **Status:** Planned
 
@@ -111,7 +146,7 @@ Enrich pattern findings with actionability metadata without changing detection l
 
 ---
 
-## v0.10 — ConfigHub Collaboration
+## v0.11 — ConfigHub Collaboration
 
 **Status:** Planned
 
@@ -121,7 +156,7 @@ Enrich pattern findings with actionability metadata without changing detection l
 
 ---
 
-## v1.0 — Fleet Intelligence & Stability
+## v1.0+ — Fleet Intelligence & Stability
 
 **Status:** Future
 

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,50 @@
+# v0.8.0 Release Notes
+
+**Release Date:** 2026-02-02 (shipped as part of v0.9.0)
+
+## Summary
+
+v0.8.0 introduces Track I: Finding Enrichment. Pattern findings now include optional metadata fields for actionability without changing detection logic.
+
+## Track I: Finding Enrichment
+
+### New Finding Fields
+
+All fields are optional and use `omitempty` for backwards compatibility:
+
+- **`confidence`**: Deterministic score (0.0-1.0) indicating finding reliability
+- **`refs`**: Stable resource identifiers for cross-run correlation
+- **`remediation`**: Structured guidance with summary, steps, and documentation links
+
+### Remediation Structure
+
+```json
+{
+  "remediation": {
+    "summary": "Brief description of the fix",
+    "steps": ["Step 1", "Step 2"],
+    "links": ["https://docs.example.com/guide"]
+  }
+}
+```
+
+### Wired Patterns
+
+Remediation guidance added to MVP patterns:
+
+- **`gitops.controller_presence`**: Guidance for installing Argo CD or Flux
+- **`k8s.ownership_chain_complete`**: Steps for investigating orphaned resources
+
+## Contract Changes
+
+- Schema version remains `patterns.v1` (additive changes only)
+- New fields use `omitempty` for backwards compatibility
+- See `docs/reference/patterns-contract.md` for full specification
+
+## Breaking Changes
+
+None.
+
+## Note
+
+v0.8.0 features were released as part of the combined v0.9.0 release due to merge ordering.

--- a/docs/releases/v0.9.1.md
+++ b/docs/releases/v0.9.1.md
@@ -1,0 +1,20 @@
+# v0.9.1 Release Notes
+
+**Release Date:** 2026-02-02
+
+## Summary
+
+v0.9.1 is a polish release within the v0.9.x stabilization window. No functional changes.
+
+## Changes
+
+### Documentation
+
+- Updated `ROADMAP.md` to reflect v0.8 and v0.9 as released
+- Added v0.9.x stabilization window section to roadmap
+- Created separate `v0.8.0.md` release notes for Track I content
+- Moved Git-aware inference scope to v0.10
+
+## Breaking Changes
+
+None.


### PR DESCRIPTION
## Summary

- Update ROADMAP.md to reflect v0.8 and v0.9 as Released
- Add v0.9.x stabilization window section to roadmap
- Move Git-aware inference scope to v0.10
- Create separate v0.8.0.md release notes for Track I content
- Create v0.9.1.md release notes for this polish

## Test plan

- [ ] Verify ROADMAP.md reflects current state accurately
- [ ] Verify release notes are consistent with v0.9.0.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)