### PR TITLE
Add tree diagrams to drift, orphans, crossplane, lifecycle-hazards

### DIFF
--- a/examples/crossplane-system/README.md
+++ b/examples/crossplane-system/README.md
@@ -39,6 +39,42 @@ No false orphans. No noise.
 | Configuration | `platform-config` | Crossplane (system) |
 | CompositeResourceDefinition | `xpostgresqlinstances.database.example.org` | Crossplane (system) |
 
+## How cub-scout Sees It
+
+```
+./cub-scout tree ownership
+
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
+
+Flux (28 resources)
+────────────────────────────────────────────────────────────────────
+  ├── boutique/cart              Deployment   ✓ 2/2
+  └── ... (27 more)
+
+Crossplane (4 resources)
+────────────────────────────────────────────────────────────────────
+  Managed by: pkg.crossplane.io/* and apiextensions.crossplane.io/* API groups
+
+  ├── crossplane-system/provider-aws               Provider          ✓ Healthy
+  ├── crossplane-system/provider-aws-1234abcd       ProviderRevision  ✓ Active
+  ├── crossplane-system/platform-config             Configuration     ✓ Healthy
+  └── crossplane-system/xpostgresqlinstances.db.x   XRD               ✓ Offered
+
+Native (0 resources)
+────────────────────────────────────────────────────────────────────
+  No orphans detected ✓
+
+════════════════════════════════════════════════════════════════════
+Ownership Distribution:
+
+  Flux         ████████████████████████████████████░░░░  88%
+  Crossplane   █████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  12%
+  Native       ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0%
+
+→ Without Crossplane detection, those 4 would show as orphans
+```
+
 ## How Detection Works
 
 cub-scout detects Crossplane ownership via:

--- a/examples/drift/README.md
+++ b/examples/drift/README.md
@@ -20,6 +20,31 @@ requests.cpu:      ──→  ✗   requests.cpu:          CRITICAL: invalid con
   100m                        500m (> limits!)
 ```
 
+## How cub-scout Sees Drift
+
+```
+DRIFT REPORT
+════════════════════════════════════════════════════════════════════
+
+Flux (3 drifted resources)
+────────────────────────────────────────────────────────────────────
+  ├── Deployment:prod/api         [Config]    WARNING
+  │   └── env LOG_LEVEL: info → debug
+  ├── Deployment:prod/worker      [Rollout]   WARNING
+  │   └── imagePullPolicy: Always → IfNotPresent
+  └── Deployment:prod/web         [Capacity]  CRITICAL
+      └── requests.cpu: 100m → 500m  ⚠ exceeds limits (200m)
+
+════════════════════════════════════════════════════════════════════
+Summary: 3 findings │ 2 warning │ 1 critical │ 3 affected objects
+
+  Config     █████████████░░░░░░░░░░░░░░░░░░  33%
+  Rollout    █████████████░░░░░░░░░░░░░░░░░░  33%
+  Capacity   █████████████░░░░░░░░░░░░░░░░░░  33%  ← includes invalid state
+
+→ Fix critical first: cub-scout drift --file desired.yaml --fail-on critical
+```
+
 ## Examples
 
 | Example | Drift Type | Severity | Why It Matters |

--- a/examples/drift/env-var-drift/README.md
+++ b/examples/drift/env-var-drift/README.md
@@ -38,6 +38,23 @@ PORT: 8080         ──→  ✓  PORT: 8080         ← matches
 cub-scout compares the desired manifest against what's actually running.
 Any mismatch is a drift finding with a severity and classification.
 
+## Ownership Context
+
+```
+./cub-scout trace deploy/api -n prod
+
+TRACE: Deployment:prod/api
+════════════════════════════════════════════════════════════════════
+  GitRepository/platform-config (flux-system)
+  └── Kustomization/apps (flux-system)
+      └── Deployment/api (prod)               ← Owner: Flux
+          ├── env LOG_LEVEL: info (Git)
+          │                  debug (Live)      ← DRIFT
+          └── env PORT: 8080 (Git = Live)      ✓ OK
+```
+
+The drift is in a Flux-managed resource — someone bypassed GitOps with `kubectl set env`.
+
 ## Desired State
 
 ```yaml

--- a/examples/drift/image-policy-drift/README.md
+++ b/examples/drift/image-policy-drift/README.md
@@ -46,6 +46,27 @@ image: myworker:latest    ──→  ✓  image: myworker:latest         ← mat
 
 Drifting from `Always` → `IfNotPresent` means your pods silently stop getting updates.
 
