### PR TITLE
fix: resolve golangci-lint failures on main CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,8 +136,9 @@ jobs:
 
       - name: Install ArgoCD
         run: |
-          kubectl create namespace argocd
-          kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+          kubectl create namespace argocd || true
+          # Use server-side apply to avoid oversized last-applied annotations on Argo CRDs.
+          kubectl apply --server-side --force-conflicts -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
           kubectl wait --for=condition=available deployment/argocd-server -n argocd --timeout=180s
 
       - name: Deploy Flux example

--- a/cmd/cub-scout/debug_model.go
+++ b/cmd/cub-scout/debug_model.go
@@ -25,8 +25,8 @@ const (
 	DebugStepSelectMode = iota
 	DebugStepPickResource
 	DebugStepWorkloadStatus
-	DebugStepContainerLogs  // Step for viewing container logs
-	DebugStepEventTimeline  // Step for viewing event timeline
+	DebugStepContainerLogs // Step for viewing container logs
+	DebugStepEventTimeline // Step for viewing event timeline
 	DebugStepOwnership
 	DebugStepPipelineHealth
 	DebugStepSourceHealth
@@ -230,8 +230,8 @@ type ChainLink struct {
 // RootCauseAnalysis is the final diagnosis
 type RootCauseAnalysis struct {
 	// Classification
-	Category   string `json:"category"` // source_auth, source_fetch, build_error, apply_error, workload_crash
-	Stage      string `json:"stage"`    // source, build, apply, sync, workload
+	Category   string `json:"category"`   // source_auth, source_fetch, build_error, apply_error, workload_crash
+	Stage      string `json:"stage"`      // source, build, apply, sync, workload
 	Confidence string `json:"confidence"` // high, medium, low
 
 	// Details
@@ -249,8 +249,7 @@ type RootCauseAnalysis struct {
 // DebugModel is the Bubbletea model for the debug wizard
 type DebugModel struct {
 	// Navigation
-	step   int
-	cursor int
+	step int
 
 	// Step 1: Entry mode selection
 	entryModes      []DebugEntryMode
@@ -259,7 +258,6 @@ type DebugModel struct {
 	// Step 2: Resource picker
 	resources      []ResourceItem
 	resourceCursor int
-	filterInput    string
 
 	// Step: Container logs
 	logPodCursor    int  // Which pod's logs to show
@@ -267,9 +265,8 @@ type DebugModel struct {
 	logShowPrevious bool // Show previous container logs
 
 	// Step: Event timeline
-	eventScrollPos  int  // Scroll position in event list
-	eventShowAll    bool // Show all events vs just warnings/errors
-	eventFilterKind string // Filter by resource kind (Pod, Deployment, etc.)
+	eventScrollPos int  // Scroll position in event list
+	eventShowAll   bool // Show all events vs just warnings/errors
 
 	// Session state
 	session *DebugSession
@@ -291,9 +288,7 @@ type DebugModel struct {
 	err  error
 
 	// Help/Education overlay
-	showHelp      bool
-	showEducation bool
-	educationKey  string
+	showHelp bool
 }
 
 // ResourceItem represents a resource in the picker
@@ -987,13 +982,13 @@ func runDebugAnalysisFromModel(ctx context.Context, dynClient dynamic.Interface,
 				url, _, _ := unstructured.NestedString(obj.Object, "spec", "url")
 
 				session.SourceStatus = &SourceStatus{
-					Kind:    link.Kind,
-					Name:    link.Name,
+					Kind:      link.Kind,
+					Name:      link.Name,
 					Namespace: link.Namespace,
-					Ready:   failure.Ready,
-					Reason:  failure.Reason,
-					Message: failure.Message,
-					URL:     url,
+					Ready:     failure.Ready,
+					Reason:    failure.Reason,
+					Message:   failure.Message,
+					URL:       url,
 				}
 				break
 			}

--- a/cmd/cub-scout/debug_views.go
+++ b/cmd/cub-scout/debug_views.go
@@ -17,9 +17,6 @@ var (
 			Foreground(lipgloss.Color("212")).
 			MarginBottom(1)
 
-	debugSubtitleStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("241"))
-
 	debugSelectedStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("82")).
 				Bold(true)

--- a/cmd/cub-scout/drift.go
+++ b/cmd/cub-scout/drift.go
@@ -87,7 +87,9 @@ func init() {
 	driftCmd.Flags().StringVar(&driftFormat, "format", "ascii", "Output format: ascii, json")
 	driftCmd.Flags().StringVar(&driftFailOn, "fail-on", "", "Exit non-zero if max severity >= level (info, warning, critical)")
 
-	driftCmd.MarkFlagRequired("file")
+	if err := driftCmd.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
 }
 
 func runDrift(cmd *cobra.Command, args []string) error {

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -732,31 +732,9 @@ func renderMapListFromEntries(entries []MapEntry) error {
 	}
 
 	if effectiveFormat == "json" {
-		// Get cluster context
-		cluster := os.Getenv("CLUSTER_NAME")
-		if cluster == "" {
-			cluster = getCurrentContext()
-		}
-		if cluster == "" {
-			cluster = "unknown"
-		}
-
-		// Convert to mapsvc.Entry slice
-		mapsvcEntries := make([]mapsvc.Entry, len(entries))
-		for i, e := range entries {
-			mapsvcEntries[i] = mapsvc.Entry(e)
-		}
-
-		// Get namespace filter
-		var ns *string
-		if mapNamespace != "" {
-			ns = &mapNamespace
-		}
-
-		output := mapsvc.BuildMapListJSON(mapsvcEntries, cluster, ns)
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(output)
+		return enc.Encode(entries)
 	}
 
 	if effectiveFormat == "md" {

--- a/internal/patterns/pattern_gitops_presence.go
+++ b/internal/patterns/pattern_gitops_presence.go
@@ -16,10 +16,6 @@ func init() {
 	})
 }
 
-// GitOps CRD kinds to check for
-var argoCDKinds = []string{"Application", "ApplicationSet"}
-var fluxKinds = []string{"Kustomization", "HelmRelease", "GitRepository"}
-
 // detectGitOpsControllerPresence checks for GitOps controller CRDs in the graph.
 func detectGitOpsControllerPresence(g *graph.Graph) ([]Finding, Status) {
 	var findings []Finding

--- a/pkg/agent/crossplane_lineage.go
+++ b/pkg/agent/crossplane_lineage.go
@@ -170,11 +170,6 @@ func (i *UnstructuredIndex) Len() int {
 	return len(i.all)
 }
 
-// newUnstructuredIndex is the internal constructor (kept for backward compat).
-func newUnstructuredIndex(objects []*unstructured.Unstructured) *UnstructuredIndex {
-	return NewUnstructuredIndex(objects)
-}
-
 func (i *UnstructuredIndex) keyFor(apiVersion, kind, name, namespace string) string {
 	return apiVersion + "|" + kind + "|" + namespace + "|" + name
 }

--- a/pkg/agent/drift_correlation_render.go
+++ b/pkg/agent/drift_correlation_render.go
@@ -86,7 +86,7 @@ func RenderCorrelationASCII(corr DriftCorrelation) string {
 	b.WriteString("\n\n")
 
 	// Summary with icon
-	icon := "ℹ"
+	var icon string
 	if corr.HasDrift && corr.HasFailure {
 		icon = "⚠"
 	} else if corr.HasFailure {

--- a/test/ascii/map/list/basic.json.golden
+++ b/test/ascii/map/list/basic.json.golden
@@ -1,92 +1,50 @@
-{
-  "command": "map-list",
-  "context": {
-    "cluster": "test-cluster",
-    "namespace": null
+[
+  {
+    "id": "default/default/apps/Deployment/api",
+    "clusterName": "default",
+    "namespace": "default",
+    "kind": "Deployment",
+    "name": "api",
+    "apiVersion": "apps/v1",
+    "owner": "Flux",
+    "status": "Ready",
+    "createdAt": "<TIMESTAMP>",
+    "updatedAt": "<TIMESTAMP>"
   },
-  "resources": [
-    {
-      "id": {
-        "kind": "Deployment",
-        "namespace": "default",
-        "name": "api"
-      },
-      "owner": {
-        "type": "Flux",
-        "ref": null
-      },
-      "status": "Ready"
-    },
-    {
-      "id": {
-        "kind": "Service",
-        "namespace": "default",
-        "name": "api"
-      },
-      "owner": {
-        "type": "Flux",
-        "ref": null
-      },
-      "status": "Ready"
-    },
-    {
-      "id": {
-        "kind": "Kustomization",
-        "namespace": "flux-system",
-        "name": "my-app"
-      },
-      "owner": {
-        "type": "Native",
-        "ref": null
-      },
-      "status": "Ready"
-    },
-    {
-      "id": {
-        "kind": "Deployment",
-        "namespace": "prod",
-        "name": "web"
-      },
-      "owner": {
-        "type": "Native",
-        "ref": null
-      },
-      "status": "NotReady"
-    }
-  ],
-  "summary": {
-    "total": 4,
-    "byOwner": [
-      {
-        "ownerType": "Flux",
-        "count": 2
-      },
-      {
-        "ownerType": "ArgoCD",
-        "count": 0
-      },
-      {
-        "ownerType": "Helm",
-        "count": 0
-      },
-      {
-        "ownerType": "ConfigHub",
-        "count": 0
-      },
-      {
-        "ownerType": "Native",
-        "count": 2
-      }
-    ],
-    "byStatus": [
-      {
-        "status": "NotReady",
-        "count": 1
-      },
-      {
-        "status": "Ready",
-        "count": 3
-      }
-    ]
+  {
+    "id": "default/default//Service/api",
+    "clusterName": "default",
+    "namespace": "default",
+    "kind": "Service",
+    "name": "api",
+    "apiVersion": "v1",
+    "owner": "Flux",
+    "status": "Ready",
+    "createdAt": "<TIMESTAMP>",
+    "updatedAt": "<TIMESTAMP>"
+  },
+  {
+    "id": "default/flux-system/kustomize.toolkit.fluxcd.io/Kustomization/my-app",
+    "clusterName": "default",
+    "namespace": "flux-system",
+    "kind": "Kustomization",
+    "name": "my-app",
+    "apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+    "owner": "Native",
+    "status": "Ready",
+    "createdAt": "<TIMESTAMP>",
+    "updatedAt": "<TIMESTAMP>"
+  },
+  {
+    "id": "default/prod/apps/Deployment/web",
+    "clusterName": "default",
+    "namespace": "prod",
+    "kind": "Deployment",
+    "name": "web",
+    "apiVersion": "apps/v1",
+    "owner": "Native",
+    "status": "NotReady",
+    "createdAt": "<TIMESTAMP>",
+    "updatedAt": "<TIMESTAMP>"
   }
-}
+]


### PR DESCRIPTION
## Summary
- Fixed lint issues from `main` and aligned CI on this branch.
- Restored `map list` JSON output to the array-only CLI contract (`[]Entry`) for both `--json` and `--format json`.
- Updated ASCII JSON golden for `map list --format json` to match the restored contract.
- Fixed GitOps E2E ArgoCD installation flake by using server-side apply in CI.

## Why
- `map list --json` is documented and tested as array output in the v1.0 CLI contract.
- Recent envelope output broke integration and ASCII/golden expectations.
- GitOps E2E could fail on ArgoCD CRD annotation size limits during apply.

## Changes
1. `cmd/cub-scout/map.go`
- `renderMapListFromEntries`: JSON format now encodes `entries` directly.

2. `test/ascii/map/list/basic.json.golden`
- Updated expected JSON from envelope object to array entries.

3. `.github/workflows/ci.yaml`
- `Install ArgoCD` step now uses:
  - `kubectl create namespace argocd || true`
  - `kubectl apply --server-side --force-conflicts -n argocd -f ...`

## Validation
- Local:
  - `go test ./test/ascii/...`
  - targeted integration/json checks passed with `-tags=integration` where applicable.
- CI:
  - Run `21797759192` completed successfully after these fixes.

## Notes
- This preserves the existing v1.0 user-facing JSON contract for `map list`.
- No tree/ASCII rendering behavior changes were introduced.
