### PR TITLE
Add ownership trees to apptique + rm-demos pattern examples

### DIFF
--- a/examples/apptique-examples/argo-app-of-apps/README.md
+++ b/examples/apptique-examples/argo-app-of-apps/README.md
@@ -45,6 +45,33 @@ argo-app-of-apps/
 2. Each child app syncs its respective manifests directory
 3. Two-level hierarchy: Root → Child App → Workloads
 
+## How cub-scout Sees It
+
+```
+./cub-scout tree ownership
+
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
+
+ArgoCD (5 resources)
+────────────────────────────────────────────────────────────────────
+  Application/apptique-apps (root)
+  ├── Application/apptique-dev (child)
+  │   └── Deployment/frontend (apptique-dev)      ✓ 1/1
+  └── Application/apptique-prod (child)
+      └── Deployment/frontend (apptique-prod)      ✓ 2/2
+
+════════════════════════════════════════════════════════════════════
+
+  Root App           Child Apps          Workloads
+  ──────────         ──────────          ─────────
+  apptique-apps ──→  apptique-dev  ──→  frontend (1 replica)
+                └──→ apptique-prod ──→  frontend (2 replicas)
+
+→ Trace any level: cub-scout trace deploy/frontend -n apptique-dev
+→ Check all sync:  cub-scout gitops status
+```
+
 ## What It Demonstrates
 
 | What you'll see | Why it matters |

--- a/examples/apptique-examples/argo-applicationset/README.md
+++ b/examples/apptique-examples/argo-applicationset/README.md
@@ -39,6 +39,35 @@ argo-applicationset/
 2. Generates one Application per directory (`dev`, `prod`)
 3. Each Application deploys to its own namespace
 
+## How cub-scout Sees It
+
+```
+./cub-scout tree ownership
+
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
+
+ArgoCD (4 resources)
+────────────────────────────────────────────────────────────────────
+  ApplicationSet/apptique (argocd)
+  │
+  ├── generates → Application/apptique-dev (argocd)
+  │              └── Deployment/frontend (apptique-dev)     ✓ 1/1
+  │
+  └── generates → Application/apptique-prod (argocd)
+                 └── Deployment/frontend (apptique-prod)    ✓ 2/2
+
+════════════════════════════════════════════════════════════════════
+
+  Generator                 Discovered           Deployed
+  ─────────                 ──────────           ────────
+  apps/apptique/ scanner →  dev/ directory  →    apptique-dev/frontend
+                         →  prod/ directory →    apptique-prod/frontend
+
+→ Add a directory = add an environment (no YAML changes needed)
+→ Trace any app:   cub-scout trace deploy/frontend -n apptique-prod
+```
+
 ## What It Demonstrates
 
 | What you'll see | Why it matters |

--- a/examples/apptique-examples/flux-monorepo/README.md
+++ b/examples/apptique-examples/flux-monorepo/README.md
@@ -55,6 +55,39 @@ flux-monorepo/
 2. Each cluster has a Flux Kustomization CR pointing to an overlay path
 3. Kustomize builds base + overlay → produces Deployments in the target namespace
 
+## How cub-scout Sees It
+
+```
+./cub-scout tree ownership
+
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
+
+Flux (4 resources)
+────────────────────────────────────────────────────────────────────
+  GitRepository/apptique-examples (flux-system)
+  │   URL: confighub/cub-scout@main
+  │   Status: ✓ Artifact up to date
+  │
+  ├── Kustomization/apptique-dev (flux-system)
+  │   Path: ./apps/apptique/overlays/dev
+  │   └── Deployment/frontend (apptique-dev)     ✓ 1/1
+  │
+  └── Kustomization/apptique-prod (flux-system)
+      Path: ./apps/apptique/overlays/prod
+      └── Deployment/frontend (apptique-prod)    ✓ 2/2
+
+════════════════════════════════════════════════════════════════════
+
+  Git Source           Kustomization        Overlay Path             Workload
+  ──────────           ─────────────        ────────────             ────────
+  apptique-examples →  apptique-dev    →    overlays/dev/       →   frontend (1r)
+                    →  apptique-prod   →    overlays/prod/      →   frontend (2r)
+
+→ Trace the full chain: cub-scout trace deploy/frontend -n apptique-dev
+→ Parse repo offline:   cub-scout parse-repo --path flux-monorepo/
+```
+
 ## What It Demonstrates
 
 | What you'll see | Why it matters |

