### PR TITLE
feat: align canonical workload scope across map/tree/docs

### DIFF
--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -294,10 +294,10 @@ var mapProblemsCmd = &cobra.Command{
 	Use:     "issues",
 	Aliases: []string{"problems"},
 	Short:   "List resources with issues",
-	Long: `List resources that have issues - failed deployments, stuck reconciliations, etc.
+	Long: `List resources that have issues - failed workloads, stuck reconciliations, etc.
 
 Shows:
-  - Deployments with unavailable replicas
+  - Deployments/StatefulSets with unavailable replicas
   - Flux Kustomizations/HelmReleases not ready
   - Argo CD Applications not synced/healthy`,
 	RunE: runMapProblems,
@@ -318,7 +318,7 @@ Shows:
 var mapWorkloadsCmd = &cobra.Command{
 	Use:   "workloads",
 	Short: "List workloads grouped by owner",
-	Long: `List all workloads (Deployments, StatefulSets, DaemonSets) grouped by owner.
+	Long: `List canonical workloads (Deployments, StatefulSets) grouped by owner.
 
 Owners: Flux, ArgoCD, Helm, Terraform, Crossplane, ConfigHub, Native`,
 	RunE: runMapWorkloads,
@@ -354,7 +354,7 @@ var mapDashboardCmd = &cobra.Command{
 
 Shows:
 - Deployer health (Flux Kustomizations, HelmReleases, ArgoCD Applications)
-- Workload health (Deployments, StatefulSets, DaemonSets)
+- Workload health (Deployments, StatefulSets)
 - GitOps coverage percentage
 - Breakdown by owner with visual bars
 - Shadow IT warnings for native workloads
@@ -1402,21 +1402,16 @@ func runMapStatus(cmd *cobra.Command, args []string) error {
 	// Count workloads
 	workloadsReady, workloadsTotal := 0, 0
 
-	// Check Deployments
-	if depList, err := dynClient.Resource(schema.GroupVersionResource{
-		Group: "apps", Version: "v1", Resource: "deployments",
-	}).List(ctx, v1.ListOptions{}); err == nil {
-		for _, dep := range depList.Items {
-			ns := dep.GetNamespace()
-			if strings.HasPrefix(ns, "kube-") || ns == "local-path-storage" {
-				continue
-			}
-			workloadsTotal++
-			if isDeploymentReady(&dep) {
-				workloadsReady++
-			}
+	forEachCanonicalWorkload(ctx, dynClient, "", func(workload *unstructured.Unstructured) {
+		ns := workload.GetNamespace()
+		if strings.HasPrefix(ns, "kube-") || ns == "local-path-storage" {
+			return
 		}
-	}
+		workloadsTotal++
+		if isWorkloadReady(workload) {
+			workloadsReady++
+		}
+	})
 
 	// Output
 	problems := (deployersTotal - deployersReady) + (workloadsTotal - workloadsReady)
@@ -1490,22 +1485,17 @@ func runMapProblems(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Check Deployments
-	if depList, err := dynClient.Resource(schema.GroupVersionResource{
-		Group: "apps", Version: "v1", Resource: "deployments",
-	}).List(ctx, v1.ListOptions{}); err == nil {
-		for _, dep := range depList.Items {
-			ns := dep.GetNamespace()
-			if strings.HasPrefix(ns, "kube-") || ns == "local-path-storage" {
-				continue
-			}
-			if !isDeploymentReady(&dep) {
-				desired, available := getDeploymentReplicas(&dep)
-				workloadIssues = append(workloadIssues, fmt.Sprintf("✗ Deployment/%s in %s: %d/%d ready",
-					dep.GetName(), ns, available, desired))
-			}
+	forEachCanonicalWorkload(ctx, dynClient, "", func(workload *unstructured.Unstructured) {
+		ns := workload.GetNamespace()
+		if strings.HasPrefix(ns, "kube-") || ns == "local-path-storage" {
+			return
 		}
-	}
+		if !isWorkloadReady(workload) {
+			desired, available := getWorkloadReplicas(workload)
+			workloadIssues = append(workloadIssues, fmt.Sprintf("✗ %s/%s in %s: %d/%d ready",
+				workload.GetKind(), workload.GetName(), ns, available, desired))
+		}
+	})
 
 	totalIssues := len(deployerIssues) + len(workloadIssues)
 
@@ -1749,41 +1739,48 @@ func runMapWorkloads(cmd *cobra.Command, args []string) error {
 
 	// Count by owner
 	ownerCounts := map[string]int{}
+	kindCounts := map[string]int{}
 	var total int
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "STATUS\tNAMESPACE\tNAME\tOWNER\tMANAGED-BY\tIMAGE")
-	fmt.Fprintln(w, "──────\t─────────\t────\t─────\t──────────\t─────")
+	fmt.Fprintln(w, "STATUS\tKIND\tNAMESPACE\tNAME\tOWNER\tMANAGED-BY\tIMAGE")
+	fmt.Fprintln(w, "──────\t────\t─────────\t────\t─────\t──────────\t─────")
 
-	// Get Deployments
-	if depList, err := dynClient.Resource(schema.GroupVersionResource{
-		Group: "apps", Version: "v1", Resource: "deployments",
-	}).List(ctx, v1.ListOptions{}); err == nil {
-		for _, dep := range depList.Items {
-			ns := dep.GetNamespace()
-			if isSystemNamespace(ns) {
-				continue
-			}
-
-			total++
-			status := SymOK
-			if !isDeploymentReady(&dep) {
-				status = SymError
-			}
-
-			owner, managedBy := detectOwnership(&dep)
-			ownerCounts[owner]++
-			image := getContainerImage(&dep)
-
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				status, ns, dep.GetName(), owner, managedBy, image)
+	forEachCanonicalWorkload(ctx, dynClient, "", func(workload *unstructured.Unstructured) {
+		ns := workload.GetNamespace()
+		if isSystemNamespace(ns) {
+			return
 		}
-	}
+
+		total++
+		kind := workload.GetKind()
+		kindCounts[kind]++
+
+		status := SymOK
+		if !isWorkloadReady(workload) {
+			status = SymError
+		}
+
+		owner, managedBy := detectOwnership(workload)
+		ownerCounts[owner]++
+		image := getContainerImage(workload)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			status, kind, ns, workload.GetName(), owner, managedBy, image)
+	})
 
 	w.Flush()
 
 	// Summary
 	if total > 0 {
+		kindOrder := []string{"Deployment", "StatefulSet"}
+		kindParts := []string{}
+		for _, kind := range kindOrder {
+			if count := kindCounts[kind]; count > 0 {
+				kindParts = append(kindParts, fmt.Sprintf("%d %s", count, kind))
+			}
+		}
+
 		// Build owner breakdown in consistent order
 		owners := []string{"Flux", "ArgoCD", "Helm", "ConfigHub", "Native"}
 		var parts []string
@@ -1792,7 +1789,11 @@ func runMapWorkloads(cmd *cobra.Command, args []string) error {
 				parts = append(parts, fmt.Sprintf("%d %s", count, owner))
 			}
 		}
-		fmt.Printf("\n%d workloads: %s\n", total, strings.Join(parts, ", "))
+		if len(parts) > 0 {
+			fmt.Printf("\n%d workloads (%s): %s\n", total, strings.Join(kindParts, ", "), strings.Join(parts, ", "))
+		} else {
+			fmt.Printf("\n%d workloads (%s)\n", total, strings.Join(kindParts, ", "))
+		}
 	}
 
 	return nil
@@ -1886,30 +1887,25 @@ func runMapSprawl(cmd *cobra.Command, args []string) error {
 
 	var fluxCount, argoCount, helmCount, configHubCount, nativeCount int
 
-	// Get all Deployments and count by owner
-	if depList, err := dynClient.Resource(schema.GroupVersionResource{
-		Group: "apps", Version: "v1", Resource: "deployments",
-	}).List(ctx, v1.ListOptions{}); err == nil {
-		for _, dep := range depList.Items {
-			ns := dep.GetNamespace()
-			if isSystemNamespace(ns) {
-				continue
-			}
-			owner, _ := detectOwnership(&dep)
-			switch owner {
-			case "Flux":
-				fluxCount++
-			case "ArgoCD":
-				argoCount++
-			case "Helm":
-				helmCount++
-			case "ConfigHub":
-				configHubCount++
-			case "Native":
-				nativeCount++
-			}
+	forEachCanonicalWorkload(ctx, dynClient, "", func(workload *unstructured.Unstructured) {
+		ns := workload.GetNamespace()
+		if isSystemNamespace(ns) {
+			return
 		}
-	}
+		owner, _ := detectOwnership(workload)
+		switch owner {
+		case "Flux":
+			fluxCount++
+		case "ArgoCD":
+			argoCount++
+		case "Helm":
+			helmCount++
+		case "ConfigHub":
+			configHubCount++
+		case "Native":
+			nativeCount++
+		}
+	})
 
 	total := fluxCount + argoCount + helmCount + configHubCount + nativeCount
 	managed := total - nativeCount
@@ -2008,35 +2004,29 @@ func runMapDashboard(cmd *cobra.Command, args []string) error {
 	workloadsReady, workloadsTotal := 0, 0
 	var fluxCount, argoCount, helmCount, configHubCount, nativeCount int
 
-	// Check Deployments
-	if depList, err := dynClient.Resource(schema.GroupVersionResource{
-		Group: "apps", Version: "v1", Resource: "deployments",
-	}).List(ctx, v1.ListOptions{}); err == nil {
-		for _, dep := range depList.Items {
-			ns := dep.GetNamespace()
-			if isSystemNamespace(ns) {
-				continue
-			}
-			workloadsTotal++
-			if isDeploymentReady(&dep) {
-				workloadsReady++
-			}
-			// Count by owner
-			owner, _ := detectOwnership(&dep)
-			switch owner {
-			case "Flux":
-				fluxCount++
-			case "ArgoCD":
-				argoCount++
-			case "Helm":
-				helmCount++
-			case "ConfigHub":
-				configHubCount++
-			case "Native":
-				nativeCount++
-			}
+	forEachCanonicalWorkload(ctx, dynClient, "", func(workload *unstructured.Unstructured) {
+		ns := workload.GetNamespace()
+		if isSystemNamespace(ns) {
+			return
 		}
-	}
+		workloadsTotal++
+		if isWorkloadReady(workload) {
+			workloadsReady++
+		}
+		owner, _ := detectOwnership(workload)
+		switch owner {
+		case "Flux":
+			fluxCount++
+		case "ArgoCD":
+			argoCount++
+		case "Helm":
+			helmCount++
+		case "ConfigHub":
+			configHubCount++
+		case "Native":
+			nativeCount++
+		}
+	})
 
 	// Health status
 	problems := (deployersTotal - deployersReady) + (workloadsTotal - workloadsReady)
@@ -2103,29 +2093,24 @@ func runMapBypass(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAMESPACE\tNAME\tIMAGE")
-	fmt.Fprintln(w, "─────────\t────\t─────")
+	fmt.Fprintln(w, "KIND\tNAMESPACE\tNAME\tIMAGE")
+	fmt.Fprintln(w, "────\t─────────\t────\t─────")
 
 	var nativeCount int
 
-	// Get all Deployments
-	if depList, err := dynClient.Resource(schema.GroupVersionResource{
-		Group: "apps", Version: "v1", Resource: "deployments",
-	}).List(ctx, v1.ListOptions{}); err == nil {
-		for _, dep := range depList.Items {
-			ns := dep.GetNamespace()
-			if isSystemNamespace(ns) {
-				continue
-			}
-
-			owner, _ := detectOwnership(&dep)
-			if owner == "Native" {
-				nativeCount++
-				image := getContainerImage(&dep)
-				fmt.Fprintf(w, "%s\t%s\t%s\n", ns, dep.GetName(), image)
-			}
+	forEachCanonicalWorkload(ctx, dynClient, "", func(workload *unstructured.Unstructured) {
+		ns := workload.GetNamespace()
+		if isSystemNamespace(ns) {
+			return
 		}
-	}
+
+		owner, _ := detectOwnership(workload)
+		if owner == "Native" {
+			nativeCount++
+			image := getContainerImage(workload)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", workload.GetKind(), ns, workload.GetName(), image)
+		}
+	})
 
 	w.Flush()
 
@@ -2155,6 +2140,45 @@ func makeBar(count, total, width int) string {
 
 // Helper functions for the new commands
 
+type workloadResource struct {
+	kind     string
+	resource string
+}
+
+var canonicalWorkloadResources = []workloadResource{
+	{kind: "Deployment", resource: "deployments"},
+	{kind: "StatefulSet", resource: "statefulsets"},
+}
+
+func forEachCanonicalWorkload(ctx context.Context, dynClient dynamic.Interface, namespace string, fn func(*unstructured.Unstructured)) {
+	for _, workload := range canonicalWorkloadResources {
+		gvr := schema.GroupVersionResource{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: workload.resource,
+		}
+
+		resourceClient := dynClient.Resource(gvr)
+		listFn := resourceClient.List
+		if namespace != "" {
+			listFn = resourceClient.Namespace(namespace).List
+		}
+
+		workloadList, err := listFn(ctx, v1.ListOptions{})
+		if err != nil {
+			continue
+		}
+
+		for i := range workloadList.Items {
+			item := workloadList.Items[i]
+			if item.GetKind() == "" {
+				item.SetKind(workload.kind)
+			}
+			fn(&item)
+		}
+	}
+}
+
 func isResourceReady(obj *unstructured.Unstructured) bool {
 	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
 	if !found {
@@ -2179,21 +2203,30 @@ func isArgoAppHealthy(obj *unstructured.Unstructured) bool {
 }
 
 func isDeploymentReady(obj *unstructured.Unstructured) bool {
-	desired, _, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas")
-	available, _, _ := unstructured.NestedInt64(obj.Object, "status", "readyReplicas")
-	if desired == 0 {
-		desired = 1
-	}
-	return available >= desired
+	return isWorkloadReady(obj)
 }
 
 func getDeploymentReplicas(obj *unstructured.Unstructured) (int64, int64) {
-	desired, _, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas")
-	available, _, _ := unstructured.NestedInt64(obj.Object, "status", "readyReplicas")
-	if desired == 0 {
-		desired = 1
+	return getWorkloadReplicas(obj)
+}
+
+func isWorkloadReady(obj *unstructured.Unstructured) bool {
+	desired, ready := getWorkloadReplicas(obj)
+	return ready >= desired
+}
+
+func getWorkloadReplicas(obj *unstructured.Unstructured) (int64, int64) {
+	switch obj.GetKind() {
+	case "Deployment", "StatefulSet":
+		desired, _, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas")
+		ready, _, _ := unstructured.NestedInt64(obj.Object, "status", "readyReplicas")
+		if desired == 0 {
+			desired = 1
+		}
+		return desired, ready
+	default:
+		return 1, 0
 	}
-	return desired, available
 }
 
 func getConditionReason(obj *unstructured.Unstructured) string {

--- a/cmd/cub-scout/map_workload_scope_test.go
+++ b/cmd/cub-scout/map_workload_scope_test.go
@@ -1,0 +1,191 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestForEachCanonicalWorkload_IncludesDeploymentAndStatefulSet(t *testing.T) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "apps", Version: "v1", Resource: "deployments"}:  "DeploymentList",
+		{Group: "apps", Version: "v1", Resource: "statefulsets"}: "StatefulSetList",
+	}
+
+	deployment := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "apps",
+			},
+		},
+	}
+
+	statefulSet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"metadata": map[string]interface{}{
+				"name":      "postgres",
+				"namespace": "apps",
+			},
+		},
+	}
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, deployment, statefulSet)
+
+	var got []string
+	forEachCanonicalWorkload(context.Background(), client, "", func(workload *unstructured.Unstructured) {
+		got = append(got, workload.GetKind()+"/"+workload.GetNamespace()+"/"+workload.GetName())
+	})
+	sort.Strings(got)
+
+	want := []string{
+		"Deployment/apps/api",
+		"StatefulSet/apps/postgres",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d workloads, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected workload at %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestForEachCanonicalWorkload_RespectsNamespaceFilter(t *testing.T) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "apps", Version: "v1", Resource: "deployments"}:  "DeploymentList",
+		{Group: "apps", Version: "v1", Resource: "statefulsets"}: "StatefulSetList",
+	}
+
+	deployment := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "apps",
+			},
+		},
+	}
+	statefulSet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"metadata": map[string]interface{}{
+				"name":      "postgres",
+				"namespace": "databases",
+			},
+		},
+	}
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, deployment, statefulSet)
+
+	var got []string
+	forEachCanonicalWorkload(context.Background(), client, "apps", func(workload *unstructured.Unstructured) {
+		got = append(got, workload.GetKind()+"/"+workload.GetNamespace()+"/"+workload.GetName())
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 workload in namespace filter, got %d: %v", len(got), got)
+	}
+	if got[0] != "Deployment/apps/api" {
+		t.Fatalf("unexpected workload from namespace filter: %s", got[0])
+	}
+}
+
+func TestGetWorkloadReplicas_StatefulSetParity(t *testing.T) {
+	tests := []struct {
+		name   string
+		obj    *unstructured.Unstructured
+		wantD  int64
+		wantR  int64
+		wantOK bool
+	}{
+		{
+			name:   "deployment ready",
+			obj:    newWorkload("Deployment", "api", "apps", 3, 3),
+			wantD:  3,
+			wantR:  3,
+			wantOK: true,
+		},
+		{
+			name:   "statefulset ready",
+			obj:    newWorkload("StatefulSet", "postgres", "apps", 2, 2),
+			wantD:  2,
+			wantR:  2,
+			wantOK: true,
+		},
+		{
+			name:   "statefulset not ready",
+			obj:    newWorkload("StatefulSet", "postgres", "apps", 3, 1),
+			wantD:  3,
+			wantR:  1,
+			wantOK: false,
+		},
+		{
+			name: "deployment default replicas to one",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "defaulted",
+						"namespace": "apps",
+					},
+					"status": map[string]interface{}{
+						"readyReplicas": int64(1),
+					},
+				},
+			},
+			wantD:  1,
+			wantR:  1,
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired, ready := getWorkloadReplicas(tt.obj)
+			if desired != tt.wantD || ready != tt.wantR {
+				t.Fatalf("getWorkloadReplicas() = (%d, %d), want (%d, %d)", desired, ready, tt.wantD, tt.wantR)
+			}
+			if got := isWorkloadReady(tt.obj); got != tt.wantOK {
+				t.Fatalf("isWorkloadReady() = %v, want %v", got, tt.wantOK)
+			}
+		})
+	}
+}
+
+func newWorkload(kind, name, namespace string, desired, ready int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"replicas": desired,
+			},
+			"status": map[string]interface{}{
+				"readyReplicas": ready,
+			},
+		},
+	}
+}

