### PR TITLE
Add import E2E tests, worked examples, and fix stale goldens

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@
 # - Level 1 (unit): Always runs, all Go tests
 # - Level 2 (integration): Needs cluster, basic commands
 # - Level 3 (gitops): Needs Flux + ArgoCD, ownership detection
+# - Level 6 (connected): Needs ConfigHub auth, import round-trip
 #
 # See test/test-levels.yaml for level definitions.
 
@@ -18,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       level:
-        description: 'Test level (smoke, unit, integration, gitops, demos, full)'
+        description: 'Test level (smoke, unit, integration, gitops, demos, connected, full)'
         required: false
         default: 'integration'
 
@@ -257,6 +258,51 @@ jobs:
           ./cub-scout demo scenario bigbank-incident --cleanup || true
           ./cub-scout demo scenario break-glass || true
           ./cub-scout demo scenario break-glass --cleanup || true
+
+  # ==========================================================================
+  # Level 6: Connected E2E (needs ConfigHub auth, manual trigger)
+  # ==========================================================================
+  connected:
+    name: Connected E2E
+    runs-on: ubuntu-latest
+    needs: integration
+    if: github.event_name == 'workflow_dispatch' && (github.event.inputs.level == 'connected' || github.event.inputs.level == 'full')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: cub-scout-linux
+
+      - name: Make binary executable
+        run: chmod +x cub-scout
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: connected-cluster
+
+      - name: Authenticate to ConfigHub
+        if: env.CUB_AUTH_TOKEN != ''
+        run: |
+          echo "$CUB_AUTH_TOKEN" | cub auth login --token -
+        env:
+          CUB_AUTH_TOKEN: ${{ secrets.CUB_AUTH_TOKEN }}
+
+      - name: Run import dry-run tests
+        run: go test -tags=integration ./test/integration/... -run 'TestImportDryRun' -v -timeout 120s
+
+      - name: Run import round-trip tests
+        if: env.CUB_AUTH_TOKEN != ''
+        run: go test -tags=integration ./test/integration/... -run 'TestImportFull|TestImportIdempotent|TestImportCleanup' -v -timeout 300s
+        env:
+          CUB_AUTH_TOKEN: ${{ secrets.CUB_AUTH_TOKEN }}
 
   # ==========================================================================
   # Full test (manual trigger only)

--- a/cmd/cub-scout/bundle_test.go
+++ b/cmd/cub-scout/bundle_test.go
@@ -2131,6 +2131,459 @@ func TestBundleSummarize_RiskSignals(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// Evidence Export v1 Contract Tests (#166)
+//
+// These tests validate the BundleSummary schema against the evidence-export-v1
+// spec (docs/reference/evidence-export-v1.md). They ensure that:
+// 1. Required fields are always present in JSON output
+// 2. Optional fields are omitted (not null) when absent
+// 3. All 5 rendering formats produce output without panics
+// 4. The mapping from DebugBundle → BundleSummary is stable
+// =============================================================================
+
+func TestEvidenceExportV1_RequiredFields(t *testing.T) {
+	// Per evidence-export-v1.md, these fields are required:
+	// formatVersion, target, capturedAt, changes, evidence.bundlePath
+
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "contract-required-fields")
+
+	writer := agent.NewBundleWriter("v0.20.0-test")
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "api",
+				Namespace: "prod",
+			},
+		},
+	}
+
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	reader := agent.NewBundleReader()
+	readBundle, err := reader.Read(bundleDir)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	summary := buildBundleSummary(readBundle, bundleDir)
+
+	// Marshal to JSON and parse as generic map to verify wire format
+	jsonBytes, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		t.Fatalf("JSON marshal failed: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &raw); err != nil {
+		t.Fatalf("JSON unmarshal to map failed: %v", err)
+	}
+
+	// Required fields per spec
+	requiredTopLevel := []string{"formatVersion", "target", "capturedAt", "changes", "evidence"}
+	for _, field := range requiredTopLevel {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("Required field %q missing from JSON output", field)
+		}
+	}
+
+	// formatVersion must be "v1"
+	if fv, ok := raw["formatVersion"].(string); !ok || fv != "v1" {
+		t.Errorf("formatVersion = %v, want \"v1\"", raw["formatVersion"])
+	}
+
+	// evidence.bundlePath is required
+	evidence, ok := raw["evidence"].(map[string]interface{})
+	if !ok {
+		t.Fatal("evidence field is not an object")
+	}
+	if _, ok := evidence["bundlePath"]; !ok {
+		t.Error("Required field evidence.bundlePath missing")
+	}
+
+	// changes must have driftCount and eventCount
+	changes, ok := raw["changes"].(map[string]interface{})
+	if !ok {
+		t.Fatal("changes field is not an object")
+	}
+	for _, field := range []string{"driftCount", "eventCount"} {
+		if _, ok := changes[field]; !ok {
+			t.Errorf("Required field changes.%s missing", field)
+		}
+	}
+}
+
+func TestEvidenceExportV1_OptionalFieldsOmitted(t *testing.T) {
+	// Per spec: "Omit absent fields: Optional fields are omitted, not null"
+	// When cluster, namespace, gitContext, riskSignals are not set, they
+	// should be absent from JSON (not present as null).
+	//
+	// Note: We build the BundleSummary directly (not via Write/Read) because
+	// BundleWriter.Write auto-captures git context from the working directory.
+	// This test validates the summary → JSON contract, not the capture behavior.
+
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			FormatVersion:   "v1",
+			CubScoutVersion: "v0.20.0-test",
+			CreatedAt:       time.Date(2026, 2, 6, 10, 0, 0, 0, time.UTC),
+			Target: agent.BundleTarget{
+				Kind: "Deployment",
+				Name: "api",
+				// No namespace, no cluster
+			},
+			// No GitContext
+		},
+		// No drift findings, no events → no risk signals
+	}
+
+	summary := buildBundleSummary(bundle, "/tmp/test-bundle")
+	jsonBytes, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		t.Fatalf("JSON marshal failed: %v", err)
+	}
+
+	jsonStr := string(jsonBytes)
+
+	// Optional fields with omitempty should not appear
+	optionalOmitted := []string{"cluster", "namespace", "gitContext", "riskSignals"}
+	for _, field := range optionalOmitted {
+		// Check the JSON string for the key - it should not appear
+		if strings.Contains(jsonStr, `"`+field+`"`) {
+			t.Errorf("Optional field %q should be omitted when empty, but found in JSON:\n%s", field, jsonStr)
+		}
+	}
+
+	// Optional nested fields should also be omitted
+	nestedOptional := []string{"categories", "objects"}
+	for _, field := range nestedOptional {
+		if strings.Contains(jsonStr, `"`+field+`"`) {
+			t.Errorf("Optional nested field %q should be omitted when empty", field)
+		}
+	}
+}
+
+func TestEvidenceExportV1_FullPayload(t *testing.T) {
+	// Verify a fully populated BundleSummary matches the spec schema
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "contract-full-payload")
+
+	writer := agent.NewBundleWriter("v0.20.0-test")
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "payments-api",
+				Namespace: "payments",
+				Cluster:   "prod-east",
+			},
+			GitContext: &agent.BundleGitContext{
+				CommitSHA: "abc123def456",
+				Branch:    "main",
+				RemoteURL: "https://github.com/acme/apps",
+			},
+		},
+		DriftFindings: []agent.DriftFinding{
+			{
+				ID:             "d1",
+				ObjectID:       "Deployment:payments/payments-api",
+				Path:           "spec.replicas",
+				Classification: agent.DriftCapacity,
+				Severity:       agent.DriftSeverityCritical,
+			},
+			{
+				ID:             "d2",
+				ObjectID:       "Deployment:payments/payments-api",
+				Path:           "spec.template.spec.containers[0].image",
+				Classification: agent.DriftImage,
+				Severity:       agent.DriftSeverityWarning,
+			},
+			{
+				ID:             "d3",
+				ObjectID:       "HPA:payments/payments-hpa",
+				Path:           "spec.minReplicas",
+				Classification: agent.DriftConfig,
+				Severity:       agent.DriftSeverityCritical,
+			},
+		},
+		Events: []agent.TimelineEvent{
+			{ResourceKind: "Pod", ResourceName: "payments-api-abc", K8sEvent: agent.K8sEvent{Type: "Warning", Reason: "FailedScheduling"}},
+			{ResourceKind: "Pod", ResourceName: "payments-api-def"},
+		},
+	}
+
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	reader := agent.NewBundleReader()
+	readBundle, err := reader.Read(bundleDir)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	summary := buildBundleSummary(readBundle, bundleDir)
+
+	// Marshal to JSON, then unmarshal to verify round-trip
+	jsonBytes, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		t.Fatalf("JSON marshal failed: %v", err)
+	}
+
+	var parsed BundleSummary
+	if err := json.Unmarshal(jsonBytes, &parsed); err != nil {
+		t.Fatalf("JSON round-trip unmarshal failed: %v", err)
+	}
+
+	// Verify all expected fields
+	if parsed.FormatVersion != "v1" {
+		t.Errorf("FormatVersion = %s, want v1", parsed.FormatVersion)
+	}
+	if parsed.Cluster != "prod-east" {
+		t.Errorf("Cluster = %s, want prod-east", parsed.Cluster)
+	}
+	if parsed.Namespace != "payments" {
+		t.Errorf("Namespace = %s, want payments", parsed.Namespace)
+	}
+	if parsed.Target != "Deployment/payments-api" {
+		t.Errorf("Target = %s, want Deployment/payments-api", parsed.Target)
+	}
+	if parsed.CapturedAt == "" {
+		t.Error("CapturedAt should not be empty")
+	}
+
+	// Verify git context round-trips
+	if parsed.GitContext == nil {
+		t.Fatal("GitContext should not be nil")
+	}
+	if parsed.GitContext.Commit != "abc123def456" {
+		t.Errorf("GitContext.Commit = %s, want abc123def456", parsed.GitContext.Commit)
+	}
+	if parsed.GitContext.Branch != "main" {
+		t.Errorf("GitContext.Branch = %s, want main", parsed.GitContext.Branch)
+	}
+	if parsed.GitContext.Remote != "https://github.com/acme/apps" {
+		t.Errorf("GitContext.Remote = %s, want https://github.com/acme/apps", parsed.GitContext.Remote)
+	}
+
+	// Verify changes
+	if parsed.Changes.DriftCount != 3 {
+		t.Errorf("DriftCount = %d, want 3", parsed.Changes.DriftCount)
+	}
+	if parsed.Changes.EventCount != 2 {
+		t.Errorf("EventCount = %d, want 2", parsed.Changes.EventCount)
+	}
+	// Categories should be sorted per spec
+	for i := 1; i < len(parsed.Changes.Categories); i++ {
+		if parsed.Changes.Categories[i] < parsed.Changes.Categories[i-1] {
+			t.Errorf("Categories not sorted: %v", parsed.Changes.Categories)
+			break
+		}
+	}
+	// Objects should be sorted per spec
+	for i := 1; i < len(parsed.Changes.Objects); i++ {
+		if parsed.Changes.Objects[i] < parsed.Changes.Objects[i-1] {
+			t.Errorf("Objects not sorted: %v", parsed.Changes.Objects)
+			break
+		}
+	}
+
+	// Verify risk signals (3 drift findings: 2 critical, 1 warning, plus 1 warning event)
+	if len(parsed.RiskSignals) == 0 {
+		t.Error("RiskSignals should not be empty with critical/warning drift")
+	}
+	for _, rs := range parsed.RiskSignals {
+		if rs.Level != "critical" && rs.Level != "warning" {
+			t.Errorf("RiskSignal level = %s, want critical or warning", rs.Level)
+		}
+		if rs.Message == "" {
+			t.Error("RiskSignal message should not be empty")
+		}
+	}
+
+	// Verify evidence
+	if parsed.Evidence.BundlePath != bundleDir {
+		t.Errorf("Evidence.BundlePath = %s, want %s", parsed.Evidence.BundlePath, bundleDir)
+	}
+}
+
+func TestEvidenceExportV1_AllFormatsNoPanic(t *testing.T) {
+	// Every rendering format should handle all bundle shapes without panicking.
+	// Spec lists 5 formats: json, ascii, ticket, pr, slack
+
+	bundles := []struct {
+		name    string
+		summary BundleSummary
+	}{
+		{
+			name: "full",
+			summary: BundleSummary{
+				FormatVersion: "v1",
+				Cluster:       "prod",
+				Namespace:     "app",
+				Target:        "Deployment/api",
+				CapturedAt:    "2026-02-06T10:00:00Z",
+				GitContext:    &BundleSummaryGitContext{Commit: "abc", Branch: "main", Remote: "https://github.com/a/b"},
+				Changes:       BundleSummaryChanges{DriftCount: 3, EventCount: 5, Categories: []string{"capacity", "config"}, Objects: []string{"Deployment:prod/a"}},
+				RiskSignals:   []BundleSummaryRiskSignal{{Level: "critical", Message: "3 critical"}},
+				Evidence:      BundleSummaryEvidence{BundlePath: "/tmp/bundle"},
+			},
+		},
+		{
+			name: "minimal",
+			summary: BundleSummary{
+				FormatVersion: "v1",
+				Target:        "Deployment/api",
+				CapturedAt:    "2026-02-06T10:00:00Z",
+				Changes:       BundleSummaryChanges{DriftCount: 0, EventCount: 0},
+				Evidence:      BundleSummaryEvidence{BundlePath: "/tmp/bundle"},
+			},
+		},
+		{
+			name: "no-git",
+			summary: BundleSummary{
+				FormatVersion: "v1",
+				Cluster:       "staging",
+				Target:        "StatefulSet/db",
+				CapturedAt:    "2026-02-06T10:00:00Z",
+				Changes:       BundleSummaryChanges{DriftCount: 1, EventCount: 0, Categories: []string{"config"}},
+				RiskSignals:   []BundleSummaryRiskSignal{{Level: "warning", Message: "1 warning"}},
+				Evidence:      BundleSummaryEvidence{BundlePath: "/tmp/bundle"},
+			},
+		},
+	}
+
+	formats := []struct {
+		name   string
+		render func(BundleSummary) string
+	}{
+		{"ascii", renderSummaryASCII},
+		{"ticket", renderSummaryTicket},
+		{"pr", renderSummaryPR},
+		{"slack", renderSummarySlack},
+	}
+
+	for _, bundle := range bundles {
+		for _, format := range formats {
+			t.Run(bundle.name+"/"+format.name, func(t *testing.T) {
+				output := format.render(bundle.summary)
+				if output == "" {
+					t.Errorf("%s/%s produced empty output", bundle.name, format.name)
+				}
+			})
+		}
+
+		// Also test JSON format
+		t.Run(bundle.name+"/json", func(t *testing.T) {
+			data, err := json.MarshalIndent(bundle.summary, "", "  ")
+			if err != nil {
+				t.Errorf("JSON marshal failed: %v", err)
+			}
+			if len(data) == 0 {
+				t.Error("JSON produced empty output")
+			}
+		})
+	}
+}
+
+func TestEvidenceExportV1_MappingStability(t *testing.T) {
+	// Verify the mapping from DebugBundle → BundleSummary matches
+	// the spec in evidence-export-v1.md (Mapping table).
+	//
+	// This test creates a known DebugBundle, builds BundleSummary,
+	// and asserts each field maps correctly per the spec table.
+
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "contract-mapping")
+
+	writer := agent.NewBundleWriter("v0.20.0-test")
+
+	fixedTime := time.Date(2026, 2, 6, 14, 30, 0, 0, time.UTC)
+
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			CreatedAt: fixedTime,
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "payments-api",
+				Namespace: "payments",
+				Cluster:   "prod-east",
+			},
+			GitContext: &agent.BundleGitContext{
+				CommitSHA: "abc123",
+				Branch:    "main",
+				RemoteURL: "https://github.com/acme/apps",
+			},
+		},
+		DriftFindings: []agent.DriftFinding{
+			{ID: "d1", ObjectID: "Deployment:payments/payments-api", Classification: agent.DriftCapacity, Severity: agent.DriftSeverityCritical},
+		},
+		Events: []agent.TimelineEvent{
+			{ResourceKind: "Pod", ResourceName: "api-1"},
+			{ResourceKind: "Pod", ResourceName: "api-2"},
+		},
+	}
+
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	reader := agent.NewBundleReader()
+	readBundle, err := reader.Read(bundleDir)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	summary := buildBundleSummary(readBundle, bundleDir)
+
+	// Spec: formatVersion ← hard-coded "v1"
+	if summary.FormatVersion != "v1" {
+		t.Errorf("Mapping: formatVersion = %s, want v1 (hard-coded per spec)", summary.FormatVersion)
+	}
+
+	// Spec: cluster ← metadata.json → target.cluster
+	if summary.Cluster != "prod-east" {
+		t.Errorf("Mapping: cluster = %s, want prod-east (from target.cluster)", summary.Cluster)
+	}
+
+	// Spec: namespace ← metadata.json → target.namespace
+	if summary.Namespace != "payments" {
+		t.Errorf("Mapping: namespace = %s, want payments (from target.namespace)", summary.Namespace)
+	}
+
+	// Spec: target ← metadata.json → target.kind/name (concatenated)
+	if summary.Target != "Deployment/payments-api" {
+		t.Errorf("Mapping: target = %s, want Deployment/payments-api (kind/name)", summary.Target)
+	}
+
+	// Spec: changes.driftCount ← drift.json → len(findings)
+	if summary.Changes.DriftCount != 1 {
+		t.Errorf("Mapping: changes.driftCount = %d, want 1 (len of drift findings)", summary.Changes.DriftCount)
+	}
+
+	// Spec: changes.eventCount ← events.json → len(events)
+	if summary.Changes.EventCount != 2 {
+		t.Errorf("Mapping: changes.eventCount = %d, want 2 (len of events)", summary.Changes.EventCount)
+	}
+
+	// Spec: gitContext ← metadata.json → gitContext (direct copy)
+	if summary.GitContext == nil {
+		t.Fatal("Mapping: gitContext should not be nil (from metadata.gitContext)")
+	}
+	if summary.GitContext.Commit != "abc123" {
+		t.Errorf("Mapping: gitContext.commit = %s, want abc123", summary.GitContext.Commit)
+	}
+
+	// Spec: evidence.bundlePath ← input argument
+	if summary.Evidence.BundlePath != bundleDir {
+		t.Errorf("Mapping: evidence.bundlePath = %s, want %s (input arg)", summary.Evidence.BundlePath, bundleDir)
+	}
+}
+
 func TestBundleSummarize_Deterministic(t *testing.T) {
 	// Create a bundle
 	tmpDir := t.TempDir()

--- a/cmd/cub-scout/import_suggest_golden_test.go
+++ b/cmd/cub-scout/import_suggest_golden_test.go
@@ -1,0 +1,365 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// updateImportSuggestGolden controls golden file updates.
+// Set via: UPDATE_GOLDEN=1 go test ./cmd/cub-scout/ -run TestImportSuggest
+var updateImportSuggestGolden = os.Getenv("UPDATE_GOLDEN") == "1"
+
+// TestImportSuggest_ArniePattern verifies the suggestion engine against
+// an ArgoCD folder-per-environment cluster (the "Arnie" pattern).
+//
+// Input: 6 Deployments across 3 envs (dev/staging/prod), all ArgoCD-managed
+// with Application paths like envs/dev, envs/staging, envs/prod.
+// Plus 3 Helm-managed redis instances and 1 unmanaged ConfigMap.
+//
+// Expected: variant inference from Application paths, correct app grouping,
+// Helm workloads grouped separately, Native workload detected.
+func TestImportSuggest_ArniePattern(t *testing.T) {
+	workloads := []WorkloadInfo{
+		// ArgoCD-managed api deployments
+		{
+			Kind: "Deployment", Namespace: "myapp-dev", Name: "api",
+			Owner: "ArgoCD", Ready: true, Replicas: 1,
+			ApplicationPath: "envs/dev",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "api",
+				"app.kubernetes.io/instance":   "api-dev",
+				"argocd.argoproj.io/instance":  "myapp-dev",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "myapp-staging", Name: "api",
+			Owner: "ArgoCD", Ready: true, Replicas: 2,
+			ApplicationPath: "envs/staging",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "api",
+				"app.kubernetes.io/instance":   "api-staging",
+				"argocd.argoproj.io/instance":  "myapp-staging",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "myapp-prod", Name: "api",
+			Owner: "ArgoCD", Ready: true, Replicas: 3,
+			ApplicationPath: "envs/prod",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "api",
+				"app.kubernetes.io/instance":   "api-prod",
+				"argocd.argoproj.io/instance":  "myapp-prod",
+			},
+		},
+		// ArgoCD-managed worker deployments
+		{
+			Kind: "Deployment", Namespace: "myapp-dev", Name: "worker",
+			Owner: "ArgoCD", Ready: true, Replicas: 1,
+			ApplicationPath: "envs/dev",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "worker",
+				"app.kubernetes.io/instance":   "worker-dev",
+				"argocd.argoproj.io/instance":  "myapp-dev",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "myapp-staging", Name: "worker",
+			Owner: "ArgoCD", Ready: true, Replicas: 1,
+			ApplicationPath: "envs/staging",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "worker",
+				"app.kubernetes.io/instance":   "worker-staging",
+				"argocd.argoproj.io/instance":  "myapp-staging",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "myapp-prod", Name: "worker",
+			Owner: "ArgoCD", Ready: true, Replicas: 2,
+			ApplicationPath: "envs/prod",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "worker",
+				"app.kubernetes.io/instance":   "worker-prod",
+				"argocd.argoproj.io/instance":  "myapp-prod",
+			},
+		},
+		// Helm-managed redis
+		{
+			Kind: "StatefulSet", Namespace: "myapp-dev", Name: "redis",
+			Owner: "Helm", Ready: true, Replicas: 1,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "redis",
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+		{
+			Kind: "StatefulSet", Namespace: "myapp-staging", Name: "redis",
+			Owner: "Helm", Ready: true, Replicas: 1,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "redis",
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+		{
+			Kind: "StatefulSet", Namespace: "myapp-prod", Name: "redis",
+			Owner: "Helm", Ready: true, Replicas: 3,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "redis",
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+	}
+
+	runImportSuggestGolden(t, "arnie-pattern", workloads)
+}
+
+// TestImportSuggest_BankoPattern verifies the suggestion engine against
+// a Flux monorepo cluster (the "Banko" pattern).
+//
+// Input: Deployments managed by Flux Kustomizations with paths like
+// ./apps/payment-api/overlays/dev and ./apps/payment-api/overlays/prod.
+//
+// Expected: variant inference from Kustomization paths.
+func TestImportSuggest_BankoPattern(t *testing.T) {
+	workloads := []WorkloadInfo{
+		{
+			Kind: "Deployment", Namespace: "payment-dev", Name: "payment-api",
+			Owner: "Flux", Ready: true, Replicas: 1,
+			KustomizationPath: "./apps/payment-api/overlays/dev",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":                   "payment-api",
+				"kustomize.toolkit.fluxcd.io/name":         "payment-dev",
+				"kustomize.toolkit.fluxcd.io/namespace":    "flux-system",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "payment-prod", Name: "payment-api",
+			Owner: "Flux", Ready: true, Replicas: 3,
+			KustomizationPath: "./apps/payment-api/overlays/prod",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":                   "payment-api",
+				"kustomize.toolkit.fluxcd.io/name":         "payment-prod",
+				"kustomize.toolkit.fluxcd.io/namespace":    "flux-system",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "payment-dev", Name: "payment-worker",
+			Owner: "Flux", Ready: true, Replicas: 1,
+			KustomizationPath: "./apps/payment-worker/overlays/dev",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":                   "payment-worker",
+				"kustomize.toolkit.fluxcd.io/name":         "payment-dev",
+				"kustomize.toolkit.fluxcd.io/namespace":    "flux-system",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "payment-prod", Name: "payment-worker",
+			Owner: "Flux", Ready: true, Replicas: 2,
+			KustomizationPath: "./apps/payment-worker/overlays/prod",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":                   "payment-worker",
+				"kustomize.toolkit.fluxcd.io/name":         "payment-prod",
+				"kustomize.toolkit.fluxcd.io/namespace":    "flux-system",
+			},
+		},
+	}
+
+	runImportSuggestGolden(t, "banko-pattern", workloads)
+}
+
+// TestImportSuggest_MixedOwners verifies the suggestion engine when
+// Flux, ArgoCD, Helm, and Native workloads coexist in the same namespace.
+//
+// Expected: each workload correctly grouped by app, mixed owners handled gracefully.
+func TestImportSuggest_MixedOwners(t *testing.T) {
+	workloads := []WorkloadInfo{
+		{
+			Kind: "Deployment", Namespace: "checkout", Name: "checkout-api",
+			Owner: "Flux", Ready: true, Replicas: 2,
+			KustomizationPath: "./apps/checkout/overlays/prod",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":                "checkout-api",
+				"kustomize.toolkit.fluxcd.io/name":      "checkout-prod",
+				"kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "checkout", Name: "checkout-frontend",
+			Owner: "ArgoCD", Ready: true, Replicas: 2,
+			ApplicationPath: "apps/checkout/prod",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "checkout-frontend",
+				"argocd.argoproj.io/instance": "checkout-prod",
+			},
+		},
+		{
+			Kind: "StatefulSet", Namespace: "checkout", Name: "checkout-db",
+			Owner: "Helm", Ready: true, Replicas: 1,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "checkout-db",
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "checkout", Name: "debug-tools",
+			Owner: "Native", Ready: true, Replicas: 1,
+			Labels: map[string]string{},
+		},
+	}
+
+	runImportSuggestGolden(t, "mixed-owners", workloads)
+}
+
+// TestImportSuggest_Empty verifies graceful degradation with no workloads.
+func TestImportSuggest_Empty(t *testing.T) {
+	runImportSuggestGolden(t, "empty", []WorkloadInfo{})
+}
+
+// TestImportSuggest_NamespaceFallback verifies variant inference from namespace
+// patterns when no GitOps paths are available (e.g., plain Helm releases).
+func TestImportSuggest_NamespaceFallback(t *testing.T) {
+	workloads := []WorkloadInfo{
+		{
+			Kind: "Deployment", Namespace: "orders-prod", Name: "orders-api",
+			Owner: "Helm", Ready: true, Replicas: 3,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "orders-api",
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "orders-staging", Name: "orders-api",
+			Owner: "Helm", Ready: true, Replicas: 1,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "orders-api",
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+		{
+			Kind: "Deployment", Namespace: "orders-prod", Name: "orders-worker",
+			Owner: "Helm", Ready: true, Replicas: 2,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "orders-worker",
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+	}
+
+	runImportSuggestGolden(t, "namespace-fallback", workloads)
+}
+
+// suggestGoldenOutput is the JSON structure we write to golden files.
+// It captures both the HubAppSpaceSuggestion (primary) and the input summary.
+type suggestGoldenOutput struct {
+	TestDescription string                  `json:"testDescription"`
+	InputSummary    suggestInputSummary     `json:"inputSummary"`
+	Suggestion      suggestGoldenSuggestion `json:"suggestion"`
+}
+
+type suggestInputSummary struct {
+	WorkloadCount int                    `json:"workloadCount"`
+	Namespaces    []string               `json:"namespaces"`
+	Owners        map[string]int         `json:"owners"`
+}
+
+type suggestGoldenSuggestion struct {
+	AppSpace string            `json:"appSpace"`
+	Units    []suggestGoldenUnit `json:"units"`
+}
+
+type suggestGoldenUnit struct {
+	Slug      string   `json:"slug"`
+	App       string   `json:"app"`
+	Variant   string   `json:"variant"`
+	Workloads []string `json:"workloads"`
+}
+
+func runImportSuggestGolden(t *testing.T, name string, workloads []WorkloadInfo) {
+	t.Helper()
+
+	// Run the suggestion engine
+	suggestion := SuggestHubAppSpaceStructure(workloads, "")
+
+	// Build input summary for context
+	nsSet := make(map[string]bool)
+	ownerCounts := make(map[string]int)
+	for _, w := range workloads {
+		nsSet[w.Namespace] = true
+		ownerCounts[w.Owner]++
+	}
+	namespaces := make([]string, 0, len(nsSet))
+	for ns := range nsSet {
+		namespaces = append(namespaces, ns)
+	}
+	sort.Strings(namespaces)
+
+	// Convert to golden output format
+	units := make([]suggestGoldenUnit, len(suggestion.Units))
+	for i, u := range suggestion.Units {
+		wlNames := make([]string, len(u.Workloads))
+		for j, w := range u.Workloads {
+			wlNames[j] = fmt.Sprintf("%s/%s/%s", w.Kind, w.Namespace, w.Name)
+		}
+		sort.Strings(wlNames)
+		units[i] = suggestGoldenUnit{
+			Slug:      u.Slug,
+			App:       u.App,
+			Variant:   u.Variant,
+			Workloads: wlNames,
+		}
+	}
+
+	output := suggestGoldenOutput{
+		TestDescription: name,
+		InputSummary: suggestInputSummary{
+			WorkloadCount: len(workloads),
+			Namespaces:    namespaces,
+			Owners:        ownerCounts,
+		},
+		Suggestion: suggestGoldenSuggestion{
+			AppSpace: suggestion.AppSpace,
+			Units:    units,
+		},
+	}
+
+	// Marshal to stable JSON
+	actual, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal output: %v", err)
+	}
+	actualStr := string(actual) + "\n"
+
+	// Golden file path
+	goldenPath := filepath.Join("testdata", "import-suggest", name+".golden.json")
+
+	if updateImportSuggestGolden {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(goldenPath), err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(actualStr), 0o644); err != nil {
+			t.Fatalf("write golden %s: %v", goldenPath, err)
+		}
+		t.Logf("updated golden: %s", goldenPath)
+		return
+	}
+
+	// Read and compare
+	expected, err := os.ReadFile(goldenPath)
+	if os.IsNotExist(err) {
+		t.Fatalf("golden file not found: %s\n\nActual output:\n%s\n\nRun with UPDATE_GOLDEN=1 to create it:\n  UPDATE_GOLDEN=1 go test ./cmd/cub-scout/ -run TestImportSuggest", goldenPath, actualStr)
+	}
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if actualStr != string(expected) {
+		t.Errorf("output does not match golden file %s\n\n--- EXPECTED ---\n%s\n--- ACTUAL ---\n%s",
+			goldenPath, string(expected), actualStr)
+	}
+}

