### PR TITLE
feat: add app-of-apps and applicationset lineage to ownership views

### DIFF
--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -1736,6 +1736,7 @@ func runMapWorkloads(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("create dynamic client: %w", err)
 	}
+	argoLineage := buildArgoLineageIndex(ctx, dynClient)
 
 	// Count by owner
 	ownerCounts := map[string]int{}
@@ -1762,6 +1763,14 @@ func runMapWorkloads(cmd *cobra.Command, args []string) error {
 		}
 
 		owner, managedBy := detectOwnership(workload)
+		if owner == "ArgoCD" {
+			if appName, _, lineage := resolveArgoOwnershipLineage(workload, argoLineage); appName != "" {
+				managedBy = appName
+				if lineage != "" {
+					managedBy = appName + " <- " + lineage
+				}
+			}
+		}
 		ownerCounts[owner]++
 		image := getContainerImage(workload)
 
@@ -2406,6 +2415,157 @@ func getArgoResourceCount(obj *unstructured.Unstructured) int {
 	return len(resources)
 }
 
+type argoOwnershipLineage struct {
+	ApplicationName      string
+	ApplicationNamespace string
+	ParentApplication    string
+	ParentApplicationSet string
+}
+
+type argoLineageIndex struct {
+	byAppName          map[string]argoOwnershipLineage
+	byNamespacedAppKey map[string]argoOwnershipLineage
+}
+
+func newArgoLineageIndex() *argoLineageIndex {
+	return &argoLineageIndex{
+		byAppName:          map[string]argoOwnershipLineage{},
+		byNamespacedAppKey: map[string]argoOwnershipLineage{},
+	}
+}
+
+func buildArgoLineageIndex(ctx context.Context, dynClient dynamic.Interface) *argoLineageIndex {
+	index := newArgoLineageIndex()
+
+	appGVR := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+	appList, err := dynClient.Resource(appGVR).List(ctx, v1.ListOptions{})
+	if err != nil {
+		return index
+	}
+
+	for _, app := range appList.Items {
+		lineage := argoOwnershipLineage{
+			ApplicationName:      app.GetName(),
+			ApplicationNamespace: app.GetNamespace(),
+		}
+
+		labels := app.GetLabels()
+		if labels != nil {
+			parentApp := strings.TrimSpace(labels["argocd.argoproj.io/instance"])
+			if parentApp != "" && parentApp != lineage.ApplicationName {
+				lineage.ParentApplication = parentApp
+			}
+		}
+		if lineage.ParentApplication == "" {
+			annotations := app.GetAnnotations()
+			if annotations != nil {
+				parentApp := parseArgoTrackingIDAppName(annotations["argocd.argoproj.io/tracking-id"])
+				if parentApp != "" && parentApp != lineage.ApplicationName {
+					lineage.ParentApplication = parentApp
+				}
+			}
+		}
+
+		for _, ownerRef := range app.GetOwnerReferences() {
+			if strings.EqualFold(ownerRef.Kind, "ApplicationSet") && ownerRef.Name != "" {
+				lineage.ParentApplicationSet = ownerRef.Name
+				break
+			}
+		}
+
+		index.add(lineage)
+	}
+
+	return index
+}
+
+func argoLineageDetailScore(lineage argoOwnershipLineage) int {
+	score := 0
+	if lineage.ParentApplicationSet != "" {
+		score += 2
+	}
+	if lineage.ParentApplication != "" {
+		score += 1
+	}
+	if lineage.ApplicationNamespace == "argocd" {
+		score += 1
+	}
+	return score
+}
+
+func (idx *argoLineageIndex) add(lineage argoOwnershipLineage) {
+	if lineage.ApplicationName == "" {
+		return
+	}
+
+	nsKey := lineage.ApplicationNamespace + "/" + lineage.ApplicationName
+	idx.byNamespacedAppKey[nsKey] = lineage
+
+	current, exists := idx.byAppName[lineage.ApplicationName]
+	if !exists || argoLineageDetailScore(lineage) > argoLineageDetailScore(current) {
+		idx.byAppName[lineage.ApplicationName] = lineage
+	}
+}
+
+func (idx *argoLineageIndex) lookupByAppName(appName string) (argoOwnershipLineage, bool) {
+	if idx == nil {
+		return argoOwnershipLineage{}, false
+	}
+	lineage, ok := idx.byAppName[appName]
+	return lineage, ok
+}
+
+func parseArgoTrackingIDAppName(trackingID string) string {
+	if trackingID == "" {
+		return ""
+	}
+	parts := strings.SplitN(trackingID, ":", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[0])
+}
+
+func argoApplicationNameFromResource(obj *unstructured.Unstructured) string {
+	labels := obj.GetLabels()
+	if labels != nil {
+		if appName := strings.TrimSpace(labels["argocd.argoproj.io/instance"]); appName != "" {
+			return appName
+		}
+	}
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		return parseArgoTrackingIDAppName(annotations["argocd.argoproj.io/tracking-id"])
+	}
+	return ""
+}
+
+func resolveArgoOwnershipLineage(obj *unstructured.Unstructured, index *argoLineageIndex) (appName, appNamespace, lineage string) {
+	appName = argoApplicationNameFromResource(obj)
+	if appName == "" {
+		return "", "", ""
+	}
+
+	if index == nil {
+		return appName, "", ""
+	}
+
+	appLineage, ok := index.lookupByAppName(appName)
+	if !ok {
+		return appName, "", ""
+	}
+
+	segments := []string{}
+	if appLineage.ParentApplicationSet != "" {
+		segments = append(segments, "applicationset/"+appLineage.ParentApplicationSet)
+	}
+	if appLineage.ParentApplication != "" {
+		segments = append(segments, "application/"+appLineage.ParentApplication)
+	}
+
+	return appName, appLineage.ApplicationNamespace, strings.Join(segments, " <- ")
+}
+
 func detectOwnership(obj *unstructured.Unstructured) (string, string) {
 	labels := obj.GetLabels()
 	if labels == nil {
@@ -2434,9 +2594,8 @@ func detectOwnership(obj *unstructured.Unstructured) (string, string) {
 	}
 	// ArgoCD tracking-id annotation (format: <app-name>:<group>/<kind>:<namespace>/<name>)
 	if tracking, ok := annotations["argocd.argoproj.io/tracking-id"]; ok {
-		parts := strings.SplitN(tracking, ":", 2)
-		if len(parts) > 0 && parts[0] != "" {
-			return "ArgoCD", parts[0]
+		if appName := parseArgoTrackingIDAppName(tracking); appName != "" {
+			return "ArgoCD", appName
 		}
 	}
 	// Helm

--- a/cmd/cub-scout/map_workload_scope_test.go
+++ b/cmd/cub-scout/map_workload_scope_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -188,4 +189,104 @@ func newWorkload(kind, name, namespace string, desired, ready int64) *unstructur
 			},
 		},
 	}
