### PR TITLE
docs: normalize archive import docs to canonical current docs (#133)

### DIFF
--- a/docs/archive/IMPORT-FROM-LIVE.md
+++ b/docs/archive/IMPORT-FROM-LIVE.md
@@ -1,6 +1,15 @@
 # Import from LIVE: How Detection Works Without Git
 
-**Technical explainer** — How we detect ownership, variant, and structure from the cluster without parsing Git repos.
+**Archive status:** Historical reference only (not canonical for current releases).
+
+Use these maintained docs first:
+
+- [How To: Import Workloads to ConfigHub](../howto/import-to-confighub.md)
+- [Pipeline Source Resolution](../reference/pipeline-source-resolution.md)
+- [GitOps Patterns Reference](../reference/gitops-patterns.md)
+- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md)
+
+**Technical explainer** - How we detect ownership, variant, and structure from the cluster without parsing Git repos.
 
 ---
 

--- a/docs/archive/IMPORT-FROM-SOURCES.md
+++ b/docs/archive/IMPORT-FROM-SOURCES.md
@@ -1,6 +1,15 @@
 # Import Architecture: TUI vs GUI
 
-**Architecture** — What the TUI handles (single cluster, LIVE data) vs what the GUI handles (fleet, Git integration).
+**Archive status:** Historical reference only (not canonical for current releases).
+
+Use these maintained docs first:
+
+- [How To: Import Workloads to ConfigHub](../howto/import-to-confighub.md)
+- [GitOps Patterns Reference](../reference/gitops-patterns.md)
+- [Roadmap 1.x Connected/Upsell](../roadmap-1x-connected-upsell.md)
+- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md)
+
+**Architecture** - What the TUI handles (single cluster, LIVE data) vs what the GUI handles (fleet, Git integration).
 
 ---
 

--- a/docs/archive/IMPORT-GIT-REFERENCE-ARCHITECTURES.md
+++ b/docs/archive/IMPORT-GIT-REFERENCE-ARCHITECTURES.md
@@ -1,8 +1,17 @@
 # Import Patterns: GitOps Architectures → ConfigHub
 
-**Pattern reference** — How App-of-Apps, ApplicationSet, Flux Tenancy, and Mono-repo patterns map to Hub → App Space → Unit.
+**Archive status:** Historical reference only (not canonical for current releases).
 
-**Prerequisites:** Read [IMPORT-FROM-SOURCES.md](IMPORT-FROM-SOURCES.md) for LIVE vs GIT capabilities, and [02-HUB-APPSPACE-MODEL.md](planning/map/02-HUB-APPSPACE-MODEL.md) for the model.
+Use these maintained docs first:
+
+- [GitOps Patterns Reference](../reference/gitops-patterns.md)
+- [View Hierarchies with tree](../howto/tree-hierarchies.md)
+- [Pipeline Source Resolution](../reference/pipeline-source-resolution.md)
+- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md)
+
+**Pattern reference** - How App-of-Apps, ApplicationSet, Flux Tenancy, and Mono-repo patterns map to Hub -> App Space -> Unit.
+
+**Historical prerequisites:** Read [IMPORT-FROM-SOURCES.md](IMPORT-FROM-SOURCES.md) for LIVE vs GIT capabilities.
 
 ---
 

--- a/docs/archive/IMPORTING-WORKLOADS.md
+++ b/docs/archive/IMPORTING-WORKLOADS.md
@@ -1,6 +1,15 @@
 # Importing Workloads into ConfigHub
 
-**Status: Working** — Import your cluster workloads into ConfigHub in 30 seconds.
+**Archive status:** Historical reference only (not canonical for current releases).
+
+Use these maintained docs first:
+
+- [How To: Import Workloads to ConfigHub](../howto/import-to-confighub.md)
+- [Commands Reference](../reference/commands.md)
+- [Trace Context Troubleshooting](../howto/trace-context-troubleshooting.md)
+- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md)
+
+**Historical status:** Working snapshot from pre-1.0 iteration.
 
 ---
 

--- a/docs/archive/JOURNEY-IMPORT.md
+++ b/docs/archive/JOURNEY-IMPORT.md
@@ -1,5 +1,13 @@
 # Journey: Import Workloads
 
