### PR TITLE
test(patterns): add connected mode integration tests (v0.11)

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1294,17 +1294,46 @@ Implementation of connected mode infrastructure:
 
 ---
 
+### PR #81: Connected Mode Integration Tests
+
+**Branch:** `track-v0.11/connected-integration-tests`
+
+Comprehensive integration tests for connected mode using httptest:
+
+**Test hooks added:**
+- `CUB_SCOUT_GITHUB_API_BASE` - Override GitHub API base URL (for httptest)
+- `CUB_SCOUT_TEST_GRAPH_JSON` - Load graph from JSON file (avoid cluster access)
+
+**Tests implemented:**
+- `TestConnectedModeEquivalence` - Verifies `--git-url + --git-ref` produces same output as `--git-root`
+- `TestConnectedModeFailures` - Tests all 6 failure scenarios produce correct skip_reasons:
+  - `git_source repository not found` (404 + repo doesn't exist)
+  - `git_source ref not found` (404 + repo exists)
+  - `git_source authentication required` (401)
+  - `git_source rate limited` (429)
+  - `git_source fetch failed` (5xx)
+  - `git_source tarball invalid` (200 with corrupt content)
+
+**Fixture:**
+- `testdata/connected-repo/` - Minimal repo with ApplicationSet + Kustomization
+
+**Golden files locked:**
+- 2 equivalence goldens (text + JSON)
+- 6 failure scenario goldens
+
+---
+
 ### v0.11 Status
 
 | Component | Status |
 |-----------|--------|
 | Contract (PR #79) | ✅ Merged |
 | Plumbing (PR #80) | ✅ Merged |
-| Integration tests (PR3) | Pending |
+| Integration tests (PR #81) | ✅ Created |
 
 ---
 
 ### Next Steps
 
-- PR3: Integration tests and golden updates for connected mode
+- Merge PR #81 when approved
 - Update ROADMAP.md when v0.11 complete

--- a/cmd/cub-scout/patterns_cmd.go
+++ b/cmd/cub-scout/patterns_cmd.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -307,6 +308,11 @@ func resolveGitContext(gitRoot, gitURL, gitRef, gitSubpath string) (*gitctx.GitC
 // buildPatternsGraph builds a graph for pattern detection.
 // Collects K8s ownership chain + GitOps CRDs.
 func buildPatternsGraph(namespace string, empty bool) (*graph.Graph, error) {
+	// Test hook: load graph from JSON file if CUB_SCOUT_TEST_GRAPH_JSON is set
+	if graphJSONPath := os.Getenv("CUB_SCOUT_TEST_GRAPH_JSON"); graphJSONPath != "" {
+		return loadGraphFromJSON(graphJSONPath)
+	}
+
 	// Get cluster name
 	cluster := os.Getenv("CUB_SCOUT_TEST_CLUSTER")
 	if cluster == "" {
@@ -361,4 +367,27 @@ func buildPatternsGraph(namespace string, empty bool) (*graph.Graph, error) {
 	}
 
 	return g, nil
+}
+
+// loadGraphFromJSON loads a graph from a JSON file for testing.
+// This is a test hook to avoid requiring real cluster access.
+func loadGraphFromJSON(path string) (*graph.Graph, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read graph JSON: %w", err)
+	}
+
+	var g graph.Graph
+	if err := json.Unmarshal(data, &g); err != nil {
+		return nil, fmt.Errorf("failed to parse graph JSON: %w", err)
+	}
+
+	// Override timestamp for deterministic output if test time is set
+	if testTime := os.Getenv("CUB_SCOUT_TEST_TIME"); testTime != "" {
+		if t, err := time.Parse(time.RFC3339, testTime); err == nil {
+			g.GeneratedAt = t
+		}
+	}
+
+	return &g, nil
 }

--- a/cmd/cub-scout/patterns_cmd.go
+++ b/cmd/cub-scout/patterns_cmd.go
@@ -308,7 +308,8 @@ func resolveGitContext(gitRoot, gitURL, gitRef, gitSubpath string) (*gitctx.GitC
 // buildPatternsGraph builds a graph for pattern detection.
 // Collects K8s ownership chain + GitOps CRDs.
 func buildPatternsGraph(namespace string, empty bool) (*graph.Graph, error) {
-	// Test hook: load graph from JSON file if CUB_SCOUT_TEST_GRAPH_JSON is set
+	// TEST HOOK: Load graph from JSON file to bypass cluster access in integration tests.
+	// In production this env var is never set, so real K8s graph collection is always used.
 	if graphJSONPath := os.Getenv("CUB_SCOUT_TEST_GRAPH_JSON"); graphJSONPath != "" {
 		return loadGraphFromJSON(graphJSONPath)
 	}

--- a/internal/gitsource/gitsource.go
+++ b/internal/gitsource/gitsource.go
@@ -44,7 +44,8 @@ const DefaultMaxSize = 100 * 1024 * 1024
 const DefaultGitHubAPIBase = "https://api.github.com"
 
 // getGitHubAPIBase returns the GitHub API base URL.
-// Uses CUB_SCOUT_GITHUB_API_BASE env var if set (for testing), otherwise DefaultGitHubAPIBase.
+// TEST HOOK: Uses CUB_SCOUT_GITHUB_API_BASE env var if set (for httptest integration tests).
+// In production this env var is never set, so api.github.com is always used.
 func getGitHubAPIBase() string {
 	if base := os.Getenv("CUB_SCOUT_GITHUB_API_BASE"); base != "" {
 		return strings.TrimSuffix(base, "/")

--- a/internal/gitsource/gitsource.go
+++ b/internal/gitsource/gitsource.go
@@ -40,6 +40,18 @@ const DefaultTimeout = 60 * time.Second
 // DefaultMaxSize is the default maximum tarball size (100 MB).
 const DefaultMaxSize = 100 * 1024 * 1024
 
+// DefaultGitHubAPIBase is the default GitHub API base URL.
+const DefaultGitHubAPIBase = "https://api.github.com"
+
+// getGitHubAPIBase returns the GitHub API base URL.
+// Uses CUB_SCOUT_GITHUB_API_BASE env var if set (for testing), otherwise DefaultGitHubAPIBase.
+func getGitHubAPIBase() string {
+	if base := os.Getenv("CUB_SCOUT_GITHUB_API_BASE"); base != "" {
+		return strings.TrimSuffix(base, "/")
+	}
+	return DefaultGitHubAPIBase
+}
+
 // Result represents the outcome of a Materialize call.
 type Result struct {
 	// Path is the local directory containing the extracted snapshot.
@@ -125,7 +137,7 @@ func Materialize(opts Options) Result {
 
 	// Construct tarball URL
 	// GitHub API: GET /repos/{owner}/{repo}/tarball/{ref}
-	tarballURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/tarball/%s", owner, repo, opts.Ref)
+	tarballURL := fmt.Sprintf("%s/repos/%s/%s/tarball/%s", getGitHubAPIBase(), owner, repo, opts.Ref)
 
 	// Create request
 	req, err := http.NewRequest("GET", tarballURL, nil)
@@ -276,7 +288,7 @@ func mapHTTPStatus(status int) string {
 // When tarball returns 404, we check if the repo exists to determine the cause.
 func resolve404Reason(client *http.Client, owner, repo, token string) string {
 	// Check if repository exists
-	repoURL := fmt.Sprintf("https://api.github.com/repos/%s/%s", owner, repo)
+	repoURL := fmt.Sprintf("%s/repos/%s/%s", getGitHubAPIBase(), owner, repo)
 	req, err := http.NewRequest("HEAD", repoURL, nil)
 	if err != nil {
 		return SkipReasonRepoNotFound

--- a/test/golden/patterns-detect-connected/patterns_detect_connected_test.go
+++ b/test/golden/patterns-detect-connected/patterns_detect_connected_test.go
@@ -353,6 +353,10 @@ func createDeterministicTarball(t *testing.T, dir string) []byte {
 		Mode:     0755,
 		Typeflag: tar.TypeDir,
 		ModTime:  modTime,
+		Uid:      0, // Zero for determinism
+		Gid:      0,
+		Uname:    "",
+		Gname:    "",
 	})
 
 	// Add files
@@ -367,6 +371,10 @@ func createDeterministicTarball(t *testing.T, dir string) []byte {
 			Name:    topDir + "/" + relPath,
 			Mode:    0644,
 			ModTime: modTime,
+			Uid:     0, // Zero for determinism
+			Gid:     0,
+			Uname:   "",
+			Gname:   "",
 		}
 
 		if info.IsDir() {

--- a/test/golden/patterns-detect-connected/patterns_detect_connected_test.go
+++ b/test/golden/patterns-detect-connected/patterns_detect_connected_test.go
@@ -1,0 +1,427 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+// Package patterns_detect_connected_test provides integration tests for v0.11 connected mode.
+//
+// These tests verify that:
+// 1. --git-url + --git-ref produces equivalent output to --git-root
+// 2. HTTP failure scenarios produce correct skip_reason strings
+// 3. Output is deterministic and matches goldens
+package patterns_detect_connected_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/test/golden"
+)
+
+const (
+	testFixtureDir = "../../../testdata/connected-repo"
+	testGraphJSON  = "../../../testdata/connected-repo/graph.json"
+	testTime       = "2026-01-01T00:00:00Z"
+)
+
+// TestConnectedModeEquivalence verifies that connected mode produces the same
+// output as local mode when given the same repository content.
+func TestConnectedModeEquivalence(t *testing.T) {
+	// Build the binary
+	binary := buildBinary(t)
+
+	// Create deterministic tarball from fixture
+	tarballData := createDeterministicTarball(t, testFixtureDir)
+
+	// Start test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Tarball endpoint
+		if strings.Contains(r.URL.Path, "/tarball/") {
+			w.Header().Set("Content-Type", "application/gzip")
+			w.WriteHeader(http.StatusOK)
+			w.Write(tarballData)
+			return
+		}
+		// Repo existence check (for 404 disambiguation)
+		if r.Method == "HEAD" && strings.HasPrefix(r.URL.Path, "/repos/") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	// Get absolute path to fixture
+	absFixture, err := filepath.Abs(testFixtureDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absGraph, err := filepath.Abs(testGraphJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run with --git-root (local mode)
+	localOutput := runPatterns(t, binary, []string{
+		"patterns", "detect",
+	}, map[string]string{
+		"CUB_SCOUT_TEST_GRAPH_JSON":   absGraph,
+		"CUB_SCOUT_TEST_TIME":         testTime,
+		"CUB_SCOUT_TEST_CLUSTER":      "test-cluster",
+	}, "--git-root", absFixture)
+
+	// Run with --git-url + --git-ref (connected mode)
+	connectedOutput := runPatterns(t, binary, []string{
+		"patterns", "detect",
+		"--git-url", "https://github.com/test/repo",
+		"--git-ref", "abc123def456",
+	}, map[string]string{
+		"CUB_SCOUT_TEST_GRAPH_JSON":   absGraph,
+		"CUB_SCOUT_TEST_TIME":         testTime,
+		"CUB_SCOUT_TEST_CLUSTER":      "test-cluster",
+		"CUB_SCOUT_GITHUB_API_BASE":   server.URL,
+	})
+
+	// Outputs should be equivalent
+	if localOutput != connectedOutput {
+		t.Errorf("Connected mode output differs from local mode:\n--- Local ---\n%s\n--- Connected ---\n%s", localOutput, connectedOutput)
+	}
+
+	// Update golden
+	golden.AssertGolden(t, "patterns-detect-connected/detect-connected-equivalence.golden.txt", localOutput)
+
+	// Also test JSON output equivalence
+	localJSON := runPatterns(t, binary, []string{
+		"patterns", "detect", "--json",
+	}, map[string]string{
+		"CUB_SCOUT_TEST_GRAPH_JSON":   absGraph,
+		"CUB_SCOUT_TEST_TIME":         testTime,
+		"CUB_SCOUT_TEST_CLUSTER":      "test-cluster",
+	}, "--git-root", absFixture)
+
+	connectedJSON := runPatterns(t, binary, []string{
+		"patterns", "detect", "--json",
+		"--git-url", "https://github.com/test/repo",
+		"--git-ref", "abc123def456",
+	}, map[string]string{
+		"CUB_SCOUT_TEST_GRAPH_JSON":   absGraph,
+		"CUB_SCOUT_TEST_TIME":         testTime,
+		"CUB_SCOUT_TEST_CLUSTER":      "test-cluster",
+		"CUB_SCOUT_GITHUB_API_BASE":   server.URL,
+	})
+
+	if localJSON != connectedJSON {
+		t.Errorf("Connected mode JSON output differs from local mode:\n--- Local ---\n%s\n--- Connected ---\n%s", localJSON, connectedJSON)
+	}
+
+	golden.AssertGolden(t, "patterns-detect-connected/detect-connected-equivalence.golden.json", localJSON)
+}
+
+// TestConnectedModeFailures verifies that HTTP failures produce correct skip_reason strings.
+func TestConnectedModeFailures(t *testing.T) {
+	binary := buildBinary(t)
+
+	absGraph, err := filepath.Abs(testGraphJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		tarballStatus  int
+		repoStatus     int // For 404 disambiguation
+		goldenFile     string
+		wantSkipReason string
+	}{
+		{
+			name:           "repository not found",
+			tarballStatus:  http.StatusNotFound,
+			repoStatus:     http.StatusNotFound,
+			goldenFile:     "detect-connected-repo-not-found.golden.txt",
+			wantSkipReason: "git_source repository not found",
+		},
+		{
+			name:           "ref not found",
+			tarballStatus:  http.StatusNotFound,
+			repoStatus:     http.StatusOK, // Repo exists, ref doesn't
+			goldenFile:     "detect-connected-ref-not-found.golden.txt",
+			wantSkipReason: "git_source ref not found",
+		},
+		{
+			name:           "authentication required",
+			tarballStatus:  http.StatusUnauthorized,
+			repoStatus:     http.StatusUnauthorized,
+			goldenFile:     "detect-connected-auth-required.golden.txt",
+			wantSkipReason: "git_source authentication required",
+		},
+		{
+			name:           "rate limited",
+			tarballStatus:  http.StatusTooManyRequests,
+			repoStatus:     http.StatusTooManyRequests,
+			goldenFile:     "detect-connected-rate-limited.golden.txt",
+			wantSkipReason: "git_source rate limited",
+		},
+		{
+			name:           "fetch failed",
+			tarballStatus:  http.StatusInternalServerError,
+			repoStatus:     http.StatusInternalServerError,
+			goldenFile:     "detect-connected-fetch-failed.golden.txt",
+			wantSkipReason: "git_source fetch failed",
+		},
+		{
+			name:           "tarball invalid",
+			tarballStatus:  http.StatusOK, // Returns 200 but invalid content
+			repoStatus:     http.StatusOK,
+			goldenFile:     "detect-connected-tarball-invalid.golden.txt",
+			wantSkipReason: "git_source tarball invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Tarball endpoint
+				if strings.Contains(r.URL.Path, "/tarball/") {
+					if tt.name == "tarball invalid" {
+						// Return invalid gzip
+						w.Header().Set("Content-Type", "application/gzip")
+						w.WriteHeader(http.StatusOK)
+						w.Write([]byte("not a valid tarball"))
+						return
+					}
+					w.WriteHeader(tt.tarballStatus)
+					return
+				}
+				// Repo existence check
+				if r.Method == "HEAD" && strings.HasPrefix(r.URL.Path, "/repos/") && !strings.Contains(r.URL.Path, "/tarball/") {
+					w.WriteHeader(tt.repoStatus)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			output := runPatterns(t, binary, []string{
+				"patterns", "detect",
+				"--git-url", "https://github.com/test/repo",
+				"--git-ref", "abc123",
+			}, map[string]string{
+				"CUB_SCOUT_TEST_GRAPH_JSON":   absGraph,
+				"CUB_SCOUT_TEST_TIME":         testTime,
+				"CUB_SCOUT_TEST_CLUSTER":      "test-cluster",
+				"CUB_SCOUT_GITHUB_API_BASE":   server.URL,
+			})
+
+			// Verify skip_reason appears in output
+			if !strings.Contains(output, tt.wantSkipReason) {
+				t.Errorf("Output should contain skip_reason %q:\n%s", tt.wantSkipReason, output)
+			}
+
+			golden.AssertGolden(t, "patterns-detect-connected/"+tt.goldenFile, output)
+		})
+	}
+}
+
+// buildBinary compiles the cub-scout binary for testing.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+
+	// Use existing binary if CUB_SCOUT_BINARY is set
+	if binary := os.Getenv("CUB_SCOUT_BINARY"); binary != "" {
+		return binary
+	}
+
+	// Find project root (directory with go.mod)
+	projectRoot := findProjectRoot(t)
+
+	// Build to temp location
+	tmpDir := t.TempDir()
+	binary := filepath.Join(tmpDir, "cub-scout")
+
+	cmd := exec.Command("go", "build", "-o", binary, "./cmd/cub-scout")
+	cmd.Dir = projectRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to build binary: %v\n%s", err, out)
+	}
+
+	return binary
+}
+
+// findProjectRoot walks up the directory tree to find go.mod.
+func findProjectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find project root (no go.mod)")
+		}
+		dir = parent
+	}
+}
+
+// runPatterns executes the patterns command and returns stdout.
+func runPatterns(t *testing.T, binary string, args []string, env map[string]string, extraArgs ...string) string {
+	t.Helper()
+
+	fullArgs := append(args, extraArgs...)
+	cmd := exec.Command(binary, fullArgs...)
+
+	// Set environment
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	// Exit code 4 (pattern failures) is acceptable
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 4 {
+			// Pattern failures are expected in some tests
+		} else if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
+			t.Logf("Command stderr: %s", stderr.String())
+		}
+	}
+
+	return stdout.String()
+}
+
+// createDeterministicTarball creates a gzipped tarball from a directory.
+// Files are sorted and timestamps are fixed for determinism.
+func createDeterministicTarball(t *testing.T, dir string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// Fixed timestamp
+	modTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Collect all files
+	var files []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+		// Skip .git directory in tarball (GitHub doesn't include it)
+		if strings.HasPrefix(relPath, ".git") {
+			return nil
+		}
+		files = append(files, relPath)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sort for determinism
+	sort.Strings(files)
+
+	// GitHub tarballs have a top-level directory
+	topDir := "test-repo-abc123"
+
+	// Add top-level directory
+	tw.WriteHeader(&tar.Header{
+		Name:     topDir + "/",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+		ModTime:  modTime,
+	})
+
+	// Add files
+	for _, relPath := range files {
+		fullPath := filepath.Join(dir, relPath)
+		info, err := os.Stat(fullPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		header := &tar.Header{
+			Name:    topDir + "/" + relPath,
+			Mode:    0644,
+			ModTime: modTime,
+		}
+
+		if info.IsDir() {
+			header.Typeflag = tar.TypeDir
+			header.Mode = 0755
+			header.Name += "/"
+		} else {
+			header.Typeflag = tar.TypeReg
+			header.Size = info.Size()
+		}
+
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+
+		if !info.IsDir() {
+			data, err := os.ReadFile(fullPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tw.Write(data); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.Bytes()
+}
+
+// readTarball is a debug helper to inspect tarball contents.
+func readTarball(data []byte) ([]string, error) {
+	gzr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, hdr.Name)
+	}
+	return names, nil
+}

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-auth-required.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-auth-required.golden.txt
@@ -1,0 +1,41 @@
+PATTERNS DETECT
+Schema: patterns.v1
+
+[SKIP] gitops.argocd.applicationset_generators
+  ApplicationSet Generator Summary
+  skip_reason: git_source authentication required
+  findings (0):
+    (none)
+
+[PASS] gitops.argocd.resources_present
+  Argo CD Resources Present
+  findings (1):
+    - [info] Argo CD ApplicationSets detected: 1
+
+[PASS] gitops.controller_presence
+  GitOps Controller Presence
+  findings (2):
+    - [info] Argo CD controller detected
+      evidence (1):
+        - 1 ApplicationSet(s)
+    - [info] Flux controller detected
+      evidence (1):
+        - 1 Kustomization(s)
+
+[SKIP] gitops.flux.kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source authentication required
+  findings (0):
+    (none)
+
+[PASS] gitops.flux.resources_present
+  Flux Resources Present
+  findings (1):
+    - [info] Flux Kustomizations detected: 1
+
+[SKIP] k8s.ownership_chain_complete
+  Kubernetes Ownership Chain Complete
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)
+

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.json
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": "patterns.v1",
+  "patterns": [
+    {
+      "id": "gitops.argocd.applicationset_generators",
+      "name": "ApplicationSet Generator Summary",
+      "status": "pass",
+      "findings": [
+        {
+          "pattern": "gitops.argocd.applicationset_generators",
+          "severity": "info",
+          "message": "ApplicationSet generators: git=1 list=1",
+          "refs": [
+            "git:path:argocd/applicationset.yaml"
+          ]
+        },
+        {
+          "pattern": "gitops.argocd.applicationset_generators",
+          "severity": "info",
+          "message": "ApplicationSets in graph: 1"
+        }
+      ]
+    },
+    {
+      "id": "gitops.argocd.resources_present",
+      "name": "Argo CD Resources Present",
+      "status": "pass",
+      "findings": [
+        {
+          "pattern": "gitops.argocd.resources_present",
+          "severity": "info",
+          "message": "Argo CD ApplicationSets detected: 1"
+        }
+      ]
+    },
+    {
+      "id": "gitops.controller_presence",
+      "name": "GitOps Controller Presence",
+      "status": "pass",
+      "findings": [
+        {
+          "pattern": "gitops.controller_presence",
+          "severity": "info",
+          "message": "Argo CD controller detected",
+          "evidence": [
+            "1 ApplicationSet(s)"
+          ]
+        },
+        {
+          "pattern": "gitops.controller_presence",
+          "severity": "info",
+          "message": "Flux controller detected",
+          "evidence": [
+            "1 Kustomization(s)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "gitops.flux.kustomization_paths",
+      "name": "Flux Kustomization Paths",
+      "status": "pass",
+      "findings": [
+        {
+          "pattern": "gitops.flux.kustomization_paths",
+          "severity": "info",
+          "message": "Flux Kustomizations in graph: 1"
+        },
+        {
+          "pattern": "gitops.flux.kustomization_paths",
+          "severity": "info",
+          "message": "Kustomization paths: ./clusters/prod",
+          "refs": [
+            "git:path:flux/kustomization.yaml"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "gitops.flux.resources_present",
+      "name": "Flux Resources Present",
+      "status": "pass",
+      "findings": [
+        {
+          "pattern": "gitops.flux.resources_present",
+          "severity": "info",
+          "message": "Flux Kustomizations detected: 1"
+        }
+      ]
+    },
+    {
+      "id": "k8s.ownership_chain_complete",
+      "name": "Kubernetes Ownership Chain Complete",
+      "status": "skip",
+      "skip_reason": "no Deployment/ReplicaSet/Pod nodes in graph",
+      "findings": []
+    }
+  ]
+}

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.txt
@@ -1,0 +1,41 @@
+PATTERNS DETECT
+Schema: patterns.v1
+
+[PASS] gitops.argocd.applicationset_generators
+  ApplicationSet Generator Summary
+  findings (2):
+    - [info] ApplicationSet generators: git=1 list=1
+    - [info] ApplicationSets in graph: 1
+
+[PASS] gitops.argocd.resources_present
+  Argo CD Resources Present
+  findings (1):
+    - [info] Argo CD ApplicationSets detected: 1
+
+[PASS] gitops.controller_presence
+  GitOps Controller Presence
+  findings (2):
+    - [info] Argo CD controller detected
+      evidence (1):
+        - 1 ApplicationSet(s)
+    - [info] Flux controller detected
+      evidence (1):
+        - 1 Kustomization(s)
+
+[PASS] gitops.flux.kustomization_paths
+  Flux Kustomization Paths
+  findings (2):
+    - [info] Flux Kustomizations in graph: 1
+    - [info] Kustomization paths: ./clusters/prod
+
+[PASS] gitops.flux.resources_present
+  Flux Resources Present
+  findings (1):
+    - [info] Flux Kustomizations detected: 1
+
+[SKIP] k8s.ownership_chain_complete
+  Kubernetes Ownership Chain Complete
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)
+

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-fetch-failed.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-fetch-failed.golden.txt
@@ -1,0 +1,41 @@
+PATTERNS DETECT
+Schema: patterns.v1
+
+[SKIP] gitops.argocd.applicationset_generators
+  ApplicationSet Generator Summary
+  skip_reason: git_source fetch failed
+  findings (0):
+    (none)
+
+[PASS] gitops.argocd.resources_present
+  Argo CD Resources Present
+  findings (1):
+    - [info] Argo CD ApplicationSets detected: 1
+
+[PASS] gitops.controller_presence
+  GitOps Controller Presence
+  findings (2):
+    - [info] Argo CD controller detected
+      evidence (1):
+        - 1 ApplicationSet(s)
+    - [info] Flux controller detected
+      evidence (1):
+        - 1 Kustomization(s)
+
+[SKIP] gitops.flux.kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source fetch failed
+  findings (0):
+    (none)
+
+[PASS] gitops.flux.resources_present
+  Flux Resources Present
+  findings (1):
+    - [info] Flux Kustomizations detected: 1
+
+[SKIP] k8s.ownership_chain_complete
+  Kubernetes Ownership Chain Complete
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)
+

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-rate-limited.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-rate-limited.golden.txt
@@ -1,0 +1,41 @@
+PATTERNS DETECT
+Schema: patterns.v1
+
+[SKIP] gitops.argocd.applicationset_generators
+  ApplicationSet Generator Summary
+  skip_reason: git_source rate limited
+  findings (0):
+    (none)
+
+[PASS] gitops.argocd.resources_present
+  Argo CD Resources Present
+  findings (1):
+    - [info] Argo CD ApplicationSets detected: 1
+
+[PASS] gitops.controller_presence
+  GitOps Controller Presence
+  findings (2):
+    - [info] Argo CD controller detected
+      evidence (1):
+        - 1 ApplicationSet(s)
+    - [info] Flux controller detected
+      evidence (1):
+        - 1 Kustomization(s)
+
+[SKIP] gitops.flux.kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source rate limited
+  findings (0):
+    (none)
+
+[PASS] gitops.flux.resources_present
+  Flux Resources Present
+  findings (1):
+    - [info] Flux Kustomizations detected: 1
+
+[SKIP] k8s.ownership_chain_complete
+  Kubernetes Ownership Chain Complete
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)
+

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-ref-not-found.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-ref-not-found.golden.txt
@@ -1,0 +1,41 @@
+PATTERNS DETECT
+Schema: patterns.v1
+
+[SKIP] gitops.argocd.applicationset_generators
+  ApplicationSet Generator Summary
+  skip_reason: git_source ref not found
+  findings (0):
+    (none)
+
+[PASS] gitops.argocd.resources_present
+  Argo CD Resources Present
+  findings (1):
+    - [info] Argo CD ApplicationSets detected: 1
+
+[PASS] gitops.controller_presence
+  GitOps Controller Presence
+  findings (2):
+    - [info] Argo CD controller detected
+      evidence (1):
+        - 1 ApplicationSet(s)
+    - [info] Flux controller detected
+      evidence (1):
+        - 1 Kustomization(s)
+
+[SKIP] gitops.flux.kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source ref not found
+  findings (0):
+    (none)
+
+[PASS] gitops.flux.resources_present
+  Flux Resources Present
+  findings (1):
+    - [info] Flux Kustomizations detected: 1
+
+[SKIP] k8s.ownership_chain_complete
+  Kubernetes Ownership Chain Complete
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)
+

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-repo-not-found.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-repo-not-found.golden.txt
@@ -1,0 +1,41 @@
+PATTERNS DETECT
+Schema: patterns.v1
+
+[SKIP] gitops.argocd.applicationset_generators
+  ApplicationSet Generator Summary
+  skip_reason: git_source repository not found
+  findings (0):
+    (none)
+
+[PASS] gitops.argocd.resources_present
+  Argo CD Resources Present
+  findings (1):
+    - [info] Argo CD ApplicationSets detected: 1
+
+[PASS] gitops.controller_presence
+  GitOps Controller Presence
+  findings (2):
+    - [info] Argo CD controller detected
+      evidence (1):
+        - 1 ApplicationSet(s)
+    - [info] Flux controller detected
+      evidence (1):
+        - 1 Kustomization(s)
+
+[SKIP] gitops.flux.kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source repository not found
+  findings (0):
+    (none)
+
+[PASS] gitops.flux.resources_present
+  Flux Resources Present
+  findings (1):
+    - [info] Flux Kustomizations detected: 1
+
+[SKIP] k8s.ownership_chain_complete
+  Kubernetes Ownership Chain Complete
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)
+

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-tarball-invalid.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-tarball-invalid.golden.txt
@@ -1,0 +1,41 @@
+PATTERNS DETECT
+Schema: patterns.v1
+
+[SKIP] gitops.argocd.applicationset_generators
+  ApplicationSet Generator Summary
+  skip_reason: git_source tarball invalid
+  findings (0):
+    (none)
+
+[PASS] gitops.argocd.resources_present
+  Argo CD Resources Present
+  findings (1):
+    - [info] Argo CD ApplicationSets detected: 1
+
+[PASS] gitops.controller_presence
+  GitOps Controller Presence
+  findings (2):
+    - [info] Argo CD controller detected
+      evidence (1):
+        - 1 ApplicationSet(s)
+    - [info] Flux controller detected
+      evidence (1):
+        - 1 Kustomization(s)
+
+[SKIP] gitops.flux.kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source tarball invalid
+  findings (0):
+    (none)
+
+[PASS] gitops.flux.resources_present
+  Flux Resources Present
+  findings (1):
+    - [info] Flux Kustomizations detected: 1
+
+[SKIP] k8s.ownership_chain_complete
+  Kubernetes Ownership Chain Complete
+  skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
+  findings (0):
+    (none)
+

--- a/testdata/connected-repo/README.md
+++ b/testdata/connected-repo/README.md
@@ -1,0 +1,35 @@
+# Connected Mode Test Fixture
+
+This directory contains a minimal repository fixture for testing connected mode
+(v0.11) git-aware patterns.
+
+## Structure
+
+```
+connected-repo/
+├── .git/.keep                      # Makes this a valid git root
+├── graph.json                      # Graph with ApplicationSet + Kustomization nodes
+├── argocd/
+│   └── applicationset.yaml         # ApplicationSet with list + git generators
+├── flux/
+│   └── kustomization.yaml          # Kustomization with spec.path
+└── clusters/
+    └── prod/
+        └── kustomization.yaml      # Target path for Flux Kustomization
+```
+
+## Usage
+
+### Local mode (--git-root)
+```bash
+./cub-scout patterns detect --git-root testdata/connected-repo
+```
+
+### Connected mode (--git-url + --git-ref)
+Used in integration tests with httptest server providing the tarball.
+
+## Env vars for testing
+
+- `CUB_SCOUT_TEST_GRAPH_JSON=testdata/connected-repo/graph.json` - Load graph from JSON
+- `CUB_SCOUT_TEST_TIME=2026-01-01T00:00:00Z` - Deterministic timestamps
+- `CUB_SCOUT_GITHUB_API_BASE=http://localhost:PORT` - Override GitHub API (httptest)

--- a/testdata/connected-repo/argocd/applicationset.yaml
+++ b/testdata/connected-repo/argocd/applicationset.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: test-appset
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - cluster: prod
+            url: https://kubernetes.default.svc
+          - cluster: staging
+            url: https://staging.example.com
+    - git:
+        repoURL: https://github.com/example/repo
+        revision: HEAD
+        directories:
+          - path: apps/*
+  template:
+    metadata:
+      name: '{{cluster}}-app'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example/repo
+        targetRevision: HEAD
+        path: 'apps/{{path}}'
+      destination:
+        server: '{{url}}'
+        namespace: default

--- a/testdata/connected-repo/clusters/prod/kustomization.yaml
+++ b/testdata/connected-repo/clusters/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml

--- a/testdata/connected-repo/flux/kustomization.yaml
+++ b/testdata/connected-repo/flux/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: test-kustomization
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./clusters/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: default

--- a/testdata/connected-repo/graph.json
+++ b/testdata/connected-repo/graph.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "graph.v1",
+  "generated_at": "2026-01-01T00:00:00Z",
+  "cluster": "test-cluster",
+  "nodes": [
+    {
+      "id": "test-cluster/argocd/ApplicationSet/test-appset",
+      "cluster": "test-cluster",
+      "namespace": "argocd",
+      "kind": "ApplicationSet",
+      "name": "test-appset",
+      "api_version": "argoproj.io/v1alpha1"
+    },
+    {
+      "id": "test-cluster/flux-system/Kustomization/test-kustomization",
+      "cluster": "test-cluster",
+      "namespace": "flux-system",
+      "kind": "Kustomization",
+      "name": "test-kustomization",
+      "api_version": "kustomize.toolkit.fluxcd.io/v1"
+    }
+  ],
+  "edges": []
+}


### PR DESCRIPTION
## Summary
- Add test hooks for httptest integration (CUB_SCOUT_GITHUB_API_BASE, CUB_SCOUT_TEST_GRAPH_JSON)
- Implement TestConnectedModeEquivalence verifying connected mode matches local mode output
- Implement TestConnectedModeFailures testing all 6 HTTP failure scenarios with correct skip_reasons
- Add testdata/connected-repo/ fixture with ApplicationSet and Kustomization manifests

## Test hooks (test-only, never set in production)

| Env var | Purpose |
|---------|---------|
| `CUB_SCOUT_GITHUB_API_BASE` | Override GitHub API base URL for `httptest` server |
| `CUB_SCOUT_TEST_GRAPH_JSON` | Load graph from JSON file to bypass cluster access |

These hooks are harmless in production (env vars are never set, so defaults are always used).

## Test plan
- [x] `go test ./test/golden/patterns-detect-connected/...` passes
- [x] `go test ./...` passes (full suite)
- [x] Golden files locked for equivalence (text + JSON) and all 6 failure scenarios
- [x] 404 disambiguation verified: repo-not-found vs ref-not-found produce distinct skip_reasons
- [x] No absolute paths in golden outputs
- [x] Tarball determinism: sorted entries, fixed timestamps, uid/gid zeroed

## Reviewer notes

- Hooks are test-only; goldens lock equivalence + skip reasons; no network required
- Exit code 2 is never asserted for runtime failures (only for invalid flag combos in patterns_cmd_test.go)
- Runtime failures → pattern SKIP with deterministic skip_reason

To regenerate goldens: `go test ./test/golden/patterns-detect-connected/... -update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)