+## Ownership Context
+
+```
+./cub-scout trace deploy/worker -n prod
+
+TRACE: Deployment:prod/worker
+════════════════════════════════════════════════════════════════════
+  GitRepository/platform-config (flux-system)
+  └── Kustomization/apps (flux-system)
+      └── Deployment/worker (prod)                     ← Owner: Flux
+          ├── imagePullPolicy: Always (Git)
+          │                    IfNotPresent (Live)      ← DRIFT
+          └── image: myworker:latest (Git = Live)       ✓ OK
+
+  Impact:
+  ├── Pod worker-8f7d6c-abc12  Running  image cached 21d ago
+  ├── Pod worker-8f7d6c-def34  Running  image cached 21d ago
+  └── Pod worker-8f7d6c-ghi56  Running  image cached 21d ago
+      └── ⚠ All 3 pods using stale image (3 weeks old)
+```
+
 ## Desired State
 
 ```yaml

--- a/examples/drift/resource-drift/README.md
+++ b/examples/drift/resource-drift/README.md
@@ -52,6 +52,31 @@ limits.memory:   512Mi ──→  ✓  limits.memory:   512Mi← matches
 When `limits < requests`, Kubernetes rejects the pod spec. Existing pods keep running,
 but any scale-up, rollout, or node migration will fail.
 
+## Ownership Context
+
+```
+./cub-scout trace deploy/web -n prod
+
+TRACE: Deployment:prod/web
+════════════════════════════════════════════════════════════════════
+  GitRepository/platform-config (flux-system)
+  └── Kustomization/apps (flux-system)
+      └── Deployment/web (prod)                    ← Owner: Flux
+          ├── resources.requests.cpu:  100m (Git)
+          │                            500m (Live)  ← CRITICAL DRIFT
+          ├── resources.limits.cpu:    200m (Git = Live)  ✓ OK
+          ├── resources.requests.memory: 256Mi      ✓ OK
+          └── resources.limits.memory:   512Mi      ✓ OK
+
+  ⚠ INVALID STATE: requests.cpu (500m) > limits.cpu (200m)
+  ┌──────────────────────────────────────────────────────┐
+  │  Current pods: running (created before the edit)     │
+  │  Next restart: FAIL — Insufficient cpu               │
+  │  Next scale-up: FAIL — pod spec rejected             │
+  │  Next rollout: FAIL — new ReplicaSet blocked         │
+  └──────────────────────────────────────────────────────┘
+```
+
 ## Desired State
 
 ```yaml

--- a/examples/lifecycle-hazards/README.md
+++ b/examples/lifecycle-hazards/README.md
@@ -1,6 +1,53 @@
 # Lifecycle Hazards Example
 
-This example demonstrates GitOps lifecycle hazards when migrating Helm charts to ArgoCD.
+## The Problem
+
+You're migrating a Helm chart to ArgoCD. The chart has `post-install` and `post-upgrade`
+hooks — but ArgoCD doesn't distinguish between install and upgrade. Every sync is an "upgrade."
+
+Your `db-migrate` Job runs on `post-install,post-upgrade`. Under Helm, it ran once on install
+and once per upgrade. Under ArgoCD, it runs on **every single sync** — including manual
+retries and auto-sync.
+
+**cub-scout detects these hazards:**
+
+```
+./cub-scout scan --file helm-hooks.yaml --lifecycle-hazards
+
+LIFECYCLE HAZARD SCAN
+════════════════════════════════════════════════════════════════════
+
+┌─────────────────────────────────────────────────────────────────┐
+│  Helm Chart Migration → ArgoCD                                   │
+│                                                                   │
+│  helm.sh/hook annotation         ArgoCD Phase    Hazard?         │
+│  ─────────────────────           ────────────    ───────         │
+│  pre-install            ──→      PreSync         ⚠ ambiguous    │
+│  pre-upgrade            ──→      PreSync         ⚠ ambiguous    │
+│  post-install           ──→      PostSync        ⚠ ambiguous    │
+│  post-upgrade           ──→      PostSync        ⚠ ambiguous    │
+│  test                   ──→      PostSync        ⚠ runs on sync │
+│  argocd.argoproj.io/hook ──→     (explicit)      ✓ safe         │
+└─────────────────────────────────────────────────────────────────┘
+
+Hazards (2):
+  ├── [WARNING] Job/db-migrate
+  │   Rule: helm-hook-ambiguity
+  │   Risk: ArgoCD treats every sync as upgrade;
+  │         post-install may run unexpectedly
+  │
+  └── [WARNING] Job/notify-deploy
+      Rule: postsync-idempotency-risk
+      Risk: Job runs on every sync;
+            ensure operation is idempotent
+
+Safe (1):
+  └── [OK] Job/schema-validate
+      argocd.argoproj.io/hook: PreSync  ← explicit, no ambiguity
+
+════════════════════════════════════════════════════════════════════
+Summary: 2 hazards │ 1 safe │ 3 hooks scanned
+```
 
 ## Quick Start
 