+**Archive status:** Historical reference only (not canonical for current releases).
+
+Use these maintained docs first:
+
+- [How To: Import Workloads to ConfigHub](../howto/import-to-confighub.md)
+- [Trace Context Troubleshooting](../howto/trace-context-troubleshooting.md)
+- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md)
+
 **Time:** 5-10 minutes
 **Goal:** Import your cluster workloads into ConfigHub as Units
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -52,6 +52,11 @@ The content has been consolidated into CLI-GUIDE.md and the docs/ directory.
 - `IMPORT-FROM-SOURCES.md` - Import architecture
 - `IMPORT-GIT-REFERENCE-ARCHITECTURES.md` - GitOps import patterns
 - `IMPORTING-WORKLOADS.md` - Workload import guide
+- `JOURNEY-IMPORT.md` - Historical journey walkthrough
+
+Canonical import docs:
+- [`docs/howto/import-to-confighub.md`](../howto/import-to-confighub.md)
+- [`docs/reference/import-docs-crosswalk.md`](../reference/import-docs-crosswalk.md)
 
 **Case Studies:**
 - `EXAMPLES-TUI-MAP-FLEET-IITS-STUDIES.md` - Enterprise case studies

--- a/docs/howto/import-to-confighub.md
+++ b/docs/howto/import-to-confighub.md
@@ -242,3 +242,4 @@ cub-scout import
 
 - [Business Outcomes](../../outcomes/README.md) - Why ConfigHub import matters
 - [ConfigHub Documentation](https://docs.confighub.com) - Full ConfigHub guide
+- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md) - Archived import docs mapped to current docs

--- a/docs/reference/import-docs-crosswalk.md
+++ b/docs/reference/import-docs-crosswalk.md
@@ -1,0 +1,31 @@
+# Import Docs Crosswalk
+
+This page maps archived import docs to the current canonical docs.
+
+Use this page when you find an old import doc in `docs/archive/` and want the maintained equivalent.
+
+## Canonical Docs (Current)
+
+- [How To: Import Workloads to ConfigHub](../howto/import-to-confighub.md)
+- [Pipeline Source Resolution](pipeline-source-resolution.md)
+- [GitOps Patterns Reference](gitops-patterns.md)
+- [View Hierarchies with tree](../howto/tree-hierarchies.md)
+- [Trace Context Troubleshooting](../howto/trace-context-troubleshooting.md)
+- [Commands Reference](commands.md)
+- [Roadmap](../roadmap.md)
+
+## Archive-to-Current Mapping
+
+| Archived doc | Use this now | Notes |
+|---|---|---|
+| `docs/archive/IMPORTING-WORKLOADS.md` | `docs/howto/import-to-confighub.md`, `docs/reference/commands.md` | Old wizard/flags examples are historical. Validate against current command docs. |
+| `docs/archive/JOURNEY-IMPORT.md` | `docs/howto/import-to-confighub.md`, `docs/howto/trace-context-troubleshooting.md` | Journey narrative kept for background only. |
+| `docs/archive/IMPORT-FROM-LIVE.md` | `docs/reference/pipeline-source-resolution.md`, `docs/reference/gitops-patterns.md` | LIVE-only inference guidance is historical framing, not contract text. |
+| `docs/archive/IMPORT-FROM-SOURCES.md` | `docs/reference/gitops-patterns.md`, `docs/roadmap-1x-connected-upsell.md` | TUI vs GUI split remains directional; connected details evolve in 1.x. |
+| `docs/archive/IMPORT-GIT-REFERENCE-ARCHITECTURES.md` | `docs/reference/gitops-patterns.md`, `docs/howto/tree-hierarchies.md` | Architecture examples are reference patterns, not strict runtime guarantees. |
+
+## Scope Notes
+
+- Archive docs are preserved for context and examples.
+- Canonical behavior for current releases is defined by docs outside `docs/archive/`.
+- For future connected features (for example ApplicationSet generator visualization), treat archive docs as provisional and track current roadmap/issues.


### PR DESCRIPTION
## Summary
- add a canonical import-doc crosswalk in current docs
- add archive-status banners to all import archive docs
- point archive import docs to maintained howto/reference pages
- add canonical import pointers in archive index and current import howto

## Files
- docs/reference/import-docs-crosswalk.md (new)
- docs/archive/IMPORT-FROM-LIVE.md
- docs/archive/IMPORT-FROM-SOURCES.md
- docs/archive/IMPORT-GIT-REFERENCE-ARCHITECTURES.md
- docs/archive/IMPORTING-WORKLOADS.md
- docs/archive/JOURNEY-IMPORT.md
- docs/archive/README.md
- docs/howto/import-to-confighub.md

## Why
Issue #133 calls for normalizing archived import docs so users land on canonical, maintained docs first, while preserving historical content for context.

## Testing
- docs-only change
- manual link/path review completed