--- a/cmd/cub-scout/testdata/import-suggest/arnie-pattern.golden.json
+++ b/cmd/cub-scout/testdata/import-suggest/arnie-pattern.golden.json
@@ -1,0 +1,92 @@
+{
+  "testDescription": "arnie-pattern",
+  "inputSummary": {
+    "workloadCount": 9,
+    "namespaces": [
+      "myapp-dev",
+      "myapp-prod",
+      "myapp-staging"
+    ],
+    "owners": {
+      "ArgoCD": 6,
+      "Helm": 3
+    }
+  },
+  "suggestion": {
+    "appSpace": "myapp-team",
+    "units": [
+      {
+        "slug": "api-dev",
+        "app": "api",
+        "variant": "dev",
+        "workloads": [
+          "Deployment/myapp-dev/api"
+        ]
+      },
+      {
+        "slug": "api-prod",
+        "app": "api",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/myapp-prod/api"
+        ]
+      },
+      {
+        "slug": "api-staging",
+        "app": "api",
+        "variant": "staging",
+        "workloads": [
+          "Deployment/myapp-staging/api"
+        ]
+      },
+      {
+        "slug": "redis-dev",
+        "app": "redis",
+        "variant": "dev",
+        "workloads": [
+          "StatefulSet/myapp-dev/redis"
+        ]
+      },
+      {
+        "slug": "redis-prod",
+        "app": "redis",
+        "variant": "prod",
+        "workloads": [
+          "StatefulSet/myapp-prod/redis"
+        ]
+      },
+      {
+        "slug": "redis-staging",
+        "app": "redis",
+        "variant": "staging",
+        "workloads": [
+          "StatefulSet/myapp-staging/redis"
+        ]
+      },
+      {
+        "slug": "worker-dev",
+        "app": "worker",
+        "variant": "dev",
+        "workloads": [
+          "Deployment/myapp-dev/worker"
+        ]
+      },
+      {
+        "slug": "worker-prod",
+        "app": "worker",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/myapp-prod/worker"
+        ]
+      },
+      {
+        "slug": "worker-staging",
+        "app": "worker",
+        "variant": "staging",
+        "workloads": [
+          "Deployment/myapp-staging/worker"
+        ]
+      }
+    ]
+  }
+}

--- a/cmd/cub-scout/testdata/import-suggest/banko-pattern.golden.json
+++ b/cmd/cub-scout/testdata/import-suggest/banko-pattern.golden.json
@@ -1,0 +1,50 @@
+{
+  "testDescription": "banko-pattern",
+  "inputSummary": {
+    "workloadCount": 4,
+    "namespaces": [
+      "payment-dev",
+      "payment-prod"
+    ],
+    "owners": {
+      "Flux": 4
+    }
+  },
+  "suggestion": {
+    "appSpace": "payment-team",
+    "units": [
+      {
+        "slug": "payment-api-dev",
+        "app": "payment-api",
+        "variant": "dev",
+        "workloads": [
+          "Deployment/payment-dev/payment-api"
+        ]
+      },
+      {
+        "slug": "payment-api-prod",
+        "app": "payment-api",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/payment-prod/payment-api"
+        ]
+      },
+      {
+        "slug": "payment-worker-dev",
+        "app": "payment-worker",
+        "variant": "dev",
+        "workloads": [
+          "Deployment/payment-dev/payment-worker"
+        ]
+      },
+      {
+        "slug": "payment-worker-prod",
+        "app": "payment-worker",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/payment-prod/payment-worker"
+        ]
+      }
+    ]
+  }
+}

--- a/cmd/cub-scout/testdata/import-suggest/empty.golden.json
+++ b/cmd/cub-scout/testdata/import-suggest/empty.golden.json
@@ -1,0 +1,12 @@
+{
+  "testDescription": "empty",
+  "inputSummary": {
+    "workloadCount": 0,
+    "namespaces": [],
+    "owners": {}
+  },
+  "suggestion": {
+    "appSpace": "imported-team",
+    "units": []
+  }
+}

--- a/cmd/cub-scout/testdata/import-suggest/mixed-owners.golden.json
+++ b/cmd/cub-scout/testdata/import-suggest/mixed-owners.golden.json
@@ -1,0 +1,52 @@
+{
+  "testDescription": "mixed-owners",
+  "inputSummary": {
+    "workloadCount": 4,
+    "namespaces": [
+      "checkout"
+    ],
+    "owners": {
+      "ArgoCD": 1,
+      "Flux": 1,
+      "Helm": 1,
+      "Native": 1
+    }
+  },
+  "suggestion": {
+    "appSpace": "checkout-team",
+    "units": [
+      {
+        "slug": "checkout",
+        "app": "checkout",
+        "variant": "default",
+        "workloads": [
+          "Deployment/checkout/debug-tools"
+        ]
+      },
+      {
+        "slug": "checkout-api-prod",
+        "app": "checkout-api",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/checkout/checkout-api"
+        ]
+      },
+      {
+        "slug": "checkout-db",
+        "app": "checkout-db",
+        "variant": "default",
+        "workloads": [
+          "StatefulSet/checkout/checkout-db"
+        ]
+      },
+      {
+        "slug": "checkout-frontend-prod",
+        "app": "checkout-frontend",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/checkout/checkout-frontend"
+        ]
+      }
+    ]
+  }
+}

