### PR TITLE
v1 readiness: regression audit, pipeline semantics, and trace context hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ tmp/
 .env.local
 .cache/
 .confighub/
+test/regression/output/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cub-scout Makefile
 # Canonical verification commands for development and CI
 
-.PHONY: build test test-race fmt lint clean
+.PHONY: build test test-race fmt lint clean regression-argo
 
 # Default target
 all: build test
@@ -40,3 +40,7 @@ verify: build test
 
 # Full verification (format check + build + test + race)
 verify-full: fmt-check build test test-race
+
+# Run Argo regression audit (v0.4.0 vs v0.19.6)
+regression-argo:
+	./test/regression/argo-version-audit.sh

--- a/cmd/cub-scout/localcluster.go
+++ b/cmd/cub-scout/localcluster.go
@@ -2945,6 +2945,9 @@ func (m LocalClusterModel) getPanelPipelines() string {
 		}
 	}
 	b.WriteString(fmt.Sprintf("%d/%d pipelines healthy\n\n", healthy, len(m.gitops)))
+	if hasUnknownPipelineSource(m.gitops) {
+		b.WriteString(lcDimStyle.Render(unknownPipelineSourceHelp()) + "\n\n")
+	}
 
 	// Flux Kustomizations
 	if len(kustomizations) > 0 {
@@ -2986,10 +2989,7 @@ func renderPipelineFlow(b *strings.Builder, g GitOpsResource) {
 	}
 
 	// Visual flow: Source ──▶ Deployer ──▶ Resources
-	source := g.Source
-	if source == "" {
-		source = "unknown"
-	}
+	source := displayPipelineSource(g.Source)
 
 	// Truncate source if too long
 	if len(source) > 20 {
@@ -3016,6 +3016,32 @@ func renderPipelineFlow(b *strings.Builder, g GitOpsResource) {
 	if g.Status != "Ready" && g.Status != "Healthy" && g.Status != "" {
 		b.WriteString(fmt.Sprintf("  %s\n", statusStyle.Render("status: "+g.Status)))
 	}
+}
+
+// displayPipelineSource returns the human-facing source value used in pipeline views.
+// Source resolution order by deployer kind:
+//  1. Flux Kustomization: spec.sourceRef.name
+//  2. Flux HelmRelease:   spec.chart.spec.chart
+//  3. Argo Application:   spec.source.repoURL
+//  4. Fallback:           "unknown" (missing/unreadable source field)
+func displayPipelineSource(source string) string {
+	if strings.TrimSpace(source) == "" {
+		return "unknown"
+	}
+	return source
+}
+
+func hasUnknownPipelineSource(gitops []GitOpsResource) bool {
+	for _, g := range gitops {
+		if displayPipelineSource(g.Source) == "unknown" {
+			return true
+		}
+	}
+	return false
+}
+
+func unknownPipelineSourceHelp() string {
+	return "unknown = source field missing/unreadable (spec.sourceRef/spec.source.repoURL/spec.chart)"
 }
 
 func (m LocalClusterModel) getPanelDrift() string {
@@ -4759,10 +4785,7 @@ func (m LocalClusterModel) renderDashboard() string {
 				break
 			}
 			// Format: source@rev  ->  name  ->  N resources
-			source := g.Source
-			if source == "" {
-				source = "unknown"
-			}
+			source := displayPipelineSource(g.Source)
 			resourceCount := ""
 			if g.InventoryCount > 0 {
 				resourceCount = fmt.Sprintf("  ->  %d resources", g.InventoryCount)
@@ -4824,6 +4847,9 @@ func (m LocalClusterModel) renderDashboard() string {
 			if nativePct > 30 {
 				b.WriteString("\n  " + lcWarnStyle.Render(fmt.Sprintf("⚠ %d%% unmanaged (Native) — check security", nativePct)) + "\n")
 			}
+		}
+		if hasUnknownPipelineSource(m.gitops) {
+			b.WriteString("  " + lcDimStyle.Render(unknownPipelineSourceHelp()) + "\n")
 		}
 	}
 	b.WriteString("\n")

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -78,6 +78,12 @@ PLAIN TEXT MODE:
 
 Local cluster mode reads from your current kubectl context.
 Hub mode requires ConfigHub authentication (cub auth login).
+
+Pipeline source semantics (TUI p view):
+  - Flux Kustomization: spec.sourceRef.name
+  - Flux HelmRelease:   spec.chart.spec.chart
+  - Argo Application:   spec.source.repoURL
+  - unknown:            source field missing/unreadable
 `,
 	RunE: runMapTUI,
 }

--- a/cmd/cub-scout/trace.go
+++ b/cmd/cub-scout/trace.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -99,6 +101,12 @@ Diff mode (--diff) shows what would change if GitOps reconciled:
   - For Flux: runs 'flux diff kustomization' or 'flux diff helmrelease'
   - For ArgoCD: runs 'argocd app diff'
   - Useful for debugging "why isn't my change applying?" and upgrade tracing
+
+Trace context troubleshooting (ArgoCD):
+  - argocd context
+  - argocd app list
+  - argocd logout <server>
+  - argocd login <server>
 `,
 	Args: cobra.RangeArgs(0, 2),
 	RunE: runTrace,
@@ -1309,11 +1317,17 @@ func runArgoDiff(ctx context.Context, name string, ownership *agent.Ownership) e
 
 	// Run argocd app diff
 	cmd := exec.CommandContext(ctx, "argocd", "app", "diff", appName)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 
 	err := cmd.Run()
 	if err != nil {
+		combinedOutput := stderrBuf.String() + stdoutBuf.String()
+		if help, ok := agent.FormatArgoContextError(combinedOutput); ok {
+			return fmt.Errorf("%s", help)
+		}
+
 		// Exit code 1 means there are differences
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if exitErr.ExitCode() == 1 {

--- a/cmd/cub-scout/tui_snapshot_test.go
+++ b/cmd/cub-scout/tui_snapshot_test.go
@@ -216,6 +216,26 @@ func TestTUISnapshot_Map(t *testing.T) {
 	compareGolden(t, got, goldenPath)
 }
 
+// TestTUISnapshot_PipelinesUnknownSource locks wording for unknown source semantics.
+func TestTUISnapshot_PipelinesUnknownSource(t *testing.T) {
+	m := initialLocalModel()
+	m.ready = true
+	m.width = testWidth
+	m.height = testHeight
+
+	m.gitops = []GitOpsResource{
+		{Kind: "Kustomization", Name: "apps", Namespace: "flux-system", Status: "Ready", Source: "", Path: "./apps", InventoryCount: 8},
+		{Kind: "HelmRelease", Name: "nginx", Namespace: "ingress", Status: "Ready", Source: "nginx", InventoryCount: 2},
+		{Kind: "Application", Name: "guestbook", Namespace: "argocd", Status: "Healthy", Source: "", Path: "guestbook", InventoryCount: 3},
+	}
+
+	got := m.getPanelPipelines()
+
+	repoRoot := findRepoRoot(t)
+	goldenPath := filepath.Join(repoRoot, "test", "ascii", "tui", "pipelines_unknown_source.txt")
+	compareGolden(t, got, goldenPath)
+}
+
 // TestTUISnapshot_SuggestWorkloads tests the suggestion overlay for workloads panel.
 // Verifies that cub-scout commands are prioritized (trace/tree first, then kubectl).
 func TestTUISnapshot_SuggestWorkloads(t *testing.T) {
@@ -297,10 +317,10 @@ func TestShellCompletion_BashGeneration(t *testing.T) {
 
 	// Verify key patterns are present (Cobra-generated patterns)
 	expectedPatterns := []string{
-		"cub-scout",               // Command name
-		"__cub-scout_debug",       // Debug function
-		"__cub-scout_init",        // Init function
-		"COMPREPLY",               // Bash completion variable
+		"cub-scout",         // Command name
+		"__cub-scout_debug", // Debug function
+		"__cub-scout_init",  // Init function
+		"COMPREPLY",         // Bash completion variable
 	}
 
 	for _, pattern := range expectedPatterns {
@@ -327,9 +347,9 @@ func TestShellCompletion_ZshGeneration(t *testing.T) {
 
 	// Verify key patterns are present (Cobra-generated patterns)
 	expectedPatterns := []string{
-		"cub-scout",     // Command name
-		"#compdef",      // Zsh compdef header
-		"_cub-scout",    // Zsh completion function
+		"cub-scout",  // Command name
+		"#compdef",   // Zsh compdef header
+		"_cub-scout", // Zsh completion function
 	}
 
 	for _, pattern := range expectedPatterns {

--- a/docs/howto/trace-context-troubleshooting.md
+++ b/docs/howto/trace-context-troubleshooting.md
@@ -1,0 +1,35 @@
+# Trace Context Troubleshooting (ArgoCD)
+
+Use this when `cub-scout trace` fails because the local `argocd` context points to a stale or invalid endpoint.
+
+## Inspect and reset path
+
+1. Inspect current context:
+
+```bash
+argocd context
+```
+
+2. Verify endpoint reachability/auth:
+
+```bash
+argocd app list
+```
+
+3. Reset stale context:
+
+```bash
+argocd logout <server>
+```
+
+4. Re-authenticate:
+
+```bash
+argocd login <server>
+```
+
+5. Retry trace:
+
+```bash
+cub-scout trace --app <app-name>
+```

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -56,6 +56,16 @@ cub-scout map [flags]
 | `?` | Help |
 | `q` | Quit |
 
+### Pipeline Source Semantics
+
+In the pipelines view (`p`):
+- Flux `Kustomization`: source from `spec.sourceRef.name`
+- Flux `HelmRelease`: source from `spec.chart.spec.chart`
+- Argo CD `Application`: source from `spec.source.repoURL`
+- `unknown`: source field missing/unreadable
+
+See `docs/reference/pipeline-source-resolution.md` for details.
+
 ---
 
 ## map list
@@ -232,6 +242,20 @@ cub-scout trace deployment/nginx -n demo --diff
 cub-scout trace deployment/nginx -n demo --format json
 cub-scout trace deployment/nginx -n demo --format md
 ```
+
+### Argo Context Troubleshooting
+
+If trace fails due to stale/invalid Argo endpoint context, run:
+
+```bash
+argocd context
+argocd app list
+argocd logout <server>
+argocd login <server>
+cub-scout trace --app <app-name>
+```
+
+See `docs/howto/trace-context-troubleshooting.md` for the full flow.
 
 ### Supported Sources
 

--- a/docs/reference/pipeline-source-resolution.md
+++ b/docs/reference/pipeline-source-resolution.md
@@ -1,0 +1,16 @@
+# Pipeline Source Resolution
+
+This reference defines how `cub-scout map` pipeline views resolve the displayed source.
+
+## Resolution order
+
+1. Flux `Kustomization`: `spec.sourceRef.name`
+2. Flux `HelmRelease`: `spec.chart.spec.chart`
+3. Argo CD `Application`: `spec.source.repoURL`
+4. Fallback: `unknown`
+
+## Meaning of `unknown`
+
+`unknown` means the source field is missing or unreadable in the deployer spec.
+
+It does **not** imply an error by itself. It means cub-scout cannot extract source metadata from the object fields above.

--- a/docs/reference/views.md
+++ b/docs/reference/views.md
@@ -97,6 +97,10 @@ Complete reference for all interactive TUI views.
 - Flux: Kustomizations, HelmReleases
 - ArgoCD: Applications, ApplicationSets
 - Status: Applied/Synced, Suspended, Failed
+- Source value follows deployer-specific extraction rules
+- `unknown` means source field missing/unreadable (not a failure by itself)
+
+See: `docs/reference/pipeline-source-resolution.md`
 
 **Layout:**
 ```

--- a/docs/releases/argo-regression-audit-v0.4.0-v0.19.6.md
+++ b/docs/releases/argo-regression-audit-v0.4.0-v0.19.6.md
@@ -1,0 +1,27 @@
+# Argo Regression Audit: v0.4.0 vs v0.19.6
+
+Result: no regressions detected.
+
+Generated: 2026-02-08T22:23:24Z
+Cluster: kind-cub-scout-regression-argo
+Fixtures:
+- test/fixtures/regression/argo-minimal-crds.yaml
+- test/fixtures/regression/argo-app-of-apps.yaml
+- test/fixtures/regression/argo-applicationset.yaml
+
+Expected fixture counts:
+- Argo-owned Deployments: 4
+- Argo Applications: 5
+
+| Check | v0.4.0 | v0.19.6 | Status | Notes |
+|---|---:|---:|---|---|
+| tree ownership: Argo-owned deployment visibility | 0 | 4 | intentional improvement | Improved in v0.19.6 |
+| tree git: Argo Application visibility | 0 | 0 | intentional gap | No change; tracked as follow-on work |
+| App-of-Apps parent/child visibility in tree git | false | false | intentional gap (tracked by #128) | Not yet surfaced in current `tree git` output |
+| ApplicationSet -> generated visibility in tree git | false | false | intentional gap (tracked by #132) | Not yet surfaced in current `tree git` output |
+
+## Raw outputs
+- v0.4.0 tree ownership JSON:   /Users/alexis/public/github-repos/cub-scout/test/regression/output/20260208-222216/v0.4.0.tree.ownership.json
+- v0.19.6 tree ownership JSON:   /Users/alexis/public/github-repos/cub-scout/test/regression/output/20260208-222216/v0.19.6.tree.ownership.json
+- v0.4.0 tree git JSON:   /Users/alexis/public/github-repos/cub-scout/test/regression/output/20260208-222216/v0.4.0.tree.git.json
+- v0.19.6 tree git JSON:   /Users/alexis/public/github-repos/cub-scout/test/regression/output/20260208-222216/v0.19.6.tree.git.json

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -105,6 +105,19 @@ cub-scout tree composition  # Crossplane XR → composed resources
 
 ---
 
+## 1.0 Readiness Audit
+
+Argo hierarchy behavior audit command (issue #125):
+
+```bash
+./test/regression/argo-version-audit.sh
+```
+
+Reference report:
+- `docs/releases/argo-regression-audit-v0.4.0-v0.19.6.md`
+
+---
+
 ## What's New Since v0.19.6
 
 - Improved README with "Getting Value Fast" section

--- a/docs/roadmap-1x-connected-upsell.md
+++ b/docs/roadmap-1x-connected-upsell.md
@@ -1,0 +1,170 @@
+# cub-scout 1.x Roadmap and Connected Upsell Plan
+
+Status: Draft for review
+Date: 2026-02-08
+
+## Why this plan
+
+This plan synthesizes:
+- Artem feedback themes (Argo hierarchy trust, context clarity, workload scope, migration path)
+- Existing cub-scout roadmap direction (`docs/roadmap.md`)
+- Connected/fleet value framing from local planning docs
+
+The goal is to sequence 1.x so we:
+- protect 1.0 trust first
+- ship connected value in clear steps
+- create strong, honest upsell points
+
+## Planning principles
+
+- Single-Cluster-First: if it does not work cleanly on one cluster, it is not fleet-ready.
+- Deterministic first: no fuzzy behavior in map/tree/trace contracts.
+- Explain before upsell: every paid prompt must correspond to a real user pain in current flow.
+- Additive adoption: keep Flux/Argo/Helm workflows; avoid replacement framing.
+- Contract discipline: changes to tree/map behavior must be covered by fixtures and golden outputs.
+
+## Current reality snapshot
+
+- 1.0 baseline is stable, but Argo hierarchy trust must be validated and hardened.
+- Existing docs show tension:
+  - some guidance says App-of-Apps/ApplicationSet parents are not modeled as Units
+  - other planning/docs describe explicit parent/child visibility as desired
+- This is acceptable for 1.0 only if we make current behavior explicit and document near-term intent.
+
+## 1.x roadmap (execution order)
+
+### Phase A: 1.0.x trust hardening (now)
+
+Scope:
+- Close P0s before broad connected expansion.
+
+Primary issues:
+- #125 regression audit for Argo tree/appset/app-of-apps
+- #126 pipeline semantics (`unknown -> ...`)
+- #127 trace context hardening
+- #129 workload scope definition
+
+Exit criteria:
+- Reproducible v0.4.0 vs v0.19.6 comparison report exists and is linked from docs.
+- Known behavior gaps are classified as intentional or regression.
+- Map/trace UX has no unresolved “what does this mean?” dead ends.
+
+### Phase B: 1.1 connected foundation (next)
+
+Scope:
+- Make connected mode clearly better than OSS for single-cluster operations.
+
+Deliverables:
+- Better connected hierarchy navigation defaults (cluster-aware filtering and clear mode state).
+- First-class trace context diagnostics and reset path in connected workflows.
+- Canonical migration guide from Argo/Helm to ConfigHub (#130), promoted out of archive.
+
+Exit criteria:
+- A user can import one real cluster and understand Hub/App Space/Unit mapping without external guidance.
+- “Break-glass to managed” flow is documented and testable in one guided path.
+
+### Phase C: 1.2 Argo hierarchy intelligence (next)
+
+Scope:
+- Resolve App-of-Apps/ApplicationSet visibility gap and unify tree mental model.
+
+Deliverables:
+- Ownership/tree lineage support for:
+  - parent Application -> child Applications
+  - ApplicationSet -> generated Applications
+- Fixture-backed coverage for both patterns (#128, #132).
+- Explicit inferred-vs-explicit relationship markers in output and docs.
+
+Exit criteria:
+- Argo users can answer “who generated this app?” and “what is parent of this app?” in one command/view.
+
+### Phase D: 1.3 fleet and governance expansion (later)
+
+Scope:
+- Fleet-level workflows and governance surfaces that justify paid tiers.
+
+Deliverables:
+- Multi-cluster topology view and scoped roadmap implementation (#131).
+- Archive normalization and source-of-truth docs index (#133).
+- Progressive rollout, revision history, incident-centered views (as connected/fleet features).
+
+Exit criteria:
+- Fleet value is visible in under 2 minutes from connected onboarding.
+- Tier boundaries are clear and non-contradictory in product/docs.
+
+## Connected upsell strategy
+
+## Tier story
+
+- OSS (single cluster, no account):
+  - map/trace/scan/orphans/issues
+  - value: immediate cluster understanding and risk detection
+- Connected (single cluster + ConfigHub):
+  - import, hierarchy, WET vs LIVE causality, break-glass acceptance path
+  - value: durable operational context and managed state
+- Fleet/Enterprise (multi-cluster):
+  - fleet queries, matrix/compare, rollout/revisions/timeline/security
+  - value: cross-cluster control and audit/compliance scale
+
+## Upsell triggers (command-level)
+
+- `map orphans`:
+  - trigger: user sees unmanaged resources
+  - upsell: “Connect to classify, import, and track these with revisioned state.”
+- `trace`:
+  - trigger: user can trace local chain but lacks cross-cluster history
+  - upsell: “Connect for full DRY->WET->LIVE provenance and change history.”
+- `scan`:
+  - trigger: user finds local risk
+  - upsell: “Upgrade to fleet-wide risk posture and trend tracking.”
+- `map` / `tree`:
+  - trigger: local view is useful but context is fragmented
+  - upsell: “Connect to see org/hub/app-space hierarchy and cluster scoping.”
+
+## Upsell quality bar
+
+- Prompts must be tied to an immediate, visible limitation.
+- Prompts must never block core OSS workflows.
+- Every prompt should map to one concrete action, not generic marketing.
+
+## Metrics to validate roadmap and upsell
+
+- Time to first trust signal:
+  - user confirms output correctness for one known resource in <2 minutes.
+- Time to first connected value:
+  - successful dry-run import understanding in <5 minutes.
+- Argo hierarchy confidence:
+  - % of App-of-Apps/ApplicationSet fixture assertions passing in CI.
+- Upsell usefulness:
+  - conversion events after “limitation moments” (orphans, trace depth, fleet query need).
+
+## Risks and mitigations
+
+- Risk: Feature drift between docs and runtime behavior.
+  - Mitigation: promote one canonical “current behavior vs planned behavior” section in docs.
+- Risk: Over-promising lineage semantics before robust fixtures.
+  - Mitigation: ship inferred markers and confidence labels early.
+- Risk: Complex connected story dilutes OSS value.
+  - Mitigation: keep OSS reflexes sharp (map, trace, scan) and additive messaging.
+
+## Near-term actions (next 2 sprints)
+
+1. Complete #125 and publish comparison report.
+2. Land #126 + #127 with tests and docs.
+3. Finalize workload scope contract (#129).
+4. Draft and publish canonical migration path (#130).
+5. Start lineage fixture implementation for #128.
+
+## Source references
+
+- `docs/roadmap.md`
+- `docs/archive/IMPORT-FROM-LIVE.md`
+- `docs/archive/IMPORT-FROM-SOURCES.md`
+- `docs/archive/IMPORT-GIT-REFERENCE-ARCHITECTURES.md`
+- `docs/archive/IMPORTING-WORKLOADS.md`
+- `docs/archive/JOURNEY-IMPORT.md`
+- `/Users/alexis/Public/github-repos/confighub-agent/planning/REPO-SKELETON-TAXONOMY.md`
+- `/Users/alexis/Public/github-repos/confighub-agent/planning/RENDERED-MANIFEST-PATTERN.md`
+- `/Users/alexis/Public/github-repos/confighub-agent/planning/RENDERED-MANIFEST-PATTERN-FULL-PRODUCT.md`
+- `/Users/alexis/Public/github-repos/confighub-agent/planning/VIEW-TIERS.md`
+- `/Users/alexis/Public/github-repos/confighub-agent/planning/RM-DEMOS-ARGOCD.md`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,6 +186,7 @@ Theme: *Delight on top of substance*
 * Hub package tests added
 * Removed "experimental" messaging from README
 * GOTOOLCHAIN=local for air-gapped build compatibility
+* Release-readiness Argo regression audit command + fixtures added (`test/regression/argo-version-audit.sh`, issue #125)
 
 The UX surface is now **stable and locked**.
 

--- a/pkg/agent/argo_trace.go
+++ b/pkg/agent/argo_trace.go
@@ -93,11 +93,9 @@ func (a *ArgoTracer) traceApplication(ctx context.Context, appName, namespace st
 			}, nil
 		}
 
-		// Check for authentication/connection errors
-		if strings.Contains(combinedOutput, "server address unspecified") ||
-			strings.Contains(combinedOutput, "not logged in") ||
-			strings.Contains(combinedOutput, "authentication required") {
-			return nil, fmt.Errorf("argocd CLI not connected - run 'argocd login <server>' first")
+		// Detect stale/invalid context and print actionable remediation path.
+		if help, ok := FormatArgoContextError(combinedOutput); ok {
+			return nil, fmt.Errorf("%s", help)
 		}
 
 		return nil, fmt.Errorf("argocd app get failed: %w: %s", err, combinedOutput)
@@ -311,4 +309,61 @@ func (a *ArgoTracer) TraceByOwnership(ctx context.Context, ownership Ownership) 
 
 	// The ownership.Name is the Application name
 	return a.TraceApplication(ctx, ownership.Name)
+}
+
+// FormatArgoContextError detects stale/invalid argocd context errors and
+// returns a remediation-focused message. The bool return is true when a
+// context issue was detected.
+func FormatArgoContextError(output string) (string, bool) {
+	out := strings.ToLower(output)
+
+	containsAny := func(parts ...string) bool {
+		for _, p := range parts {
+			if strings.Contains(out, p) {
+				return true
+			}
+		}
+		return false
+	}
+
+	reason := ""
+	switch {
+	case containsAny(
+		"server address unspecified",
+		"not logged in",
+		"authentication required",
+		"unauthorized",
+		"permission denied",
+		"token is expired",
+	):
+		reason = "authentication/context is missing or expired"
+	case containsAny(
+		"context deadline exceeded",
+		"connection refused",
+		"i/o timeout",
+		"dial tcp",
+		"no such host",
+		"x509:",
+		"certificate signed by unknown authority",
+		"tls:",
+		"rpc error: code = unavailable",
+		"transport is closing",
+	):
+		reason = "current Argo endpoint is unreachable or stale"
+	default:
+		return "", false
+	}
+
+	msg := fmt.Sprintf(
+		"argocd context appears stale or invalid (%s).\n\n"+
+			"Trace context troubleshooting:\n"+
+			"  1) argocd context\n"+
+			"  2) argocd app list\n"+
+			"  3) argocd logout <server>\n"+
+			"  4) argocd login <server>\n\n"+
+			"Then retry:\n"+
+			"  cub-scout trace --app <app-name>",
+		reason,
+	)
+	return msg, true
 }

--- a/pkg/agent/argo_trace_test.go
+++ b/pkg/agent/argo_trace_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -455,5 +456,62 @@ func TestArgoHistoryWithEmptyArray(t *testing.T) {
 	// Empty history array should result in nil or empty History
 	if len(result.History) != 0 {
 		t.Errorf("Expected empty history, got %d entries", len(result.History))
+	}
+}
+
+func TestFormatArgoContextError(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantMatch  bool
+		wantReason string
+	}{
+		{
+			name:       "stale endpoint",
+			output:     "rpc error: code = Unavailable desc = connection error: dial tcp 10.0.0.1:443: i/o timeout",
+			wantMatch:  true,
+			wantReason: "unreachable or stale",
+		},
+		{
+			name:       "missing login",
+			output:     "FATA[0000] Argo CD server address unspecified",
+			wantMatch:  true,
+			wantReason: "missing or expired",
+		},
+		{
+			name:      "unrelated command failure",
+			output:    "application not found",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := FormatArgoContextError(tt.output)
+			if ok != tt.wantMatch {
+				t.Fatalf("FormatArgoContextError() match = %v, want %v (msg=%q)", ok, tt.wantMatch, got)
+			}
+			if !tt.wantMatch {
+				return
+			}
+
+			// Ensure remediation path is always present and actionable.
+			required := []string{
+				"argocd context",
+				"argocd app list",
+				"argocd logout <server>",
+				"argocd login <server>",
+				"cub-scout trace --app <app-name>",
+			}
+			for _, r := range required {
+				if !strings.Contains(got, r) {
+					t.Fatalf("expected remediation command %q in message: %s", r, got)
+				}
+			}
+
+			if !strings.Contains(got, tt.wantReason) {
+				t.Fatalf("expected reason fragment %q in message: %s", tt.wantReason, got)
+			}
+		})
 	}
 }

--- a/test/README.md
+++ b/test/README.md
@@ -174,6 +174,15 @@ go test -tags=integration ./test/integration/... && \
 ./test/prove-it-works.sh --level=examples    # Examples only
 ```
 
+## Version Regression Audits
+
+```bash
+# v0.4.0 vs v0.19.6 Argo hierarchy audit (issue #125)
+./test/regression/argo-version-audit.sh
+```
+
+See `test/regression/README.md` for details and output artifacts.
+
 ---
 
 ## Directory Structure

--- a/test/ascii/tui/pipelines_unknown_source.txt
+++ b/test/ascii/tui/pipelines_unknown_source.txt
@@ -1,0 +1,14 @@
+3/3 pipelines healthy
+
+unknown = source field missing/unreadable (spec.sourceRef/spec.source.repoURL/spec.chart)
+
+FLUX KUSTOMIZATIONS
+✓ unknown ──▶ apps ──▶ 8 resources
+  path: ./apps
+
+FLUX HELM RELEASES
+✓ nginx ──▶ nginx ──▶ 2 resources
+
+ARGOCD APPLICATIONS
+✓ unknown ──▶ guestbook ──▶ 3 resources
+  path: guestbook

--- a/test/fixtures/regression/README.md
+++ b/test/fixtures/regression/README.md
@@ -1,0 +1,15 @@
+# Regression Fixtures
+
+Fixtures in this folder are stable, local-only manifests for version regression audits.
+
+## Argo hierarchy fixtures (issue #125)
+
+Files:
+- `argo-minimal-crds.yaml` - Minimal local CRDs for `Application` and `ApplicationSet`
+- `argo-app-of-apps.yaml` - App-of-Apps sample with parent + child Applications
+- `argo-applicationset.yaml` - ApplicationSet sample with generated Applications
+
+Design goals:
+- No dependency on downloading Argo controller manifests
+- Deterministic names and labels
+- CI-friendly with kind clusters

--- a/test/fixtures/regression/argo-app-of-apps.yaml
+++ b/test/fixtures/regression/argo-app-of-apps.yaml
@@ -1,0 +1,145 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: regression-payments-dev
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: regression-payments-prod
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-root
+  namespace: argocd
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  project: default
+  source:
+    repoURL: https://git.example.local/platform.git
+    targetRevision: main
+    path: argo/app-of-apps/root
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+status:
+  sync:
+    status: Synced
+    revision: abcdef123456
+  health:
+    status: Healthy
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: payments-dev
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: platform-root
+    cub-scout.io/regression-suite: argo-hierarchy
+  annotations:
+    cub-scout.io/parent-application: platform-root
+spec:
+  project: default
+  source:
+    repoURL: https://git.example.local/platform.git
+    targetRevision: main
+    path: argo/app-of-apps/apps/payments-dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: regression-payments-dev
+status:
+  sync:
+    status: Synced
+    revision: bcdefa123456
+  health:
+    status: Healthy
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: payments-prod
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: platform-root
+    cub-scout.io/regression-suite: argo-hierarchy
+  annotations:
+    cub-scout.io/parent-application: platform-root
+spec:
+  project: default
+  source:
+    repoURL: https://git.example.local/platform.git
+    targetRevision: main
+    path: argo/app-of-apps/apps/payments-prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: regression-payments-prod
+status:
+  sync:
+    status: Synced
+    revision: cdefab123456
+  health:
+    status: Healthy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: regression-payments-dev
+  labels:
+    app: payments-api
+    argocd.argoproj.io/instance: payments-dev
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+        argocd.argoproj.io/instance: payments-dev
+        cub-scout.io/regression-suite: argo-hierarchy
+    spec:
+      containers:
+        - name: api
+          image: registry.k8s.io/pause:3.9
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: regression-payments-prod
+  labels:
+    app: payments-api
+    argocd.argoproj.io/instance: payments-prod
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+        argocd.argoproj.io/instance: payments-prod
+        cub-scout.io/regression-suite: argo-hierarchy
+    spec:
+      containers:
+        - name: api
+          image: registry.k8s.io/pause:3.9

--- a/test/fixtures/regression/argo-applicationset.yaml
+++ b/test/fixtures/regression/argo-applicationset.yaml
@@ -1,0 +1,145 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: regression-workloads-dev
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: regression-workloads-prod
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: workloads-generator
+  namespace: argocd
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  generators:
+    - list:
+        elements:
+          - env: dev
+          - env: prod
+  template:
+    metadata:
+      name: workloads-{{env}}
+    spec:
+      project: default
+      source:
+        repoURL: https://git.example.local/platform.git
+        targetRevision: main
+        path: argo/applicationset/{{env}}
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: regression-workloads-{{env}}
+status:
+  conditions:
+    - type: ResourcesUpToDate
+      status: "True"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workloads-dev
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/application-set-name: workloads-generator
+    cub-scout.io/regression-suite: argo-hierarchy
+  annotations:
+    cub-scout.io/generated-by-applicationset: workloads-generator
+spec:
+  project: default
+  source:
+    repoURL: https://git.example.local/platform.git
+    targetRevision: main
+    path: argo/applicationset/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: regression-workloads-dev
+status:
+  sync:
+    status: Synced
+    revision: defabc123456
+  health:
+    status: Healthy
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workloads-prod
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/application-set-name: workloads-generator
+    cub-scout.io/regression-suite: argo-hierarchy
+  annotations:
+    cub-scout.io/generated-by-applicationset: workloads-generator
+spec:
+  project: default
+  source:
+    repoURL: https://git.example.local/platform.git
+    targetRevision: main
+    path: argo/applicationset/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: regression-workloads-prod
+status:
+  sync:
+    status: Synced
+    revision: efabcd123456
+  health:
+    status: Healthy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-api
+  namespace: regression-workloads-dev
+  labels:
+    app: inventory-api
+    argocd.argoproj.io/instance: workloads-dev
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inventory-api
+  template:
+    metadata:
+      labels:
+        app: inventory-api
+        argocd.argoproj.io/instance: workloads-dev
+        cub-scout.io/regression-suite: argo-hierarchy
+    spec:
+      containers:
+        - name: api
+          image: registry.k8s.io/pause:3.9
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-api
+  namespace: regression-workloads-prod
+  labels:
+    app: checkout-api
+    argocd.argoproj.io/instance: workloads-prod
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: checkout-api
+  template:
+    metadata:
+      labels:
+        app: checkout-api
+        argocd.argoproj.io/instance: workloads-prod
+        cub-scout.io/regression-suite: argo-hierarchy
+    spec:
+      containers:
+        - name: api
+          image: registry.k8s.io/pause:3.9

--- a/test/fixtures/regression/argo-minimal-crds.yaml
+++ b/test/fixtures/regression/argo-minimal-crds.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.argoproj.io
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  group: argoproj.io
+  scope: Namespaced
+  names:
+    plural: applications
+    singular: application
+    kind: Application
+    shortNames:
+      - app
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applicationsets.argoproj.io
+  labels:
+    cub-scout.io/regression-suite: argo-hierarchy
+spec:
+  group: argoproj.io
+  scope: Namespaced
+  names:
+    plural: applicationsets
+    singular: applicationset
+    kind: ApplicationSet
+    shortNames:
+      - appset
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -1,0 +1,26 @@
+# Regression Audits
+
+This folder contains release-readiness regression checks that compare behavior across tagged versions.
+
+## Argo tree audit (issue #125)
+
+Compare `v0.4.0` vs `v0.19.6` for:
+- `tree ownership`
+- `tree git`
+- App-of-Apps parent/child visibility
+- ApplicationSet -> generated Application visibility
+
+Run:
+
+```bash
+./test/regression/argo-version-audit.sh
+```
+
+Artifacts are written to `test/regression/output/<timestamp>/`:
+- `report.md` (matrix with `intentional` vs `regression` classification)
+- `summary.json` (machine-readable)
+- raw command JSON outputs for both versions
+
+Notes:
+- Requires Docker + kind + kubectl + jq + Go.
+- Uses only local fixtures under `test/fixtures/regression` (no external Argo install required).

--- a/test/regression/argo-version-audit.sh
+++ b/test/regression/argo-version-audit.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# Compare Argo tree behavior between v0.4.0 and v0.19.6 using deterministic local fixtures.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_DIR="${TMPDIR:-/tmp}/cub-scout-regression"
+OUTPUT_DIR=""
+CLUSTER_NAME="cub-scout-regression-argo"
+KEEP_CLUSTER=0
+SKIP_BUILD=0
+WRITE_DOC=0
+
+V040_REF="v0.4.0"
+V0196_REF="v0.19.6"
+BIN_V040="${WORK_DIR}/bin/cub-scout-${V040_REF}"
+BIN_V0196="${WORK_DIR}/bin/cub-scout-${V0196_REF}"
+
+EXPECTED_ARGO_DEPLOYMENTS=4
+EXPECTED_ARGO_APPLICATIONS=5
+
+usage() {
+  cat <<USAGE
+Usage: test/regression/argo-version-audit.sh [options]
+
+Options:
+  --cluster-name NAME    Kind cluster name (default: ${CLUSTER_NAME})
+  --output-dir DIR       Output directory (default: test/regression/output/<timestamp>)
+  --keep-cluster         Do not delete a cluster created by this script
+  --skip-build           Reuse existing binaries in ${WORK_DIR}/bin
+  --bin-v040 PATH        Path to v0.4.0 binary
+  --bin-v0196 PATH       Path to v0.19.6 binary
+  --write-doc            Copy generated report into docs/releases/argo-regression-audit-v0.4.0-v0.19.6.md
+  -h, --help             Show this help
+USAGE
+}
+
+log() {
+  printf '[argo-audit] %s\n' "$*"
+}
+
+fail() {
+  printf '[argo-audit] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster-name)
+      CLUSTER_NAME="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --keep-cluster)
+      KEEP_CLUSTER=1
+      shift
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    --bin-v040)
+      BIN_V040="$2"
+      shift 2
+      ;;
+    --bin-v0196)
+      BIN_V0196="$2"
+      shift 2
+      ;;
+    --write-doc)
+      WRITE_DOC=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "${OUTPUT_DIR}" ]]; then
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  OUTPUT_DIR="${ROOT_DIR}/test/regression/output/${stamp}"
+fi
+
+require_cmd git
+require_cmd go
+require_cmd jq
+require_cmd kubectl
+require_cmd kind
+require_cmd docker
+
+if ! docker info >/dev/null 2>&1; then
+  fail "docker is not running (required for kind)"
+fi
+
+mkdir -p "${WORK_DIR}/bin" "${WORK_DIR}/worktrees" "${OUTPUT_DIR}"
+
+created_cluster=0
+cleanup() {
+  if [[ "${created_cluster}" -eq 1 && "${KEEP_CLUSTER}" -eq 0 ]]; then
+    log "deleting temporary kind cluster ${CLUSTER_NAME}"
+    kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+ensure_cluster() {
+  if ! kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+    log "creating kind cluster ${CLUSTER_NAME}"
+    kind create cluster --name "${CLUSTER_NAME}" >/dev/null
+    created_cluster=1
+  else
+    log "reusing existing kind cluster ${CLUSTER_NAME}"
+  fi
+  kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+}
+
+build_binary() {
+  local ref="$1"
+  local out="$2"
+  local safe_ref="${ref//[^A-Za-z0-9._-]/_}"
+  local wt="${WORK_DIR}/worktrees/${safe_ref}"
+
+  if [[ ! -d "${wt}/.git" && ! -f "${wt}/go.mod" ]]; then
+    log "creating worktree for ${ref}"
+    git -C "${ROOT_DIR}" worktree add --detach "${wt}" "${ref}" >/dev/null
+  else
+    log "refreshing worktree for ${ref}"
+    git -C "${wt}" checkout --detach "${ref}" >/dev/null
+  fi
+
+  log "building ${ref}"
+  (
+    cd "${wt}"
+    GOCACHE="${WORK_DIR}/gocache-${safe_ref}" go build -o "${out}" ./cmd/cub-scout
+  )
+}
+
+prepare_fixtures() {
+  log "applying Argo CRD fixtures"
+  kubectl apply -f "${ROOT_DIR}/test/fixtures/regression/argo-minimal-crds.yaml" >/dev/null
+  kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=60s >/dev/null
+  kubectl wait --for=condition=Established crd/applicationsets.argoproj.io --timeout=60s >/dev/null
+
+  log "applying App-of-Apps fixture"
+  kubectl apply -f "${ROOT_DIR}/test/fixtures/regression/argo-app-of-apps.yaml" >/dev/null
+
+  log "applying ApplicationSet fixture"
+  kubectl apply -f "${ROOT_DIR}/test/fixtures/regression/argo-applicationset.yaml" >/dev/null
+}
+
+run_capture() {
+  local bin="$1"
+  local tag="$2"
+
+  log "running ${tag}: tree ownership"
+  "${bin}" tree ownership --all --json > "${OUTPUT_DIR}/${tag}.tree.ownership.json"
+
+  log "running ${tag}: tree git"
+  "${bin}" tree git --json > "${OUTPUT_DIR}/${tag}.tree.git.json"
+}
+
+read_argo_owner_count() {
+  local path="$1"
+  jq -r '
+    if type == "object" and (.summary.byOwner? != null) then
+      (.summary.byOwner.ArgoCD // 0)
+    elif type == "object" and ((.groups? // []) | type == "array") then
+      ([.groups[]? | select((.owner // "") == "ArgoCD") | ((.items // []) | length)] | add // 0)
+    elif type == "array" then
+      ([.[]? | select((.owner // "") == "ArgoCD")] | length)
+    else
+      0
+    end
+  ' "${path}" 2>/dev/null || echo 0
+}
+
+read_argo_app_count() {
+  local path="$1"
+  jq -r '
+    if type == "object" then
+      ((.argoApplications // .applications // []) | length)
+    elif type == "array" then
+      ([.[]? | select((.kind // "") == "Application")] | length)
+    else
+      0
+    end
+  ' "${path}" 2>/dev/null || echo 0
+}
+
+read_app_of_apps_visibility() {
+  local path="$1"
+  jq -r '
+    def apps:
+      if type == "object" then
+        (.argoApplications // .applications // [])
+      elif type == "array" then
+        .
+      else
+        []
+      end;
+
+    apps | any(
+      (.parent != null) or
+      (.parentApp != null) or
+      (.parentApplication != null) or
+      (.parentRef != null) or
+      ((.ownerRef? | type == "object") and ((.ownerRef.kind // "") | ascii_downcase) == "application")
+    )
+  ' "${path}" 2>/dev/null || echo false
+}
+
+read_appset_visibility() {
+  local path="$1"
+  jq -r '
+    def apps:
+      if type == "object" then
+        (.argoApplications // .applications // [])
+      elif type == "array" then
+        .
+      else
+        []
+      end;
+
+    (((.applicationSets // .argoApplicationSets // []) | length) > 0) or
+    (apps | any(
+      (.applicationSet != null) or
+      (.applicationSetName != null) or
+      (.generatedBy != null) or
+      (.generatedByApplicationSet != null)
+    ))
+  ' "${path}" 2>/dev/null || echo false
+}
+
+classify_count() {
+  local old="$1"
+  local new="$2"
+  local expected="$3"
+
+  if (( new < old )); then
+    echo regression
+  elif (( new > old )); then
+    echo intentional
+  elif (( new < expected )); then
+    echo intentional-gap
+  else
+    echo match
+  fi
+}
+
+classify_bool() {
+  local old="$1"
+  local new="$2"
+
+  if [[ "${old}" == "true" && "${new}" == "false" ]]; then
+    echo regression
+  elif [[ "${old}" == "false" && "${new}" == "true" ]]; then
+    echo intentional
+  elif [[ "${old}" == "false" && "${new}" == "false" ]]; then
+    echo intentional-gap
+  else
+    echo match
+  fi
+}
+
+classification_label() {
+  case "$1" in
+    regression)
+      echo regression
+      ;;
+    intentional)
+      echo "intentional improvement"
+      ;;
+    intentional-gap)
+      echo "known gap (no regression)"
+      ;;
+    *)
+      echo match
+      ;;
+  esac
+}
+
+ensure_cluster
+prepare_fixtures
+
+if [[ "${SKIP_BUILD}" -eq 0 ]]; then
+  build_binary "${V040_REF}" "${BIN_V040}"
+  build_binary "${V0196_REF}" "${BIN_V0196}"
+fi
+
+[[ -x "${BIN_V040}" ]] || fail "v0.4.0 binary not found/executable: ${BIN_V040}"
+[[ -x "${BIN_V0196}" ]] || fail "v0.19.6 binary not found/executable: ${BIN_V0196}"
+
+run_capture "${BIN_V040}" "v0.4.0"
+run_capture "${BIN_V0196}" "v0.19.6"
+
+ownership_old="$(read_argo_owner_count "${OUTPUT_DIR}/v0.4.0.tree.ownership.json")"
+ownership_new="$(read_argo_owner_count "${OUTPUT_DIR}/v0.19.6.tree.ownership.json")"
+apps_old="$(read_argo_app_count "${OUTPUT_DIR}/v0.4.0.tree.git.json")"
+apps_new="$(read_argo_app_count "${OUTPUT_DIR}/v0.19.6.tree.git.json")"
+app_of_apps_old="$(read_app_of_apps_visibility "${OUTPUT_DIR}/v0.4.0.tree.git.json")"
+app_of_apps_new="$(read_app_of_apps_visibility "${OUTPUT_DIR}/v0.19.6.tree.git.json")"
+appset_old="$(read_appset_visibility "${OUTPUT_DIR}/v0.4.0.tree.git.json")"
+appset_new="$(read_appset_visibility "${OUTPUT_DIR}/v0.19.6.tree.git.json")"
+
+class_ownership="$(classify_count "${ownership_old}" "${ownership_new}" "${EXPECTED_ARGO_DEPLOYMENTS}")"
+class_apps="$(classify_count "${apps_old}" "${apps_new}" "${EXPECTED_ARGO_APPLICATIONS}")"
+class_app_of_apps="$(classify_bool "${app_of_apps_old}" "${app_of_apps_new}")"
+class_appset="$(classify_bool "${appset_old}" "${appset_new}")"
+
+report_path="${OUTPUT_DIR}/report.md"
+cat > "${report_path}" <<REPORT
+# Argo Regression Audit: v0.4.0 vs v0.19.6
+
+Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+Cluster: kind-${CLUSTER_NAME}
+Fixtures:
+- test/fixtures/regression/argo-minimal-crds.yaml
+- test/fixtures/regression/argo-app-of-apps.yaml
+- test/fixtures/regression/argo-applicationset.yaml
+
+Expected fixture counts:
+- Argo-owned Deployments: ${EXPECTED_ARGO_DEPLOYMENTS}
+- Argo Applications: ${EXPECTED_ARGO_APPLICATIONS}
+
+| Check | v0.4.0 | v0.19.6 | Status | Notes |
+|---|---:|---:|---|---|
+| tree ownership: Argo-owned deployment visibility | ${ownership_old} | ${ownership_new} | $(classification_label "${class_ownership}") | If below expected on both: intentional gap; if lower in v0.19.6: regression |
+| tree git: Argo Application visibility | ${apps_old} | ${apps_new} | $(classification_label "${class_apps}") | Compares observed applications in git view |
+| App-of-Apps parent/child visibility in tree git | ${app_of_apps_old} | ${app_of_apps_new} | $(classification_label "${class_app_of_apps}") | Known gap tracked by #128 when false |
+| ApplicationSet -> generated visibility in tree git | ${appset_old} | ${appset_new} | $(classification_label "${class_appset}") | Known gap tracked by #132 when false |
+
+## Raw outputs
+- v0.4.0 tree ownership JSON: \
+  ${OUTPUT_DIR}/v0.4.0.tree.ownership.json
+- v0.19.6 tree ownership JSON: \
+  ${OUTPUT_DIR}/v0.19.6.tree.ownership.json
+- v0.4.0 tree git JSON: \
+  ${OUTPUT_DIR}/v0.4.0.tree.git.json
+- v0.19.6 tree git JSON: \
+  ${OUTPUT_DIR}/v0.19.6.tree.git.json
+REPORT
+
+# JSON summary for CI and automation.
+cat > "${OUTPUT_DIR}/summary.json" <<JSON
+{
+  "ownership": {
+    "v0_4_0": ${ownership_old},
+    "v0_19_6": ${ownership_new},
+    "classification": "${class_ownership}",
+    "status": "$(classification_label "${class_ownership}")"
+  },
+  "gitApplications": {
+    "v0_4_0": ${apps_old},
+    "v0_19_6": ${apps_new},
+    "classification": "${class_apps}",
+    "status": "$(classification_label "${class_apps}")"
+  },
+  "appOfAppsVisibility": {
+    "v0_4_0": ${app_of_apps_old},
+    "v0_19_6": ${app_of_apps_new},
+    "classification": "${class_app_of_apps}",
+    "status": "$(classification_label "${class_app_of_apps}")"
+  },
+  "applicationSetVisibility": {
+    "v0_4_0": ${appset_old},
+    "v0_19_6": ${appset_new},
+    "classification": "${class_appset}",
+    "status": "$(classification_label "${class_appset}")"
+  }
+}
+JSON
+
+if [[ "${WRITE_DOC}" -eq 1 ]]; then
+  cp "${report_path}" "${ROOT_DIR}/docs/releases/argo-regression-audit-v0.4.0-v0.19.6.md"
+  log "updated docs/releases/argo-regression-audit-v0.4.0-v0.19.6.md"
+fi
+
+log "report: ${report_path}"
+log "summary: ${OUTPUT_DIR}/summary.json"
+
+regressions=0
+for cls in "${class_ownership}" "${class_apps}" "${class_app_of_apps}" "${class_appset}"; do
+  if [[ "${cls}" == "regression" ]]; then
+    regressions=$((regressions + 1))
+  fi
+done
+
+if (( regressions > 0 )); then
+  fail "regression(s) detected: ${regressions}"
+fi
+
+log "no regressions detected (intentional gaps may remain for #128/#132)"


### PR DESCRIPTION
## Summary

This PR delivers v1-readiness work for Artem feedback issues:
- #125 regression audit command + fixtures + release-readiness report
- #126 pipeline source semantics clarification (`unknown` meaning)
- #127 stale Argo trace context hardening with actionable remediation

## What changed

### Issue #125
- Added reproducible audit script comparing `v0.4.0` vs `v0.19.6`:
  - `test/regression/argo-version-audit.sh`
- Added deterministic local Argo fixtures (App-of-Apps + ApplicationSet):
  - `test/fixtures/regression/*`
- Added audit docs and release-readiness references:
  - `docs/releases/argo-regression-audit-v0.4.0-v0.19.6.md`
  - updates in `docs/releases/v1.0.0.md`, `docs/roadmap.md`, `test/README.md`, `Makefile`
- Added `.gitignore` rule for generated audit output:
  - `test/regression/output/`

### Issue #126
- Clarified pipeline source semantics in TUI help/docs:
  - `cmd/cub-scout/map.go`
  - `docs/reference/pipeline-source-resolution.md`
  - `docs/reference/commands.md`
  - `docs/reference/views.md`
- Added explicit in-panel explanation for unknown source values:
  - `cmd/cub-scout/localcluster.go`
- Added golden coverage for unknown-source pipeline rendering:
  - `cmd/cub-scout/tui_snapshot_test.go`
  - `test/ascii/tui/pipelines_unknown_source.txt`

### Issue #127
- Added stale/invalid Argo context detection and remediation guidance:
  - `pkg/agent/argo_trace.go`
- Added tests for stale-endpoint/auth error flow:
  - `pkg/agent/argo_trace_test.go`
- Added same remediation path to `trace --diff` Argo flow:
  - `cmd/cub-scout/trace.go`
- Added troubleshooting doc:
  - `docs/howto/trace-context-troubleshooting.md`

### Planning output requested earlier
- Added 1.x connected roadmap draft:
  - `docs/roadmap-1x-connected-upsell.md`

## Validation

- `go test ./cmd/cub-scout`
- `go test ./pkg/agent`
- `go test ./pkg/agent -run TestFormatArgoContextError`
- `go test ./cmd/cub-scout -run 'TestTUISnapshot_PipelinesUnknownSource|TestTUISnapshot_Map|TestTUISnapshot_Tree'`

Closes #125
Closes #126
Closes #127
