### PR TITLE
Attribute D2 pattern to Control Plane (controlplane.io)

### DIFF
--- a/docs/sessions/2025-02-14-examples-quality-audit.md
+++ b/docs/sessions/2025-02-14-examples-quality-audit.md
@@ -77,7 +77,7 @@ Every example directory now follows the pattern:
 | `apptique-examples/flux-monorepo/README.md` | Kustomization chain, offline parse-repo |
 | `drift/README.md` | Parent file tying 3 drift examples together |
 | `workflows/README.md` | Artifact workflow + fleet demo coverage |
-| `d2-control-plane/README.md` | D2 "Control Plane" Flux reference architecture |
+| `d2-control-plane/README.md` | Control Plane (controlplaneio-fluxcd) Flux reference architecture |
 | `d2-control-plane/control-plane.yaml` | Full YAML fixture with Flux labels |
 
 ### 6. Issues Filed

--- a/examples/README.md
+++ b/examples/README.md
@@ -112,7 +112,7 @@ Expected output for each example is in `test/fixtures/expected-output/examples/`
 | [workflows/](workflows/) | **Working** | Artifact + fleet demos (CI → local, env comparison) | CI/CD integration, sharing bundles, comparing environments |
 | [apptique-examples/](apptique-examples/) | **Working** | Real GitOps patterns (Flux, Argo) | Learning GitOps ownership |
 | [platform-example/](platform-example/) | **Working** | Full Flux learning environment (~35 resources) | Learning GitOps + orphan detection |
-| [d2-control-plane/](d2-control-plane/) | **Working** | Flux "Control Plane" pattern (infra + apps) | D2 pattern detection, layer separation |
+| [d2-control-plane/](d2-control-plane/) | **Working** | [Control Plane](https://controlplane.io) Flux ref arch (infra + apps) | Pattern detection, layer separation |
 | [flux-boutique/](flux-boutique/) | **Working** | 5-service Flux demo | TUI view showcase, trace demo |
 | [orphans/](orphans/) | **Working** | Realistic orphan resources | Orphan detection demo |
 | [drift/](drift/) | **Working** | Drift detection examples | Learning drift detection |

--- a/examples/d2-control-plane/README.md
+++ b/examples/d2-control-plane/README.md
@@ -1,10 +1,15 @@
-# D2 Control Plane Pattern
+# Control Plane — Flux Reference Architecture
+
+> **[Control Plane](https://controlplane.io)** (controlplaneio-fluxcd) maintains the
+> production-grade Flux reference architectures. cub-scout uses the shorthand **D2** for
+> their split-repo pattern internally.
 
 ## The Problem
 
-You've adopted the Flux reference architecture: `clusters/`, `infrastructure/`, and `apps/`
-in separate directories (or repos). Your cluster has platform components (cert-manager, monitoring)
-managed by the platform team, and tenant apps (payment-api, frontend) managed by dev teams.
+You've adopted the Control Plane Flux reference architecture: `clusters/`, `infrastructure/`,
+and `apps/` in separate directories (or repos). Your cluster has platform components
+(cert-manager, monitoring) managed by the platform team, and tenant apps (payment-api,
+frontend) managed by dev teams.
 
 During an incident you need to answer: *"Is the problem in infrastructure or in an app?
 Who owns the broken resource?"*
@@ -42,8 +47,8 @@ $ ./cub-scout tree ownership
 
 ## Architecture
 
-The D2 pattern (named after the Flux CD "Control Plane" reference architecture) separates
-concerns into three layers:
+The [Control Plane reference architecture](https://github.com/controlplaneio-fluxcd)
+separates concerns into three layers:
 
 ```
 platform-config/
@@ -87,7 +92,7 @@ platform-config/
 
 | What you'll see | Why it matters |
 |-----------------|----------------|
-| Pattern auto-detection ("D2-style") | cub-scout recognizes the Flux reference architecture |
+| Pattern auto-detection ("Control Plane / D2-style") | cub-scout recognizes the Control Plane Flux reference architecture |
 | Infrastructure vs app separation in ownership tree | Answers "is it platform or app?" instantly |
 | Flux Kustomization chains | GitRepository → Kustomization → HelmRelease → Deployment |
 | Mixed deployer types (Kustomization + HelmRelease) | Real clusters use both |
@@ -129,17 +134,18 @@ flux get kustomizations --watch
 
 ## Pattern Variants
 
-The D2 pattern has several real-world variants:
+The Control Plane architecture has several real-world variants:
 
 | Variant | Description | Example |
 |---------|-------------|---------|
-| **Single-repo D2** | All layers in one repo | This example |
-| **Multi-repo D2** (Fluxy) | fleet-repo + infra-repo + apps-repo | See [Multi-Repo Fleet](../rm-demos-argocd/repo-patterns/multi-repo/) |
-| **D2 + OCI** | Git → CI → OCI artifact → Flux | Enterprise pattern |
+| **Single-repo** | All layers in one repo | This example |
+| **Split-repo** (D2 split) | fleet-repo + infra-repo + apps-repo | See [Multi-Repo Fleet](../rm-demos-argocd/repo-patterns/multi-repo/) |
+| **Control Plane + OCI** | Git → CI → OCI artifact → Flux | Enterprise pattern |
 
 ## See Also
 
-- [Platform Example](../platform-example/) — Full D2 learning environment with orphans
+- [controlplaneio-fluxcd](https://github.com/controlplaneio-fluxcd) — Control Plane's Flux reference architectures
+- [Platform Example](../platform-example/) — Full Control Plane learning environment with orphans
 - [Flux Boutique](../flux-boutique/) — Simpler Flux-only example
 - [Flux Monorepo](../apptique-examples/flux-monorepo/) — Monorepo variant with overlays
 - [GitOps Repo Structures](../../docs/reference/gitops-repo-structures.md) — All patterns documented

--- a/examples/d2-control-plane/control-plane.yaml
+++ b/examples/d2-control-plane/control-plane.yaml
@@ -1,6 +1,10 @@
-# D2 "Control Plane" Pattern — Flux Reference Architecture
+# Control Plane — Flux Reference Architecture
 #
-# This fixture represents the standard Flux CD reference architecture:
+# Based on the reference architectures maintained by Control Plane
+# (https://github.com/controlplaneio-fluxcd). cub-scout uses "D2" as
+# an internal shorthand for this pattern family.
+#
+# This fixture represents the standard structure:
 # - clusters/ directory for per-cluster bootstrap
 # - infrastructure/ for platform components (cert-manager, monitoring)
 # - apps/ for tenant applications (payment-api, frontend)


### PR DESCRIPTION
## Summary

- Credit Control Plane (controlplaneio-fluxcd) as the maintainers of the Flux reference architectures
- Clarify "D2" is cub-scout's internal shorthand, not the pattern's real name
- Link to https://controlplane.io and https://github.com/controlplaneio-fluxcd

🤖 Generated with [Claude Code](https://claude.com/claude-code)