--- a/cmd/cub-scout/testdata/import-suggest/namespace-fallback.golden.json
+++ b/cmd/cub-scout/testdata/import-suggest/namespace-fallback.golden.json
@@ -1,0 +1,42 @@
+{
+  "testDescription": "namespace-fallback",
+  "inputSummary": {
+    "workloadCount": 3,
+    "namespaces": [
+      "orders-prod",
+      "orders-staging"
+    ],
+    "owners": {
+      "Helm": 3
+    }
+  },
+  "suggestion": {
+    "appSpace": "orders-team",
+    "units": [
+      {
+        "slug": "orders-api-prod",
+        "app": "orders-api",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/orders-prod/orders-api"
+        ]
+      },
+      {
+        "slug": "orders-api-staging",
+        "app": "orders-api",
+        "variant": "staging",
+        "workloads": [
+          "Deployment/orders-staging/orders-api"
+        ]
+      },
+      {
+        "slug": "orders-worker-prod",
+        "app": "orders-worker",
+        "variant": "prod",
+        "workloads": [
+          "Deployment/orders-prod/orders-worker"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/EXAMPLES-OVERVIEW.md
+++ b/docs/EXAMPLES-OVERVIEW.md
@@ -114,6 +114,15 @@ kubectl apply -f examples/demo-data/manifests.yaml
 | [flux9s/](../examples/integrations/flux9s/) | Proposal | K9s-style TUI for Flux |
 | [confighub-oci/](../examples/integrations/confighub-oci/) | Working | ConfigHub OCI integration |
 
+### Import & Discovery Examples
+
+| Example | Pattern | Shows |
+|---------|---------|-------|
+| [import-from-live/](../examples/import-from-live/) | ArgoCD | Cluster-only discovery — no Git required |
+| [combined-git-live/](../examples/combined-git-live/) | Flux | Git repo + cluster alignment |
+| [fleet-import/](../examples/fleet-import/) | Multi-cluster | Aggregating imports from 2 clusters |
+| [demo-data-adt/](../examples/demo-data-adt/) | App-Deployment-Target | Multi-app × multi-env with version skew |
+
 ### Real-World Examples
 
 #### Apptique (Google Online Boutique)

--- a/docs/howto/import-from-live.md
+++ b/docs/howto/import-from-live.md
@@ -1,0 +1,86 @@
+# Import from Live Cluster
+
+Discover workloads from a running cluster and propose an App structure for ConfigHub — without needing Git access.
+
+## When to Use This
+
+- You have workloads running and want to understand what's there
+- Git repos aren't organized or immediately available
+- You want a quick read-only assessment before planning a migration
+- You're onboarding an existing cluster into ConfigHub
+
+## How It Works
+
+cub-scout reads the cluster (Deployments, StatefulSets, DaemonSets), detects who manages each workload, and proposes how to organize them as Apps in ConfigHub.
+
+It reads labels and annotations — it never modifies anything.
+
+## Quick Start
+
+```bash
+# See everything (all namespaces, dry-run)
+./cub-scout import --dry-run
+
+# Focus on one namespace
+./cub-scout import -n payment-prod --dry-run
+
+# Get structured JSON output
+./cub-scout import --dry-run --json
+```
+
+## What cub-scout Detects
+
+| Owner | How It's Detected |
+|-------|-------------------|
+| **Flux** | `kustomize.toolkit.fluxcd.io/*` or `helm.toolkit.fluxcd.io/*` labels |
+| **ArgoCD** | `argocd.argoproj.io/instance` label or tracking-id annotation |
+| **Helm** | `app.kubernetes.io/managed-by: Helm` |
+| **ConfigHub** | `confighub.com/UnitSlug` label |
+| **Native** | None of the above — unmanaged |
+
+## What cub-scout Proposes
+
+Given the detected workloads, cub-scout suggests:
+
+- **App Space** — a team workspace name (inferred from namespace patterns)
+- **Units** — one per workload variant, with `app` and `variant` labels
+- **Variant** — inferred from GitOps paths (`envs/prod` → `prod`) or namespace patterns (`myapp-prod` → `prod`)
+
+The proposal uses the current ConfigHub API (Space/Unit). In practice, think of it as:
+
+| cub-scout proposes | You should read as |
+|--------------------|--------------------|
+| App Space: `myapp-team` | Team workspace for the myapp service |
+| Unit: `api-prod` | The api component, production deployment |
+| Unit: `api-dev` | The api component, dev deployment |
+
+## Variant Inference Priority
+
+cub-scout infers the environment variant in this order:
+
+1. **Flux Kustomization path** — `spec.path: ./overlays/prod` → `prod`
+2. **ArgoCD Application path** — `spec.source.path: envs/staging` → `staging`
+3. **Kubernetes labels** — `app.kubernetes.io/instance: api-prod` → `prod`
+4. **Namespace pattern** — `myapp-staging` → `staging`
+5. **Workload name** — fallback
+
+## What Happens Next
+
+cub-scout's job stops at the proposal. It discovers and explains — it doesn't create anything in ConfigHub.
+
+The next steps are ConfigHub's responsibility:
+- Create Units from the proposal (via `cub unit create` or the ConfigHub UI)
+- Set up bridge workers and targets
+- Connect the OCI pipeline (ConfigHub renders → Flux/Argo deploys)
+
+See [Import to ConfigHub](import-to-confighub.md) for the full migration path.
+
+## Worked Example
+
+See [examples/import-from-live/](../../examples/import-from-live/) for a complete worked example with fixture manifests and expected JSON output.
+
+## Related Docs
+
+- [Import to ConfigHub](import-to-confighub.md) — Full migration path (includes ConfigHub steps)
+- [ConfigHub Glossary](../reference/glossary.md) — Terminology reference
+- [Hub/AppSpace Examples](../reference/hub-appspace-examples.md) — Real-world mapping patterns

--- a/docs/howto/import-to-confighub.md
+++ b/docs/howto/import-to-confighub.md
@@ -2,8 +2,24 @@
 
 This is the canonical migration path for moving existing ArgoCD/Helm-managed workloads into ConfigHub.
 
+## Ownership Split
+
+The import process involves two tools with distinct responsibilities:
+
+| Step | Who | What |
+|------|-----|------|
+| **Discover** | cub-scout | Scan cluster, detect ownership, propose App structure |
+| **Import** | ConfigHub | Create Units, set up bridge workers, connect OCI pipeline |
+| **Deploy** | Flux/ArgoCD | Pull rendered manifests from ConfigHub's OCI registry, apply to cluster |
+
+cub-scout is read-only — it discovers and proposes. ConfigHub handles the actual import and lifecycle.
+
+For cluster-only discovery (no Git required), see [Import from Live](import-from-live.md).
+
+## Scope
+
 Scope boundary:
-- This guide is only about workload import and controller cutover.
+- This guide covers workload discovery (cub-scout) and import (ConfigHub).
 - Helm/Kustomize rendering pipelines are Provisional scope.
 - Do not treat this import flow as a rendering/templating workflow.
 
@@ -130,6 +146,10 @@ Then continue using your existing Argo/Helm flow while you revise mapping.
 
 ## Related Docs
 
-- [Business Outcomes](../../outcomes/README.md) - Why ConfigHub import matters
-- [ConfigHub Documentation](https://docs.confighub.com) - Full ConfigHub guide
-- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md) - Archived import docs mapped to current docs
+- [Import from Live](import-from-live.md) — Cluster-only discovery (no Git required)
+- [Import from Live Example](../../examples/import-from-live/) — Worked example with fixtures
+- [Combined Git+Live Example](../../examples/combined-git-live/) — Git repo + cluster alignment
+- [Fleet Import Example](../../examples/fleet-import/) — Multi-cluster aggregation
+- [Business Outcomes](../../outcomes/README.md) — Why ConfigHub import matters
+- [ConfigHub Documentation](https://docs.confighub.com) — Full ConfigHub guide
+- [Import Docs Crosswalk](../reference/import-docs-crosswalk.md) — Archived import docs mapped to current docs

--- a/docs/reference/evidence-export-v1.md
+++ b/docs/reference/evidence-export-v1.md
@@ -1,0 +1,218 @@
+# Evidence Export v1
+
+**Status:** Specification
+**Version:** evidence-export.v1
+**Since:** v0.19
+**Issue:** #166
+
+---
+
+## Purpose
+
+This document defines the **evidence export format** for cub-scout debug bundles.
+Evidence exports are derived from bundle contents and formatted for consumption by
+external systems (tickets, chat, CI/CD, audit storage).
+
+**Key invariant:** Creating or exporting evidence MUST NOT modify intended or runtime state.
+Evidence is read-only and observational.
+
+---
+
+## Ownership Split
+
+| Concern | Owner | Notes |
+|---------|-------|-------|
+| Bundle capture (cluster observation) | cub-scout | `cub-scout debug` captures bundle |
+| Bundle summarization | cub-scout | `bundle summarize --format <fmt>` |
+| Evidence export API | ConfigHub (future) | POST to Slack, Jira, S3 |
+| Evidence correlation (across bundles) | ConfigHub (future) | Timeline, ChangeSet linkage |
+
+cub-scout owns the **summary schema** (`BundleSummary`) and the **rendering formats**
+(ticket, PR, Slack, ASCII, JSON). ConfigHub owns the **export API** and **evidence storage**.
+
+---
+
+## BundleSummary Schema (cub-scout)
+
+The `BundleSummary` is the structured output of `bundle summarize --format json`.
+This is the canonical evidence payload that cub-scout produces.
+
+```json
+{
+  "formatVersion": "v1",
+  "cluster": "prod-east",
+  "namespace": "payments",
+  "target": "Deployment/payments-api",
+  "capturedAt": "2026-02-06T14:30:00Z",
+  "gitContext": {
+    "commit": "abc123def456",
+    "branch": "main",
+    "remote": "https://github.com/acme/apps"
+  },
+  "changes": {
+    "driftCount": 3,
+    "eventCount": 12,
+    "categories": ["config", "replica-count"],
+    "objects": ["Deployment/payments-api", "HPA/payments-api-hpa"]
+  },
+  "riskSignals": [
+    {
+      "level": "critical",
+      "message": "3 critical drift finding(s)"
+    }
+  ],
+  "evidence": {
+    "bundlePath": "./debug-bundle-2026-02-06",
+    "bundleHash": "sha256:789xyz..."
+  }
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `formatVersion` | string | Yes | Always `"v1"` for this schema |
+| `cluster` | string | No | Cluster name from bundle metadata |
+| `namespace` | string | No | Target namespace |
+| `target` | string | Yes | Target resource (e.g., `Deployment/api`) |
+| `capturedAt` | string | Yes | ISO 8601 timestamp of bundle creation |
+| `gitContext` | object | No | Git context at capture time |
+| `gitContext.commit` | string | No | Git commit SHA |
+| `gitContext.branch` | string | No | Git branch name |
+| `gitContext.remote` | string | No | Git remote URL |
+| `changes` | object | Yes | Summary of detected changes |
+| `changes.driftCount` | int | Yes | Number of drift findings |
+| `changes.eventCount` | int | Yes | Number of Kubernetes events |
+| `changes.categories` | []string | No | Categories of changes detected |
+| `changes.objects` | []string | No | Affected resource identifiers |
+| `riskSignals` | []object | No | Potential issues detected |
+| `riskSignals[].level` | string | Yes | `"warning"` or `"critical"` |
+| `riskSignals[].message` | string | Yes | Human-readable risk description |
+| `evidence` | object | Yes | Bundle provenance |
+| `evidence.bundlePath` | string | Yes | Path to the source bundle |
+| `evidence.bundleHash` | string | No | SHA-256 digest of bundle contents |
+
+---
+
+## Rendering Formats
+
+`bundle summarize --format <fmt>` produces the following formats:
+
+| Format | Use Case | Content Type |
+|--------|----------|--------------|
+| `json` | Machine consumption, CI/CD | `application/json` |
+| `ascii` | Terminal display | `text/plain` |
+| `ticket` | Jira, Linear, GitHub Issues | `text/markdown` |
+| `pr` | Pull request description | `text/markdown` |
+| `slack` | Slack Block Kit | `application/json` |
+
+### Stable Rendering Rules
+
+1. **Deterministic:** Same bundle + same format = identical output
+2. **No external lookups:** Renderers use only bundle contents
+3. **Omit absent fields:** Optional fields are omitted, not null
+4. **Sorted arrays:** Categories, objects, risk signals sorted for determinism
+
+---
+
+## Mapping: Bundle Contents → BundleSummary
+
+The `BundleSummary` is derived entirely from the debug bundle's internal files:
+
+| BundleSummary field | Source in bundle | Derivation |
+|---------------------|-----------------|------------|
+| `formatVersion` | Hard-coded | Always `"v1"` |
+| `cluster` | `metadata.json → target.cluster` | Direct copy |
+| `namespace` | `metadata.json → target.namespace` | Direct copy |
+| `target` | `metadata.json → target.kind/name` | Concatenated |
+| `capturedAt` | `metadata.json → createdAt` | Direct copy |
+| `gitContext` | `metadata.json → gitContext` | Direct copy (if present) |
+| `changes.driftCount` | `drift.json → len(findings)` | Count of drift findings |
+| `changes.eventCount` | `events.json → len(events)` | Count of K8s events |
+| `changes.categories` | `drift.json → unique(finding.category)` | Deduplicated, sorted |
+| `changes.objects` | `drift.json → unique(finding.resource)` | Deduplicated, sorted |
+| `riskSignals` | `session.json → rootCause + drift severity` | Aggregated from analysis |
+| `evidence.bundlePath` | Input argument | Path provided to CLI |
+| `evidence.bundleHash` | Computed | SHA-256 of bundle directory |
+
+---
+
+## Mapping: BundleSummary → Slack Block Kit
+
+The Slack format maps `BundleSummary` fields to Slack Block Kit elements:
+
+| BundleSummary field | Slack Block Kit element |
+|---------------------|------------------------|
+| `target` | Header block text |
+| `cluster`, `namespace` | Section fields |
+| `capturedAt` | Context element |
+| `changes.driftCount` | Section field (bold count) |
+| `changes.categories` | Section field (comma-joined) |
+| `riskSignals` | Context elements with level emoji |
+| `evidence.bundlePath` | Not included (local path) |
+
+---
+
+## Mapping: BundleSummary → Ticket Markdown
+
+The ticket format maps `BundleSummary` to markdown:
+
+| Section | Source |
+|---------|--------|
+| Title (`# Summary`) | `target` + `cluster` |
+| Metadata table | `cluster`, `namespace`, `capturedAt` |
+| Changes section | `changes.driftCount`, `changes.eventCount` |
+| Categories | `changes.categories` as bullet list |
+| Risk Signals | `riskSignals` as warning/critical markers |
+| Git Context | `gitContext.commit`, `gitContext.branch` |
+| Evidence | `evidence.bundlePath` |
+
+---
+
+## Exit Codes
+
+| Exit Code | Meaning |
+|-----------|---------|
+| 0 | Summary generated successfully |
+| 1 | Bundle read error or invalid format |
+
+---
+
+## Relationship to Future Evidence API
+
+When ConfigHub implements the evidence export API, cub-scout's `BundleSummary` will
+be the payload. The API surface is out of scope for cub-scout:
+
+```
+cub-scout (produces)          ConfigHub (consumes)
+─────────────────────         ──────────────────────
+BundleSummary (JSON)    →     Evidence ingestion API
+                              Evidence storage
+                              Slack/Jira export
+                              Timeline correlation
+```
+
+cub-scout will NOT implement:
+- Posting to Slack (ConfigHub API does this)
+- Creating Jira tickets (ConfigHub API does this)
+- S3 upload (ConfigHub API does this)
+- Evidence correlation across bundles (ConfigHub Timeline does this)
+
+cub-scout WILL continue to own:
+- Bundle capture from cluster
+- Bundle summarization (all 5 formats)
+- Deterministic replay
+- Local CLI rendering
+
+---
+
+## See Also
+
+| Doc | Purpose |
+|-----|---------|
+| [../debug-bundle.md](../debug-bundle.md) | Debug bundle format specification |
+| [cli-contract.md](cli-contract.md) | CLI contract for `bundle summarize` |
+| [json-contracts.md](json-contracts.md) | JSON contract index |
+| [../bundle-diff.md](../bundle-diff.md) | Bundle diff v1 specification |
+| [../bundle-timeline.md](../bundle-timeline.md) | Bundle timeline v1 specification |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -189,8 +189,51 @@ Format: `RISK-2025-XXXX`
 
 ---
 
+## Emerging Concepts (ConfigHub Evolution)
+
+> **Note:** ConfigHub's data model is evolving. The concepts below describe the
+> direction of travel. The current API still uses Space/Unit/Target. cub-scout
+> uses App/Deployment language in user-facing output while mapping to the
+> current API under the hood.
+
+### App (Multi-Unit)
+
+A collection of components (api, worker, database) owned by one team, deployed
+together. The "App" is what users think about — the Unit is the implementation detail.
+
+```
+App: payment-service
+├── Components: api, worker, redis
+└── Deployments: dev, staging, prod
+```
+
+### Deployment (App × Target)
+
+The junction of an App and a Target. What you get when you deploy an App to a
+specific environment. Maps to what was previously "a Space with multiple Units."
+
+### OCI Transport
+
+ConfigHub's default transport for rendered manifests. The pipeline is:
+
+```
+Git → ConfigHub renders → OCI artifact → Flux/Argo pulls from OCI → cluster
+```
+
+cub-scout does not interact with OCI directly. It discovers workloads from the
+cluster end of this pipeline.
+
+### Bridge Worker
+
+Connector between ConfigHub and external systems (Kubernetes, ArgoCD, Flux).
+Bridge workers handle the actual deployment — ConfigHub orchestrates, Flux/Argo
+apply.
+
+---
+
 ## See Also
 
 - [Hub/AppSpace Examples](hub-appspace-examples.md) — Model examples
 - [Import to ConfigHub](../howto/import-to-confighub.md) — Import architecture
+- [Import from Live](../howto/import-from-live.md) — Cluster-only import (no Git required)
 - [Scan for risk issues](../howto/scan-for-risks.md) — risk scanning guide

--- a/docs/reference/hub-appspace-examples.md
+++ b/docs/reference/hub-appspace-examples.md
@@ -451,9 +451,21 @@ These mappings are working defaults, not immutable doctrine. Domain-to-platform 
 
 ---
 
+## Worked Import Examples
+
+These examples show cub-scout's import discovery in action, with static fixtures and expected JSON output:
+
+| Example | Pattern | What It Shows |
+|---------|---------|---------------|
+| [Import from Live](../../examples/import-from-live/) | Arnie (ArgoCD) | Cluster-only discovery, variant inference from Application paths |
+| [Combined Git + Live](../../examples/combined-git-live/) | Banko (Flux) | Git repo + cluster alignment, drift detection |
+| [Fleet Import](../../examples/fleet-import/) | Multi-cluster | Aggregating 2 cluster imports into a unified App proposal |
+
 ## See Also
 
 - [Hub/AppSpace Model](#hub-appspace-model) - Conceptual model
 - [Adoption Patterns](#adoption-patterns) - Banko/Arnie source details
+- [Import to ConfigHub](../howto/import-to-confighub.md) - Full migration path
+- [Import from Live](../howto/import-from-live.md) - Cluster-only import guide
 - [Keybindings Reference](keybindings.md) - All keyboard shortcuts
 - [Views Reference](views.md) - What each view shows

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -27,6 +27,7 @@ Start here for machine-readable output contracts.
 | Bundle diff | [../bundle-diff.md](../bundle-diff.md) | `bundle-diff.v1` |
 | Bundle timeline | [../bundle-timeline.md](../bundle-timeline.md) | `bundle-timeline.v1` |
 | Catalog | [../catalog.md](../catalog.md) | `catalog.v1` |
+| Evidence export | [evidence-export-v1.md](evidence-export-v1.md) | `evidence-export.v1` |
 | General CLI JSON behavior | [cli-contract.md](cli-contract.md) + [commands.md](commands.md) | Command-specific |
 | GitOps checkpoint proposal schemas | [gitops-checkpoint-schemas.md](gitops-checkpoint-schemas.md) | `change-intent.v1`, `execution-report.v1`, `change-interaction-card.v1`, `decision-receipt.v1`, `execution-receipt.v1`, `outcome-receipt.v1` |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,7 @@ Worked examples showing how cub-scout discovers workloads and proposes ConfigHub
 | [import-from-live/](import-from-live/) | **ArgoCD** (Arnie) | Cluster-only discovery — no Git required |
 | [combined-git-live/](combined-git-live/) | **Flux** (Banko) | Git repo + cluster alignment |
 | [fleet-import/](fleet-import/) | **Multi-cluster** | Aggregating imports from 2 clusters into a unified proposal |
+| [demo-data-adt/](demo-data-adt/) | **App-Deployment-Target** | Multi-app × multi-env with version skew detection |
 
 These examples use static fixtures (no live cluster needed) and include expected JSON output for validation.
 
@@ -124,6 +125,7 @@ Expected output for each example is in `test/fixtures/expected-output/examples/`
 | [import-from-live/](import-from-live/) | **Working** | Cluster-only import (ArgoCD/Arnie pattern) | Learning import discovery, no Git needed |
 | [combined-git-live/](combined-git-live/) | **Working** | Git + cluster alignment (Flux/Banko pattern) | Learning combined discovery, Git drift detection |
 | [fleet-import/](fleet-import/) | **Working** | Multi-cluster fleet aggregation | Learning fleet import, cross-cluster proposals |
+| [demo-data-adt/](demo-data-adt/) | **Working** | App-Deployment-Target model (multi-app × multi-env) | Learning ADT model, version skew, scan |
 | [workflows/](workflows/) | **Working** | Artifact + fleet demos (CI → local, env comparison) | CI/CD integration, sharing bundles, comparing environments |
 | [apptique-examples/](apptique-examples/) | **Working** | Real GitOps patterns (Flux, Argo) | Learning GitOps ownership |
 | [platform-example/](platform-example/) | **Working** | Full Flux learning environment (~35 resources) | Learning GitOps + orphan detection |

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,19 @@ cub-scout demo quick
 
 Clone and deploy these repos to see the agent in action with real GitOps setups.
 
-### Apptique Examples (NEW)
+### Import & Discovery Examples (NEW)
+
+Worked examples showing how cub-scout discovers workloads and proposes ConfigHub App structures:
+
+| Example | Pattern | Shows |
+|---------|---------|-------|
+| [import-from-live/](import-from-live/) | **ArgoCD** (Arnie) | Cluster-only discovery — no Git required |
+| [combined-git-live/](combined-git-live/) | **Flux** (Banko) | Git repo + cluster alignment |
+| [fleet-import/](fleet-import/) | **Multi-cluster** | Aggregating imports from 2 clusters into a unified proposal |
+
+These examples use static fixtures (no live cluster needed) and include expected JSON output for validation.
+
+### Apptique Examples
 
 Multiple GitOps patterns using Google's Online Boutique app — **included in this repo**:
 
@@ -109,6 +121,9 @@ Expected output for each example is in `test/fixtures/expected-output/examples/`
 
 | File/Folder | Type | What | Use When |
 |-------------|------|------|----------|
+| [import-from-live/](import-from-live/) | **Working** | Cluster-only import (ArgoCD/Arnie pattern) | Learning import discovery, no Git needed |
+| [combined-git-live/](combined-git-live/) | **Working** | Git + cluster alignment (Flux/Banko pattern) | Learning combined discovery, Git drift detection |
+| [fleet-import/](fleet-import/) | **Working** | Multi-cluster fleet aggregation | Learning fleet import, cross-cluster proposals |
 | [workflows/](workflows/) | **Working** | Artifact + fleet demos (CI → local, env comparison) | CI/CD integration, sharing bundles, comparing environments |
 | [apptique-examples/](apptique-examples/) | **Working** | Real GitOps patterns (Flux, Argo) | Learning GitOps ownership |
 | [platform-example/](platform-example/) | **Working** | Full Flux learning environment (~35 resources) | Learning GitOps + orphan detection |

--- a/examples/combined-git-live/README.md
+++ b/examples/combined-git-live/README.md
@@ -1,0 +1,169 @@
+# Combined Git + Live Cluster Alignment
+
+This example shows `cub-scout combined --suggest --json` aligning a Git repo
+structure with live cluster state. It uses the "Banko" pattern -- a Flux monorepo
+with Kustomize base/overlay per app.
+
+## The Scenario
+
+You have a payments team ("Banko") that runs two services via Flux.
+You want to understand: does the cluster match what's in Git?
+
+## 1. Here's the Git Repo
+
+```
+git-repo/
+├── apps/
+│   ├── payment-api/
+│   │   ├── base/
+│   │   │   ├── deployment.yaml
+│   │   │   ├── service.yaml
+│   │   │   └── kustomization.yaml
+│   │   └── overlays/
+│   │       ├── dev/kustomization.yaml
+│   │       └── prod/kustomization.yaml
+│   ├── payment-worker/
+│   │   ├── base/
+│   │   │   ├── deployment.yaml
+│   │   │   └── kustomization.yaml
+│   │   └── overlays/
+│   │       ├── dev/kustomization.yaml
+│   │       └── prod/kustomization.yaml
+│   └── notifications-service/          <-- defined in Git, not deployed yet
+│       └── base/
+│           ├── deployment.yaml
+│           └── kustomization.yaml
+└── platform/
+    └── monitoring/
+        └── kustomization.yaml
+```
+
+Standard Flux monorepo. Each app has a `base/` and environment-specific
+`overlays/`. Kustomizations patch replicas and resource limits per environment.
+
+## 2. Here's What's Running
+
+The cluster has five Deployments across two namespaces:
+
+| Namespace      | Deployment       | Owner  | Replicas | Notes                 |
+|----------------|------------------|--------|----------|-----------------------|
+| payment-dev    | payment-api      | Flux   | 1        | Matches Git overlay   |
+| payment-dev    | payment-worker   | Flux   | 1        | Matches Git overlay   |
+| payment-prod   | payment-api      | Flux   | 3        | Matches Git overlay   |
+| payment-prod   | payment-worker   | Flux   | 2        | Matches Git overlay   |
+| payment-prod   | cache-warmer     | Native | 1        | Not in Git            |
+
+The Flux-managed Deployments carry `kustomize.toolkit.fluxcd.io/*` labels.
+The `cache-warmer` was applied manually -- no GitOps labels at all.
+
+## 3. Here's What cub-scout Finds
+
+```bash
+./cub-scout combined \
+  --git-path examples/combined-git-live/git-repo \
+  --namespace payment-dev,payment-prod \
+  --suggest --json
+```
+
+The alignment result sorts every app into one of three buckets:
+
+| App                   | Status       | What It Means                               |
+|-----------------------|--------------|---------------------------------------------|
+| payment-api (dev)     | aligned      | In Git, in cluster, Flux labels match       |
+| payment-api (prod)    | aligned      | In Git, in cluster, Flux labels match       |
+| payment-worker (dev)  | aligned      | In Git, in cluster, Flux labels match       |
+| payment-worker (prod) | aligned      | In Git, in cluster, Flux labels match       |
+| notifications-service | git-only     | Defined in Git, not deployed anywhere       |
+| cache-warmer          | cluster-only | Running in cluster, no matching Git source  |
+
+cub-scout doesn't guess whether `git-only` or `cluster-only` is a problem.
+It reports the facts. You decide what to do about it.
+
+## 4. Here's the Proposal
+
+When you add `--suggest`, cub-scout generates a ConfigHub App structure:
+
+```
+PROPOSED HUB/APP SPACE MODEL
+
+  HUB (Platform Catalog)
+    Base: payment-api (apps/payment-api/base)
+    Base: payment-worker (apps/payment-worker/base)
+    Base: notifications-service (apps/notifications-service/base)
+
+  APP SPACE: banko-team
+    Deployer: Flux
+    Reconciliation Rules:
+      variant=prod  -> drift:revert, approval:required
+      variant=dev   -> drift:accept, approval:none
+
+    payment-api
+      payment-api-dev    (variant=dev)   aligned
+      payment-api-prod   (variant=prod)  aligned
+
+    payment-worker
+      payment-worker-dev  (variant=dev)   aligned
+      payment-worker-prod (variant=prod)  aligned
+
+    notifications-service
+      notifications-service (variant=default)  NOT DEPLOYED
+
+    cache-warmer
+      cache-warmer (variant=default)  ORPHAN (not in Git)
+
+  Summary: 4 aligned, 1 git-only, 1 cluster-only
+```
+
+Variant inference comes from the Kustomization overlay paths:
+`overlays/dev` becomes variant `dev`, `overlays/prod` becomes variant `prod`.
+
+## Key Points
+
+- **Combined mode merges two information sources.** Git tells you what should
+  exist. The cluster tells you what actually exists. cub-scout shows the gap.
+
+- **Three states, no ambiguity.** `aligned` means both sources agree. `git-only`
+  means intent without deployment. `cluster-only` means deployment without intent.
+
+- **Read-only.** cub-scout never modifies the cluster or the Git repo. The
+  `--suggest` flag produces a proposal, not an action.
+
+- **Variant inference is deterministic.** It comes from Kustomization paths, not
+  guessing. If the path contains `overlays/prod`, the variant is `prod`.
+
+## Files in This Example
+
+| File | Purpose |
+|------|---------|
+| `git-repo/` | Simulated Flux monorepo with base/overlay Kustomize structure |
+| `cluster-fixtures/deployments.yaml` | Cluster Deployments with Flux labels + one orphan |
+| `expected-output/alignment.json` | Full JSON output from `combined --suggest --json` |
+
+## Try It
+
+If you have a cluster with these resources deployed:
+
+```bash
+# Apply the fixtures
+kubectl create namespace payment-dev
+kubectl create namespace payment-prod
+kubectl apply -f examples/combined-git-live/cluster-fixtures/deployments.yaml
+
+# Run combined alignment
+./cub-scout combined \
+  --git-path examples/combined-git-live/git-repo \
+  --namespace payment-dev \
+  --suggest
+
+# JSON output for scripting
+./cub-scout combined \
+  --git-path examples/combined-git-live/git-repo \
+  --namespace payment-dev \
+  --suggest --json | jq '.alignment[] | select(.status != "aligned")'
+```
+
+## See Also
+
+- [Flux Monorepo Pattern](../apptique-examples/flux-monorepo/) -- Single-app Flux example
+- [Fleet Import](../fleet-import/) -- Aggregating imports from multiple clusters
+- [CLI-GUIDE.md](../../CLI-GUIDE.md) -- Full CLI reference

--- a/examples/combined-git-live/cluster-fixtures/deployments.yaml
+++ b/examples/combined-git-live/cluster-fixtures/deployments.yaml
@@ -1,0 +1,182 @@
+# Cluster state: Flux-managed workloads + one cluster-only Deployment.
+# Apply these to simulate what cub-scout would discover from a live cluster.
+#
+# Flux-managed workloads carry kustomize.toolkit.fluxcd.io/* labels.
+# The cache-warmer Deployment has no GitOps labels (Native owner).
+
+---
+# payment-api in dev (Flux-managed)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-api
+  namespace: payment-dev
+  labels:
+    app.kubernetes.io/name: payment-api
+    app.kubernetes.io/part-of: banko
+    environment: dev
+    kustomize.toolkit.fluxcd.io/name: banko-dev
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-api
+        app.kubernetes.io/part-of: banko
+        environment: dev
+    spec:
+      containers:
+        - name: api
+          image: banko/payment-api:v1.8.2
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+# payment-api in prod (Flux-managed)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-api
+  namespace: payment-prod
+  labels:
+    app.kubernetes.io/name: payment-api
+    app.kubernetes.io/part-of: banko
+    environment: prod
+    kustomize.toolkit.fluxcd.io/name: banko-prod
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-api
+        app.kubernetes.io/part-of: banko
+        environment: prod
+    spec:
+      containers:
+        - name: api
+          image: banko/payment-api:v1.8.2
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+# payment-worker in dev (Flux-managed)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-worker
+  namespace: payment-dev
+  labels:
+    app.kubernetes.io/name: payment-worker
+    app.kubernetes.io/part-of: banko
+    environment: dev
+    kustomize.toolkit.fluxcd.io/name: banko-dev
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-worker
+        app.kubernetes.io/part-of: banko
+        environment: dev
+    spec:
+      containers:
+        - name: worker
+          image: banko/payment-worker:v1.8.2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+---
+# payment-worker in prod (Flux-managed)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-worker
+  namespace: payment-prod
+  labels:
+    app.kubernetes.io/name: payment-worker
+    app.kubernetes.io/part-of: banko
+    environment: prod
+    kustomize.toolkit.fluxcd.io/name: banko-prod
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-worker
+        app.kubernetes.io/part-of: banko
+        environment: prod
+    spec:
+      containers:
+        - name: worker
+          image: banko/payment-worker:v1.8.2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+# cache-warmer in prod (cluster-only -- not in Git)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-warmer
+  namespace: payment-prod
+  labels:
+    app.kubernetes.io/name: cache-warmer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cache-warmer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cache-warmer
+    spec:
+      containers:
+        - name: warmer
+          image: banko/cache-warmer:v0.2.1
+          env:
+            - name: REDIS_URL
+              value: "redis:6379"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi

--- a/examples/combined-git-live/expected-output/alignment.json
+++ b/examples/combined-git-live/expected-output/alignment.json
@@ -1,0 +1,232 @@
+{
+  "gitRepo": {
+    "type": "flux-tenant-mono",
+    "apps": [
+      {
+        "name": "payment-api",
+        "basePath": "apps/payment-api/base",
+        "variants": [
+          { "name": "dev", "path": "apps/payment-api/overlays/dev" },
+          { "name": "prod", "path": "apps/payment-api/overlays/prod" }
+        ]
+      },
+      {
+        "name": "payment-worker",
+        "basePath": "apps/payment-worker/base",
+        "variants": [
+          { "name": "dev", "path": "apps/payment-worker/overlays/dev" },
+          { "name": "prod", "path": "apps/payment-worker/overlays/prod" }
+        ]
+      },
+      {
+        "name": "notifications-service",
+        "basePath": "apps/notifications-service/base",
+        "variants": []
+      }
+    ]
+  },
+  "cluster": {
+    "namespace": "payment-dev,payment-prod",
+    "model": "hub-appspace",
+    "workloads": [
+      {
+        "kind": "Deployment",
+        "namespace": "payment-dev",
+        "name": "payment-api",
+        "owner": "Flux",
+        "connected": false,
+        "ready": true,
+        "replicas": 1,
+        "kustomizationPath": "./apps/payment-api/overlays/dev",
+        "labels": {
+          "app.kubernetes.io/name": "payment-api",
+          "app.kubernetes.io/part-of": "banko",
+          "environment": "dev",
+          "kustomize.toolkit.fluxcd.io/name": "banko-dev",
+          "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+        }
+      },
+      {
+        "kind": "Deployment",
+        "namespace": "payment-prod",
+        "name": "payment-api",
+        "owner": "Flux",
+        "connected": false,
+        "ready": true,
+        "replicas": 3,
+        "kustomizationPath": "./apps/payment-api/overlays/prod",
+        "labels": {
+          "app.kubernetes.io/name": "payment-api",
+          "app.kubernetes.io/part-of": "banko",
+          "environment": "prod",
+          "kustomize.toolkit.fluxcd.io/name": "banko-prod",
+          "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+        }
+      },
+      {
+        "kind": "Deployment",
+        "namespace": "payment-dev",
+        "name": "payment-worker",
+        "owner": "Flux",
+        "connected": false,
+        "ready": true,
+        "replicas": 1,
+        "kustomizationPath": "./apps/payment-worker/overlays/dev",
+        "labels": {
+          "app.kubernetes.io/name": "payment-worker",
+          "app.kubernetes.io/part-of": "banko",
+          "environment": "dev",
+          "kustomize.toolkit.fluxcd.io/name": "banko-dev",
+          "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+        }
+      },
+      {
+        "kind": "Deployment",
+        "namespace": "payment-prod",
+        "name": "payment-worker",
+        "owner": "Flux",
+        "connected": false,
+        "ready": true,
+        "replicas": 2,
+        "kustomizationPath": "./apps/payment-worker/overlays/prod",
+        "labels": {
+          "app.kubernetes.io/name": "payment-worker",
+          "app.kubernetes.io/part-of": "banko",
+          "environment": "prod",
+          "kustomize.toolkit.fluxcd.io/name": "banko-prod",
+          "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+        }
+      },
+      {
+        "kind": "Deployment",
+        "namespace": "payment-prod",
+        "name": "cache-warmer",
+        "owner": "Native",
+        "connected": false,
+        "ready": true,
+        "replicas": 1,
+        "labels": {
+          "app.kubernetes.io/name": "cache-warmer"
+        }
+      }
+    ]
+  },
+  "alignment": [
+    {
+      "app": "payment-api",
+      "gitVariant": "dev",
+      "livePath": "./apps/payment-api/overlays/dev",
+      "status": "aligned",
+      "workloads": ["payment-dev/payment-api"]
+    },
+    {
+      "app": "payment-api",
+      "gitVariant": "prod",
+      "livePath": "./apps/payment-api/overlays/prod",
+      "status": "aligned",
+      "workloads": ["payment-prod/payment-api"]
+    },
+    {
+      "app": "payment-worker",
+      "gitVariant": "dev",
+      "livePath": "./apps/payment-worker/overlays/dev",
+      "status": "aligned",
+      "workloads": ["payment-dev/payment-worker"]
+    },
+    {
+      "app": "payment-worker",
+      "gitVariant": "prod",
+      "livePath": "./apps/payment-worker/overlays/prod",
+      "status": "aligned",
+      "workloads": ["payment-prod/payment-worker"]
+    },
+    {
+      "app": "notifications-service",
+      "gitVariant": "",
+      "status": "git-only"
+    },
+    {
+      "app": "cache-warmer",
+      "status": "cluster-only",
+      "workloads": ["payment-prod/cache-warmer"]
+    }
+  ],
+  "proposal": {
+    "hubBases": [
+      { "name": "payment-api", "gitPath": "apps/payment-api/base", "source": "git" },
+      { "name": "payment-worker", "gitPath": "apps/payment-worker/base", "source": "git" },
+      { "name": "notifications-service", "gitPath": "apps/notifications-service/base", "source": "git" }
+    ],
+    "appSpace": "banko-team",
+    "deployer": "Flux",
+    "reconciliation": [
+      { "match": { "variant": "prod" }, "drift": "revert", "approval": "required" },
+      { "match": { "variant": "dev" }, "drift": "accept", "approval": "none" }
+    ],
+    "units": [
+      {
+        "slug": "cache-warmer",
+        "app": "cache-warmer",
+        "variant": "default",
+        "workloads": ["payment-prod/cache-warmer"],
+        "status": "cluster-only",
+        "labels": { "app": "cache-warmer", "variant": "default" }
+      },
+      {
+        "slug": "notifications-service",
+        "app": "notifications-service",
+        "variant": "default",
+        "gitPath": "apps/notifications-service/base",
+        "status": "git-only",
+        "labels": { "app": "notifications-service", "variant": "default" }
+      },
+      {
+        "slug": "payment-api-dev",
+        "app": "payment-api",
+        "variant": "dev",
+        "upstream": "payment-api",
+        "gitPath": "apps/payment-api/overlays/dev",
+        "workloads": ["payment-dev/payment-api"],
+        "status": "aligned",
+        "labels": { "app": "payment-api", "variant": "dev", "team": "banko" }
+      },
+      {
+        "slug": "payment-api-prod",
+        "app": "payment-api",
+        "variant": "prod",
+        "upstream": "payment-api",
+        "gitPath": "apps/payment-api/overlays/prod",
+        "workloads": ["payment-prod/payment-api"],
+        "status": "aligned",
+        "labels": { "app": "payment-api", "variant": "prod", "team": "banko" }
+      },
+      {
+        "slug": "payment-worker-dev",
+        "app": "payment-worker",
+        "variant": "dev",
+        "upstream": "payment-worker",
+        "gitPath": "apps/payment-worker/overlays/dev",
+        "workloads": ["payment-dev/payment-worker"],
+        "status": "aligned",
+        "labels": { "app": "payment-worker", "variant": "dev", "team": "banko" }
+      },
+      {
+        "slug": "payment-worker-prod",
+        "app": "payment-worker",
+        "variant": "prod",
+        "upstream": "payment-worker",
+        "gitPath": "apps/payment-worker/overlays/prod",
+        "workloads": ["payment-prod/payment-worker"],
+        "status": "aligned",
+        "labels": { "app": "payment-worker", "variant": "prod", "team": "banko" }
+      }
+    ],
+    "clusterOnly": [
+      {
+        "app": "cache-warmer",
+        "workloads": ["payment-prod/cache-warmer"],
+        "owner": "Native"
+      }
+    ]
+  }
+}

--- a/examples/combined-git-live/git-repo/apps/notifications-service/base/deployment.yaml
+++ b/examples/combined-git-live/git-repo/apps/notifications-service/base/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications-service
+  labels:
+    app.kubernetes.io/name: notifications-service
+    app.kubernetes.io/part-of: banko
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notifications-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: notifications-service
+        app.kubernetes.io/part-of: banko
+    spec:
+      containers:
+        - name: notifications
+          image: banko/notifications-service:v0.3.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SMTP_HOST
+              value: "mailgun:587"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/examples/combined-git-live/git-repo/apps/notifications-service/base/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/apps/notifications-service/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: notifications-service
+      app.kubernetes.io/part-of: banko

--- a/examples/combined-git-live/git-repo/apps/payment-api/base/deployment.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-api/base/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-api
+  labels:
+    app.kubernetes.io/name: payment-api
+    app.kubernetes.io/part-of: banko
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-api
+        app.kubernetes.io/part-of: banko
+    spec:
+      containers:
+        - name: api
+          image: banko/payment-api:v1.8.2
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: DB_HOST
+              value: "postgres:5432"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10

--- a/examples/combined-git-live/git-repo/apps/payment-api/base/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-api/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: payment-api
+      app.kubernetes.io/part-of: banko

--- a/examples/combined-git-live/git-repo/apps/payment-api/base/service.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-api/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-api
+  labels:
+    app.kubernetes.io/name: payment-api
+    app.kubernetes.io/part-of: banko
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: payment-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/examples/combined-git-live/git-repo/apps/payment-api/overlays/dev/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-api/overlays/dev/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: payment-dev
+
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      environment: dev
+
+patches:
+  - target:
+      kind: Deployment
+      name: payment-api
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1

--- a/examples/combined-git-live/git-repo/apps/payment-api/overlays/prod/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-api/overlays/prod/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: payment-prod
+
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      environment: prod
+
+patches:
+  - target:
+      kind: Deployment
+      name: payment-api
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: "250m"
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: "256Mi"
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: "500m"
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: "512Mi"

--- a/examples/combined-git-live/git-repo/apps/payment-worker/base/deployment.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-worker/base/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-worker
+  labels:
+    app.kubernetes.io/name: payment-worker
+    app.kubernetes.io/part-of: banko
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-worker
+        app.kubernetes.io/part-of: banko
+    spec:
+      containers:
+        - name: worker
+          image: banko/payment-worker:v1.8.2
+          env:
+            - name: QUEUE_URL
+              value: "rabbitmq:5672"
+            - name: DB_HOST
+              value: "postgres:5432"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/examples/combined-git-live/git-repo/apps/payment-worker/base/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-worker/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: payment-worker
+      app.kubernetes.io/part-of: banko

--- a/examples/combined-git-live/git-repo/apps/payment-worker/overlays/dev/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-worker/overlays/dev/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: payment-dev
+
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      environment: dev
+
+patches:
+  - target:
+      kind: Deployment
+      name: payment-worker
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1

--- a/examples/combined-git-live/git-repo/apps/payment-worker/overlays/prod/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/apps/payment-worker/overlays/prod/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: payment-prod
+
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      environment: prod
+
+patches:
+  - target:
+      kind: Deployment
+      name: payment-worker
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 2

--- a/examples/combined-git-live/git-repo/platform/monitoring/kustomization.yaml
+++ b/examples/combined-git-live/git-repo/platform/monitoring/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources: []
+
+# Placeholder for monitoring stack (e.g., Prometheus, Grafana).
+# In a real repo this would reference HelmReleases or remote bases.

--- a/examples/demo-data-adt/README.md
+++ b/examples/demo-data-adt/README.md
@@ -1,0 +1,98 @@
+# Demo Data: App-Deployment-Target Pattern
+
+This example demonstrates the **App-Deployment-Target** model using a subset of
+the [demo-data dataset](https://github.com/confighubai/examples-internal/tree/main/demo-data).
+
+## What This Shows
+
+The App-Deployment-Target model organizes workloads as:
+
+```
+App (eshop)
+├── Deployment: dev     (1 replica, debug logging)
+├── Deployment: staging (2 replicas, info logging)
+└── Deployment: prod    (3 replicas, warn logging, resource limits)
+```
+
+Each Deployment maps to a ConfigHub Space. Each component (api, worker)
+maps to a Unit within that Space.
+
+## Fixtures
+
+| File | App | Environment | Owner | Version Skew |
+|------|-----|-------------|-------|-------------|
+| `dev-eshop.yaml` | eshop | dev | Helm | api:4.2.1 |
+| `prod-eshop.yaml` | eshop | prod | Helm | api:**4.2.0** (behind dev!) |
+| `prod-website.yaml` | website | prod | ArgoCD | frontend:2.1.0 |
+
+**Intentional version skew**: `us-prod-eshop` has `eshop/api:4.2.0` while
+`dev-eshop` has `eshop/api:4.2.1`. This is a common pattern where prod
+lags behind dev after a deploy freeze.
+
+## Labels
+
+All resources carry ConfigHub labels for multi-dimensional querying:
+
+| Label | Values | Use |
+|-------|--------|-----|
+| `App` | eshop, website | Group by application |
+| `AppOwner` | Product, Marketing | Group by team |
+| `TargetRole` | dev, prod | Filter by environment |
+| `TargetRegion` | us-east | Filter by region |
+
+## Try It
+
+### Scan for risks (works today, no cluster needed)
+
+```bash
+./cub-scout scan --file examples/demo-data-adt/fixtures/dev-eshop.yaml
+./cub-scout scan --file examples/demo-data-adt/fixtures/prod-eshop.yaml
+```
+
+### Import discovery (needs cluster)
+
+```bash
+# Deploy fixtures
+kubectl create namespace dev-eshop
+kubectl create namespace us-prod-eshop
+kubectl apply -f examples/demo-data-adt/fixtures/dev-eshop.yaml
+kubectl apply -f examples/demo-data-adt/fixtures/prod-eshop.yaml
+
+# Discover and propose App structure
+./cub-scout import -n dev-eshop --dry-run --json
+./cub-scout import -n us-prod-eshop --dry-run --json
+```
+
+### Ownership detection
+
+```bash
+# See who manages what
+./cub-scout map list -n dev-eshop
+./cub-scout map list -n us-prod-eshop
+./cub-scout map list -n us-prod-website
+```
+
+## Future: Fleet Queries (Connected Mode)
+
+When connected mode fleet queries are implemented, this example will
+demonstrate cross-environment queries:
+
+```bash
+# All prod deployments (future)
+./cub-scout fleet query "Labels.TargetRole=prod"
+
+# Version skew detection (future)
+./cub-scout fleet diff --app eshop --field image
+
+# All apps owned by Product team (future)
+./cub-scout fleet query "Labels.AppOwner=Product"
+```
+
+## Source
+
+Full 6-app × 6-target dataset:
+[confighubai/examples-internal/demo-data](https://github.com/confighubai/examples-internal/tree/main/demo-data)
+
+Related issues:
+- confighubai/confighub#3639 — App-Deployment-Target model
+- confighubai/confighub#3666 — Opinionated Apps/Targets UI

--- a/examples/demo-data-adt/fixtures/dev-eshop.yaml
+++ b/examples/demo-data-adt/fixtures/dev-eshop.yaml
@@ -1,0 +1,80 @@
+# Dev environment for eshop app
+# Labels: App=eshop, AppOwner=Product, TargetRole=dev, TargetRegion=us-east
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eshop-api
+  namespace: dev-eshop
+  labels:
+    app.kubernetes.io/name: eshop-api
+    app.kubernetes.io/instance: eshop
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: eshop-api-1.0.0
+    confighub.com/UnitSlug: eshop-api
+  annotations:
+    confighub.com/SpaceName: dev-eshop
+    confighub.com/Labels.App: eshop
+    confighub.com/Labels.AppOwner: Product
+    confighub.com/Labels.TargetRole: dev
+    confighub.com/Labels.TargetRegion: us-east
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eshop-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eshop-api
+    spec:
+      containers:
+        - name: api
+          image: eshop/api:4.2.1
+          ports:
+            - containerPort: 8080
+          env:
+            - name: LOG_LEVEL
+              value: debug
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eshop-worker
+  namespace: dev-eshop
+  labels:
+    app.kubernetes.io/name: eshop-worker
+    app.kubernetes.io/instance: eshop
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: eshop-worker-1.0.0
+    confighub.com/UnitSlug: eshop-worker
+  annotations:
+    confighub.com/SpaceName: dev-eshop
+    confighub.com/Labels.App: eshop
+    confighub.com/Labels.AppOwner: Product
+    confighub.com/Labels.TargetRole: dev
+    confighub.com/Labels.TargetRegion: us-east
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eshop-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eshop-worker
+    spec:
+      containers:
+        - name: worker
+          image: eshop/worker:4.2.1
+          env:
+            - name: LOG_LEVEL
+              value: debug
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/examples/demo-data-adt/fixtures/prod-eshop.yaml
+++ b/examples/demo-data-adt/fixtures/prod-eshop.yaml
@@ -1,0 +1,87 @@
+# Prod environment for eshop app (US region)
+# Labels: App=eshop, AppOwner=Product, TargetRole=prod, TargetRegion=us-east
+# NOTE: api image is 4.2.0 (intentional version skew vs dev which has 4.2.1)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eshop-api
+  namespace: us-prod-eshop
+  labels:
+    app.kubernetes.io/name: eshop-api
+    app.kubernetes.io/instance: eshop
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: eshop-api-1.0.0
+    confighub.com/UnitSlug: eshop-api
+  annotations:
+    confighub.com/SpaceName: us-prod-eshop
+    confighub.com/Labels.App: eshop
+    confighub.com/Labels.AppOwner: Product
+    confighub.com/Labels.TargetRole: prod
+    confighub.com/Labels.TargetRegion: us-east
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eshop-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eshop-api
+    spec:
+      containers:
+        - name: api
+          image: eshop/api:4.2.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: LOG_LEVEL
+              value: warn
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eshop-worker
+  namespace: us-prod-eshop
+  labels:
+    app.kubernetes.io/name: eshop-worker
+    app.kubernetes.io/instance: eshop
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: eshop-worker-1.0.0
+    confighub.com/UnitSlug: eshop-worker
+  annotations:
+    confighub.com/SpaceName: us-prod-eshop
+    confighub.com/Labels.App: eshop
+    confighub.com/Labels.AppOwner: Product
+    confighub.com/Labels.TargetRole: prod
+    confighub.com/Labels.TargetRegion: us-east
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eshop-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eshop-worker
+    spec:
+      containers:
+        - name: worker
+          image: eshop/worker:4.2.1
+          env:
+            - name: LOG_LEVEL
+              value: warn
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/examples/demo-data-adt/fixtures/prod-website.yaml
+++ b/examples/demo-data-adt/fixtures/prod-website.yaml
@@ -1,0 +1,40 @@
+# Prod environment for website app (US region)
+# Labels: App=website, AppOwner=Marketing, TargetRole=prod, TargetRegion=us-east
+# Managed by ArgoCD (different owner than eshop which uses Helm)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: website-frontend
+  namespace: us-prod-website
+  labels:
+    app.kubernetes.io/name: website-frontend
+    app.kubernetes.io/instance: website
+    argocd.argoproj.io/instance: website-prod
+    confighub.com/UnitSlug: website-frontend
+  annotations:
+    confighub.com/SpaceName: us-prod-website
+    confighub.com/Labels.App: website
+    confighub.com/Labels.AppOwner: Marketing
+    confighub.com/Labels.TargetRole: prod
+    confighub.com/Labels.TargetRegion: us-east
+    argocd.argoproj.io/tracking-id: "website-prod:apps/Deployment:us-prod-website/website-frontend"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: website-frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: website-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: website/frontend:2.1.0
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi

--- a/examples/fleet-import/README.md
+++ b/examples/fleet-import/README.md
@@ -1,0 +1,177 @@
+# Fleet Import: Multi-Cluster Aggregation
+
+This example shows `cub-scout import-cluster-aggregator` merging import data from
+two clusters into a unified App proposal.
+
+## The Scenario
+
+You've already run `cub-scout import --json` against two separate clusters -- a dev
+cluster and a prod cluster. Now you want a single view of what's running across
+both, grouped by app rather than by cluster.
+
+## 1. You've Imported Two Clusters Separately
+
+Each cluster was scanned independently:
+
+**Dev cluster** (`cluster-dev.json`) -- 3 workloads:
+
+| Namespace    | Workload       | Kind        | Owner | Replicas |
+|--------------|----------------|-------------|-------|----------|
+| payment-dev  | payment-api    | Deployment  | Flux  | 1        |
+| payment-dev  | payment-worker | Deployment  | Flux  | 1        |
+| payment-dev  | redis          | StatefulSet | Helm  | 1        |
+
+**Prod cluster** (`cluster-prod.json`) -- 4 workloads:
+
+| Namespace    | Workload       | Kind        | Owner  | Replicas |
+|--------------|----------------|-------------|--------|----------|
+| payment-prod | payment-api    | Deployment  | Flux   | 3        |
+| payment-prod | payment-worker | Deployment  | Flux   | 2        |
+| payment-prod | redis          | StatefulSet | Helm   | 3        |
+| payment-prod | cache-warmer   | Deployment  | Native | 1        |
+
+The prod cluster has one extra workload (`cache-warmer`) that doesn't exist in dev.
+
+## 2. Here's the Fleet View
+
+```bash
+./cub-scout import-cluster-aggregator \
+  examples/fleet-import/cluster-dev.json \
+  examples/fleet-import/cluster-prod.json
+```
+
+The aggregator produces a summary:
+
+```
+FLEET SUMMARY
+  Clusters: 2
+  Workloads: 7
+
+  Ownership:
+    Flux: 4
+    Helm: 2
+    Native: 1
+
+  Apps across clusters:
+    payment-api (2 clusters)
+    payment-worker (2 clusters)
+    redis (2 clusters)
+    cache-warmer
+```
+
+Three apps run on both clusters. One (`cache-warmer`) runs only on prod.
+
+## 3. Here's the Unified Proposal
+
+Add `--suggest` to generate a single App structure that spans both clusters:
+
+```bash
+./cub-scout import-cluster-aggregator \
+  examples/fleet-import/cluster-dev.json \
+  examples/fleet-import/cluster-prod.json \
+  --suggest
+```
+
+```
+PROPOSED HUB/APP SPACE MODEL
+
+  APP SPACE: fleet-team
+    Deployer: Flux
+    Reconciliation Rules:
+      variant=prod  -> drift:revert, approval:required
+      variant=dev   -> drift:accept, approval:none
+
+    cache-warmer
+      cache-warmer (variant=default)
+
+    payment-api
+      payment-api-dev  (variant=dev)   cluster-dev.json:payment-dev/payment-api
+      payment-api-prod (variant=prod)  cluster-prod.json:payment-prod/payment-api
+
+    payment-worker
+      payment-worker-dev  (variant=dev)   cluster-dev.json:payment-dev/payment-worker
+      payment-worker-prod (variant=prod)  cluster-prod.json:payment-prod/payment-worker
+
+    redis
+      redis-dev  (variant=dev)   cluster-dev.json:payment-dev/redis
+      redis-prod (variant=prod)  cluster-prod.json:payment-prod/redis
+```
+
+Workload references include the source cluster so you can trace where each
+instance lives: `cluster-prod.json:payment-prod/payment-api` means the
+`payment-api` Deployment in the `payment-prod` namespace of the prod cluster.
+
+## Key Points
+
+- **Fleet aggregation is read-only.** It merges existing import JSONs. It doesn't
+  connect to clusters or modify anything.
+
+- **Apps are grouped across clusters.** `payment-api` appears once in the proposal
+  with two variants (`dev` and `prod`), not as two separate entries.
+
+- **Variant inference uses the same logic.** The `environment` label on each
+  workload determines the variant. Dev workloads become `variant=dev`, prod
+  workloads become `variant=prod`.
+
+- **Reconciliation rules are per-variant.** Prod gets `drift:revert` +
+  `approval:required`. Dev gets `drift:accept` + `approval:none`. These are
+  suggestions, not enforced policy.
+
+- **The input format is flexible.** The aggregator accepts raw `ImportResult` JSON
+  (from `cub-scout import --json`) or `CombinedResult` JSON (from
+  `cub-scout combined --json`).
+
+## Files in This Example
+
+| File | Purpose |
+|------|---------|
+| `cluster-dev.json` | ImportResult from the dev cluster (3 workloads) |
+| `cluster-prod.json` | ImportResult from the prod cluster (4 workloads) |
+| `expected-output/fleet-summary.json` | Full JSON output from the aggregator with `--suggest` |
+
+## Try It
+
+```bash
+# Plain text summary
+./cub-scout import-cluster-aggregator \
+  examples/fleet-import/cluster-dev.json \
+  examples/fleet-import/cluster-prod.json
+
+# With unified proposal
+./cub-scout import-cluster-aggregator \
+  examples/fleet-import/cluster-dev.json \
+  examples/fleet-import/cluster-prod.json \
+  --suggest
+
+# JSON output for scripting
+./cub-scout import-cluster-aggregator \
+  examples/fleet-import/cluster-dev.json \
+  examples/fleet-import/cluster-prod.json \
+  --suggest --json
+
+# Pipe to jq to see which apps run on multiple clusters
+./cub-scout import-cluster-aggregator \
+  examples/fleet-import/cluster-dev.json \
+  examples/fleet-import/cluster-prod.json \
+  --json | jq '.summary.byApp | to_entries[] | select(.value | length > 1)'
+```
+
+## Full Workflow
+
+In practice, you'd generate the per-cluster JSONs first, then aggregate:
+
+```bash
+# Step 1: Scan each cluster
+for ctx in dev-cluster prod-cluster; do
+  kubectl config use-context $ctx
+  ./cub-scout import --json > ${ctx}.json
+done
+
+# Step 2: Aggregate into fleet view
+./cub-scout import-cluster-aggregator dev-cluster.json prod-cluster.json --suggest --json
+```
+
+## See Also
+
+- [Combined Git + Live](../combined-git-live/) -- Aligning Git intent with cluster state
+- [CLI-GUIDE.md](../../CLI-GUIDE.md) -- Full CLI reference

--- a/examples/fleet-import/cluster-dev.json
+++ b/examples/fleet-import/cluster-dev.json
@@ -1,0 +1,77 @@
+{
+  "namespace": "payment-dev",
+  "model": "hub-appspace",
+  "workloads": [
+    {
+      "kind": "Deployment",
+      "namespace": "payment-dev",
+      "name": "payment-api",
+      "owner": "Flux",
+      "connected": false,
+      "ready": true,
+      "replicas": 1,
+      "kustomizationPath": "./apps/payment-api/overlays/dev",
+      "labels": {
+        "app.kubernetes.io/name": "payment-api",
+        "app.kubernetes.io/part-of": "banko",
+        "environment": "dev",
+        "kustomize.toolkit.fluxcd.io/name": "banko-dev",
+        "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+      }
+    },
+    {
+      "kind": "Deployment",
+      "namespace": "payment-dev",
+      "name": "payment-worker",
+      "owner": "Flux",
+      "connected": false,
+      "ready": true,
+      "replicas": 1,
+      "kustomizationPath": "./apps/payment-worker/overlays/dev",
+      "labels": {
+        "app.kubernetes.io/name": "payment-worker",
+        "app.kubernetes.io/part-of": "banko",
+        "environment": "dev",
+        "kustomize.toolkit.fluxcd.io/name": "banko-dev",
+        "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+      }
+    },
+    {
+      "kind": "StatefulSet",
+      "namespace": "payment-dev",
+      "name": "redis",
+      "owner": "Helm",
+      "connected": false,
+      "ready": true,
+      "replicas": 1,
+      "labels": {
+        "app.kubernetes.io/name": "redis",
+        "app.kubernetes.io/managed-by": "Helm",
+        "environment": "dev"
+      }
+    }
+  ],
+  "suggestion": {
+    "appSpace": "banko-team",
+    "units": [
+      {
+        "slug": "payment-api-dev",
+        "app": "payment-api",
+        "variant": "dev",
+        "workloads": ["payment-dev/payment-api"]
+      },
+      {
+        "slug": "payment-worker-dev",
+        "app": "payment-worker",
+        "variant": "dev",
+        "workloads": ["payment-dev/payment-worker"]
+      },
+      {
+        "slug": "redis-dev",
+        "app": "redis",
+        "variant": "dev",
+        "workloads": ["payment-dev/redis"]
+      }
+    ]
+  }
+}

--- a/examples/fleet-import/cluster-prod.json
+++ b/examples/fleet-import/cluster-prod.json
@@ -1,0 +1,95 @@
+{
+  "namespace": "payment-prod",
+  "model": "hub-appspace",
+  "workloads": [
+    {
+      "kind": "Deployment",
+      "namespace": "payment-prod",
+      "name": "payment-api",
+      "owner": "Flux",
+      "connected": false,
+      "ready": true,
+      "replicas": 3,
+      "kustomizationPath": "./apps/payment-api/overlays/prod",
+      "labels": {
+        "app.kubernetes.io/name": "payment-api",
+        "app.kubernetes.io/part-of": "banko",
+        "environment": "prod",
+        "kustomize.toolkit.fluxcd.io/name": "banko-prod",
+        "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+      }
+    },
+    {
+      "kind": "Deployment",
+      "namespace": "payment-prod",
+      "name": "payment-worker",
+      "owner": "Flux",
+      "connected": false,
+      "ready": true,
+      "replicas": 2,
+      "kustomizationPath": "./apps/payment-worker/overlays/prod",
+      "labels": {
+        "app.kubernetes.io/name": "payment-worker",
+        "app.kubernetes.io/part-of": "banko",
+        "environment": "prod",
+        "kustomize.toolkit.fluxcd.io/name": "banko-prod",
+        "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+      }
+    },
+    {
+      "kind": "StatefulSet",
+      "namespace": "payment-prod",
+      "name": "redis",
+      "owner": "Helm",
+      "connected": false,
+      "ready": true,
+      "replicas": 3,
+      "labels": {
+        "app.kubernetes.io/name": "redis",
+        "app.kubernetes.io/managed-by": "Helm",
+        "environment": "prod"
+      }
+    },
+    {
+      "kind": "Deployment",
+      "namespace": "payment-prod",
+      "name": "cache-warmer",
+      "owner": "Native",
+      "connected": false,
+      "ready": true,
+      "replicas": 1,
+      "labels": {
+        "app.kubernetes.io/name": "cache-warmer"
+      }
+    }
+  ],
+  "suggestion": {
+    "appSpace": "banko-team",
+    "units": [
+      {
+        "slug": "payment-api-prod",
+        "app": "payment-api",
+        "variant": "prod",
+        "workloads": ["payment-prod/payment-api"]
+      },
+      {
+        "slug": "payment-worker-prod",
+        "app": "payment-worker",
+        "variant": "prod",
+        "workloads": ["payment-prod/payment-worker"]
+      },
+      {
+        "slug": "redis-prod",
+        "app": "redis",
+        "variant": "prod",
+        "workloads": ["payment-prod/redis"]
+      },
+      {
+        "slug": "cache-warmer",
+        "app": "cache-warmer",
+        "variant": "default",
+        "workloads": ["payment-prod/cache-warmer"]
+      }
+    ]
+  }
+}

--- a/examples/fleet-import/expected-output/fleet-summary.json
+++ b/examples/fleet-import/expected-output/fleet-summary.json
@@ -1,0 +1,228 @@
+{
+  "clusters": [
+    {
+      "name": "cluster-dev.json",
+      "import": {
+        "namespace": "payment-dev",
+        "model": "hub-appspace",
+        "workloads": [
+          {
+            "kind": "Deployment",
+            "namespace": "payment-dev",
+            "name": "payment-api",
+            "owner": "Flux",
+            "connected": false,
+            "ready": true,
+            "replicas": 1,
+            "kustomizationPath": "./apps/payment-api/overlays/dev",
+            "labels": {
+              "app.kubernetes.io/name": "payment-api",
+              "app.kubernetes.io/part-of": "banko",
+              "environment": "dev",
+              "kustomize.toolkit.fluxcd.io/name": "banko-dev",
+              "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+            }
+          },
+          {
+            "kind": "Deployment",
+            "namespace": "payment-dev",
+            "name": "payment-worker",
+            "owner": "Flux",
+            "connected": false,
+            "ready": true,
+            "replicas": 1,
+            "kustomizationPath": "./apps/payment-worker/overlays/dev",
+            "labels": {
+              "app.kubernetes.io/name": "payment-worker",
+              "app.kubernetes.io/part-of": "banko",
+              "environment": "dev",
+              "kustomize.toolkit.fluxcd.io/name": "banko-dev",
+              "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+            }
+          },
+          {
+            "kind": "StatefulSet",
+            "namespace": "payment-dev",
+            "name": "redis",
+            "owner": "Helm",
+            "connected": false,
+            "ready": true,
+            "replicas": 1,
+            "labels": {
+              "app.kubernetes.io/name": "redis",
+              "app.kubernetes.io/managed-by": "Helm",
+              "environment": "dev"
+            }
+          }
+        ],
+        "suggestion": {
+          "appSpace": "banko-team",
+          "units": [
+            { "slug": "payment-api-dev", "app": "payment-api", "variant": "dev", "workloads": ["payment-dev/payment-api"] },
+            { "slug": "payment-worker-dev", "app": "payment-worker", "variant": "dev", "workloads": ["payment-dev/payment-worker"] },
+            { "slug": "redis-dev", "app": "redis", "variant": "dev", "workloads": ["payment-dev/redis"] }
+          ]
+        }
+      }
+    },
+    {
+      "name": "cluster-prod.json",
+      "import": {
+        "namespace": "payment-prod",
+        "model": "hub-appspace",
+        "workloads": [
+          {
+            "kind": "Deployment",
+            "namespace": "payment-prod",
+            "name": "payment-api",
+            "owner": "Flux",
+            "connected": false,
+            "ready": true,
+            "replicas": 3,
+            "kustomizationPath": "./apps/payment-api/overlays/prod",
+            "labels": {
+              "app.kubernetes.io/name": "payment-api",
+              "app.kubernetes.io/part-of": "banko",
+              "environment": "prod",
+              "kustomize.toolkit.fluxcd.io/name": "banko-prod",
+              "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+            }
+          },
+          {
+            "kind": "Deployment",
+            "namespace": "payment-prod",
+            "name": "payment-worker",
+            "owner": "Flux",
+            "connected": false,
+            "ready": true,
+            "replicas": 2,
+            "kustomizationPath": "./apps/payment-worker/overlays/prod",
+            "labels": {
+              "app.kubernetes.io/name": "payment-worker",
+              "app.kubernetes.io/part-of": "banko",
+              "environment": "prod",
+              "kustomize.toolkit.fluxcd.io/name": "banko-prod",
+              "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+            }
+          },
+          {
+            "kind": "StatefulSet",
+            "namespace": "payment-prod",
+            "name": "redis",
+            "owner": "Helm",
+            "connected": false,
+            "ready": true,
+            "replicas": 3,
+            "labels": {
+              "app.kubernetes.io/name": "redis",
+              "app.kubernetes.io/managed-by": "Helm",
+              "environment": "prod"
+            }
+          },
+          {
+            "kind": "Deployment",
+            "namespace": "payment-prod",
+            "name": "cache-warmer",
+            "owner": "Native",
+            "connected": false,
+            "ready": true,
+            "replicas": 1,
+            "labels": {
+              "app.kubernetes.io/name": "cache-warmer"
+            }
+          }
+        ],
+        "suggestion": {
+          "appSpace": "banko-team",
+          "units": [
+            { "slug": "payment-api-prod", "app": "payment-api", "variant": "prod", "workloads": ["payment-prod/payment-api"] },
+            { "slug": "payment-worker-prod", "app": "payment-worker", "variant": "prod", "workloads": ["payment-prod/payment-worker"] },
+            { "slug": "redis-prod", "app": "redis", "variant": "prod", "workloads": ["payment-prod/redis"] },
+            { "slug": "cache-warmer", "app": "cache-warmer", "variant": "default", "workloads": ["payment-prod/cache-warmer"] }
+          ]
+        }
+      }
+    }
+  ],
+  "summary": {
+    "totalClusters": 2,
+    "totalWorkloads": 7,
+    "byOwner": {
+      "Flux": 4,
+      "Helm": 2,
+      "Native": 1
+    },
+    "byApp": {
+      "payment-api": ["cluster-dev.json", "cluster-prod.json"],
+      "payment-worker": ["cluster-dev.json", "cluster-prod.json"],
+      "redis": ["cluster-dev.json", "cluster-prod.json"],
+      "cache-warmer": ["cluster-prod.json"]
+    }
+  },
+  "proposal": {
+    "appSpace": "fleet-team",
+    "deployer": "Flux",
+    "reconciliation": [
+      { "match": { "variant": "prod" }, "drift": "revert", "approval": "required" },
+      { "match": { "variant": "dev" }, "drift": "accept", "approval": "none" }
+    ],
+    "units": [
+      {
+        "slug": "cache-warmer",
+        "app": "cache-warmer",
+        "variant": "default",
+        "status": "aligned",
+        "workloads": ["cluster-prod.json:payment-prod/cache-warmer"],
+        "labels": { "app": "cache-warmer", "variant": "default" }
+      },
+      {
+        "slug": "payment-api-dev",
+        "app": "payment-api",
+        "variant": "dev",
+        "status": "aligned",
+        "workloads": ["cluster-dev.json:payment-dev/payment-api"],
+        "labels": { "app": "payment-api", "variant": "dev" }
+      },
+      {
+        "slug": "payment-api-prod",
+        "app": "payment-api",
+        "variant": "prod",
+        "status": "aligned",
+        "workloads": ["cluster-prod.json:payment-prod/payment-api"],
+        "labels": { "app": "payment-api", "variant": "prod" }
+      },
+      {
+        "slug": "payment-worker-dev",
+        "app": "payment-worker",
+        "variant": "dev",
+        "status": "aligned",
+        "workloads": ["cluster-dev.json:payment-dev/payment-worker"],
+        "labels": { "app": "payment-worker", "variant": "dev" }
+      },
+      {
+        "slug": "payment-worker-prod",
+        "app": "payment-worker",
+        "variant": "prod",
+        "status": "aligned",
+        "workloads": ["cluster-prod.json:payment-prod/payment-worker"],
+        "labels": { "app": "payment-worker", "variant": "prod" }
+      },
+      {
+        "slug": "redis-dev",
+        "app": "redis",
+        "variant": "dev",
+        "status": "aligned",
+        "workloads": ["cluster-dev.json:payment-dev/redis"],
+        "labels": { "app": "redis", "variant": "dev" }
+      },
+      {
+        "slug": "redis-prod",
+        "app": "redis",
+        "variant": "prod",
+        "status": "aligned",
+        "workloads": ["cluster-prod.json:payment-prod/redis"],
+        "labels": { "app": "redis", "variant": "prod" }
+      }
+    ]
+  }
+}

--- a/examples/import-from-live/README.md
+++ b/examples/import-from-live/README.md
@@ -1,0 +1,292 @@
+# Import from Live Cluster
+
+Discover workloads from a running Kubernetes cluster and propose a ConfigHub
+App structure -- without touching Git, without modifying anything.
+
+This example uses the "Arnie" pattern: ArgoCD with a folder-per-environment
+(`envs/dev`, `envs/staging`, `envs/prod`) in a single deploy repo.
+
+## The Problem
+
+You have workloads running in a cluster. Some are managed by ArgoCD, some by
+Helm, and a few are unmanaged leftovers. You want to understand what you have
+and organize it into ConfigHub, but you don't want to start by hand-mapping
+everything from Git repos.
+
+`cub-scout import --dry-run` reads your live cluster and proposes an App
+structure. No Git access required. No cluster modifications. Just read-only
+discovery.
+
+## What's Running
+
+This example simulates a cluster with 13 resources across three namespaces:
+
+| Resource | Namespace | Owner | How Detected |
+|----------|-----------|-------|--------------|
+| Application/myapp-dev | argocd | ArgoCD | ArgoCD Application CR |
+| Application/myapp-staging | argocd | ArgoCD | ArgoCD Application CR |
+| Application/myapp-prod | argocd | ArgoCD | ArgoCD Application CR |
+| Deployment/api | myapp-dev | ArgoCD | `argocd.argoproj.io/instance` label |
+| Deployment/api | myapp-staging | ArgoCD | `argocd.argoproj.io/instance` label |
+| Deployment/api | myapp-prod | ArgoCD | `argocd.argoproj.io/instance` label |
+| Deployment/worker | myapp-dev | ArgoCD | `argocd.argoproj.io/instance` label |
+| Deployment/worker | myapp-staging | ArgoCD | `argocd.argoproj.io/instance` label |
+| Deployment/worker | myapp-prod | ArgoCD | `argocd.argoproj.io/instance` label |
+| StatefulSet/redis | myapp-dev | Helm | `app.kubernetes.io/managed-by: Helm` label |
+| StatefulSet/redis | myapp-staging | Helm | `app.kubernetes.io/managed-by: Helm` label |
+| StatefulSet/redis | myapp-prod | Helm | `app.kubernetes.io/managed-by: Helm` label |
+| ConfigMap/debug-config | myapp-prod | Native | No GitOps labels |
+
+The fixture files in `fixtures/` contain the full YAML manifests.
+
+## Running the Discovery
+
+Preview what cub-scout would propose without making any changes:
+
+```bash
+./cub-scout import --dry-run
+```
+
+For machine-readable output:
+
+```bash
+./cub-scout import --dry-run --json
+```
+
+To scope discovery to specific namespaces:
+
+```bash
+./cub-scout import --dry-run -n myapp-prod
+```
+
+### What the ASCII Output Looks Like
+
+```
+Import Preview (dry-run)
+════════════════════════════════════════════════════════════════════
+
+Discovered 9 workloads across 3 namespaces
+
+  NAMESPACE       NAME     KIND          OWNER    READY
+  myapp-dev       api      Deployment    ArgoCD   1/1
+  myapp-dev       worker   Deployment    ArgoCD   1/1
+  myapp-dev       redis    StatefulSet   Helm     1/1
+  myapp-staging   api      Deployment    ArgoCD   2/2
+  myapp-staging   worker   Deployment    ArgoCD   1/1
+  myapp-staging   redis    StatefulSet   Helm     1/1
+  myapp-prod      api      Deployment    ArgoCD   3/3
+  myapp-prod      worker   Deployment    ArgoCD   2/2
+  myapp-prod      redis    StatefulSet   Helm     3/3
+
+Suggested App Structure
+────────────────────────────────────────────────────────────────────
+
+  App Space: myapp-team
+
+  App: api
+    api-dev       → Deployment/myapp-dev/api
+    api-staging   → Deployment/myapp-staging/api
+    api-prod      → Deployment/myapp-prod/api
+
+  App: worker
+    worker-dev    → Deployment/myapp-dev/worker
+    worker-staging → Deployment/myapp-staging/worker
+    worker-prod   → Deployment/myapp-prod/worker
+
+  App: redis
+    redis-dev     → StatefulSet/myapp-dev/redis
+    redis-staging → StatefulSet/myapp-staging/redis
+    redis-prod    → StatefulSet/myapp-prod/redis
+
+Skipped:
+  ConfigMap/myapp-prod/debug-config (Native — no ownership signal)
+
+════════════════════════════════════════════════════════════════════
+This is a dry run. No changes were made.
+```
+
+## What cub-scout Proposes
+
+The suggestion engine groups workloads into an App structure using two signals:
+
+1. **Component name** from `app.kubernetes.io/name` label (e.g., `api`, `worker`, `redis`)
+2. **Environment variant** inferred from ArgoCD Application paths (`envs/dev` becomes `dev`)
+
+Here is the JSON suggestion output (`--dry-run --json`):
+
+```json
+{
+  "appSpace": "myapp-team",
+  "units": [
+    {
+      "slug": "api-dev",
+      "app": "api",
+      "variant": "dev",
+      "workloads": [
+        "Deployment/myapp-dev/api"
+      ]
+    },
+    {
+      "slug": "api-prod",
+      "app": "api",
+      "variant": "prod",
+      "workloads": [
+        "Deployment/myapp-prod/api"
+      ]
+    },
+    {
+      "slug": "api-staging",
+      "app": "api",
+      "variant": "staging",
+      "workloads": [
+        "Deployment/myapp-staging/api"
+      ]
+    },
+    {
+      "slug": "redis-dev",
+      "app": "redis",
+      "variant": "dev",
+      "workloads": [
+        "StatefulSet/myapp-dev/redis"
+      ]
+    },
+    {
+      "slug": "redis-prod",
+      "app": "redis",
+      "variant": "prod",
+      "workloads": [
+        "StatefulSet/myapp-prod/redis"
+      ]
+    },
+    {
+      "slug": "redis-staging",
+      "app": "redis",
+      "variant": "staging",
+      "workloads": [
+        "StatefulSet/myapp-staging/redis"
+      ]
+    },
+    {
+      "slug": "worker-dev",
+      "app": "worker",
+      "variant": "dev",
+      "workloads": [
+        "Deployment/myapp-dev/worker"
+      ]
+    },
+    {
+      "slug": "worker-prod",
+      "app": "worker",
+      "variant": "prod",
+      "workloads": [
+        "Deployment/myapp-prod/worker"
+      ]
+    },
+    {
+      "slug": "worker-staging",
+      "app": "worker",
+      "variant": "staging",
+      "workloads": [
+        "Deployment/myapp-staging/worker"
+      ]
+    }
+  ]
+}
+```
+
+This output matches the golden test at
+`cmd/cub-scout/testdata/import-suggest/arnie-pattern.golden.json`.
+
+### Reading the Proposal
+
+The output uses **App language** (what users see) which maps to **ConfigHub API
+language** (what the system uses) like this:
+
+| App Language | ConfigHub API | This Example |
+|--------------|---------------|--------------|
+| App Space | Space | `myapp-team` |
+| App (component) | app field on Unit | `api`, `worker`, `redis` |
+| Environment | variant field on Unit | `dev`, `staging`, `prod` |
+| Unit | Unit | `api-dev`, `api-prod`, etc. |
+
+So when the proposal says "App: api, Environments: dev/staging/prod", it means
+three Units (`api-dev`, `api-staging`, `api-prod`) inside the Space `myapp-team`.
+
+### Variant Inference
+
+cub-scout infers variants (environments) from the ArgoCD Application's
+`spec.source.path`:
+
+| Application Path | Inferred Variant |
+|------------------|-----------------|
+| `envs/dev` | `dev` |
+| `envs/staging` | `staging` |
+| `envs/prod` | `prod` |
+
+The last path segment is used as the variant. For Flux workloads, the same logic
+applies to the Kustomization's `spec.path` (e.g., `./apps/api/overlays/dev`
+yields `dev`). For Helm-only workloads without path context, cub-scout falls
+back to namespace-based inference (e.g., `myapp-dev` yields `dev`).
+
+## Ownership Detection
+
+cub-scout detects ownership by parsing actual labels and annotations on each
+resource. It never guesses.
+
+| Owner | Detection Rule | Example Labels |
+|-------|---------------|----------------|
+| ArgoCD | `argocd.argoproj.io/instance` label present | `argocd.argoproj.io/instance: myapp-dev` |
+| Helm | `app.kubernetes.io/managed-by` equals `Helm` | `app.kubernetes.io/managed-by: Helm` |
+| Native | None of the known ownership labels found | (no GitOps labels) |
+
+In this example:
+- The 6 Deployments (api + worker across 3 envs) are ArgoCD-managed
+- The 3 StatefulSets (redis across 3 envs) are Helm-managed
+- The debug-config ConfigMap is Native (unmanaged)
+
+Native resources are detected and reported but excluded from the App structure
+proposal. They have no ownership signal, so cub-scout cannot safely assign them
+to an App.
+
+## What Happens Next
+
+cub-scout's job stops at the proposal. It reads the cluster, detects ownership,
+and suggests a structure. It does not write anything to the cluster or to
+ConfigHub.
+
+The next step -- actually creating the App Space and Units in ConfigHub -- is
+handled by ConfigHub's bridge import. That is ConfigHub's responsibility, not
+cub-scout's.
+
+The typical flow:
+
+1. **cub-scout discovers** (this example) -- read-only scan, propose structure
+2. **You review** -- adjust naming, merge or split Apps as needed
+3. **ConfigHub imports** -- bridge import creates the Space, Units, and OCI pipeline
+4. **Flux/Argo deploys** -- your existing deployers continue to run, now tracked by ConfigHub
+
+For details on the ConfigHub side, see the
+[ConfigHub bridge import documentation](https://docs.confighub.com/guides/bridge-import).
+
+## Fixtures
+
+The `fixtures/` directory contains Kubernetes manifests representing the cluster
+state. These are standard YAML you could apply with `kubectl apply -f`:
+
+| File | Contents |
+|------|----------|
+| `fixtures/applications.yaml` | 3 ArgoCD Application CRs (dev, staging, prod) |
+| `fixtures/deployments.yaml` | 6 Deployments with ArgoCD labels (api + worker x 3 envs) |
+| `fixtures/statefulsets.yaml` | 3 StatefulSets with Helm labels (redis x 3 envs) |
+| `fixtures/native.yaml` | 1 unmanaged ConfigMap (debug-config) |
+
+The expected JSON output is at `expected-output/suggestion.json`.
+
+## Related Docs
+
+| Doc | What It Covers |
+|-----|----------------|
+| [CLI-GUIDE.md](../../CLI-GUIDE.md) | Full `import` command reference |
+| [docs/howto/import-to-confighub.md](../../docs/howto/import-to-confighub.md) | Canonical import path (Argo/Helm to ConfigHub) |
+| [Argo App-of-Apps example](../apptique-examples/argo-app-of-apps/) | ArgoCD hierarchy detection |
+| [Flux Monorepo example](../apptique-examples/flux-monorepo/) | Flux ownership detection |

--- a/examples/import-from-live/expected-output/suggestion.json
+++ b/examples/import-from-live/expected-output/suggestion.json
@@ -1,0 +1,77 @@
+{
+  "appSpace": "myapp-team",
+  "units": [
+    {
+      "slug": "api-dev",
+      "app": "api",
+      "variant": "dev",
+      "workloads": [
+        "Deployment/myapp-dev/api"
+      ]
+    },
+    {
+      "slug": "api-prod",
+      "app": "api",
+      "variant": "prod",
+      "workloads": [
+        "Deployment/myapp-prod/api"
+      ]
+    },
+    {
+      "slug": "api-staging",
+      "app": "api",
+      "variant": "staging",
+      "workloads": [
+        "Deployment/myapp-staging/api"
+      ]
+    },
+    {
+      "slug": "redis-dev",
+      "app": "redis",
+      "variant": "dev",
+      "workloads": [
+        "StatefulSet/myapp-dev/redis"
+      ]
+    },
+    {
+      "slug": "redis-prod",
+      "app": "redis",
+      "variant": "prod",
+      "workloads": [
+        "StatefulSet/myapp-prod/redis"
+      ]
+    },
+    {
+      "slug": "redis-staging",
+      "app": "redis",
+      "variant": "staging",
+      "workloads": [
+        "StatefulSet/myapp-staging/redis"
+      ]
+    },
+    {
+      "slug": "worker-dev",
+      "app": "worker",
+      "variant": "dev",
+      "workloads": [
+        "Deployment/myapp-dev/worker"
+      ]
+    },
+    {
+      "slug": "worker-prod",
+      "app": "worker",
+      "variant": "prod",
+      "workloads": [
+        "Deployment/myapp-prod/worker"
+      ]
+    },
+    {
+      "slug": "worker-staging",
+      "app": "worker",
+      "variant": "staging",
+      "workloads": [
+        "Deployment/myapp-staging/worker"
+      ]
+    }
+  ]
+}

--- a/examples/import-from-live/fixtures/applications.yaml
+++ b/examples/import-from-live/fixtures/applications.yaml
@@ -1,0 +1,87 @@
+# Copyright (C) ConfigHub, Inc.
+# SPDX-License-Identifier: MIT
+#
+# ArgoCD Application CRs for the "Arnie" pattern (folder-per-environment).
+# Three Applications pointing at envs/dev, envs/staging, envs/prod in the
+# same deploy repo.
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: myapp-dev
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: myapp
+    app.kubernetes.io/instance: myapp-dev
+    environment: dev
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/acme/myapp-deploy.git
+    targetRevision: HEAD
+    path: envs/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: myapp-dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: myapp-staging
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: myapp
+    app.kubernetes.io/instance: myapp-staging
+    environment: staging
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/acme/myapp-deploy.git
+    targetRevision: HEAD
+    path: envs/staging
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: myapp-staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: myapp-prod
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: myapp
+    app.kubernetes.io/instance: myapp-prod
+    environment: prod
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/acme/myapp-deploy.git
+    targetRevision: HEAD
+    path: envs/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: myapp-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/examples/import-from-live/fixtures/deployments.yaml
+++ b/examples/import-from-live/fixtures/deployments.yaml
@@ -1,0 +1,150 @@
+# Copyright (C) ConfigHub, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Six Deployments managed by ArgoCD — api and worker across three environments.
+# Each has the argocd.argoproj.io/instance label pointing back to its
+# ArgoCD Application, plus app.kubernetes.io/name for the component name.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: myapp-dev
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: myapp-dev
+    argocd.argoproj.io/instance: myapp-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+        - name: api
+          image: acme/api:v1.2.0
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: myapp-staging
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: myapp-staging
+    argocd.argoproj.io/instance: myapp-staging
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+        - name: api
+          image: acme/api:v1.2.0
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: myapp-prod
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: myapp-prod
+    argocd.argoproj.io/instance: myapp-prod
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+        - name: api
+          image: acme/api:v1.2.0
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: myapp-dev
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/instance: myapp-dev
+    argocd.argoproj.io/instance: myapp-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worker
+    spec:
+      containers:
+        - name: worker
+          image: acme/worker:v1.2.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: myapp-staging
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/instance: myapp-staging
+    argocd.argoproj.io/instance: myapp-staging
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worker
+    spec:
+      containers:
+        - name: worker
+          image: acme/worker:v1.2.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: myapp-prod
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/instance: myapp-prod
+    argocd.argoproj.io/instance: myapp-prod
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worker
+    spec:
+      containers:
+        - name: worker
+          image: acme/worker:v1.2.0

--- a/examples/import-from-live/fixtures/native.yaml
+++ b/examples/import-from-live/fixtures/native.yaml
@@ -1,0 +1,17 @@
+# Copyright (C) ConfigHub, Inc.
+# SPDX-License-Identifier: MIT
+#
+# An unmanaged ConfigMap — no GitOps labels, no Helm annotation.
+# cub-scout classifies this as "Native" (not managed by any known controller).
+# It appears in the discovery output but is excluded from the App structure
+# proposal because it has no ownership signal.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: debug-config
+  namespace: myapp-prod
+data:
+  DEBUG_LEVEL: "verbose"
+  TRACE_ENABLED: "true"
+  LOG_FORMAT: "json"

--- a/examples/import-from-live/fixtures/statefulsets.yaml
+++ b/examples/import-from-live/fixtures/statefulsets.yaml
@@ -1,0 +1,90 @@
+# Copyright (C) ConfigHub, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Three Redis StatefulSets managed by Helm — one per environment.
+# The Helm ownership label (app.kubernetes.io/managed-by: Helm) is how
+# cub-scout detects these as Helm-managed.
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: myapp-dev
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: redis-18.6.1
+    app.kubernetes.io/instance: redis
+spec:
+  serviceName: redis-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          ports:
+            - containerPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: myapp-staging
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: redis-18.6.1
+    app.kubernetes.io/instance: redis
+spec:
+  serviceName: redis-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          ports:
+            - containerPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: myapp-prod
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: redis-18.6.1
+    app.kubernetes.io/instance: redis
+spec:
+  serviceName: redis-headless
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          ports:
+            - containerPort: 6379

--- a/test/fixtures/import-e2e/argo-deployments.yaml
+++ b/test/fixtures/import-e2e/argo-deployments.yaml
@@ -1,0 +1,51 @@
+# Copyright (C) ConfigHub, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Two Deployments managed by ArgoCD — api and worker in a single namespace.
+# Each has the argocd.argoproj.io/instance label for ownership detection.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: e2e-import
+    argocd.argoproj.io/instance: e2e-import
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+        - name: api
+          image: nginx:alpine
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/instance: e2e-import
+    argocd.argoproj.io/instance: e2e-import
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worker
+    spec:
+      containers:
+        - name: worker
+          image: nginx:alpine

--- a/test/fixtures/import-e2e/helm-statefulset.yaml
+++ b/test/fixtures/import-e2e/helm-statefulset.yaml
@@ -1,0 +1,33 @@
+# Copyright (C) ConfigHub, Inc.
+# SPDX-License-Identifier: MIT
+#
+# A Redis StatefulSet managed by Helm.
+# The Helm ownership label (app.kubernetes.io/managed-by: Helm) is how
+# cub-scout detects this as Helm-managed.
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: redis-18.6.1
+    app.kubernetes.io/instance: redis
+spec:
+  serviceName: redis-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          ports:
+            - containerPort: 6379

--- a/test/fixtures/import-e2e/native-configmap.yaml
+++ b/test/fixtures/import-e2e/native-configmap.yaml
@@ -1,0 +1,13 @@
+# Copyright (C) ConfigHub, Inc.
+# SPDX-License-Identifier: MIT
+#
+# An unmanaged ConfigMap — no GitOps labels, no Helm annotation.
+# cub-scout classifies this as "Native" (not managed by any known controller).
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: debug-config
+data:
+  DEBUG_LEVEL: "verbose"
+  TRACE_ENABLED: "true"

--- a/test/integration/import_e2e_test.go
+++ b/test/integration/import_e2e_test.go
@@ -1,0 +1,528 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+//go:build integration
+// +build integration
+
+// Package integration provides E2E tests for the import command.
+//
+// These tests exercise the full import round-trip:
+//   - Deploy fixtures to a kind cluster
+//   - Run cub-scout import --dry-run --json to test discovery + proposal
+//   - Run cub-scout import -y to create real Spaces/Units in ConfigHub
+//   - Verify the created resources via cub CLI
+//   - Clean up (deferred)
+//
+// Dry-run tests (TestImportDryRun*) need only a Kubernetes cluster.
+// Full round-trip tests (TestImportFull*, TestImportIdempotent, TestImportCleanup)
+// also require ConfigHub authentication (cub auth login).
+//
+// Run with:
+//
+//	go test -tags=integration ./test/integration/... -run TestImport -v -timeout 300s
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixtureDir is the path to the import E2E fixtures relative to this test file.
+const fixtureDir = "../fixtures/import-e2e"
+
+// createTestNamespace creates a uniquely named namespace and registers cleanup.
+func createTestNamespace(t *testing.T) string {
+	t.Helper()
+	skipIfNoCluster(t)
+
+	name := fmt.Sprintf("e2e-import-%d", time.Now().UnixMilli())
+
+	cmd := exec.Command("kubectl", "create", "namespace", name)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to create namespace %s: %s (%v)", name, string(output), err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCmd := exec.Command("kubectl", "delete", "namespace", name, "--ignore-not-found", "--wait=false")
+		if out, err := cleanupCmd.CombinedOutput(); err != nil {
+			t.Logf("Warning: cleanup namespace %s failed: %s (%v)", name, string(out), err)
+		}
+	})
+
+	t.Logf("Created test namespace: %s", name)
+	return name
+}
+
+// deployFixtures applies all YAML fixtures to the given namespace.
+func deployFixtures(t *testing.T, namespace string) {
+	t.Helper()
+
+	// Apply each fixture file individually so namespace override works
+	files := []string{
+		fixtureDir + "/argo-deployments.yaml",
+		fixtureDir + "/helm-statefulset.yaml",
+		fixtureDir + "/native-configmap.yaml",
+	}
+
+	for _, f := range files {
+		cmd := exec.Command("kubectl", "apply", "-f", f, "-n", namespace)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Failed to apply fixture %s: %s (%v)", f, string(output), err)
+		}
+		t.Logf("Applied: %s", f)
+	}
+
+	// Wait briefly for resources to be created
+	time.Sleep(2 * time.Second)
+}
+
+// waitForDeployments waits for all deployments in the namespace to be available.
+func waitForDeployments(t *testing.T, namespace string) {
+	t.Helper()
+
+	cmd := exec.Command("kubectl", "wait", "--for=condition=available",
+		"deployment", "--all", "-n", namespace, "--timeout=60s")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Warning: not all deployments ready (may be OK): %s", string(output))
+	}
+}
+
+// deleteTestSpace deletes a ConfigHub space and all its contents.
+func deleteTestSpace(t *testing.T, slug string) {
+	t.Helper()
+
+	cmd := exec.Command("cub", "space", "delete", slug, "--recursive")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Warning: cleanup space %s failed: %s (%v)", slug, string(output), err)
+	} else {
+		t.Logf("Deleted test space: %s", slug)
+	}
+}
+
+// spaceExistsInList checks whether a space slug appears in `cub space list --json`.
+func spaceExistsInList(t *testing.T, slug string) bool {
+	t.Helper()
+
+	cmd := exec.Command("cub", "space", "list", "--json")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Warning: space list failed: %s (%v)", string(output), err)
+		return false
+	}
+
+	var spaces []map[string]interface{}
+	if err := json.Unmarshal(output, &spaces); err != nil {
+		t.Logf("Warning: failed to parse space list: %v", err)
+		return false
+	}
+
+	for _, s := range spaces {
+		if s["Slug"] == slug {
+			return true
+		}
+	}
+	return false
+}
+
+// =============================================================================
+// JSON types matching the actual import --dry-run --json output.
+//
+// The actual output shape is:
+//
+//	{
+//	  "namespaces": ["ns1"],
+//	  "proposal": { "appSpace": "...", "deployer": "...", "units": [...], ... },
+//	  "workloads": [{ "kind": "...", "name": "...", "owner": "...", ... }]
+//	}
+// =============================================================================
+
+// importDryRunResult matches the top-level JSON output of `import --dry-run --json`.
+type importDryRunResult struct {
+	Namespaces []string         `json:"namespaces"`
+	Proposal   *importProposal  `json:"proposal"`
+	Workloads  []importWorkload `json:"workloads"`
+}
+
+// importProposal matches the "proposal" object in the JSON output.
+type importProposal struct {
+	AppSpace    string             `json:"appSpace"`
+	Deployer    string             `json:"deployer,omitempty"`
+	Units       []importUnit       `json:"units"`
+	ClusterOnly []importClusterApp `json:"clusterOnly,omitempty"`
+}
+
+// importUnit matches a unit in the proposal.
+type importUnit struct {
+	Slug      string            `json:"slug"`
+	App       string            `json:"app"`
+	Variant   string            `json:"variant"`
+	Workloads []string          `json:"workloads"`
+	Status    string            `json:"status,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+// importClusterApp matches a cluster-only app in the proposal.
+type importClusterApp struct {
+	App       string   `json:"app"`
+	Workloads []string `json:"workloads"`
+	Owner     string   `json:"owner"`
+}
+
+// importWorkload matches a workload in the JSON output.
+type importWorkload struct {
+	Kind      string            `json:"kind"`
+	Namespace string            `json:"namespace"`
+	Name      string            `json:"name"`
+	Owner     string            `json:"owner"`
+	Connected bool              `json:"connected"`
+	Ready     bool              `json:"ready"`
+	Replicas  int32             `json:"replicas"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+// =============================================================================
+// Dry-Run Tests (cluster only, no ConfigHub needed)
+// =============================================================================
+
+// TestImportDryRunJSON verifies that import --dry-run --json produces valid output
+// with correct workload discovery and ownership detection.
+func TestImportDryRunJSON(t *testing.T) {
+	skipIfNoCluster(t)
+
+	ns := createTestNamespace(t)
+	deployFixtures(t, ns)
+	waitForDeployments(t, ns)
+
+	// Run import --dry-run --json
+	output := runCubAgent(t, "import", "-n", ns, "--dry-run", "--json")
+
+	// Must parse as our expected structure
+	var result importDryRunResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("import --dry-run --json output is not valid JSON: %v\nOutput (first 500 chars): %.500s", err, output)
+	}
+
+	// Must have namespaces
+	if len(result.Namespaces) == 0 {
+		t.Error("Expected at least one namespace in output")
+	}
+
+	// Must have workloads
+	// We deployed 2 Deployments + 1 StatefulSet = 3 workloads
+	// (ConfigMap is not a workload type — import only discovers Deployments/StatefulSets/DaemonSets)
+	if len(result.Workloads) < 3 {
+		t.Errorf("Expected at least 3 workloads, got %d", len(result.Workloads))
+	}
+
+	// Check ownership detection
+	foundArgo := 0
+	foundHelm := 0
+	for _, w := range result.Workloads {
+		switch w.Owner {
+		case "ArgoCD":
+			foundArgo++
+		case "Helm":
+			foundHelm++
+		}
+	}
+
+	if foundArgo != 2 {
+		t.Errorf("Expected 2 ArgoCD-owned workloads, found %d", foundArgo)
+	}
+	if foundHelm != 1 {
+		t.Errorf("Expected 1 Helm-owned workload, found %d", foundHelm)
+	}
+
+	// Must have a proposal
+	if result.Proposal == nil {
+		t.Fatal("Expected 'proposal' to be present, got nil")
+	}
+
+	// Proposal must have appSpace
+	if result.Proposal.AppSpace == "" {
+		t.Error("Expected proposal.appSpace to be non-empty")
+	}
+
+	// Proposal must have units
+	if len(result.Proposal.Units) == 0 {
+		t.Error("Expected at least one unit in proposal")
+	}
+
+	t.Logf("Dry-run result: %d workloads, appSpace=%s, %d units",
+		len(result.Workloads), result.Proposal.AppSpace, len(result.Proposal.Units))
+}
+
+// TestImportDryRunSuggestionContract verifies the JSON contract shape of the
+// import output, ensuring all required fields are present and valid.
+func TestImportDryRunSuggestionContract(t *testing.T) {
+	skipIfNoCluster(t)
+
+	ns := createTestNamespace(t)
+	deployFixtures(t, ns)
+	waitForDeployments(t, ns)
+
+	output := runCubAgent(t, "import", "-n", ns, "--dry-run", "--json")
+
+	var result importDryRunResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("Failed to parse import JSON output: %v", err)
+	}
+
+	// Contract: namespaces contains the namespace we requested
+	found := false
+	for _, n := range result.Namespaces {
+		if n == ns {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected namespaces to contain %s, got %v", ns, result.Namespaces)
+	}
+
+	// Contract: each workload has required fields
+	validOwners := map[string]bool{
+		"Flux": true, "ArgoCD": true, "Helm": true, "Native": true,
+		"ConfigHub": true, "Terraform": true, "Crossplane": true,
+	}
+	for i, w := range result.Workloads {
+		if w.Kind == "" {
+			t.Errorf("Workload[%d]: kind is empty", i)
+		}
+		if w.Namespace == "" {
+			t.Errorf("Workload[%d]: namespace is empty", i)
+		}
+		if w.Name == "" {
+			t.Errorf("Workload[%d]: name is empty", i)
+		}
+		if w.Owner == "" {
+			t.Errorf("Workload[%d] (%s/%s): owner is empty", i, w.Kind, w.Name)
+		}
+		if !validOwners[w.Owner] {
+			t.Errorf("Workload[%d] (%s/%s): unexpected owner %q", i, w.Kind, w.Name, w.Owner)
+		}
+	}
+
+	// Contract: proposal has non-empty appSpace
+	if result.Proposal == nil {
+		t.Fatal("proposal is nil")
+	}
+	if result.Proposal.AppSpace == "" {
+		t.Error("proposal.appSpace is empty")
+	}
+
+	// Contract: each unit has slug and workloads
+	for i, u := range result.Proposal.Units {
+		if u.Slug == "" {
+			t.Errorf("Unit[%d]: slug is empty", i)
+		}
+		if len(u.Workloads) == 0 {
+			t.Errorf("Unit[%d] (%s): workloads array is empty", i, u.Slug)
+		}
+	}
+
+	t.Logf("Contract check passed: %d workloads, %d units",
+		len(result.Workloads), len(result.Proposal.Units))
+}
+
+// =============================================================================
+// Full Round-Trip Tests (cluster + ConfigHub)
+// =============================================================================
+
+// TestImportFullRoundTrip exercises the complete import lifecycle:
+// discover → propose → create space + units → verify in ConfigHub → cleanup.
+func TestImportFullRoundTrip(t *testing.T) {
+	skipIfNoCluster(t)
+	skipIfNotConnected(t)
+
+	ns := createTestNamespace(t)
+	deployFixtures(t, ns)
+	waitForDeployments(t, ns)
+
+	// Step 1: Dry-run to capture what will be created
+	dryRunOutput := runCubAgent(t, "import", "-n", ns, "--dry-run", "--json")
+
+	var dryResult importDryRunResult
+	if err := json.Unmarshal([]byte(dryRunOutput), &dryResult); err != nil {
+		t.Fatalf("Failed to parse dry-run output: %v", err)
+	}
+	if dryResult.Proposal == nil {
+		t.Fatal("Dry-run returned nil proposal")
+	}
+
+	spaceName := dryResult.Proposal.AppSpace
+	if spaceName == "" {
+		t.Fatal("Dry-run returned empty appSpace — cannot proceed with import")
+	}
+	t.Logf("Will create space: %s with %d units", spaceName, len(dryResult.Proposal.Units))
+
+	// Register cleanup (runs even if import fails)
+	t.Cleanup(func() {
+		deleteTestSpace(t, spaceName)
+	})
+
+	// Step 2: Actual import (non-interactive)
+	importOutput := runCubAgentAllowFailures(t, "import", "-n", ns, "-y", "--no-log")
+	t.Logf("Import output:\n%s", importOutput)
+
+	// Import should mention creating units
+	if !strings.Contains(importOutput, "Creating unit") && !strings.Contains(importOutput, "created") {
+		t.Errorf("Import output doesn't mention creating units")
+	}
+
+	// Step 3: Verify space exists in ConfigHub
+	if !spaceExistsInList(t, spaceName) {
+		t.Fatalf("Space %s was not found in ConfigHub after import", spaceName)
+	}
+	t.Logf("Verified: space %s exists", spaceName)
+
+	// Step 4: Verify units exist
+	cmd := exec.Command("cub", "unit", "list", "--space", spaceName, "--json")
+	unitOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to list units in space %s: %s (%v)", spaceName, string(unitOutput), err)
+	}
+
+	var units []map[string]interface{}
+	if err := json.Unmarshal(unitOutput, &units); err != nil {
+		t.Fatalf("Failed to parse unit list JSON: %v", err)
+	}
+
+	// Should have created at least one unit
+	if len(units) == 0 {
+		t.Error("No units found in space after import")
+	}
+
+	// Verify no null slugs (issue #1 regression)
+	for _, u := range units {
+		slug, _ := u["Slug"].(string)
+		if slug == "" || slug == "null" {
+			t.Errorf("Unit has null or empty slug (issue #1 pattern): %v", u)
+		}
+	}
+
+	t.Logf("Round-trip complete: space=%s, units=%d", spaceName, len(units))
+}
+
+// TestImportIdempotent verifies that running import twice on the same namespace
+// does not fail and does not create duplicate resources.
+func TestImportIdempotent(t *testing.T) {
+	skipIfNoCluster(t)
+	skipIfNotConnected(t)
+
+	ns := createTestNamespace(t)
+	deployFixtures(t, ns)
+	waitForDeployments(t, ns)
+
+	// Dry-run to get the expected space name
+	dryRunOutput := runCubAgent(t, "import", "-n", ns, "--dry-run", "--json")
+	var dryResult importDryRunResult
+	if err := json.Unmarshal([]byte(dryRunOutput), &dryResult); err != nil {
+		t.Fatalf("Failed to parse dry-run output: %v", err)
+	}
+	if dryResult.Proposal == nil {
+		t.Fatal("Dry-run returned nil proposal")
+	}
+	spaceName := dryResult.Proposal.AppSpace
+
+	t.Cleanup(func() {
+		deleteTestSpace(t, spaceName)
+	})
+
+	// First import
+	output1 := runCubAgentAllowFailures(t, "import", "-n", ns, "-y", "--no-log")
+	t.Logf("First import output:\n%s", output1)
+
+	// Count units after first import
+	cmd := exec.Command("cub", "unit", "list", "--space", spaceName, "--json")
+	unitOutput1, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to list units after first import: %s (%v)", string(unitOutput1), err)
+	}
+	var units1 []map[string]interface{}
+	if err := json.Unmarshal(unitOutput1, &units1); err != nil {
+		t.Fatalf("Failed to parse unit list: %v", err)
+	}
+	count1 := len(units1)
+
+	// Second import (should not fail)
+	output2 := runCubAgentAllowFailures(t, "import", "-n", ns, "-y", "--no-log")
+	t.Logf("Second import output:\n%s", output2)
+
+	// The second import should mention "(exists)" for the space
+	if !strings.Contains(output2, "exists") && !strings.Contains(output2, "Created") {
+		t.Logf("Note: second import output doesn't show space status")
+	}
+
+	// Count units after second import — should be the same
+	cmd = exec.Command("cub", "unit", "list", "--space", spaceName, "--json")
+	unitOutput2, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to list units after second import: %s (%v)", string(unitOutput2), err)
+	}
+	var units2 []map[string]interface{}
+	if err := json.Unmarshal(unitOutput2, &units2); err != nil {
+		t.Fatalf("Failed to parse unit list: %v", err)
+	}
+	count2 := len(units2)
+
+	// Unit count should not have doubled
+	if count2 > count1 {
+		t.Errorf("Second import created additional units: first=%d, second=%d", count1, count2)
+	}
+
+	t.Logf("Idempotency check: first=%d units, second=%d units", count1, count2)
+}
+
+// TestImportCleanup verifies that deleting a space removes all resources cleanly.
+func TestImportCleanup(t *testing.T) {
+	skipIfNoCluster(t)
+	skipIfNotConnected(t)
+
+	ns := createTestNamespace(t)
+	deployFixtures(t, ns)
+	waitForDeployments(t, ns)
+
+	// Import to create resources
+	dryRunOutput := runCubAgent(t, "import", "-n", ns, "--dry-run", "--json")
+	var dryResult importDryRunResult
+	if err := json.Unmarshal([]byte(dryRunOutput), &dryResult); err != nil {
+		t.Fatalf("Failed to parse dry-run output: %v", err)
+	}
+	if dryResult.Proposal == nil {
+		t.Fatal("Dry-run returned nil proposal")
+	}
+	spaceName := dryResult.Proposal.AppSpace
+
+	// Import (no deferred cleanup — we're testing manual cleanup)
+	importOutput := runCubAgentAllowFailures(t, "import", "-n", ns, "-y", "--no-log")
+	t.Logf("Import output:\n%s", importOutput)
+
+	// Verify space exists
+	if !spaceExistsInList(t, spaceName) {
+		t.Fatalf("Space %s not found after import — nothing to test cleanup on", spaceName)
+	}
+
+	// Delete the space
+	cmd := exec.Command("cub", "space", "delete", spaceName, "--recursive")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to delete space %s: %s (%v)", spaceName, string(output), err)
+	}
+	t.Logf("Deleted space: %s", spaceName)
+
+	// Verify space is gone
+	if spaceExistsInList(t, spaceName) {
+		t.Errorf("Space %s still exists after deletion", spaceName)
+	}
+
+	t.Log("Cleanup verification passed: space deleted successfully")
+}

--- a/test/integration/import_e2e_test.go
+++ b/test/integration/import_e2e_test.go
@@ -125,8 +125,14 @@ func spaceExistsInList(t *testing.T, slug string) bool {
 	}
 
 	for _, s := range spaces {
+		// cub space list --json nests Space data inside a "Space" object
 		if s["Slug"] == slug {
 			return true
+		}
+		if inner, ok := s["Space"].(map[string]interface{}); ok {
+			if inner["Slug"] == slug {
+				return true
+			}
 		}
 	}
 	return false
@@ -402,8 +408,15 @@ func TestImportFullRoundTrip(t *testing.T) {
 	}
 
 	// Verify no null slugs (issue #1 regression)
+	// cub unit list --json nests unit data: [{Unit: {Slug: "..."}, ...}, ...]
 	for _, u := range units {
 		slug, _ := u["Slug"].(string)
+		if slug == "" {
+			// Check nested structure
+			if inner, ok := u["Unit"].(map[string]interface{}); ok {
+				slug, _ = inner["Slug"].(string)
+			}
+		}
 		if slug == "" || slug == "null" {
 			t.Errorf("Unit has null or empty slug (issue #1 pattern): %v", u)
 		}

--- a/test/prove-it-works.sh
+++ b/test/prove-it-works.sh
@@ -374,6 +374,32 @@ if [[ $CURRENT_IDX -ge 6 ]]; then
 
         subsection "Import Preview"
         run_test "import dry-run" "./cub-scout import -n boutique --dry-run"
+
+        subsection "Import E2E (fixtures)"
+        # Deploy test fixtures and run dry-run import against them
+        E2E_NS="e2e-prove-$(date +%s)"
+        kubectl create namespace "$E2E_NS" > /dev/null 2>&1
+        kubectl apply -f test/fixtures/import-e2e/ -n "$E2E_NS" > /dev/null 2>&1
+        sleep 3
+
+        run_test "import dry-run JSON (fixtures)" "./cub-scout import -n $E2E_NS --dry-run --json | python3 -c 'import sys,json; d=json.load(sys.stdin); print(f\"workloads={len(d[\"workloads\"])}, appSpace={d[\"suggestion\"][\"appSpace\"]}\")'"
+
+        # Full round-trip only if CUB_E2E_FULL=1
+        if [[ "${CUB_E2E_FULL:-0}" == "1" ]]; then
+            subsection "Import Full Round-Trip"
+            SPACE_NAME="e2e-prove-$(date +%s)"
+            run_test "import apply" "./cub-scout import -n $E2E_NS -y --no-log"
+            # Verify space was created
+            run_test "verify space" "cub space list --json | python3 -c 'import sys,json; spaces=[s[\"Slug\"] for s in json.load(sys.stdin)]; print(\"Spaces:\", spaces[:5])'"
+            # Cleanup the space (find it from the dry-run output)
+            CREATED_SPACE=$(./cub-scout import -n "$E2E_NS" --dry-run --json 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["suggestion"]["appSpace"])' 2>/dev/null)
+            if [[ -n "$CREATED_SPACE" ]]; then
+                run_test "cleanup space" "cub space delete $CREATED_SPACE --recursive"
+            fi
+        fi
+
+        # Always clean up the namespace
+        kubectl delete namespace "$E2E_NS" --ignore-not-found --wait=false > /dev/null 2>&1
     fi
 fi
 

--- a/test/unit/helpers.go
+++ b/test/unit/helpers.go
@@ -442,8 +442,14 @@ func SpaceExists(t *testing.T, slug string) bool {
 	}
 
 	for _, s := range spaces {
+		// cub space list --json nests Space data inside a "Space" object
 		if s["Slug"] == slug {
 			return true
+		}
+		if inner, ok := s["Space"].(map[string]interface{}); ok {
+			if inner["Slug"] == slug {
+				return true
+			}
 		}
 	}
 	return false

--- a/test/unit/helpers.go
+++ b/test/unit/helpers.go
@@ -3,11 +3,13 @@ package unit
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -299,4 +301,150 @@ func RunCubJSON(t *testing.T, v interface{}, args ...string) {
 	args = append(args, "--json")
 	output := RunCub(t, args...)
 	require.NoError(t, json.Unmarshal([]byte(output), v), "Failed to parse cub JSON output")
+}
+
+// RunCubAgentAllowFailure runs cub-scout and returns output even on non-zero exit.
+func RunCubAgentAllowFailure(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cubAgent := os.Getenv("CUB_AGENT")
+	if cubAgent == "" {
+		cubAgent = "./cub-scout"
+	}
+
+	cmd := exec.Command(cubAgent, args...)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+// -----------------------------------------------------------------------------
+// E2E Lifecycle Helpers — Create and clean up test resources
+// -----------------------------------------------------------------------------
+
+// CreateTestNamespace creates a uniquely named Kubernetes namespace and registers
+// cleanup to delete it when the test completes. Returns the namespace name.
+func CreateTestNamespace(t *testing.T, prefix string) string {
+	t.Helper()
+	RequireCluster(t)
+
+	name := fmt.Sprintf("%s-%d", prefix, time.Now().UnixMilli())
+
+	cmd := exec.Command("kubectl", "create", "namespace", name)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to create namespace %s: %s", name, string(output))
+
+	t.Cleanup(func() {
+		cleanupCmd := exec.Command("kubectl", "delete", "namespace", name, "--ignore-not-found", "--wait=false")
+		if out, err := cleanupCmd.CombinedOutput(); err != nil {
+			t.Logf("Warning: cleanup namespace %s failed: %s (%v)", name, string(out), err)
+		}
+	})
+
+	t.Logf("Created test namespace: %s", name)
+	return name
+}
+
+// DeployFixtures applies all YAML files from a directory into the given namespace.
+// Files are applied in alphabetical order.
+func DeployFixtures(t *testing.T, namespace, fixtureDir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(fixtureDir)
+	require.NoError(t, err, "Failed to read fixture dir: %s", fixtureDir)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+
+		path := filepath.Join(fixtureDir, entry.Name())
+		cmd := exec.Command("kubectl", "apply", "-f", path, "-n", namespace)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "Failed to apply fixture %s: %s", path, string(output))
+		t.Logf("Applied fixture: %s", entry.Name())
+	}
+}
+
+// WaitForDeployments waits until all deployments in the namespace are available
+// or the timeout is reached.
+func WaitForDeployments(t *testing.T, namespace string, timeout time.Duration) {
+	t.Helper()
+
+	cmd := exec.Command("kubectl", "wait", "--for=condition=available",
+		"deployment", "--all", "-n", namespace,
+		fmt.Sprintf("--timeout=%ds", int(timeout.Seconds())))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Warning: not all deployments available in %s (may be OK for test): %s", namespace, string(output))
+	}
+}
+
+// CreateTestSpace creates a uniquely named ConfigHub space and registers cleanup
+// to delete it when the test completes. Returns the space slug.
+func CreateTestSpace(t *testing.T, prefix string) string {
+	t.Helper()
+	RequireCubAuth(t)
+
+	slug := fmt.Sprintf("%s-%d", prefix, time.Now().UnixMilli())
+
+	cmd := exec.Command("cub", "space", "create", slug)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to create space %s: %s", slug, string(output))
+
+	t.Cleanup(func() {
+		DeleteSpace(t, slug)
+	})
+
+	t.Logf("Created test space: %s", slug)
+	return slug
+}
+
+// DeleteSpace deletes a ConfigHub space and all its units recursively.
+func DeleteSpace(t *testing.T, slug string) {
+	t.Helper()
+
+	cmd := exec.Command("cub", "space", "delete", slug, "--recursive")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Warning: cleanup space %s failed: %s (%v)", slug, string(output), err)
+	} else {
+		t.Logf("Deleted test space: %s", slug)
+	}
+}
+
+// ListUnitsInSpace returns the units in a ConfigHub space as parsed JSON objects.
+func ListUnitsInSpace(t *testing.T, space string) []map[string]interface{} {
+	t.Helper()
+
+	cmd := exec.Command("cub", "unit", "list", "--space", space, "--json")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to list units in space %s: %s", space, string(output))
+
+	var units []map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &units), "Failed to parse units JSON from space %s", space)
+	return units
+}
+
+// SpaceExists checks if a ConfigHub space exists.
+func SpaceExists(t *testing.T, slug string) bool {
+	t.Helper()
+
+	cmd := exec.Command("cub", "space", "list", "--json")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Warning: space list failed: %s (%v)", string(output), err)
+		return false
+	}
+
+	var spaces []map[string]interface{}
+	if err := json.Unmarshal(output, &spaces); err != nil {
+		t.Logf("Warning: failed to parse space list: %v", err)
+		return false
+	}
+
+	for _, s := range spaces {
+		if s["Slug"] == slug {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- **Import worked examples**: Three new examples (import-from-live, combined-git-live, fleet-import) with static fixtures and expected JSON output
- **Import-suggest golden tests**: Validates `SuggestFullProposal` output for Arnie, Banko, mixed-owners, namespace-fallback, and empty cases
- **Connected E2E test suite**: 5 tests exercising `cub-scout import` against live kind cluster (dry-run) and ConfigHub (connected)
- **Stale trace golden fixes**: Regenerated `resource-not-found` and `unmanaged-resource-json` goldens that gained `--artifacts`/`--format` flags post-v1.0
- **CI connected job**: New `workflow_dispatch` level for import round-trip with ConfigHub auth
- **Glossary updates**: Emerging ConfigHub concepts (App, Deployment, OCI Transport, Bridge Worker)

## Test plan

- [x] `go test ./test/golden/trace/... -v -count=1` — trace goldens pass (non-cluster)
- [x] `go test -tags=integration ./test/integration/... -run TestImportDryRun -v` — dry-run E2E pass against kind cluster
- [ ] `go test -tags=integration ./test/integration/... -run TestImportFull -v` — round-trip needs ConfigHub auth
- [x] `go build ./cmd/cub-scout` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)