### PR TITLE
docs: migration playbook, first-import guide, App/Deployment model

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ cub-scout works fully offline. Connected mode is optional.
 
 **Connected:** Run `cub auth login` for ConfigHub features. [Learn more](docs/WHY_CONNECTED_MODE.md)
 
+**Ready to connect?** See the [First Import guide](docs/getting-started/first-import.md) for a 10-minute walkthrough.
+
 ---
 
 ## Maps & Trees

--- a/docs/getting-started/checklist.md
+++ b/docs/getting-started/checklist.md
@@ -71,17 +71,30 @@ A friendly guide to getting comfortable with cub-scout. These are suggestions, n
 
 ---
 
-## When You're Comfortable
+## First Hour
 
-- [ ] **Connect to ConfigHub** — Unlock fleet-wide visibility (free account)
-  - See [WHY_CONNECTED_MODE.md](../WHY_CONNECTED_MODE.md)
-
-- [ ] **Import your apps** — Share ownership data with your team
+- [ ] **Connect to ConfigHub** — Free account, unlocks import and fleet features
   ```bash
-  cub-scout import --dry-run --namespace myapp
+  cub auth login
+  cub-scout status    # Should show ● Connected
   ```
 
+- [ ] **Preview an import** — See what cub-scout would tell ConfigHub
+  ```bash
+  cub-scout import --dry-run -n <namespace>
+  ```
+
+- [ ] **See the full walkthrough** — [First Import guide](first-import.md) (10 minutes)
+
+---
+
+## When You're Comfortable
+
+- [ ] **Import more namespaces** — Follow the [Migration Playbook](../howto/migration-playbook.md)
+
 - [ ] **Explore the CLI reference** — [CLI-GUIDE.md](../../CLI-GUIDE.md) has everything
+
+- [ ] **Learn why connected matters** — [WHY_CONNECTED_MODE.md](../WHY_CONNECTED_MODE.md)
 
 ---
 

