### PR TITLE
feat(patterns): add gitops.argocd/flux.resources_present patterns

### DIFF
--- a/docs/reference/gitops-patterns.md
+++ b/docs/reference/gitops-patterns.md
@@ -8,6 +8,60 @@ How common GitOps patterns (App-of-Apps, ApplicationSet, Flux Tenancy, Mono-repo
 > described here may require integration with actual GitOps controllers and
 > are out of scope for the v0.5 standalone contract.
 
+---
+
+## Interpretive Patterns (v0.9.2+)
+
+cub-scout provides **interpretive patterns** that report GitOps resource presence without inferring hierarchy or relationships.
+
+### Available Patterns
+
+| Pattern ID | Reports |
+|------------|---------|
+| `gitops.argocd.resources_present` | Application and ApplicationSet counts |
+| `gitops.flux.resources_present` | Kustomization, HelmRelease, GitRepository counts |
+| `gitops.controller_presence` | Whether any GitOps controller CRDs exist |
+
+### What These Patterns Do
+
+```bash
+# Run all patterns
+./cub-scout patterns detect --empty
+
+# Example output when Argo CD resources present:
+# [PASS] gitops.argocd.resources_present
+#   - [info] Argo CD Applications detected: 5
+#   - [info] Argo CD ApplicationSets detected: 2
+```
+
+### What These Patterns Do NOT Do
+
+These are **interpretive signals**, not hierarchy inference:
+
+- They report **presence and counts**, not relationships
+- They do **not** infer App-of-Apps parent/child structures
+- They do **not** infer tenant boundaries or isolation rules
+- They do **not** correlate generators with generated resources
+
+**Why?** Hierarchy inference requires Git context to understand:
+- Which Application is a "parent" vs "child"
+- Which ApplicationSet generated which Application
+- Which Kustomization is infrastructure vs tenant
+
+Git-aware inference is planned for v0.10+.
+
+### Prerequisites Behavior
+
+These patterns use the prerequisite system (v0.9+):
+
+- **SKIP** when no relevant CRDs exist in the graph
+- **PASS** with info findings when resources detected
+- One finding per resource kind (not per resource instance)
+
+This keeps output readable and avoids verbosity in large clusters.
+
+---
+
 ## Quick Reference
 
 | Pattern | Deployer | TUI Detects | GUI Adds |

--- a/docs/releases/v0.9.2.md
+++ b/docs/releases/v0.9.2.md
@@ -1,0 +1,53 @@
+# v0.9.2 Release Notes
+
+**Release Date:** 2026-02-02
+
+## Summary
+
+v0.9.2 adds interpretive GitOps patterns for resource visibility within the v0.9.x stabilization window.
+
+## New Patterns
+
+### gitops.argocd.resources_present
+
+Reports Argo CD resource counts when present:
+
+- "Argo CD Applications detected: N"
+- "Argo CD ApplicationSets detected: N"
+
+**Behavior:**
+- **SKIP** when no Argo CD resources in graph (via prerequisites)
+- **PASS** with info findings when resources detected
+- One finding per kind (not per resource)
+
+### gitops.flux.resources_present
+
+Reports Flux resource counts when present:
+
+- "Flux Kustomizations detected: N"
+- "Flux HelmReleases detected: N"
+- "Flux GitRepositories detected: N"
+
+**Behavior:**
+- **SKIP** when no Flux resources in graph (via prerequisites)
+- **PASS** with info findings when resources detected
+- One finding per kind (not per resource)
+
+## Design Notes
+
+These patterns are **interpretive signals**, not hierarchy inference:
+
+- They report presence and counts, not relationships
+- They do not infer parent/child, App-of-Apps, or tenant structures
+- Hierarchy inference requires Git context (planned for v0.10+)
+
+See `docs/reference/gitops-patterns.md` for conceptual reference.
+
+## Contract Changes
+
+- Schema version remains `patterns.v1` (additive changes only)
+- Two new pattern IDs added to registry
+
+## Breaking Changes
+
+None.

--- a/internal/patterns/pattern_gitops_resources.go
+++ b/internal/patterns/pattern_gitops_resources.go
@@ -1,0 +1,123 @@
+package patterns
+
+import (
+	"fmt"
+
+	"github.com/confighub/cub-scout/internal/graph"
+)
+
+func init() {
+	// Argo CD resource presence pattern
+	Register(Pattern{
+		ID:          "gitops.argocd.resources_present",
+		Name:        "Argo CD Resources Present",
+		Description: "Reports the presence and count of Argo CD resources (Applications, ApplicationSets). Provides visibility into Argo CD usage without inferring hierarchy.",
+		Category:    "gitops",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_any_of_kinds", Kinds: []string{"Application", "ApplicationSet"}},
+		},
+		Detect: detectArgoCDResourcesPresent,
+	})
+
+	// Flux resource presence pattern
+	Register(Pattern{
+		ID:          "gitops.flux.resources_present",
+		Name:        "Flux Resources Present",
+		Description: "Reports the presence and count of Flux resources (Kustomizations, HelmReleases, GitRepositories). Provides visibility into Flux usage without inferring hierarchy.",
+		Category:    "gitops",
+		Prerequisites: []Prerequisite{
+			{Type: "requires_any_of_kinds", Kinds: []string{"Kustomization", "HelmRelease", "GitRepository"}},
+		},
+		Detect: detectFluxResourcesPresent,
+	})
+}
+
+// detectArgoCDResourcesPresent reports Argo CD resource counts.
+// Prereqs guarantee at least one Argo CD resource exists.
+func detectArgoCDResourcesPresent(g *graph.Graph) ([]Finding, Status) {
+	var findings []Finding
+
+	// Count by kind
+	appCount := 0
+	appSetCount := 0
+
+	for _, node := range g.Nodes {
+		if node.APIVersion != "argoproj.io/v1alpha1" {
+			continue
+		}
+		switch node.Kind {
+		case "Application":
+			appCount++
+		case "ApplicationSet":
+			appSetCount++
+		}
+	}
+
+	// One finding per kind that's present
+	if appCount > 0 {
+		findings = append(findings, Finding{
+			Pattern:  "gitops.argocd.resources_present",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Argo CD Applications detected: %d", appCount),
+		})
+	}
+
+	if appSetCount > 0 {
+		findings = append(findings, Finding{
+			Pattern:  "gitops.argocd.resources_present",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Argo CD ApplicationSets detected: %d", appSetCount),
+		})
+	}
+
+	return findings, StatusPass
+}
+
+// detectFluxResourcesPresent reports Flux resource counts.
+// Prereqs guarantee at least one Flux resource exists.
+func detectFluxResourcesPresent(g *graph.Graph) ([]Finding, Status) {
+	var findings []Finding
+
+	// Count by kind
+	kustomizationCount := 0
+	helmReleaseCount := 0
+	gitRepoCount := 0
+
+	for _, node := range g.Nodes {
+		switch {
+		case node.Kind == "Kustomization" && node.APIVersion == "kustomize.toolkit.fluxcd.io/v1":
+			kustomizationCount++
+		case node.Kind == "HelmRelease" && node.APIVersion == "helm.toolkit.fluxcd.io/v2":
+			helmReleaseCount++
+		case node.Kind == "GitRepository" && node.APIVersion == "source.toolkit.fluxcd.io/v1":
+			gitRepoCount++
+		}
+	}
+
+	// One finding per kind that's present
+	if kustomizationCount > 0 {
+		findings = append(findings, Finding{
+			Pattern:  "gitops.flux.resources_present",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Flux Kustomizations detected: %d", kustomizationCount),
+		})
+	}
+
+	if helmReleaseCount > 0 {
+		findings = append(findings, Finding{
+			Pattern:  "gitops.flux.resources_present",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Flux HelmReleases detected: %d", helmReleaseCount),
+		})
+	}
+
+	if gitRepoCount > 0 {
+		findings = append(findings, Finding{
+			Pattern:  "gitops.flux.resources_present",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Flux GitRepositories detected: %d", gitRepoCount),
+		})
+	}
+
+	return findings, StatusPass
+}

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -862,3 +862,188 @@ func TestRenderJSON_OmitsEmptySkipReason(t *testing.T) {
 		t.Error("expected skip_reason to be omitted when empty")
 	}
 }