--- a/examples/rm-demos-argocd/repo-patterns/applicationsets/README.md
+++ b/examples/rm-demos-argocd/repo-patterns/applicationsets/README.md
@@ -83,6 +83,33 @@ $ ./cub-scout scan -n payments
   [RISK-2025-0001] payments/payment-api — missing resource limits
 ```
 
+## Ownership Tree
+
+```
+./cub-scout tree ownership
+
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
+
+ArgoCD (33 resources)
+────────────────────────────────────────────────────────────────────
+  ApplicationSet/payment-api (argocd)
+  │   Generator: clusters (selector: environment=production)
+  │
+  ├── Application/payment-api-prod-us-east-1 → payments/payment-api  ✓
+  ├── Application/payment-api-prod-us-west-1 → payments/payment-api  ✓
+  ├── Application/payment-api-prod-eu-west-1 → payments/payment-api  ✓
+  ├── Application/payment-api-prod-ap-south-1 → payments/payment-api ✗ SyncFailed
+  └── ... (28 more clusters)
+
+════════════════════════════════════════════════════════════════════
+
+  ✓ 31 synced   ✗ 1 degraded   Total: 32 clusters
+
+→ Find the problem: cub-scout gitops status
+→ Drill into it:    cub-scout trace deploy/payment-api -n payments
+```
+
 ## Why ApplicationSets Benefit from cub-scout
 
 | ApplicationSet Alone | + cub-scout |

--- a/examples/rm-demos-argocd/repo-patterns/helm-umbrella/README.md
+++ b/examples/rm-demos-argocd/repo-patterns/helm-umbrella/README.md
@@ -72,6 +72,39 @@ $ ./cub-scout scan -n platform -n monitoring
   [RISK-2025-0001] platform/kafka — missing resource limits
 ```
 
+## Ownership Tree
+
+```
+./cub-scout tree ownership
+
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
+
+Helm (5 resources)
+────────────────────────────────────────────────────────────────────
+  Release: platform-stack (platform)
+  │   Chart: platform-charts (umbrella)
+  │   Status: deployed (revision 14)
+  │
+  ├── platform/redis          Deployment   ✓ 3/3   redis:7.2.4
+  ├── platform/postgres       Deployment   ✓ 1/1   postgres:16.1
+  ├── platform/kafka          Deployment   ✓ 3/3   kafka:3.7.0
+  ├── monitoring/prometheus   Deployment   ✓ 1/1   prometheus:2.51
+  └── monitoring/grafana      Deployment   ✓ 1/1   grafana:10.4
+
+════════════════════════════════════════════════════════════════════
+
+  Umbrella Chart        Sub-charts              Live Pods
+  ──────────────        ──────────              ─────────
+  platform-stack   →    redis (sub-chart)  →    3 pods, redis:7.2.4 ✓
+                   →    postgres           →    1 pod,  postgres:16.1 ✓
+                   →    kafka              →    3 pods, kafka:3.7.0 ✓
+                   →    monitoring         →    2 pods (prometheus + grafana)
+
+→ Verify live images: cub-scout map list -q "owner=Helm"
+→ Check for drift:    cub-scout drift --helm-release platform-stack -n platform
+```
+
 ## Why Helm Umbrella Benefits from cub-scout
 
 | Helm Umbrella Alone | + cub-scout |

--- a/examples/rm-demos-argocd/repo-patterns/monorepo/README.md
+++ b/examples/rm-demos-argocd/repo-patterns/monorepo/README.md
@@ -72,6 +72,38 @@ $ ./cub-scout map list -q "namespace=*-prod"
   ✓       inventory-prod  inventory-api  Flux   inventory-api-prod
 ```
 
+## Ownership Tree
+
+```
+./cub-scout tree ownership
+
+OWNERSHIP HIERARCHY
+════════════════════════════════════════════════════════════════════
+
+Flux (9 resources)
+────────────────────────────────────────────────────────────────────
+  GitRepository/platform-configs (flux-system)
+  │
+  ├── payments
+  │   ├── Kustomization/payment-api-dev      → Deployment/payment-api (payments-dev)      ✓
+  │   ├── Kustomization/payment-api-staging   → Deployment/payment-api (payments-staging)  ✓
+  │   └── Kustomization/payment-api-prod      → Deployment/payment-api (payments-prod)     ✓
+  │
+  ├── orders
+  │   ├── Kustomization/order-api-dev         → Deployment/order-api (orders-dev)          ✓
+  │   ├── Kustomization/order-api-staging     → Deployment/order-api (orders-staging)      ✓
+  │   └── Kustomization/order-api-prod        → Deployment/order-api (orders-prod)         ✓
+  │
+  └── inventory
+      ├── Kustomization/inventory-api-dev     → Deployment/inventory-api (inventory-dev)    ✓
+      ├── Kustomization/inventory-api-staging → Deployment/inventory-api (inventory-staging) ✓
+      └── Kustomization/inventory-api-prod    → Deployment/inventory-api (inventory-prod)   ✓
+
+════════════════════════════════════════════════════════════════════
+Summary: 1 GitRepository │ 9 Kustomizations │ 9 Deployments
+         3 apps × 3 envs = 9 paths, all from one repo
+```
+
 ## Skeleton Classification
 
 | Dimension | Value |


### PR DESCRIPTION
## Summary

Add rich ownership hierarchy tree diagrams to the 6 pattern example READMEs that were missing them:

| File | Diagram added |
|------|---------------|
| `apptique/argo-app-of-apps` | Root → Child → Workload hierarchy + flow |
| `apptique/argo-applicationset` | Generator → discovered dirs → deployed apps |
| `apptique/flux-monorepo` | GitRepository → Kustomization → overlay chain |
| `rm-demos/monorepo` | 3 apps × 3 envs = 9 Kustomizations tree |
| `rm-demos/applicationsets` | Generator → 32 clusters with sync status |
| `rm-demos/helm-umbrella` | Umbrella → sub-charts → live pods |

All follow the style from `docs/howto/tree-hierarchies.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)