--- a/docs/getting-started/first-import.md
+++ b/docs/getting-started/first-import.md
@@ -1,0 +1,195 @@
+# First Import: Connect and Import in 10 Minutes
+
+**Time:** 10 minutes
+**Goal:** Connect to ConfigHub, import one namespace, see what you unlock
+
+**Prerequisite:** You've already explored standalone (`cub-scout map`, `trace`, `scan`).
+If not, start with [First Map](first-map.md).
+
+---
+
+## What, Why, When
+
+**What:** Import registers your running workloads with ConfigHub. ConfigHub becomes
+the system of record for what should be running, while cub-scout continues
+reporting what actually is.
+
+**Why:** Standalone answers "what's here now." Connected answers "what should be here,
+what changed over time, and how does this compare across environments."
+
+**When:** After you've explored standalone and want durable history, fleet queries,
+or managed lifecycle. There's no rush — standalone works indefinitely.
+
+---
+
+## Step 1: Connect (~2 min)
+
+```bash
+cub auth login
+```
+
+Your browser opens. Sign in (or create a free account). When you see "Login successful", return to the terminal.
+
+Verify the connection:
+
+```bash
+cub-scout status
+```
+
+```
+ConfigHub:  ● Connected (you@company.com)
+Cluster:    prod-east
+Context:    kind-demo
+```
+
+The TUI also shows your mode — press `cub-scout map` and look at the header:
+
+```
+┌─ CUB-SCOUT MAP ──────────────────────────────── ● Connected ─┐
+```
+
+---
+
+## Step 2: Discover (~3 min)
+
+Pick a namespace you know well. Preview what cub-scout will propose:
+
+```bash
+./cub-scout import --dry-run -n payments-prod
+```
+
+```
+Discovered 4 workloads in payments-prod:
+
+  App: payments
+  Components:
+    payment-api      Deployment   owner=ArgoCD   variant=prod
+    order-svc        Deployment   owner=ArgoCD   variant=prod
+    redis            StatefulSet  owner=Helm     variant=prod
+    debug-config     ConfigMap    owner=Native   (unmanaged)
+
+  Proposed mapping:
+    Space: payments-team
+    Units: payment-api, order-svc, redis
+    Labels: app=payments, variant=prod
+
+  Skipped: debug-config (Native/unmanaged — import separately if desired)
+
+No changes made. Use without --dry-run to import.
+```
+
+> **API note:** The output says "Space" and "Units" — those are the current CLI names.
+> Read them as: Space = where this App lives, Unit = a component of the App.
+
+**What to check:**
+- Do the component names make sense to your team?
+- Is the variant (`prod`) correctly inferred?
+- Are the right workloads included (and unmanaged ones skipped)?
+
+For machine-readable output: `./cub-scout import --dry-run -n payments-prod --json`
+
+---
+
+## Step 3: Import (~1 min)
+
+If the proposal looks right:
+
+```bash
+./cub-scout import -n payments-prod -y
+```
+
+```
+Imported 3 workloads to ConfigHub:
+  Space: payments-team
+  Units: payment-api, order-svc, redis
+
+Your existing deployer (ArgoCD, Helm) is still running.
+ConfigHub is now aware of these workloads.
+```
+
+**Nothing changed in your cluster.** Your ArgoCD Applications and Helm releases
+continue reconciling as before. The import only told ConfigHub about your workloads.
+
+---
+
+## Step 4: Verify (~2 min)
+
+Check that ConfigHub received the import:
+
+```bash
+cub unit list --space payments-team
+```
+
+```
+NAME           VARIANT   LABELS                          TARGET
+payment-api    prod      app=payments, variant=prod      prod-east
+order-svc      prod      app=payments, variant=prod      prod-east
+redis          prod      app=payments, variant=prod      prod-east
+```
+
+Trace a workload to see ConfigHub in the ownership chain:
+
+```bash
+./cub-scout trace deploy/payment-api -n payments-prod
+```
+
+```
+deploy/payment-api
+  namespace: payments-prod
+  owner: ArgoCD (Application/myapp-prod)
+  confighub: payments-team/payment-api (variant=prod)
+  source: git@github.com:acme/deploy.git @ envs/prod/payments
+```
+
+The ownership chain now includes ConfigHub context alongside the original ArgoCD ownership.
+
+---
+
+## What You Just Unlocked
+
+With your workloads registered in ConfigHub, you can now:
+
+**Connect a Git source.** ConfigHub renders your Git templates into OCI artifacts.
+Flux or Argo pulls from OCI. One pipeline, one audit trail from commit to cluster.
+
+```
+Git → ConfigHub renders → OCI artifact → Flux/Argo → cluster
+```
+
+**Query across clusters.** Once you import multiple clusters:
+
+```bash
+cub unit list --where "Labels.app='payments'"
+# See payment-api across dev, staging, prod — all clusters
+```
+
+**Track revision history.** Every change to a component is versioned in ConfigHub.
+Compare any two revisions to see exactly what changed and when.
+
+**Audit break-glass changes.** When someone hotfixes production outside the normal
+pipeline, ConfigHub tracks the accept/reject decision with who, what, and why.
+
+For the full story: [Why Connected Mode](../WHY_CONNECTED_MODE.md)
+
+---
+
+## Rollback
+
+Changed your mind? Rollback is safe:
+
+```bash
+cub unit delete payment-api --space payments-team
+cub unit delete order-svc --space payments-team
+cub unit delete redis --space payments-team
+```
+
+This removes ConfigHub's awareness. Your cluster and deployers are untouched.
+
+---
+
+## Next Steps
+
+- **Import more namespaces** — Follow the [Migration Playbook](../howto/migration-playbook.md) for a phased approach
+- **Understand discovery** — [Import from Live](../howto/import-from-live.md) explains variant inference and proposal logic
+- **See worked examples** — [examples/import-from-live/](../../examples/import-from-live/) has fixture manifests and expected output
+- **Learn the model** — [Glossary](../reference/glossary.md) explains App, Deployment, Target, and the API mapping

--- a/docs/howto/import-from-live.md
+++ b/docs/howto/import-from-live.md
@@ -40,19 +40,20 @@ It reads labels and annotations — it never modifies anything.
 
 ## What cub-scout Proposes
 
-Given the detected workloads, cub-scout suggests:
+Given the detected workloads, cub-scout suggests an App structure:
 
-- **App Space** — a team workspace name (inferred from namespace patterns)
-- **Units** — one per workload variant, with `app` and `variant` labels
+- **App** — the logical application (inferred from namespace/workload patterns)
+- **Components** — individual workload pieces (api, worker, db) with `app` and `variant` labels
 - **Variant** — inferred from GitOps paths (`envs/prod` → `prod`) or namespace patterns (`myapp-prod` → `prod`)
 
-The proposal uses the current ConfigHub API (Space/Unit). In practice, think of it as:
+> **API note:** The proposal currently uses Space/Unit terminology in CLI output.
+> Read "Space" as where the App lives, "Unit" as a component of the App.
 
 | cub-scout proposes | You should read as |
 |--------------------|--------------------|
-| App Space: `myapp-team` | Team workspace for the myapp service |
-| Unit: `api-prod` | The api component, production deployment |
-| Unit: `api-dev` | The api component, dev deployment |
+| Space: `myapp-team` | Team workspace for the myapp service |
+| Unit: `api-prod` | The api component, production Deployment |
+| Unit: `api-dev` | The api component, dev Deployment |
 
 ## Variant Inference Priority
 
@@ -69,11 +70,11 @@ cub-scout infers the environment variant in this order:
 cub-scout's job stops at the proposal. It discovers and explains — it doesn't create anything in ConfigHub.
 
 The next steps are ConfigHub's responsibility:
-- Create Units from the proposal (via `cub unit create` or the ConfigHub UI)
-- Set up bridge workers and targets
+- Create the App and its Deployments from the proposal
+- Set up bridge workers and Targets
 - Connect the OCI pipeline (ConfigHub renders → Flux/Argo deploys)
 