+
+// Tests for v0.9.2 GitOps interpretive patterns
+
+func TestArgoCDResourcesPresent_WithResources(t *testing.T) {
+	g := graph.NewGraph("test-cluster")
+
+	// Add multiple Argo CD Applications
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/argocd/Application/app1",
+		Cluster:    "test-cluster",
+		Namespace:  "argocd",
+		Kind:       "Application",
+		Name:       "app1",
+		APIVersion: "argoproj.io/v1alpha1",
+	})
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/argocd/Application/app2",
+		Cluster:    "test-cluster",
+		Namespace:  "argocd",
+		Kind:       "Application",
+		Name:       "app2",
+		APIVersion: "argoproj.io/v1alpha1",
+	})
+
+	// Add one ApplicationSet
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/argocd/ApplicationSet/appset1",
+		Cluster:    "test-cluster",
+		Namespace:  "argocd",
+		Kind:       "ApplicationSet",
+		Name:       "appset1",
+		APIVersion: "argoproj.io/v1alpha1",
+	})
+
+	pr := DetectOne(g, "gitops.argocd.resources_present")
+	if pr == nil {
+		t.Fatal("expected result")
+	}
+
+	if pr.Status != StatusPass {
+		t.Errorf("expected pass status, got %s", pr.Status)
+	}
+
+	// Should have 2 findings (one per kind)
+	if len(pr.Findings) != 2 {
+		t.Errorf("expected 2 findings (one per kind), got %d", len(pr.Findings))
+	}
+
+	// Check for correct counts in messages
+	hasApps := false
+	hasAppSets := false
+	for _, f := range pr.Findings {
+		if strings.Contains(f.Message, "Applications detected: 2") {
+			hasApps = true
+		}
+		if strings.Contains(f.Message, "ApplicationSets detected: 1") {
+			hasAppSets = true
+		}
+	}
+
+	if !hasApps {
+		t.Error("expected finding with Applications count")
+	}
+	if !hasAppSets {
+		t.Error("expected finding with ApplicationSets count")
+	}
+}
+
+func TestArgoCDResourcesPresent_Skipped(t *testing.T) {
+	g := graph.NewGraph("test-cluster")
+	// Empty graph - no Argo CD resources
+
+	pr := DetectOne(g, "gitops.argocd.resources_present")
+	if pr == nil {
+		t.Fatal("expected result")
+	}
+
+	if pr.Status != StatusSkip {
+		t.Errorf("expected skip status when no Argo CD resources, got %s", pr.Status)
+	}
+
+	if pr.SkipReason == "" {
+		t.Error("expected skip_reason to be set")
+	}
+}
+
+func TestFluxResourcesPresent_WithResources(t *testing.T) {
+	g := graph.NewGraph("test-cluster")
+
+	// Add Flux Kustomizations
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/flux-system/Kustomization/flux-system",
+		Cluster:    "test-cluster",
+		Namespace:  "flux-system",
+		Kind:       "Kustomization",
+		Name:       "flux-system",
+		APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+	})
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/flux-system/Kustomization/apps",
+		Cluster:    "test-cluster",
+		Namespace:  "flux-system",
+		Kind:       "Kustomization",
+		Name:       "apps",
+		APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+	})
+
+	// Add HelmRelease
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/default/HelmRelease/nginx",
+		Cluster:    "test-cluster",
+		Namespace:  "default",
+		Kind:       "HelmRelease",
+		Name:       "nginx",
+		APIVersion: "helm.toolkit.fluxcd.io/v2",
+	})
+
+	// Add GitRepository
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/flux-system/GitRepository/flux-system",
+		Cluster:    "test-cluster",
+		Namespace:  "flux-system",
+		Kind:       "GitRepository",
+		Name:       "flux-system",
+		APIVersion: "source.toolkit.fluxcd.io/v1",
+	})
+
+	pr := DetectOne(g, "gitops.flux.resources_present")
+	if pr == nil {
+		t.Fatal("expected result")
+	}
+
+	if pr.Status != StatusPass {
+		t.Errorf("expected pass status, got %s", pr.Status)
+	}
+
+	// Should have 3 findings (one per kind)
+	if len(pr.Findings) != 3 {
+		t.Errorf("expected 3 findings (one per kind), got %d", len(pr.Findings))
+	}
+
+	// Check for correct counts
+	hasKustomizations := false
+	hasHelmReleases := false
+	hasGitRepos := false
+	for _, f := range pr.Findings {
+		if strings.Contains(f.Message, "Kustomizations detected: 2") {
+			hasKustomizations = true
+		}
+		if strings.Contains(f.Message, "HelmReleases detected: 1") {
+			hasHelmReleases = true
+		}
+		if strings.Contains(f.Message, "GitRepositories detected: 1") {
+			hasGitRepos = true
+		}
+	}
+
+	if !hasKustomizations {
+		t.Error("expected finding with Kustomizations count")
+	}
+	if !hasHelmReleases {
+		t.Error("expected finding with HelmReleases count")
+	}
+	if !hasGitRepos {
+		t.Error("expected finding with GitRepositories count")
+	}
+}
+
+func TestFluxResourcesPresent_Skipped(t *testing.T) {
+	g := graph.NewGraph("test-cluster")
+	// Empty graph - no Flux resources
+
+	pr := DetectOne(g, "gitops.flux.resources_present")
+	if pr == nil {
+		t.Fatal("expected result")
+	}
+
+	if pr.Status != StatusSkip {
+		t.Errorf("expected skip status when no Flux resources, got %s", pr.Status)
+	}
+
+	if pr.SkipReason == "" {
+		t.Error("expected skip_reason to be set")
+	}
+}

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.json
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.json
@@ -2,6 +2,13 @@
   "schema_version": "patterns.v1",
   "patterns": [
     {
+      "id": "gitops.argocd.resources_present",
+      "name": "Argo CD Resources Present",
+      "status": "skip",
+      "skip_reason": "no Application/ApplicationSet nodes in graph",
+      "findings": []
+    },
+    {
       "id": "gitops.controller_presence",
       "name": "GitOps Controller Presence",
       "status": "fail",
@@ -30,6 +37,13 @@
           }
         }
       ]