+}
+
+func TestResolveArgoOwnershipLineage_AppOfAppsParent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}: "ApplicationList",
+	}
+
+	childApp := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "payments-prod",
+				"namespace": "argocd",
+				"labels": map[string]interface{}{
+					"argocd.argoproj.io/instance": "root-app",
+				},
+			},
+		},
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, childApp)
+	index := buildArgoLineageIndex(context.Background(), client)
+
+	workload := &unstructured.Unstructured{}
+	workload.SetLabels(map[string]string{"argocd.argoproj.io/instance": "payments-prod"})
+
+	appName, appNamespace, lineage := resolveArgoOwnershipLineage(workload, index)
+	if appName != "payments-prod" {
+		t.Fatalf("expected app name payments-prod, got %q", appName)
+	}
+	if appNamespace != "argocd" {
+		t.Fatalf("expected app namespace argocd, got %q", appNamespace)
+	}
+	if lineage != "application/root-app" {
+		t.Fatalf("expected app-of-apps lineage, got %q", lineage)
+	}
+}
+
+func TestResolveArgoOwnershipLineage_ApplicationSetParent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}: "ApplicationList",
+	}
+
+	appFromSet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "checkout-prod",
+				"namespace": "argocd",
+			},
+		},
+	}
+	appFromSet.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: "argoproj.io/v1alpha1",
+			Kind:       "ApplicationSet",
+			Name:       "checkout-set",
+			Controller: boolPtr(true),
+		},
+	})
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, appFromSet)
+	index := buildArgoLineageIndex(context.Background(), client)
+
+	workload := &unstructured.Unstructured{}
+	workload.SetLabels(map[string]string{"argocd.argoproj.io/instance": "checkout-prod"})
+
+	appName, appNamespace, lineage := resolveArgoOwnershipLineage(workload, index)
+	if appName != "checkout-prod" {
+		t.Fatalf("expected app name checkout-prod, got %q", appName)
+	}
+	if appNamespace != "argocd" {
+		t.Fatalf("expected app namespace argocd, got %q", appNamespace)
+	}
+	if lineage != "applicationset/checkout-set" {
+		t.Fatalf("expected applicationset lineage, got %q", lineage)
+	}
+}
+
+func TestResolveArgoOwnershipLineage_NoIndexMatchFallsBackToApplicationName(t *testing.T) {
+	workload := &unstructured.Unstructured{}
+	workload.SetLabels(map[string]string{"argocd.argoproj.io/instance": "billing-prod"})
+
+	appName, appNamespace, lineage := resolveArgoOwnershipLineage(workload, newArgoLineageIndex())
+	if appName != "billing-prod" {
+		t.Fatalf("expected app name fallback, got %q", appName)
+	}
+	if appNamespace != "" {
+		t.Fatalf("expected empty namespace fallback, got %q", appNamespace)
+	}
+	if lineage != "" {
+		t.Fatalf("expected empty lineage fallback, got %q", lineage)
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }

--- a/cmd/cub-scout/tree.go
+++ b/cmd/cub-scout/tree.go
@@ -459,6 +459,7 @@ func runTreeOwnership(ctx context.Context) error {
 
 	// Get current context name for cluster field
 	clusterName := getCurrentContext()
+	argoLineage := buildArgoLineageIndex(ctx, dynClient)
 
 	// Convert to mapsvc.Entry for shared renderer
 	var entries []mapsvc.Entry
@@ -469,6 +470,15 @@ func runTreeOwnership(ctx context.Context) error {
 		}
 
 		owner, ownerName := detectOwnership(workload)
+		ownerNamespace := ""
+		lineage := ""
+		if owner == "ArgoCD" {
+			if appName, appNamespace, appLineage := resolveArgoOwnershipLineage(workload, argoLineage); appName != "" {
+				ownerName = appName
+				ownerNamespace = appNamespace
+				lineage = appLineage
+			}
+		}
 
 		// Build ownerDetails map from ownerName
 		var ownerDetails map[string]string
@@ -477,6 +487,12 @@ func runTreeOwnership(ctx context.Context) error {
 			kindPrefix := ownerKindPrefix(owner)
 			ownerDetails = map[string]string{
 				"name": kindPrefix + "/" + ownerName,
+			}
+			if ownerNamespace != "" {
+				ownerDetails["namespace"] = ownerNamespace
+			}
+			if lineage != "" {
+				ownerDetails["lineage"] = lineage
 			}
 		}
 
@@ -492,7 +508,7 @@ func runTreeOwnership(ctx context.Context) error {
 	// Build opts for shared renderer
 	opts := mapsvc.OwnershipTreeOpts{
 		ShowKind:     false,
-		ShowOwnerRef: false,
+		ShowOwnerRef: true,
 		FilterOwner:  treeOwner,
 		MaxDepth:     treeDepth,
 	}
@@ -532,7 +548,11 @@ func runTreeOwnership(ctx context.Context) error {
 				// Depth truncation indicator
 				fmt.Printf("  %s %s\n", line.Connector, line.Name)
 			} else {
-				fmt.Printf("  %s %s/%s\n", line.Connector, line.Namespace, line.Name)
+				fmt.Printf("  %s %s/%s", line.Connector, line.Namespace, line.Name)
+				if line.OwnerRef != "" {
+					fmt.Printf(" -> %s", line.OwnerRef)
+				}
+				fmt.Println()
 			}
 		}
 
@@ -557,7 +577,11 @@ func runTreeOwnership(ctx context.Context) error {
 				// Depth truncation indicator
 				fmt.Printf("  %s %s%s%s\n", line.Connector, colorDim, line.Name, colorReset)
 			} else {
-				fmt.Printf("  %s %s/%s\n", line.Connector, line.Namespace, line.Name)
+				fmt.Printf("  %s %s/%s", line.Connector, line.Namespace, line.Name)
+				if line.OwnerRef != "" {
+					fmt.Printf(" %s-> %s%s", colorDim, line.OwnerRef, colorReset)
+				}
+				fmt.Println()
 			}
 		}
 	}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -176,6 +176,12 @@ Canonical workload scope (v1.0):
 - `Deployment`
 - `StatefulSet`
 