-See [Import to ConfigHub](import-to-confighub.md) for the full migration path.
+See [Import to ConfigHub](import-to-confighub.md) for the full migration path, or [Migration Playbook](migration-playbook.md) for the comprehensive guide.
 
 ## Worked Example
 
@@ -81,6 +82,6 @@ See [examples/import-from-live/](../../examples/import-from-live/) for a complet
 
 ## Related Docs
 
+- [Migration Playbook](migration-playbook.md) — Comprehensive guide with assessment, planning, validation, and rollback
 - [Import to ConfigHub](import-to-confighub.md) — Full migration path (includes ConfigHub steps)
 - [ConfigHub Glossary](../reference/glossary.md) — Terminology reference
-- [Hub/AppSpace Examples](../reference/hub-appspace-examples.md) — Real-world mapping patterns

--- a/docs/howto/import-to-confighub.md
+++ b/docs/howto/import-to-confighub.md
@@ -2,19 +2,24 @@
 
 This is the canonical migration path for moving existing ArgoCD/Helm-managed workloads into ConfigHub.
 
+For a comprehensive guide with assessment, planning, validation checklists, and rollback procedures, see the [Migration Playbook](migration-playbook.md).
+
 ## Ownership Split
 
-The import process involves two tools with distinct responsibilities:
+The import process involves three roles with distinct responsibilities:
 
 | Step | Who | What |
 |------|-----|------|
 | **Discover** | cub-scout | Scan cluster, detect ownership, propose App structure |
-| **Import** | ConfigHub | Create Units, set up bridge workers, connect OCI pipeline |
+| **Import** | ConfigHub | Create Apps/Deployments, set up bridge workers, connect OCI pipeline |
 | **Deploy** | Flux/ArgoCD | Pull rendered manifests from ConfigHub's OCI registry, apply to cluster |
 
 cub-scout is read-only — it discovers and proposes. ConfigHub handles the actual import and lifecycle.
 
 For cluster-only discovery (no Git required), see [Import from Live](import-from-live.md).
+
+> **API note:** The `cub` CLI currently uses Space/Unit commands while APIs evolve
+> toward App/Deployment language. See [Glossary](../reference/glossary.md) for the mapping.
 
 ## Scope
 
@@ -30,7 +35,7 @@ The path is intentionally:
 
 That keeps rollout and rollback simple.
 
-## Scope
+## When to Use This
 
 Use this when your workloads are currently managed by:
 - Argo CD Applications (including App-of-Apps/ApplicationSet-generated apps)
@@ -67,8 +72,8 @@ cub-scout import -n <namespace> --dry-run
 
 Review:
 - discovered workloads
-- suggested App Space
-- suggested Units/labels
+- suggested App structure
+- suggested component names and labels
 
 If the proposal is wrong, stop and adjust naming/labels strategy first.
 
@@ -84,7 +89,7 @@ Or non-interactive:
 cub-scout import -n <namespace> -y
 ```
 
-### 4. Verify Units and Mapping
+### 4. Verify Import
 
 ```bash
 cub unit list --space <suggested-space>
@@ -93,7 +98,7 @@ cub-scout tree ownership
 ```
 
 Success criteria:
-- expected Units exist in ConfigHub
+- expected workloads exist in ConfigHub
 - workload ownership context is still coherent
 - no unexpected resource drift
 
@@ -103,7 +108,7 @@ Do not immediately remove Argo/Helm control. First validate that ConfigHub state
 
 For Argo App-of-Apps/ApplicationSet setups:
 - treat generated/child Applications as workload sources of truth
-- treat parent orchestration objects as orchestration metadata, not business workload Units
+- treat parent orchestration objects as orchestration metadata, not imported
 
 ### 6. Cut Over by Policy, Not Accident
 
@@ -131,12 +136,14 @@ Scale out only after single-namespace validation passes.
 If a namespace migration is not acceptable:
 
 ```bash