--- a/cmd/cub-scout/tree.go
+++ b/cmd/cub-scout/tree.go
@@ -15,6 +15,7 @@ import (
 	"github.com/confighub/cub-scout/internal/mapsvc"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
@@ -459,22 +460,15 @@ func runTreeOwnership(ctx context.Context) error {
 	// Get current context name for cluster field
 	clusterName := getCurrentContext()
 
-	// Get Deployments
-	deployGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-	deploys, err := dynClient.Resource(deployGVR).Namespace(treeNamespace).List(ctx, v1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to list deployments: %w", err)
-	}
-
 	// Convert to mapsvc.Entry for shared renderer
 	var entries []mapsvc.Entry
-	for _, deploy := range deploys.Items {
-		ns := deploy.GetNamespace()
+	forEachCanonicalWorkload(ctx, dynClient, treeNamespace, func(workload *unstructured.Unstructured) {
+		ns := workload.GetNamespace()
 		if !treeAll && isSystemNamespace(ns) {
-			continue
+			return
 		}
 
-		owner, ownerName := detectOwnership(&deploy)
+		owner, ownerName := detectOwnership(workload)
 
 		// Build ownerDetails map from ownerName
 		var ownerDetails map[string]string
@@ -487,13 +481,13 @@ func runTreeOwnership(ctx context.Context) error {
 		}
 
 		entries = append(entries, mapsvc.Entry{
-			Name:         deploy.GetName(),
+			Name:         workload.GetName(),
 			Namespace:    ns,
-			Kind:         "Deployment",
+			Kind:         workload.GetKind(),
 			Owner:        owner,
 			OwnerDetails: ownerDetails,
 		})
-	}
+	})
 
 	// Build opts for shared renderer
 	opts := mapsvc.OwnershipTreeOpts{

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -34,7 +34,7 @@ breaking changes will be avoided within the same contract version.
 | `cub-scout map` | Interactive TUI dashboard | v0.5 |
 | `cub-scout map list` | List resources (scriptable) | v0.5 |
 | `cub-scout map status` | One-line health check | v0.5 |
-| `cub-scout map deployers` | List deployers (Deployments) | v0.5 |
+| `cub-scout map deployers` | List deployers (Flux/ArgoCD + core Deployments) | v0.5 |
 | `cub-scout map hooks` | List lifecycle hooks (Helm/ArgoCD) | v0.19 |
 | `cub-scout trace` | Trace resource to Git source | v0.5 |
 | `cub-scout scan` | Scan for CCVEs and issues | v0.5 |
@@ -191,15 +191,21 @@ cub-scout map status
 | 0 | All healthy |
 | 1 | Problems detected or error |
 
+Canonical workload scope counted by `map status` (v1.0):
+- `Deployment`
+- `StatefulSet`
+
 ---
 
 ## cub-scout map deployers
 
-List deployers (Kubernetes Deployments) in the cluster.
+List deployers in the cluster.
 
-> **v0.5 contract:** Deployers are Kubernetes Deployments. Flux Kustomizations,
-> HelmReleases, and Argo Applications are out of scope for v0.5 and may be
-> added in a future release.
+Canonical deployer scope (v1.0):
+- Flux `Kustomization`
+- Flux `HelmRelease`
+- Argo CD `Application`
+- Core Kubernetes `Deployment` (fallback where GitOps CRDs are absent)
 
 ```bash
 cub-scout map deployers [flags]
@@ -210,12 +216,13 @@ cub-scout map deployers [flags]
 ```json
 [
   {
-    "kind": "Deployment",
-    "name": "app-alpha",
-    "namespace": "default",
-    "status": "Ready",
+    "kind": "Application",
+    "name": "frontend",
+    "namespace": "argocd",
+    "status": "Healthy",
     "ready": true,
-    "revision": "-"
+    "revision": "HEAD",
+    "resources": 12
   }
 ]
 ```
@@ -223,12 +230,13 @@ cub-scout map deployers [flags]
 **Stable JSON fields:**
 | Field | Type | Description |
 |-------|------|-------------|
-| `kind` | string | Always `Deployment` in v0.5 |
-| `name` | string | Deployment name |
-| `namespace` | string | Deployment namespace |
-| `status` | string | Status string (e.g., `Ready`) |
-| `ready` | bool | Whether deployment is ready |
+| `kind` | string | Deployer kind (`Kustomization`, `HelmRelease`, `Application`, `Deployment`) |
+| `name` | string | Deployer name |
+| `namespace` | string | Deployer namespace |
+| `status` | string | Status string (for example `Ready`, `Healthy`, `NotReady`, `Unhealthy`) |
+| `ready` | bool | Whether the deployer is healthy/ready |
 | `revision` | string | Revision string (or `-` if unavailable) |
+| `resources` | number | Number of managed resources when available |
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -12,7 +12,7 @@ Complete reference for all cub-scout commands.
 | `map issues` | Show resources with problems |
 | `map crashes` | Show crashing pods |
 | `map workloads` | List workloads by owner |
-| `map deployers` | List deployers (Deployments) |
+| `map deployers` | List GitOps deployers (Flux, ArgoCD, core Deployments) |
 | `trace` | Show GitOps ownership chain |
 | `scan` | Scan for misconfigurations |
 | `tree` | Hierarchical resource views |
@@ -170,7 +170,11 @@ Shows pods with:
 
 ## map workloads
 
-List workloads grouped by owner.
+List canonical workloads grouped by owner.
+
+Canonical workload scope (v1.0):
+- `Deployment`
+- `StatefulSet`
 
 ```bash
 cub-scout map workloads [flags]
@@ -186,14 +190,17 @@ cub-scout map workloads [flags]
 
 ## map deployers
 
-List deployers.
+List GitOps deployers.
 
 ```bash
 cub-scout map deployers [flags]
 ```
 
-> **v0.5 contract:** Deployers are Kubernetes Deployments. Flux Kustomizations,
-> HelmReleases, and Argo Applications are out of scope for v0.5.
+Canonical deployer scope (v1.0):
+- Flux `Kustomization`
+- Flux `HelmRelease`
+- Argo CD `Application`
+- Core Kubernetes `Deployment` (fallback where GitOps CRDs are absent)
 
 ---
 

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -124,6 +124,8 @@ Reference report:
 - Improved CLI help with popular commands and tips
 - New "Mental Model" documentation page
 - Better discoverability for maps, trees, and JSON output
+- Canonical workload scope is now explicit and aligned across map/tree/docs: `Deployment` + `StatefulSet`
+- `tree ownership` now includes StatefulSets (parity with workload views)
 
 ---
 


### PR DESCRIPTION
Summary: canonical workload scope for v1.0 is Deployment + StatefulSet; applied across map workloads/status/issues/sprawl/dashboard/bypass and tree ownership; added parity unit tests; updated reference docs and v1.0 release notes. Validation: GOCACHE=/Users/alexis/Public/github-repos/cub-scout/.cache/go-build go test ./cmd/cub-scout/... ; GOCACHE=/Users/alexis/Public/github-repos/cub-scout/.cache/go-build go test ./test/ascii/... -run TestMapStatus_|TestTreeOwnership_. Closes #129.