+Argo lineage semantics:
+- `MANAGED-BY` shows the owning Application.
+- If lineage is detected, it is appended as:
+  `application-name <- applicationset/<name>` or
+  `application-name <- applicationset/<name> <- application/<parent>`
+
 ```bash
 cub-scout map workloads [flags]
 ```
@@ -330,7 +336,7 @@ cub-scout tree [view] [flags]
 | View | Description |
 |------|-------------|
 | `runtime` | Deployment → ReplicaSet → Pod (default) |
-| `ownership` | Resources by GitOps owner |
+| `ownership` | Resources by GitOps owner (+ ownerRef lineage) |
 | `git` | Git source structure |
 | `patterns` | Detected GitOps patterns |
 | `config` | ConfigHub relationships |
@@ -353,6 +359,9 @@ cub-scout tree suggest          # Suggested ConfigHub structure
 cub-scout tree ownership --format json   # JSON output
 cub-scout tree runtime --format md       # Markdown output
 ```
+
+`tree ownership` includes owner references for managed resources.
+For ArgoCD resources, this includes optional lineage to parent `Application` and/or `ApplicationSet` when discoverable.
 
 ---
 

--- a/docs/reference/views.md
+++ b/docs/reference/views.md
@@ -62,6 +62,7 @@ Complete reference for all interactive TUI views.
 - Resources organized under owner sections
 - Status indicators (✓ healthy, ⚠ warning, ✗ error)
 - Namespace and name
+- For ArgoCD workloads, `MANAGED-BY` may include lineage to parent `ApplicationSet` or parent `Application` when detected
 
 **Layout:**
 ```