-# Remove created Units (space-scoped)
+# Remove created state (space-scoped)
 cub unit list --space <space>
 cub unit delete <unit-slug> --space <space>
 ```
 
 Then continue using your existing Argo/Helm flow while you revise mapping.
+
+Rollback is safe: import creates ConfigHub state only — it never modifies the cluster.
 
 ## Notes
 
@@ -146,6 +153,7 @@ Then continue using your existing Argo/Helm flow while you revise mapping.
 
 ## Related Docs
 
+- [Migration Playbook](migration-playbook.md) — Comprehensive guide with assessment, planning, validation, and rollback
 - [Import from Live](import-from-live.md) — Cluster-only discovery (no Git required)
 - [Import from Live Example](../../examples/import-from-live/) — Worked example with fixtures
 - [Combined Git+Live Example](../../examples/combined-git-live/) — Git repo + cluster alignment

--- a/docs/howto/migration-playbook.md
+++ b/docs/howto/migration-playbook.md
@@ -1,0 +1,506 @@
+# Migration Playbook: Argo/Helm to ConfigHub
+
+A guided playbook for migrating existing Kubernetes workloads into ConfigHub.
+Covers assessment, planning, execution, validation, and rollback.
+
+> **Prerequisite reading:**
+> - [Import from Live](import-from-live.md) — How cub-scout discovers workloads
+> - [Import to ConfigHub](import-to-confighub.md) — The canonical 7-step import path
+> - [Glossary](../reference/glossary.md) — ConfigHub terminology
+
+---
+
+## ConfigHub Model
+
+ConfigHub uses app-centric language:
+
+| Concept | What It Is |
+|---------|-----------|
+| **App** | A logical application (e.g., payment-service) with components (api, worker, db) |
+| **Deployment** | An App deployed to a specific Target (App × environment) |
+| **Target** | A Kubernetes cluster managed by ConfigHub |
+
+The operating boundary:
+- **ConfigHub** stores and publishes explicit intended state + provenance
+- **Flux/Argo** reconcile runtime (ConfigHub does not replace your deployer)
+- **cub-scout** reports reality and drift (read-only observer)
+
+OCI is the default transport: Git → ConfigHub renders → OCI artifact → Flux/Argo pulls → cluster.
+
+> **API note:** The current `cub` CLI uses Space/Unit commands while APIs evolve.
+> App/Deployment concepts map to Space/Unit under the hood.
+> See [Glossary — Emerging Concepts](../reference/glossary.md#emerging-concepts-confighub-evolution) for details.
+
+---
+
+## Who This Is For
+
+You have a running Kubernetes cluster with workloads managed by ArgoCD, Helm, Flux, or a mix of these. You want to bring those workloads under ConfigHub management without disrupting production.
+
+This playbook assumes:
+- You have `kubectl` access to the cluster
+- You have `cub-scout` installed (v1.0+)
+- You have a ConfigHub account (`cub auth login`)
+
+---
+
+## Decision: Should You Migrate?
+
+ConfigHub adds value when you need:
+
+| Need | Without ConfigHub | With ConfigHub |
+|------|-------------------|----------------|
+| **Understand what's running** | `cub-scout map` (local, single cluster) | Same — cub-scout works standalone |
+| **Track config history** | Git log per repo, manual correlation | Unified revision history across Deployments |
+| **Compare environments** | Manual kubectl/diff per namespace | Query across Deployments by label |
+| **Multi-cluster visibility** | Repeat cub-scout per cluster | Fleet queries across all Targets |
+| **Break-glass audit trail** | Hope someone documented the hotfix | Versioned accept/reject with context |
+
+**Start with standalone cub-scout.** Migrate to ConfigHub when you need durable history, cross-cluster views, or managed lifecycle.
+
+---
+
+## Phase 1: Assess (Read-Only)
+
+Time: 15–30 minutes. No changes to cluster or ConfigHub.
+
+### 1.1 Scan Your Cluster
+
+```bash
+# Build cub-scout if needed
+go build ./cmd/cub-scout
+
+# Full cluster scan — what's running and who owns it?
+./cub-scout map list
+
+# Focus on a specific namespace
+./cub-scout map list -n payments
+
+# Ownership breakdown
+./cub-scout map list -q "owner=ArgoCD"
+./cub-scout map list -q "owner=Helm"
+./cub-scout map list -q "owner=Native"
+```
+
+### 1.2 Identify Ownership Boundaries
+
+Look for these patterns in the output:
+
+| Pattern | What It Means | Migration Approach |
+|---------|---------------|-------------------|
+| Single owner per namespace | Clean boundary | Import namespace as one App |
+| Mixed owners in one namespace | Shared namespace | Import by owner, not namespace |
+| ArgoCD App-of-Apps parent | Orchestration layer | Import child apps; parent is metadata |
+| Helm releases with no GitOps | Direct `helm install` | Import as-is; consider adding Git source later |
+| Native/unmanaged workloads | No controller | Import as-is; ConfigHub becomes first controller |
+
+### 1.3 Check for Blockers
+
+Before proceeding, verify:
+
+```bash
+# Can you reach ConfigHub?
+./cub-scout status
+
+# Is your auth valid?
+cub auth get-token
+cub context get
+```
+
+If `cub-scout status` shows **Offline** or **Standalone**, you need to authenticate first:
+
+```bash
+cub auth login
+```
+
+---
+
+## Phase 2: Plan Your Mapping
+
+Time: 30–60 minutes. Design the App/Deployment structure before importing.
+
+### 2.1 Map Namespaces to Apps
+
+Think in terms of Apps (what your team calls "a service") and Deployments (where it runs):
+
+```
+Kubernetes workload group → ConfigHub App
+Namespace × environment   → ConfigHub Deployment
+Cluster                   → ConfigHub Target
+```
+
+This isn't always 1:1. Consider these patterns:
+
+**Pattern A: One namespace = one App** (simplest)
+
+```
+Namespace: payments-prod
+  → App: payments
+    → Deployment: payments-prod (variant=prod)
+      Components: payment-api, order-svc
+```
+
+**Pattern B: Multiple namespaces = one App** (environment split)
+
+```
+Namespace: payments-dev     → App: payments, Deployment: payments-dev (variant=dev)
+Namespace: payments-staging → App: payments, Deployment: payments-staging (variant=staging)
+Namespace: payments-prod    → App: payments, Deployment: payments-prod (variant=prod)
+```
+
+**Pattern C: Platform + App split** (infra separation)
+
+```
+Namespace: cert-manager      → App: platform-infra (platform-owned)
+Namespace: ingress-nginx     → App: platform-infra (platform-owned)
+Namespace: payments-prod     → App: payments (team-owned)
+Namespace: orders-prod       → App: orders (team-owned)
+```
+
+### 2.2 Use cub-scout's Proposal
+
+cub-scout can suggest the mapping for you:
+
+```bash
+# Dry-run import for one namespace
+./cub-scout import -n payments-prod --dry-run
+
+# See the structured proposal
+./cub-scout import -n payments-prod --dry-run --json
+```
+
+Review the proposal:
+- Are the suggested App names sensible?
+- Do the component names match your team's vocabulary?
+- Are variants correctly inferred (prod, staging, dev)?
+
+If the proposal is wrong, don't import yet. Adjust your labels or naming strategy first.
+
+> **API note:** The dry-run output currently uses Space/Unit terminology.
+> Read "Space" as "where the App's Deployments live" and "Unit" as "a component of the App."
+
+### 2.3 Document Your Decisions
+
+Before executing, write down:
+
+1. **Which namespaces** are in scope for this migration wave
+2. **App names** you'll use (or let cub-scout suggest)
+3. **Component naming convention** (e.g., `{service}-{variant}` or just `{service}`)
+4. **Label strategy**: which labels map to `variant`, `region`, `team`
+5. **What stays outside**: namespaces or workloads you'll migrate later
+
+---
+
+## Phase 3: Execute (One Namespace at a Time)
+
+Time: 10–15 minutes per namespace.
+
+### 3.1 Start With Your Simplest Namespace
+
+Pick a namespace that has:
+- Few workloads (2–5)
+- Single ownership (all Argo, all Helm, or all Native)
+- Non-critical environment (dev or staging)
+
+```bash
+# Final dry-run check
+./cub-scout import -n payments-dev --dry-run
+
+# Execute import
+./cub-scout import -n payments-dev
+```
+
+Or non-interactive:
+
+```bash
+./cub-scout import -n payments-dev -y
+```
+
+### 3.2 Verify Immediately
+
+After import, verify the result:
+
+```bash
+# Check the import created the expected state in ConfigHub
+cub unit list --space payments-team
+
+# Verify cub-scout sees the new ownership
+./cub-scout map list -n payments-dev
+
+# Check ownership chain
+./cub-scout trace deploy/payment-api -n payments-dev
+```
+
+**Success criteria:**
+- Expected workloads exist in ConfigHub
+- Workload ownership context is coherent (no "unknown" or incorrect owners)
+- No unexpected resource drift
+
+### 3.3 Keep Your Existing Deployer Running
+
+**Do not remove ArgoCD or Helm control yet.**
+
+The import registers your workloads with ConfigHub. Your existing deployer (Argo, Helm, Flux) continues to reconcile. This is intentional — you validate ConfigHub's view before changing who controls what.
+
+During this validation window:
+- ConfigHub knows about your workloads (Deployments exist)
+- Your deployer still manages the actual cluster state
+- There is no conflict because cub-scout and ConfigHub are read-only observers
+
+---
+
+## Phase 4: Validate
+
+Time: 1–3 days (or however long you need confidence).
+
+### 4.1 Post-Import Checklist
+
+Run through this checklist for each migrated namespace:
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Workloads imported | `cub unit list --space <space>` | All expected workloads listed |
+| Ownership visible | `./cub-scout map list -n <ns>` | ConfigHub ownership shown |
+| Trace works | `./cub-scout trace deploy/<name> -n <ns>` | Full ownership chain |
+| No false orphans | `./cub-scout map list -q "owner=Native" -n <ns>` | Only genuinely unmanaged workloads |
+| Variants correct | `cub unit list --where "Labels.variant='prod'"` | Correct environment tagging |
+| Status healthy | `./cub-scout status` | Connected, auth valid |
+
+### 4.2 Handle Mixed Ownership
+
+If a namespace has workloads from multiple owners:
+
+```bash
+# See the ownership breakdown
+./cub-scout map list -n mixed-namespace -q "owner=ArgoCD"
+./cub-scout map list -n mixed-namespace -q "owner=Helm"
+./cub-scout map list -n mixed-namespace -q "owner=Native"
+```
+
+Import each owner group separately. In ConfigHub, they'll all be components of the same App but with different provenance.
+
+The key rule: **one controller-of-record per workload**. After import, each workload should have exactly one system reconciling its state. Mixed ownership in the same namespace is fine; mixed control of the same workload is not.
+
+### 4.3 Validate ArgoCD App-of-Apps
+
+If you have App-of-Apps or ApplicationSet patterns:
+
+```bash
+# See the hierarchy
+./cub-scout tree ownership -n argocd
+
+# List ApplicationSet-generated apps
+./cub-scout map list -q "owner=ArgoCD"
+```
+
+Import rules for Argo hierarchies:
+- **Child Applications** (the ones that manage actual workloads) → import as App components
+- **Parent Application** (App-of-Apps root) → treat as orchestration metadata, not imported
+- **ApplicationSet** → treat as a generator/template, not imported
+
+The parent/generator creates child apps; ConfigHub imports the children.
+
+---
+
+## Phase 5: Cut Over
+
+Time: varies by team.
+
+### 5.1 When to Cut Over
+
+Cut over when:
+- All post-import checks pass
+- Team is comfortable with ConfigHub's view of their workloads
+- You've decided on controller-of-record per workload
+
+### 5.2 Cut-Over Order
+
+1. **Update team policy** — document which system is controller-of-record
+2. **Configure ConfigHub Targets** — point workers at the right clusters
+3. **Remove duplicate reconciliation** — stop Argo/Helm from reconciling workloads that ConfigHub now manages
+
+**Do not skip step 1.** Policy clarity prevents the "two systems reconciling the same manifest" problem.
+
+### 5.3 What NOT to Do
+
+- Do not delete ArgoCD Applications before ConfigHub workers are running
+- Do not remove Helm releases while they're the only reconciliation source
+- Do not cut over production and dev simultaneously — stagger by environment
+- Do not assume "it worked in staging" means production is ready
+
+---
+
+## Phase 6: Expand
+
+### 6.1 Next Namespace
+
+After your first namespace is stable:
+
+```bash
+# Repeat for the next namespace
+./cub-scout import -n payments-staging --dry-run
+./cub-scout import -n payments-staging -y
+```
+
+### 6.2 Recommended Expansion Order
+
+1. **Dev** (lowest risk, fastest feedback)
+2. **Staging** (validates the pattern with more realistic workloads)
+3. **Production non-critical** (internal tools, batch jobs)
+4. **Production critical** (revenue-path services, last)
+
+### 6.3 Fleet Expansion
+
+Once multiple clusters are imported:
+
+```bash
+# Cross-cluster queries (connected mode)
+cub unit list --where "Labels.app='payment-api'"
+
+# Compare environments
+cub unit list --where "Labels.variant='prod'" --where "Labels.variant='staging'"
+```
+
+---
+
+## Rollback
+
+If an import doesn't look right, roll back before cutting over:
+
+```bash
+# List what was imported
+cub unit list --space <space>
+
+# Remove specific components
+cub unit delete <unit-slug> --space <space>
+
+# Or remove the entire space
+cub space delete <space-slug>
+```
+
+Your existing Argo/Helm/Flux deployer is still running. Removing ConfigHub state doesn't affect the cluster — it only removes ConfigHub's awareness of those workloads.
+
+**Rollback is safe because:**
+- Import creates ConfigHub state (Apps, Deployments)
+- Import does not modify cluster state
+- Your existing deployer was never stopped
+- Removing ConfigHub state returns to pre-import behavior
+
+---
+
+## Sources of Intent
+
+ConfigHub supports two sources of intent:
+
+| Source | When to Use |
+|--------|-------------|
+| **Git import** (default) | You have Git repos with manifests, Kustomize overlays, or Helm charts. ConfigHub renders and publishes via OCI. |
+| **Live import** | Git repos aren't organized or available. cub-scout discovers from the running cluster. |
+
+Both are first-class. You can start with live import and add Git sources later.
+
+The artifact publish target is OCI by default. The runtime reconciler remains Flux or Argo — ConfigHub does not replace your deployer, it feeds it rendered manifests.
+
+---
+
+## Common Patterns
+
+### Helm-Only Cluster
+
+```bash
+# Discover Helm releases
+./cub-scout map list -q "owner=Helm"
+
+# Import all Helm workloads in a namespace
+./cub-scout import -n <namespace> --dry-run
+```
+
+Helm releases become App components. The Helm release name typically becomes the component name.
+
+### ArgoCD with ApplicationSets
+
+```bash
+# See what ApplicationSets generate
+./cub-scout map list -q "owner=ArgoCD"
+
+# Import generated Applications as App components
+./cub-scout import -n <namespace> --dry-run
+```
+
+Each generated Application becomes an App component. The ApplicationSet itself is not imported.
+
+### Flux Kustomizations
+
+```bash
+# See Flux-managed workloads
+./cub-scout map list -q "owner=Flux"
+
+# Import Flux workloads
+./cub-scout import -n <namespace> --dry-run
+```
+
+Flux Kustomization paths inform the variant inference (e.g., `./overlays/prod` → `variant=prod`).
+
+### Mixed Argo + Helm in Same Namespace
+
+```bash
+# See the mix
+./cub-scout map list -n mixed-ns
+
+# Import handles both — each workload retains its detected owner
+./cub-scout import -n mixed-ns --dry-run
+```
+
+Both Argo-managed and Helm-managed workloads become components of the same App. The original owner is preserved as metadata.
+
+---
+
+## Troubleshooting
+
+### "No workloads found"
+
+```bash
+# Check you have the right namespace
+kubectl get deployments -n <namespace>
+
+# Check cub-scout can see the cluster
+./cub-scout map list
+```
+
+### "Auth expired"
+
+```bash
+# Re-authenticate
+cub auth login
+
+# Verify
+./cub-scout status
+```
+
+### "Import proposal looks wrong"
+
+Don't import. Instead:
+1. Check labels: `kubectl get deploy -n <ns> --show-labels`
+2. Check annotations: `kubectl get deploy -n <ns> -o json | jq '.items[].metadata.annotations'`
+3. Adjust workload labels if ownership detection is incorrect
+4. Re-run `./cub-scout import -n <ns> --dry-run` after fixing
+
+### "Imported but ownership chain broken"
+
+```bash
+# Trace the specific workload
+./cub-scout trace deploy/<name> -n <namespace>
+
+# Check if the deployer is still reconciling
+kubectl get deploy/<name> -n <namespace> -o json | jq '.metadata.labels'
+```
+
+---
+
+## Related Docs
+
+- [Import from Live](import-from-live.md) — Cluster-only discovery without Git
+- [Import to ConfigHub](import-to-confighub.md) — Step-by-step import reference
+- [Glossary](../reference/glossary.md) — ConfigHub terminology (including emerging App/Deployment model)
+- [Ownership Detection](ownership-detection.md) — How cub-scout identifies owners
+- [Trace Ownership](trace-ownership.md) — Following the ownership chain

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -17,6 +17,10 @@ Org: acme-corp
 
 ### Platform Hub
 
+> **Transitioning:** The Hub/AppSpace model is being replaced by App/Deployment/Target.
+> See [ConfigHub Model](#confighub-model-app-centric) below for the new language.
+> The current API still uses these concepts.
+
 Governance layer that constrains what teams can do. Owns base templates.
 
 ```