--- a/examples/orphans/README.md
+++ b/examples/orphans/README.md
@@ -56,24 +56,51 @@ Total: ~20 orphan resources across 3 namespaces
 ## Expected Output
 
 ```
-cub-scout map orphans
+cub-scout tree ownership
 
-ORPHAN RESOURCES (20)
-────────────────────────────────────────
-These resources have no GitOps owner.
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
 
-NAMESPACE       KIND            NAME                    AGE
-legacy-apps     Deployment      legacy-prometheus       3d
-legacy-apps     Service         legacy-prometheus       3d
-legacy-apps     ConfigMap       legacy-prometheus-config 3d
-temp-testing    Deployment      debug-nginx             1d
-temp-testing    Deployment      debug-busybox           1d
-default         Deployment      hotfix-worker           12h
-default         ConfigMap       old-feature-flags       7d
-default         ConfigMap       manual-override         2d
-default         Secret          manual-api-key          5d
-default         CronJob         manual-cleanup          4d
-...
+Flux (28 resources)
+────────────────────────────────────────────────────────────────────
+  ├── boutique/cart              Deployment   ✓ 2/2
+  ├── boutique/checkout          Deployment   ✓ 1/1
+  ├── boutique/frontend          Deployment   ✓ 3/3
+  └── ... (24 more)
+
+Helm (5 resources)
+────────────────────────────────────────────────────────────────────
+  ├── monitoring/prometheus      Deployment   ✓ 1/1
+  └── ... (4 more)
+
+Native (20 resources)  ⚠ ORPHANS — not managed by GitOps
+────────────────────────────────────────────────────────────────────
+  No GitOps labels detected — likely kubectl-applied
+
+  NAMESPACE       KIND            NAME                     AGE
+  ├── legacy-apps
+  │   ├── Deployment     legacy-prometheus                 3d
+  │   ├── Service        legacy-prometheus                 3d
+  │   └── ConfigMap      legacy-prometheus-config          3d
+  ├── temp-testing
+  │   ├── Deployment     debug-nginx                      1d
+  │   └── Deployment     debug-busybox                    1d
+  └── default
+      ├── Deployment     hotfix-worker                    12h
+      ├── ConfigMap      old-feature-flags                 7d
+      ├── ConfigMap      manual-override                   2d
+      ├── Secret         manual-api-key                    5d
+      └── CronJob        manual-cleanup                    4d
+
+════════════════════════════════════════════════════════════════════
+Ownership Distribution:
+
+  Flux       ████████████████████████████░░░░░░░░░░░░  53%
+  Helm       █████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   9%
+  Native     ████████████████████░░░░░░░░░░░░░░░░░░░░  38%  ← orphans
+
+→ To trace an orphan:  cub-scout trace deploy/debug-nginx -n temp-testing
+→ To import orphans:   cub-scout import -n legacy-apps
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary

- Add rich ASCII tree diagrams to the 7 example READMEs that were missing them
- Style matches the existing excellent diagrams in `docs/howto/tree-hierarchies.md`
- Uses ownership hierarchies, distribution bars, trace trees, boxed callouts

## Files changed

| File | Diagram added |
|------|---------------|
| `drift/README.md` | Ownership-grouped drift report with bar chart |
| `drift/env-var-drift/README.md` | Trace tree: Flux chain with drift inline |
| `drift/image-policy-drift/README.md` | Trace tree with pod-level impact |
| `drift/resource-drift/README.md` | Trace tree with invalid-state callout box |
| `orphans/README.md` | Full ownership hierarchy with distribution bars |
| `crossplane-system/README.md` | Mixed Flux+Crossplane ownership tree |
| `lifecycle-hazards/README.md` | Boxed hook-mapping + hazard tree |

🤖 Generated with [Claude Code](https://claude.com/claude-code)