+    },
+    {
+      "id": "gitops.flux.resources_present",
+      "name": "Flux Resources Present",
+      "status": "skip",
+      "skip_reason": "no Kustomization/HelmRelease/GitRepository nodes in graph",
+      "findings": []
     },
     {
       "id": "k8s.ownership_chain_complete",

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.txt
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.txt
@@ -1,6 +1,12 @@
 PATTERNS DETECT
 Schema: patterns.v1
 
+[SKIP] gitops.argocd.resources_present
+  Argo CD Resources Present
+  skip_reason: no Application/ApplicationSet nodes in graph
+  findings (0):
+    (none)
+
 [FAIL] gitops.controller_presence
   GitOps Controller Presence
   findings (1):
@@ -16,6 +22,12 @@ Schema: patterns.v1
       Links:
         - https://argo-cd.readthedocs.io/en/stable/getting_started/
         - https://fluxcd.io/flux/get-started/
+
+[SKIP] gitops.flux.resources_present
+  Flux Resources Present
+  skip_reason: no Kustomization/HelmRelease/GitRepository nodes in graph
+  findings (0):
+    (none)
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-explain/testdata/explain-unknown.golden.txt
+++ b/test/golden/patterns-explain/testdata/explain-unknown.golden.txt
@@ -1,5 +1,7 @@
 Error: unknown pattern: nonexistent.pattern
 
 Available patterns:
+  - gitops.argocd.resources_present
   - gitops.controller_presence
+  - gitops.flux.resources_present
   - k8s.ownership_chain_complete

--- a/test/golden/patterns-list/testdata/list.golden.txt
+++ b/test/golden/patterns-list/testdata/list.golden.txt
@@ -1,8 +1,12 @@
 PATTERNS LIST
 Schema: patterns.v1
 
-Registered patterns (2):
+Registered patterns (4):
+  - gitops.argocd.resources_present
+    Argo CD Resources Present
   - gitops.controller_presence
     GitOps Controller Presence
+  - gitops.flux.resources_present
+    Flux Resources Present
   - k8s.ownership_chain_complete
     Kubernetes Ownership Chain Complete


### PR DESCRIPTION
## Summary

Add interpretive patterns for GitOps resource visibility (v0.9.2 stabilization):

- **`gitops.argocd.resources_present`**: Reports Argo CD resource counts
  - Applications detected: N
  - ApplicationSets detected: N
  - One finding per kind (not per resource)

- **`gitops.flux.resources_present`**: Reports Flux resource counts
  - Kustomizations detected: N
  - HelmReleases detected: N
  - GitRepositories detected: N
  - One finding per kind (not per resource)

### Behavior

- **SKIP** via prerequisites when no resources present
- **PASS** with info findings when resources detected
- No hierarchy inference (interpretive signals only)

## Test plan

- [x] Unit tests for both patterns (presence/absence cases)
- [x] Golden tests updated for new pattern output
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)