@@ -24,42 +28,32 @@ Org: acme-corp
 └── Platform Hub: platform-team
     ├── Base Catalog (templates)
     ├── Policies (what's allowed)
-    └── App Spaces (team workspaces)
+    └── Spaces (team workspaces)
 ```
 
-**Hub owns the skeletons.** Base templates, shared configs, and reusable patterns live in the Hub's Base Catalog.
-
-### App Space
+### Space (formerly App Space)
 
 Team workspace. One deployer (Argo OR Flux), one team. Contains Units.
+In the new model, a Space maps to where an App's Deployments live.
 
 ```
-App Space: payments-team
+Space: payments-team
 ├── Deployer: ArgoCD
 └── Units: payment-api, order-svc, redis
 ```
 
-**App Space ≠ Environment.** Environments are labels (`variant=prod`), not separate spaces.
+**Space ≠ Environment.** Environments are labels (`variant=prod`), not separate spaces.
 
 ### Unit
 
-Single deployable workload with labels. The atomic element of config.
+Single deployable workload component with labels. In the new model, a Unit
+maps to a component of an App.
 
 ```
 Unit: payment-api
 ├── Labels: app=payment-api, variant=prod, region=us-east
 ├── Source: apps/payment-api/overlays/prod
 └── Target: prod-east-cluster
-```
-
-### App (Application)
-
-**App = a name.** Just a label value like `app=payment-api`.
-
-The "application" emerges from querying Units with that label:
-```bash
-cub query "Labels['app'] = 'payment-api'"
-# Returns all Units for payment-api across all variants/regions
 ```
 
 ### Variant
@@ -117,7 +111,7 @@ Git repository registered with ConfigHub. Contains pattern metadata (app-of-apps
 
 Tool that syncs Git to cluster: Flux CD or Argo CD.
 
-**One App Space = One Deployer.** Can't mix Flux and Argo in same App Space.
+**One Space = One Deployer.** Can't mix Flux and Argo in the same Space.
 
 ### Target
 
@@ -141,20 +135,21 @@ Discover workloads from running cluster. TUI capability.
 
 ```bash
 ./cub-scout import -n payment-prod
-# Scans cluster, detects ownership, suggests App Space structure
+# Scans cluster, detects ownership, suggests App structure
 ```
 
 ### GIT Import
 
 Parse Git repo structure for base templates, overlays, variants. GUI capability.
+Git import is the default source; live import is first-class when Git is unavailable.
 
-### Base Unit
+### Base Template
 
-Template in Hub's Base Catalog. Created from `base/` folders in Git. Never deployed directly.
+Template in the platform catalog. Created from `base/` folders in Git. Never deployed directly.
 
 ```
-apps/payment-api/base/  →  Base Unit in Hub Catalog
-apps/payment-api/overlays/prod/  →  Unit (references base)
+apps/payment-api/base/  →  Base template in catalog
+apps/payment-api/overlays/prod/  →  App component (references base)
 ```
 
 ---
@@ -189,17 +184,23 @@ Format: `RISK-2025-XXXX`
 
 ---
 
-## Emerging Concepts (ConfigHub Evolution)
+## ConfigHub Model (App-Centric)
 
-> **Note:** ConfigHub's data model is evolving. The concepts below describe the
-> direction of travel. The current API still uses Space/Unit/Target. cub-scout
-> uses App/Deployment language in user-facing output while mapping to the
-> current API under the hood.
+ConfigHub is moving to app-centric language. The invariant is unchanged:
+nothing implicit ever deploys, nothing observed silently overwrites intent.
 
-### App (Multi-Unit)
+### Operating Boundary
 
-A collection of components (api, worker, database) owned by one team, deployed
-together. The "App" is what users think about — the Unit is the implementation detail.
+| System | Role |
+|--------|------|
+| **ConfigHub** | Stores/publishes explicit intended state + provenance |
+| **Flux/Argo** | Reconcile runtime (ConfigHub does not replace your deployer) |
+| **cub-scout** | Reports reality and drift (read-only observer) |
+
+### App
+
+A logical application — the thing your team thinks of as "a service." Contains
+components (api, worker, database) owned by one team.
 
 ```
 App: payment-service
@@ -207,10 +208,14 @@ App: payment-service
 └── Deployments: dev, staging, prod
 ```
 
-### Deployment (App × Target)
+### Deployment
 
-The junction of an App and a Target. What you get when you deploy an App to a
-specific environment. Maps to what was previously "a Space with multiple Units."
+An App deployed to a specific Target (App × environment). What you get when you
+deploy an App to production, staging, etc.
+
+### Target
+
+A Kubernetes cluster managed by ConfigHub. Connected via a Bridge Worker.
 
 ### OCI Transport
 
@@ -229,11 +234,26 @@ Connector between ConfigHub and external systems (Kubernetes, ArgoCD, Flux).
 Bridge workers handle the actual deployment — ConfigHub orchestrates, Flux/Argo
 apply.
 
+### Temporary API Mapping
+
+While APIs evolve, the new concepts map to current CLI commands:
+
+| New Concept | Current CLI | Notes |
+|-------------|-------------|-------|
+| App | Space | A Space holds one App's Deployments |
+| App component | Unit | A Unit is a deployable component |
+| Deployment | Space + Units + Target | Junction of App × environment |
+| Target | Target | Unchanged |
+
+The `cub` CLI still uses `cub unit list`, `cub space delete`, etc. Read the
+output through the App/Deployment lens.
+
 ---
 
 ## See Also
 
-- [Hub/AppSpace Examples](hub-appspace-examples.md) — Model examples
+- [Migration Playbook](../howto/migration-playbook.md) — Comprehensive migration guide
 - [Import to ConfigHub](../howto/import-to-confighub.md) — Import architecture
 - [Import from Live](../howto/import-from-live.md) — Cluster-only import (no Git required)
+- [Hub/AppSpace Examples](hub-appspace-examples.md) — Mapping pattern examples
 - [Scan for risk issues](../howto/scan-for-risks.md) — risk scanning guide

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,6 +71,7 @@ Tracking issue: **#154** (master backlog tracking)
 
 - [ ] Connected hierarchy navigation defaults (cluster-aware filtering)
 - [x] Mode state visibility in TUI (QuickMode for instant display, Offline/Standalone/Connected distinction)
+- [x] Canonical migration guide from Argo/Helm to ConfigHub (`docs/howto/migration-playbook.md`)
 - [ ] Trace context diagnostics and documented reset path for connected workflows
 - [ ] "Break-glass to managed" flow documentation and guided testing
 - [ ] User-facing explainer for ASCII vs JSON model (canonical data vs presentation)


### PR DESCRIPTION
## Summary
- Add **migration playbook** (`docs/howto/migration-playbook.md`): comprehensive 6-phase guide for Argo/Helm → ConfigHub migration with rollback procedures
- Add **first-import guide** (`docs/getting-started/first-import.md`): 10-minute quick-start showing what users see at each step with ASCII mockups
- Align all import and glossary docs to the new **App/Deployment/Target** model with temporary API mapping notes
- Update checklist, README, glossary, and roadmap backlog

## Test plan
- [x] `go build ./cmd/cub-scout` passes
- [x] `go test ./...` — 35/35 packages green (docs-only changes)
- [ ] Review doc links resolve correctly
- [ ] Review ASCII mockups match current CLI output style

🤖 Generated with [Claude Code](https://claude.com/claude-code)