--- a/internal/mapsvc/jsonout.go
+++ b/internal/mapsvc/jsonout.go
@@ -7,6 +7,8 @@
 // See docs/v0.14-json-schema.md for the full specification.
 package mapsvc
 
+import "strings"
+
 // ResourceID is the canonical identity for cross-schema joins.
 type ResourceID struct {
 	Kind      string `json:"kind"`
@@ -23,18 +25,18 @@ type DisplayMeta struct {
 
 // OwnershipTreeOutput is the v0.14 JSON schema for `tree ownership`.
 type OwnershipTreeOutput struct {
-	Command string                 `json:"command"`
-	Subtype string                 `json:"subtype"`
-	Context OwnershipTreeContext   `json:"context"`
-	Groups  []OwnershipTreeGroup   `json:"groups"`
-	Summary OwnershipTreeSummary   `json:"summary"`
+	Command string               `json:"command"`
+	Subtype string               `json:"subtype"`
+	Context OwnershipTreeContext `json:"context"`
+	Groups  []OwnershipTreeGroup `json:"groups"`
+	Summary OwnershipTreeSummary `json:"summary"`
 }
 
 // OwnershipTreeContext captures query parameters.
 type OwnershipTreeContext struct {
-	Cluster   string                    `json:"cluster"`
-	Namespace *string                   `json:"namespace"` // null = all namespaces
-	Filters   OwnershipTreeFilters      `json:"filters"`
+	Cluster   string               `json:"cluster"`
+	Namespace *string              `json:"namespace"` // null = all namespaces
+	Filters   OwnershipTreeFilters `json:"filters"`
 }
 
 // OwnershipTreeFilters captures active filters.
@@ -45,15 +47,16 @@ type OwnershipTreeFilters struct {
 
 // OwnershipTreeGroup represents resources under one owner.
 type OwnershipTreeGroup struct {
-	Owner       string                   `json:"owner"`
-	DisplayMeta DisplayMeta              `json:"displayMeta"`
-	Items       []OwnershipTreeItem      `json:"items"`
+	Owner       string              `json:"owner"`
+	DisplayMeta DisplayMeta         `json:"displayMeta"`
+	Items       []OwnershipTreeItem `json:"items"`
 }
 
 // OwnershipTreeItem represents a single resource in the tree.
 type OwnershipTreeItem struct {
-	ID       ResourceID  `json:"id"`
-	OwnerRef *ResourceID `json:"ownerRef"` // null for Native
+	ID       ResourceID   `json:"id"`
+	OwnerRef *ResourceID  `json:"ownerRef"` // null for Native
+	Lineage  []ResourceID `json:"lineage,omitempty"`
 }
 
 // OwnershipTreeSummary provides aggregate counts.
@@ -111,10 +114,14 @@ func BuildOwnershipTreeJSON(entries []Entry, opts OwnershipTreeOpts, cluster str
 				},
 			}
 
-			// Parse ownerRef from OwnerDetails if available
-			if e.OwnerDetails != nil && e.OwnerDetails["name"] != "" {
+			if e.OwnerDetails != nil {
 				// OwnerDetails["name"] is like "kustomization/web-apps" or "release/redis"
-				item.OwnerRef = parseOwnerRef(e.OwnerDetails, e.Namespace)
+				if e.OwnerDetails["name"] != "" {
+					item.OwnerRef = parseOwnerRef(e.OwnerDetails, e.Namespace)
+				}
+				if lineage := parseLineageRefs(e.OwnerDetails, e.Namespace); len(lineage) > 0 {
+					item.Lineage = lineage
+				}
 			}
 
 			items[i] = item
@@ -256,6 +263,38 @@ func parseOwnerRef(details map[string]string, defaultNamespace string) *Resource
 	}
 }
 
+func parseLineageRefs(details map[string]string, defaultNamespace string) []ResourceID {
+	if details == nil {
+		return nil
+	}
+	lineage := strings.TrimSpace(details["lineage"])
+	if lineage == "" {
+		return nil
+	}
+
+	segments := strings.Split(lineage, "<-")
+	refs := make([]ResourceID, 0, len(segments))
+	for _, segment := range segments {
+		name := strings.TrimSpace(segment)
+		if name == "" {
+			continue
+		}
+
+		ref := parseOwnerRef(map[string]string{
+			"name":      name,
+			"namespace": details["namespace"],
+		}, defaultNamespace)
+		if ref != nil {
+			refs = append(refs, *ref)
+		}
+	}
+
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
 // splitOwnerRef splits "kind/name" into parts.
 func splitOwnerRef(ref string) []string {
 	idx := -1
@@ -280,6 +319,8 @@ func normalizeKind(kind string) string {
 		return "HelmRelease"
 	case "application", "Application":
 		return "Application"
+	case "applicationset", "ApplicationSet":
+		return "ApplicationSet"
 	case "release", "Release":
 		return "HelmRelease" // Helm release
 	default:
@@ -419,10 +460,10 @@ func RelationshipForRole(role string) string {
 // MapListOutput is the v0.14 JSON schema for `map list --format json`.
 // It's a flat, joinable inventory of resources with ownership attribution.
 type MapListOutput struct {
-	Command   string              `json:"command"`
-	Context   MapListContext      `json:"context"`
-	Resources []MapListResource   `json:"resources"`
-	Summary   MapListSummary      `json:"summary"`
+	Command   string            `json:"command"`
+	Context   MapListContext    `json:"context"`
+	Resources []MapListResource `json:"resources"`
+	Summary   MapListSummary    `json:"summary"`
 }
 
 // MapListContext captures query parameters for the map list.

--- a/internal/mapsvc/jsonout_test.go
+++ b/internal/mapsvc/jsonout_test.go
@@ -213,6 +213,45 @@ func TestBuildOwnershipTreeJSON_SortByNamespaceKindName(t *testing.T) {
 	}
 }
 
+func TestBuildOwnershipTreeJSON_ArgoLineage(t *testing.T) {
+	entries := []Entry{
+		{
+			Kind:      "Deployment",
+			Namespace: "payments",
+			Name:      "payments-api",
+			Owner:     "ArgoCD",
+			OwnerDetails: map[string]string{
+				"name":      "application/payments-prod",
+				"namespace": "argocd",
+				"lineage":   "applicationset/payments-set <- application/root-app",
+			},
+		},
+	}
+
+	output := BuildOwnershipTreeJSON(entries, OwnershipTreeOpts{}, "test-cluster", nil)
+
+	if len(output.Groups) != 1 || len(output.Groups[0].Items) != 1 {
+		t.Fatalf("expected one group/item, got groups=%d", len(output.Groups))
+	}
+	item := output.Groups[0].Items[0]
+
+	if item.OwnerRef == nil {
+		t.Fatalf("expected ownerRef for Argo item")
+	}
+	if item.OwnerRef.Kind != "Application" || item.OwnerRef.Name != "payments-prod" || item.OwnerRef.Namespace != "argocd" {
+		t.Fatalf("unexpected ownerRef: %#v", item.OwnerRef)
+	}
+	if len(item.Lineage) != 2 {
+		t.Fatalf("expected two lineage refs, got %d (%#v)", len(item.Lineage), item.Lineage)
+	}
+	if item.Lineage[0].Kind != "ApplicationSet" || item.Lineage[0].Name != "payments-set" {
+		t.Fatalf("unexpected first lineage ref: %#v", item.Lineage[0])
+	}
+	if item.Lineage[1].Kind != "Application" || item.Lineage[1].Name != "root-app" {
+		t.Fatalf("unexpected second lineage ref: %#v", item.Lineage[1])
+	}
+}
+
 // =============================================================================
 // Trace Schema Tests
 // =============================================================================

--- a/internal/mapsvc/render.go
+++ b/internal/mapsvc/render.go
@@ -136,6 +136,9 @@ func BuildOwnershipTreeLines(entries []Entry, opts OwnershipTreeOpts) []Ownershi
 			}
 			if opts.ShowOwnerRef && e.OwnerDetails != nil && e.OwnerDetails["name"] != "" {
 				line.OwnerRef = e.OwnerDetails["name"]
+				if lineage := strings.TrimSpace(e.OwnerDetails["lineage"]); lineage != "" {
+					line.OwnerRef += " <- " + lineage
+				}
 			}
 
 			lines = append(lines, line)

--- a/internal/mapsvc/render_test.go
+++ b/internal/mapsvc/render_test.go
@@ -123,3 +123,28 @@ func TestFormatOwnershipTree_FilterOwnerAndDepth(t *testing.T) {
 		t.Error("should not contain ArgoCD when filtering by Flux")
 	}
 }
+
+func TestFormatOwnershipTree_ShowOwnerRefWithLineage(t *testing.T) {
+	entries := []Entry{
+		{
+			Name:      "payments-api",
+			Namespace: "payments",
+			Kind:      "Deployment",
+			Owner:     "ArgoCD",
+			OwnerDetails: map[string]string{
+				"name":    "application/payments-prod",
+				"lineage": "applicationset/payments-set <- application/root-app",
+			},
+		},
+	}
+
+	opts := OwnershipTreeOpts{ShowOwnerRef: true}
+	got := FormatOwnershipTree(entries, opts)
+
+	if !strings.Contains(got, "payments/payments-api") {
+		t.Fatalf("expected workload path in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "application/payments-prod <- applicationset/payments-set <- application/root-app") {
+		t.Fatalf("expected owner ref lineage in output, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
Summary: add Argo lineage detection for workloads managed by ArgoCD Applications; resolve and surface parent Application and ApplicationSet ancestry in ownership views. Behavior: map workloads now enriches MANAGED-BY for Argo workloads with lineage when detectable; tree ownership now shows owner refs and lineage in ascii/md and JSON (new optional lineage field per item). Tests: add unit coverage for App-of-Apps and ApplicationSet lineage resolution and mapsvc render/json lineage behavior. Validation: GOCACHE=/Users/alexis/Public/github-repos/cub-scout/.cache/go-build go test ./cmd/cub-scout/... ; GOCACHE=/Users/alexis/Public/github-repos/cub-scout/.cache/go-build go test ./internal/mapsvc/... ; GOCACHE=/Users/alexis/Public/github-repos/cub-scout/.cache/go-build go test ./test/ascii/... -run TestMapStatus_|TestTreeOwnership_. Closes #128.