### PR TITLE
docs+cli: 1.0 era doc separation and App/Deployment terminology

### DIFF
--- a/cmd/cub-scout/apply.go
+++ b/cmd/cub-scout/apply.go
@@ -16,7 +16,7 @@ import (
 var applyCmd = &cobra.Command{
 	Use:   "apply [proposal.json]",
 	Short: "Apply a proposal from JSON (GUI)",
-	Long: `Apply a Hub/App Space proposal to create resources in ConfigHub.
+	Long: `Apply an App model proposal to create resources in ConfigHub.
 
 This is the GUI companion to "cub-scout import".
 
@@ -161,10 +161,10 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 		logger.Section("APPLYING")
 	}
 
-	// Step 1: Create App Space
-	fmt.Printf("  Creating App Space: %s\n", proposal.AppSpace)
+	// Step 1: Create App
+	fmt.Printf("  Creating App: %s\n", proposal.AppSpace)
 	if logger != nil {
-		logger.Log("Creating App Space: %s", proposal.AppSpace)
+		logger.Log("Creating App: %s", proposal.AppSpace)
 	}
 	if !dryRun {
 		if err := createAppSpaceForImport(proposal.AppSpace); err != nil {
@@ -180,9 +180,9 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 		}
 	}
 
-	// Step 2: Create Units
+	// Step 2: Create Deployments
 	fmt.Println()
-	fmt.Println("  Creating Units:")
+	fmt.Println("  Creating Deployments:")
 
 	created := 0
 	skipped := 0
@@ -201,7 +201,7 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 		if len(unit.Workloads) == 0 {
 			fmt.Printf("    • %s (skipped - no workloads)\n", unit.Slug)
 			if logger != nil {
-				logger.Log("Skipped unit %s: no workloads", unit.Slug)
+				logger.Log("Skipped deployment %s: no workloads", unit.Slug)
 			}
 			skipped++
 			continue
@@ -209,7 +209,7 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 
 		fmt.Printf("    • %s [%s]\n", unit.Slug, labelStr)
 		if logger != nil {
-			logger.Log("Creating unit: %s [%s]", unit.Slug, labelStr)
+			logger.Log("Creating deployment: %s [%s]", unit.Slug, labelStr)
 		}
 
 		if !dryRun {
@@ -249,7 +249,7 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 			if err := createUnitWithManifest(proposal.AppSpace, unit.Slug, labels, manifest); err != nil {
 				fmt.Printf("      ⚠ failed to create: %v\n", err)
 				if logger != nil {
-					logger.Log("  FAILED: create unit: %v", err)
+					logger.Log("  FAILED: create deployment: %v", err)
 				}
 				skipped++
 				continue
@@ -265,7 +265,7 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 	}
 
 	fmt.Println()
-	fmt.Printf("  Summary: %d units created, %d skipped\n", created, skipped)
+	fmt.Printf("  Summary: %d deployments created, %d skipped\n", created, skipped)
 
 	if logger != nil {
 		logger.LogResult(created, skipped, nil)

--- a/cmd/cub-scout/appspace.go
+++ b/cmd/cub-scout/appspace.go
@@ -14,20 +14,20 @@ import (
 
 var appSpaceCmd = &cobra.Command{
 	Use:   "app-space",
-	Short: "Manage App Spaces",
-	Long:  `Create, list, and manage App Spaces in ConfigHub.`,
+	Short: "Manage Apps",
+	Long:  `Create, list, and manage Apps in ConfigHub.`,
 }
 
 var appSpaceCreateCmd = &cobra.Command{
 	Use:   "create <name>",
-	Short: "Create an App Space",
-	Long: `Create a new App Space in ConfigHub.
+	Short: "Create an App",
+	Long: `Create a new App in ConfigHub.
 
-An App Space is a team workspace containing all environments (dev, staging, prod)
+An App is a team workspace containing all environments (dev, staging, prod)
 for applications managed by a single deployer (Flux or Argo CD).
 
 Examples:
-  # Create an App Space
+  # Create an App
   cub-scout app-space create payments-team
 
   # Create and set as current context
@@ -42,8 +42,8 @@ Examples:
 
 var appSpaceListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List App Spaces",
-	Long:  `List all App Spaces in the current organization.`,
+	Short: "List Apps",
+	Long:  `List all Apps in the current organization.`,
 	RunE:  runAppSpaceList,
 }
 
@@ -83,7 +83,7 @@ func runAppSpaceCreate(cmd *cobra.Command, args []string) error {
 	cubCmd.Stderr = os.Stderr
 
 	if err := cubCmd.Run(); err != nil {
-		return fmt.Errorf("create app space: %w", err)
+		return fmt.Errorf("create app: %w", err)
 	}
 
 	return nil
@@ -103,14 +103,14 @@ func runAppSpaceList(cmd *cobra.Command, args []string) error {
 	return cubCmd.Run()
 }
 
-// AppSpaceResult represents the result of creating an App Space
+// AppSpaceResult represents the result of creating an App
 type AppSpaceResult struct {
 	Name    string `json:"name"`
 	Created bool   `json:"created"`
 	Error   string `json:"error,omitempty"`
 }
 
-// CreateAppSpaceWithResult creates an App Space and returns structured result
+// CreateAppSpaceWithResult creates an App and returns structured result
 func CreateAppSpaceWithResult(name string, setContext bool, labels []string) (*AppSpaceResult, error) {
 	result := &AppSpaceResult{Name: name}
 
@@ -134,7 +134,7 @@ func CreateAppSpaceWithResult(name string, setContext bool, labels []string) (*A
 			return result, nil
 		}
 		result.Error = strings.TrimSpace(string(output))
-		return result, fmt.Errorf("create app space: %w", err)
+		return result, fmt.Errorf("create app: %w", err)
 	}
 
 	result.Created = true

--- a/cmd/cub-scout/combined.go
+++ b/cmd/cub-scout/combined.go
@@ -30,7 +30,7 @@ type CombinedResult struct {
 	GitRepo   *gitops.RepoStructure `json:"gitRepo,omitempty"`
 	Cluster   *ImportResult         `json:"cluster,omitempty"`
 	Alignment []AlignmentEntry      `json:"alignment,omitempty"`
-	Proposal  *FullProposal         `json:"proposal,omitempty"` // Hub/App Space proposal
+	Proposal  *FullProposal         `json:"proposal,omitempty"` // App model proposal
 }
 
 // AlignmentEntry shows how Git apps align with cluster workloads
@@ -52,20 +52,20 @@ This helps you understand:
 - What workloads are deployed in the cluster
 - How they align (or don't)
 
-Use --suggest to generate a full Hub/App Space model proposal.
-Use --apply to create the App Space and Units in ConfigHub.
+Use --suggest to generate a full App model proposal.
+Use --apply to create the App and Deployments in ConfigHub.
 
 Examples:
   # Combine Git repo with current cluster
   cub-scout combined --git-url https://github.com/org/gitops-repo --namespace demo
 
-  # Generate Hub/App Space proposal
+  # Generate App model proposal
   cub-scout combined --git-url https://github.com/org/gitops-repo --namespace demo --suggest
 
   # Preview what would be created (dry-run)
   cub-scout combined --namespace demo --suggest --apply --dry-run
 
-  # Apply: create App Space and Units in ConfigHub
+  # Apply: create App and Deployments in ConfigHub
   cub-scout combined --namespace demo --suggest --apply
 
   # Use local Git repo with JSON output
@@ -79,8 +79,8 @@ func init() {
 	combinedCmd.Flags().StringVar(&combinedGitPath, "git-path", "", "Local path to Git repository")
 	combinedCmd.Flags().StringVarP(&combinedNamespace, "namespace", "n", "", "Namespace to scan in cluster")
 	combinedCmd.Flags().BoolVar(&combinedJSON, "json", false, "Output as JSON")
-	combinedCmd.Flags().BoolVar(&combinedSuggest, "suggest", false, "Generate Hub/App Space model proposal")
-	combinedCmd.Flags().BoolVar(&combinedApply, "apply", false, "Create App Space and Units in ConfigHub")
+	combinedCmd.Flags().BoolVar(&combinedSuggest, "suggest", false, "Generate App model proposal")
+	combinedCmd.Flags().BoolVar(&combinedApply, "apply", false, "Create App and Deployments in ConfigHub")
 	combinedCmd.Flags().BoolVar(&combinedDryRun, "dry-run", false, "Show what would be created without making changes")
 
 	rootCmd.AddCommand(combinedCmd)
@@ -150,7 +150,7 @@ func runCombined(cmd *cobra.Command, args []string) error {
 		result.Alignment = buildAlignment(result.GitRepo, result.Cluster)
 	}
 
-	// Build full Hub/App Space proposal if --suggest
+	// Build full App model proposal if --suggest
 	if combinedSuggest && result.GitRepo != nil {
 		result.Proposal = SuggestFullProposal(result.GitRepo.Apps, workloads, "")
 	}
@@ -160,7 +160,7 @@ func runCombined(cmd *cobra.Command, args []string) error {
 		result.Proposal = SuggestFullProposal(nil, workloads, "")
 	}
 
-	// Apply: create App Space and Units in ConfigHub
+	// Apply: create App and Deployments in ConfigHub
 	if combinedApply && result.Proposal != nil {
 		if err := applyProposal(result.Proposal, workloads, combinedDryRun); err != nil {
 			return err
@@ -352,7 +352,7 @@ func convertToSuggestionJSON(s *HubAppSpaceSuggestion) *SuggestionJSON {
 	}
 }
 
-// applyProposal creates the App Space and Units in ConfigHub
+// applyProposal creates the App and Deployments in ConfigHub
 func applyProposal(proposal *FullProposal, workloads []WorkloadInfo, dryRun bool) error {
 	// Index workloads by namespace/name for manifest lookup
 	workloadIndex := make(map[string]WorkloadInfo)
@@ -370,8 +370,8 @@ func applyProposal(proposal *FullProposal, workloads []WorkloadInfo, dryRun bool
 		fmt.Println()
 	}
 
-	// Step 1: Create App Space
-	fmt.Printf("  Creating App Space: %s\n", proposal.AppSpace)
+	// Step 1: Create App
+	fmt.Printf("  Creating App: %s\n", proposal.AppSpace)
 	if !dryRun {
 		if err := createAppSpaceForImport(proposal.AppSpace); err != nil {
 			return fmt.Errorf("create space: %w", err)
@@ -379,9 +379,9 @@ func applyProposal(proposal *FullProposal, workloads []WorkloadInfo, dryRun bool
 		fmt.Printf("    ✓ Space created\n")
 	}
 
-	// Step 2: Create Units with workloads
+	// Step 2: Create Deployments with workloads
 	fmt.Println()
-	fmt.Println("  Creating Units:")
+	fmt.Println("  Creating Deployments:")
 
 	created := 0
 	skipped := 0
@@ -436,12 +436,12 @@ func applyProposal(proposal *FullProposal, workloads []WorkloadInfo, dryRun bool
 	}
 
 	fmt.Println()
-	fmt.Printf("  Summary: %d units created, %d skipped\n", created, skipped)
+	fmt.Printf("  Summary: %d deployments created, %d skipped\n", created, skipped)
 
 	return nil
 }
 
-// createAppSpaceForImport creates an App Space for import using cub-scout app-space create
+// createAppSpaceForImport creates an App for import using cub-scout app-space create
 func createAppSpaceForImport(name string) error {
 	result, err := CreateAppSpaceWithResult(name, true, nil)
 	if err != nil {

--- a/cmd/cub-scout/fleet.go
+++ b/cmd/cub-scout/fleet.go
@@ -73,7 +73,7 @@ var (
 
 func init() {
 	fleetCmd.Flags().BoolVar(&fleetJSON, "json", false, "Output as JSON")
-	fleetCmd.Flags().BoolVar(&fleetSuggest, "suggest", false, "Generate unified Hub/App Space proposal")
+	fleetCmd.Flags().BoolVar(&fleetSuggest, "suggest", false, "Generate unified App model proposal")
 	rootCmd.AddCommand(fleetCmd)
 }
 

--- a/cmd/cub-scout/hierarchy.go
+++ b/cmd/cub-scout/hierarchy.go
@@ -2138,11 +2138,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, loadSuggestDataCmd()
 
 		case key.Matches(msg, m.keymap.HubView):
-			// Toggle Hub/AppSpace view mode
+			// Toggle App model view mode
 			m.hubViewMode = !m.hubViewMode
 			m.rebuildFlatList()
 			if m.hubViewMode {
-				m.statusMsg = "Hub/AppSpace view enabled"
+				m.statusMsg = "App model view enabled"
 			} else {
 				m.statusMsg = "Standard view"
 			}
@@ -3133,7 +3133,7 @@ func (m *Model) advanceImportStep() (tea.Model, tea.Cmd) {
 		selected := m.getSelectedWorkloads()
 		if len(selected) > 0 {
 			// For ArgoCD imports, always use combined structure (1 Unit per Application)
-			// per Hub/AppSpace/Unit model - skip the unit structure step
+			// per App/Deployment model - skip the unit structure step
 			if m.importSource == importSourceArgoCD {
 				m.importUnitStructure = unitStructureCombined
 				m.importStep = importStepExtractConfig
@@ -3841,7 +3841,7 @@ func (m Model) renderHelpOverlay() string {
 	b.WriteString("\n")
 	b.WriteString("  " + keyStyle.Render("a") + "          " + descStyle.Render("Activity view (recent changes)"))
 	b.WriteString("\n")
-	b.WriteString("  " + keyStyle.Render("B") + "          " + descStyle.Render("Toggle Hub/AppSpace view"))
+	b.WriteString("  " + keyStyle.Render("B") + "          " + descStyle.Render("Toggle App model view"))
 	b.WriteString("\n")
 	b.WriteString("  " + keyStyle.Render("M") + "          " + descStyle.Render("Three Maps view (GitOps + ConfigHub + Repos)"))
 	b.WriteString("\n")
@@ -4146,8 +4146,8 @@ func (m Model) renderMapsView() string {
 	}
 	b.WriteString("\n")
 
-	// MAP 2b: Hub/AppSpace Model
-	b.WriteString(sectionStyle.Render("MAP 2b: HUB/APPSPACE MODEL") + " " + dimStyle.Render("(Platform + App Teams)"))
+	// MAP 2b: App Model
+	b.WriteString(sectionStyle.Render("MAP 2b: APP MODEL") + " " + dimStyle.Render("(Platform + App Teams)"))
 	b.WriteString("\n")
 
 	// Categorize spaces into platform vs app spaces
@@ -4183,7 +4183,7 @@ func (m Model) renderMapsView() string {
 	}
 
 	b.WriteString("  │\n")
-	b.WriteString(fmt.Sprintf("  └── %s\n", cyanStyle.Render("App Spaces (Teams)")))
+	b.WriteString(fmt.Sprintf("  └── %s\n", cyanStyle.Render("Apps (Teams)")))
 	if len(appSpaces) > 0 {
 		shown := 5
 		if len(appSpaces) < shown {
@@ -4428,7 +4428,7 @@ func (m Model) renderSuggestView() string {
 	// Show suggestion
 	proposal := m.suggestProposal
 
-	b.WriteString(sectionStyle.Render("Suggested App Space: ") + nameStyle.Render(proposal.AppSpace))
+	b.WriteString(sectionStyle.Render("Suggested App: ") + nameStyle.Render(proposal.AppSpace))
 	b.WriteString("\n\n")
 
 	b.WriteString(sectionStyle.Render("Suggested Units:"))
@@ -4538,7 +4538,7 @@ func (m Model) renderCreateWizard() string {
 		b.WriteString(activeStyle.Render("_"))
 
 	case createStepUnitMethod:
-		b.WriteString(dimStyle.Render("Creating unit: " + m.createName))
+		b.WriteString(dimStyle.Render("Creating deployment: " + m.createName))
 		b.WriteString("\n\n")
 		b.WriteString("How would you like to create this unit?\n\n")
 		options := []string{"Clone from existing unit", "Start with empty config"}
@@ -4551,7 +4551,7 @@ func (m Model) renderCreateWizard() string {
 		}
 
 	case createStepSelectSource:
-		b.WriteString(dimStyle.Render("Creating unit: " + m.createName))
+		b.WriteString(dimStyle.Render("Creating deployment: " + m.createName))
 		b.WriteString("\n\n")
 		b.WriteString("Select unit to clone:\n\n")
 		if len(m.createUnits) == 0 {
@@ -4568,7 +4568,7 @@ func (m Model) renderCreateWizard() string {
 		}
 
 	case createStepSelectTarget:
-		b.WriteString(dimStyle.Render("Creating unit: " + m.createName))
+		b.WriteString(dimStyle.Render("Creating deployment: " + m.createName))
 		b.WriteString("\n")
 		if m.createCloneFrom != "" {
 			b.WriteString(dimStyle.Render("Clone from: " + m.createCloneFrom))
@@ -5495,7 +5495,7 @@ func (m *Model) rebuildFlatList() {
 		m.flatList = append(m.flatList, node)
 		if node.Expanded {
 			if m.hubViewMode && node.Type == "org" {
-				// Hub/AppSpace view: group spaces
+				// App model view: group spaces
 				m.addHubAppSpaceView(node)
 			} else {
 				m.addChildrenToFlatList(node, 1)
@@ -5565,9 +5565,9 @@ func (m *Model) unitMatchesCurrentCluster(node *TreeNode) bool {
 	return matchesCluster(targetSlug, m.currentCluster)
 }
 
-// addHubAppSpaceView adds spaces grouped into Hub (platform) and AppSpaces (apps)
+// addHubAppSpaceView adds spaces grouped into Hub (platform) and Apps (apps)
 func (m *Model) addHubAppSpaceView(orgNode *TreeNode) {
-	// Categorize spaces into Hub (platform) vs AppSpaces
+	// Categorize spaces into Hub (platform) vs Apps
 	var hubSpaces, appSpaces []*TreeNode
 	for _, child := range orgNode.Children {
 		if child.Type != "space" {
@@ -5611,11 +5611,11 @@ func (m *Model) addHubAppSpaceView(orgNode *TreeNode) {
 		}
 	}
 
-	// Create virtual AppSpaces group node
+	// Create virtual Apps group node
 	if len(appSpaces) > 0 {
 		appGroup := &TreeNode{
 			ID:       orgNode.ID + "/appspaces",
-			Name:     "📦 AppSpaces (Teams)",
+			Name:     "📦 Apps (Teams)",
 			Type:     "app_group",
 			Info:     fmt.Sprintf("(%d spaces)", len(appSpaces)),
 			Parent:   orgNode,
@@ -6068,7 +6068,7 @@ func formatUnitDetails(jsonData []byte, basicData CubUnitData) string {
 	return b.String()
 }
 
-// formatGroupPatternContext creates context about Hub/AppSpace patterns
+// formatGroupPatternContext creates context about App model patterns
 func formatGroupPatternContext(node *TreeNode) string {
 	var b strings.Builder
 
@@ -6149,7 +6149,7 @@ func formatGroupPatternContext(node *TreeNode) string {
 
 	b.WriteString("\n")
 	b.WriteString("─────────────────────────────────────\n")
-	b.WriteString("Press B to toggle Hub/AppSpace view\n")
+	b.WriteString("Press B to toggle App model view\n")
 	b.WriteString("See: docs/map/reference/hub-appspace-examples.md\n")
 
 	return b.String()
@@ -6221,24 +6221,24 @@ func detectPatternFromSpaces(spaces []*TreeNode) string {
 		b.WriteString("Pattern: Banko (Flux)\n")
 		b.WriteString("• Cluster-per-directory structure\n")
 		b.WriteString("• Versioned platform components\n")
-		b.WriteString("• platform/ → Hub, clusters/* → AppSpaces\n")
+		b.WriteString("• platform/ → Hub, clusters/* → Apps\n")
 	} else if hasBase && hasDevStagingProd {
 		b.WriteString("Pattern: Arnie (ArgoCD)\n")
 		b.WriteString("• Folders-per-environment\n")
 		b.WriteString("• Promotion = file copy\n")
-		b.WriteString("• base/ → Hub, envs/* → AppSpaces\n")
+		b.WriteString("• base/ → Hub, envs/* → Apps\n")
 	} else if hasRegions && (hasBase || hasInfra) {
 		b.WriteString("Pattern: TraderX (Multi-region)\n")
-		b.WriteString("• Base/Infra Hub + regional AppSpaces\n")
+		b.WriteString("• Base/Infra Hub + regional Apps\n")
 		b.WriteString("• Labels: variant, region\n")
 	} else if hasPlatform && hasDevStagingProd {
 		b.WriteString("Pattern: KubeCon Demo\n")
 		b.WriteString("• Platform team + App teams\n")
-		b.WriteString("• platform-* → Hub, app*-dev/prod → AppSpaces\n")
+		b.WriteString("• platform-* → Hub, app*-dev/prod → Apps\n")
 	} else if hasBase && hasInfra && hasDevStagingProd {
 		b.WriteString("Pattern: curious-cub (Standard)\n")
 		b.WriteString("• Base/Infra Hub\n")
-		b.WriteString("• dev/staging/prod AppSpaces\n")
+		b.WriteString("• dev/staging/prod Apps\n")
 	} else if hasDevStagingProd {
 		b.WriteString("Pattern: Environment-based\n")
 		b.WriteString("• Spaces per environment (dev/staging/prod)\n")
@@ -6971,7 +6971,7 @@ func (m Model) renderTree() string {
 			b.WriteString(groupStyle.Render(node.Name))
 
 		case "hub_group", "app_group":
-			// Virtual grouping nodes for Hub/AppSpace view
+			// Virtual grouping nodes for App model view
 			b.WriteString(groupStyle.Render(node.Name))
 
 		case "unit":

--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -107,7 +107,7 @@ var importCmd = &cobra.Command{
 
 This command:
   1. Discovers workloads (Deployments, StatefulSets, DaemonSets)
-  2. Suggests an App Space and Units structure
+  2. Suggests an App and Deployments structure
   3. Creates everything in ConfigHub
 
 That's it. One command.
@@ -273,7 +273,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 
 	// Step 4: Confirm
 	if !importYes {
-		fmt.Printf("\nImport %d units into App Space '%s'? [y/N] ", len(proposal.Units), proposal.AppSpace)
+		fmt.Printf("\nImport %d deployments into App '%s'? [y/N] ", len(proposal.Units), proposal.AppSpace)
 		if !confirm() {
 			if logger != nil {
 				logger.Log("User aborted import")
@@ -287,7 +287,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 	// Step 5: Apply
 	if logger != nil {
 		logger.Section("APPLYING")
-		logger.Log("Creating App Space: %s", proposal.AppSpace)
+		logger.Log("Creating App: %s", proposal.AppSpace)
 	}
 	return applyImportWithLogger(proposal, allWorkloads, logger)
 }
@@ -669,7 +669,7 @@ func printDiscovery(namespaces []string, workloads []WorkloadInfo, proposal *Ful
 	fmt.Println("┌─────────────────────────────────────────────────────────────┐")
 	fmt.Println("│ WILL CREATE                                                 │")
 	fmt.Println("└─────────────────────────────────────────────────────────────┘")
-	fmt.Printf("  App Space: %s\n\n", proposal.AppSpace)
+	fmt.Printf("  App: %s\n\n", proposal.AppSpace)
 
 	for _, unit := range proposal.Units {
 		labels := []string{}
@@ -683,7 +683,7 @@ func printDiscovery(namespaces []string, workloads []WorkloadInfo, proposal *Ful
 		fmt.Printf("    workloads: %d\n", len(unit.Workloads))
 	}
 
-	fmt.Printf("\n  Total: %d units\n", len(proposal.Units))
+	fmt.Printf("\n  Total: %d deployments\n", len(proposal.Units))
 }
 
 func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, logger *ImportLogger) error {
@@ -696,13 +696,13 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 
 	fmt.Println()
 
-	// Create App Space
-	fmt.Printf("Creating App Space: %s... ", proposal.AppSpace)
+	// Create App
+	fmt.Printf("Creating App: %s... ", proposal.AppSpace)
 	result, err := CreateAppSpaceWithResult(proposal.AppSpace, true, nil)
 	if err != nil {
 		fmt.Println(SymError)
 		if logger != nil {
-			logger.Log("FAILED: App Space creation: %v", err)
+			logger.Log("FAILED: App creation: %v", err)
 			logger.LogResult(0, 1, err)
 		}
 		return fmt.Errorf("create space: %w", err)
@@ -710,16 +710,16 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 	if result.Created {
 		fmt.Println(SymOK)
 		if logger != nil {
-			logger.Log("Created App Space: %s", proposal.AppSpace)
+			logger.Log("Created App: %s", proposal.AppSpace)
 		}
 	} else {
 		fmt.Println("(exists)")
 		if logger != nil {
-			logger.Log("App Space already exists: %s", proposal.AppSpace)
+			logger.Log("App already exists: %s", proposal.AppSpace)
 		}
 	}
 
-	// Create Units
+	// Create Deployments
 	created := 0
 	failed := 0
 
@@ -728,9 +728,9 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 			continue
 		}
 
-		fmt.Printf("Creating unit: %s... ", unit.Slug)
+		fmt.Printf("Creating deployment: %s... ", unit.Slug)
 		if logger != nil {
-			logger.Log("Creating unit: %s", unit.Slug)
+			logger.Log("Creating deployment: %s", unit.Slug)
 		}
 
 		// Get first workload's manifest
@@ -762,7 +762,7 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 		if err := createUnitWithManifestSimple(proposal.AppSpace, unit.Slug, labels, manifest); err != nil {
 			fmt.Printf("✗ (%v)\n", err)
 			if logger != nil {
-				logger.Log("  FAILED: create unit: %v", err)
+				logger.Log("  FAILED: create deployment: %v", err)
 			}
 			failed++
 			continue
@@ -781,9 +781,9 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 	var finalErr error
 	if failed > 0 {
 		fmt.Printf("Done: %d created, %d failed\n", created, failed)
-		finalErr = fmt.Errorf("%d units failed", failed)
+		finalErr = fmt.Errorf("%d deployments failed", failed)
 	} else {
-		fmt.Printf("Done: %d units created\n", created)
+		fmt.Printf("Done: %d deployments created\n", created)
 	}
 
 	if logger != nil {
@@ -795,7 +795,7 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 	}
 
 	fmt.Println()
-	fmt.Println("View your units:")
+	fmt.Println("View your deployments:")
 	fmt.Printf("  cub unit list --space %s\n", proposal.AppSpace)
 
 	// Ask to start worker and set targets (skip if -y was used)
@@ -1009,7 +1009,7 @@ func startWorkerAndSetTargets(proposal *FullProposal, logger *ImportLogger) erro
 		fmt.Printf("  cub unit set-target <unit> <target> --space %s\n", proposal.AppSpace)
 	} else {
 		// Set target on all units
-		fmt.Printf("Setting target '%s' on units...\n", targetSlug)
+		fmt.Printf("Setting target '%s' on deployments...\n", targetSlug)
 		if logger != nil {
 			logger.Log("Target found: %s", targetSlug)
 		}

--- a/cmd/cub-scout/import_argocd.go
+++ b/cmd/cub-scout/import_argocd.go
@@ -416,8 +416,8 @@ func runImportArgoCD(cmd *cobra.Command, args []string) error {
 
 	fmt.Println()
 
-	// Create the unit with workload resources
-	fmt.Printf("Creating unit: %s\n", appName)
+	// Create the deployment with workload resources
+	fmt.Printf("Creating deployment: %s\n", appName)
 
 	// Combine all managed resources into a single YAML
 	var workloadYAML strings.Builder

--- a/cmd/cub-scout/import_wizard.go
+++ b/cmd/cub-scout/import_wizard.go
@@ -1649,14 +1649,14 @@ func (m ImportWizardModel) applyImport() tea.Msg {
 	return applyStartMsg{}
 }
 
-// startApplyCmd creates the app space and triggers first unit
+// startApplyCmd creates the app and triggers first deployment
 func (m ImportWizardModel) startApplyCmd() tea.Cmd {
 	return func() tea.Msg {
 		if m.proposal == nil {
 			return wizardErrMsg{err: fmt.Errorf("no proposal to apply")}
 		}
 
-		// Create App Space first
+		// Create App first
 		_, err := CreateAppSpaceWithResult(m.proposal.AppSpace, true, nil)
 		if err != nil {
 			return wizardErrMsg{err: fmt.Errorf("create space: %w", err)}
@@ -2571,7 +2571,7 @@ func (m ImportWizardModel) renderProposalTree() string {
 	b.WriteString(dimStyle.Render("→← expand/collapse  e edit  d delete"))
 	b.WriteString("\n\n")
 
-	// Tree root: App Space
+	// Tree root: App
 	appSpaceIcon := "📁"
 	appSpaceName := wizardSelectedStyle.Render(m.proposal.AppSpace)
 	b.WriteString(fmt.Sprintf("%s %s\n", appSpaceIcon, appSpaceName))
@@ -2737,7 +2737,7 @@ func (m ImportWizardModel) renderEditOverlay() string {
 		b.WriteString(dimStyle.Render("enter confirm  esc cancel"))
 
 	case editModeRenameSpace:
-		b.WriteString(headerStyle.Render("Rename App Space"))
+		b.WriteString(headerStyle.Render("Rename App"))
 		b.WriteString("\n\n")
 		b.WriteString("Current: ")
 		b.WriteString(m.proposal.AppSpace)
@@ -2826,7 +2826,7 @@ func (m ImportWizardModel) renderArchitectureDiagram() string {
 	b.WriteString(boxColor.Render("│") + "  " + titleStyle.Render("ConfigHub") + "                " + boxColor.Render("│") + "\n")
 	b.WriteString(boxColor.Render("│") + "                           " + boxColor.Render("│") + "\n")
 
-	// App Space
+	// App
 	spaceName := wizardTruncate(m.proposal.AppSpace, 18)
 	b.WriteString(boxColor.Render("│") + "  " + spaceStyle.Render(spaceName) + strings.Repeat(" ", 25-len(spaceName)) + boxColor.Render("│") + "\n")
 
@@ -2912,18 +2912,18 @@ func (m ImportWizardModel) renderApplyProgress() string {
 
 	if !m.applyComplete {
 		// Still in progress
-		b.WriteString(dimStyle.Render("Creating your App Space and Units in ConfigHub."))
+		b.WriteString(dimStyle.Render("Creating your App and Deployments in ConfigHub."))
 		b.WriteString("\n")
 		b.WriteString(dimStyle.Render("This registers your workloads for management."))
 		b.WriteString("\n\n")
 
-		b.WriteString(fmt.Sprintf("Creating App Space: %s\n", m.proposal.AppSpace))
+		b.WriteString(fmt.Sprintf("Creating App: %s\n", m.proposal.AppSpace))
 		if m.applyProgress > 0 {
 			b.WriteString(wizardSuccessStyle.Render("  ✓ Created") + "\n")
 		}
 		b.WriteString("\n")
 
-		b.WriteString("Creating Units:\n")
+		b.WriteString("Creating Deployments:\n")
 		for i, unit := range m.proposal.Units {
 			if i < len(m.applyResults) {
 				result := m.applyResults[i]

--- a/cmd/cub-scout/localcluster.go
+++ b/cmd/cub-scout/localcluster.go
@@ -4564,10 +4564,10 @@ func (m LocalClusterModel) getPanelAppHierarchy() string {
 	}
 
 	// ═══════════════════════════════════════════════════════════════════════════
-	// NAMESPACE ANALYSIS - Inferred AppSpaces
+	// NAMESPACE ANALYSIS - Inferred Apps
 	// ═══════════════════════════════════════════════════════════════════════════
 	b.WriteString("\n")
-	b.WriteString(lcSectionStyle.Render("NAMESPACE ANALYSIS") + lcDimStyle.Render(" → Inferred AppSpaces") + "\n")
+	b.WriteString(lcSectionStyle.Render("NAMESPACE ANALYSIS") + lcDimStyle.Render(" → Inferred Apps") + "\n")
 	b.WriteString("───────────────────────────────────────────────────────────\n")
 
 	// Group entries by namespace pattern (environment)

--- a/cmd/cub-scout/logger.go
+++ b/cmd/cub-scout/logger.go
@@ -90,7 +90,7 @@ func (l *ImportLogger) LogProposal(proposal *FullProposal) {
 		return
 	}
 	l.Section("PROPOSAL")
-	l.Log("App Space: %s", proposal.AppSpace)
+	l.Log("App: %s", proposal.AppSpace)
 	l.Log("Units: %d", len(proposal.Units))
 	for _, u := range proposal.Units {
 		l.Log("  %s (app=%s, variant=%s)", u.Slug, u.App, u.Variant)

--- a/cmd/cub-scout/logger_test.go
+++ b/cmd/cub-scout/logger_test.go
@@ -137,8 +137,8 @@ func TestLogProposal(t *testing.T) {
 
 	contentStr := string(content)
 
-	if !strings.Contains(contentStr, "App Space: my-team") {
-		t.Error("Missing App Space")
+	if !strings.Contains(contentStr, "App: my-team") {
+		t.Error("Missing App")
 	}
 
 	if !strings.Contains(contentStr, "nginx-prod") {

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -553,7 +553,7 @@ This is the CLI equivalent of pressing '5' or 'A' in the interactive TUI.
 
 Shows:
 - Inferred Hub (from infrastructure/platform patterns)
-- Inferred AppSpaces (from namespace patterns like prod, staging, dev)
+- Inferred Apps (from namespace patterns like prod, staging, dev)
 - Inferred labels (groups, teams)
 
 Note: This is a heuristic interpretation. Connect to ConfigHub for actual hierarchy.`,
@@ -592,7 +592,7 @@ func init() {
 
 	// Fleet-specific flags
 	mapFleetCmd.Flags().StringVar(&fleetApp, "app", "", "Filter by app label")
-	mapFleetCmd.Flags().StringVar(&fleetSpace, "space", "", "Filter by space (App Space)")
+	mapFleetCmd.Flags().StringVar(&fleetSpace, "space", "", "Filter by space (App)")
 
 	// Global map flags
 	mapCmd.PersistentFlags().BoolVar(&mapJSON, "json", false, "Output in JSON format")
@@ -1120,10 +1120,10 @@ func loadAndRenderMapStatusFromJSON(path string) error {
 	return nil // unreachable but required for compiler
 }
 
-// Fleet View: Hub/App Space model display
+// Fleet View: App model display
 var mapFleetCmd = &cobra.Command{
 	Use:   "fleet",
-	Short: "Show fleet view grouped by app and variant (Hub/App Space model)",
+	Short: "Show fleet view grouped by app and variant (App model)",
 	Long: `Display units across spaces grouped by app and variant labels.
 
 This view requires units imported with --model hub-appspace, which adds:
@@ -1144,7 +1144,7 @@ Example:
   # Filter to specific app
   cub-scout map fleet --app payment-api
 
-  # Filter to specific space (App Space)
+  # Filter to specific space (App)
   cub-scout map fleet --space payments-team
 `,
 	RunE: runMapFleet,
@@ -1175,9 +1175,9 @@ func runMapFleet(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(units) == 0 {
-		fmt.Println("No units found with app/variant labels.")
-		fmt.Println("\nTo use fleet view, import with Hub/App Space model:")
-		fmt.Println("  cub-scout import --namespace myapp-prod --model hub-appspace")
+		fmt.Println("No deployments found with app/variant labels.")
+		fmt.Println("\nTo use fleet view, import with App model:")
+		fmt.Println("  cub-scout import --namespace myapp-prod")
 		return nil
 	}
 
@@ -1203,7 +1203,7 @@ func runMapFleet(cmd *cobra.Command, args []string) error {
 	}
 	sort.Strings(appNames)
 
-	fmt.Println("ConfigHub Fleet View (Hub/App Space Model)")
+	fmt.Println("ConfigHub Fleet View (App Model)")
 	fmt.Println("Hierarchy: Application → Variant → Target")
 	fmt.Println()
 

--- a/cmd/cub-scout/patterns.go
+++ b/cmd/cub-scout/patterns.go
@@ -76,7 +76,7 @@ Shows:
 - Path conventions (D2-style, flux2-kustomize-helm, etc.)
 - Environment chains (same app across dev/staging/prod)
 - Team groupings (from namespace patterns)
-- Suggested ConfigHub organization (Hubs, AppSpaces)
+- Suggested ConfigHub organization (Hubs, Apps)
 
 This helps you understand your GitOps structure and plan imports.
 
@@ -789,7 +789,7 @@ func printPatterns(r *PatternsResult) {
 	for _, hub := range r.Suggested.Hubs {
 		fmt.Printf("\n├── Hub: %s\n", hub.Name)
 		for _, space := range hub.AppSpaces {
-			fmt.Printf("│   └── AppSpace: %s [%s]\n", space.Name, space.Env)
+			fmt.Printf("│   └── App: %s [%s]\n", space.Name, space.Env)
 		}
 	}
 	fmt.Println()

--- a/cmd/cub-scout/suggest.go
+++ b/cmd/cub-scout/suggest.go
@@ -418,8 +418,8 @@ func (s *ImportSuggestion) TotalWorkloads() int {
 	return count
 }
 
-// SuggestHubAppSpaceStructure analyzes workloads and suggests a Hub/App Space structure
-// Key difference: One App Space contains ALL variants via labels (not one space per env)
+// SuggestHubAppSpaceStructure analyzes workloads and suggests an App model structure
+// Key difference: One App contains ALL variants via labels (not one space per env)
 func SuggestHubAppSpaceStructure(workloads []WorkloadInfo, defaultSpace string) HubAppSpaceSuggestion {
 	// Group workloads by inferred app and variant
 	type unitKey struct {
@@ -477,8 +477,8 @@ func SuggestHubAppSpaceStructure(workloads []WorkloadInfo, defaultSpace string) 
 	return suggestion
 }
 
-// inferAppSpace suggests an App Space name (team workspace)
-// In Hub/App Space model, this is the team's workspace containing all their variants
+// inferAppSpace suggests an App name (team workspace)
+// In the App model, this is the team's workspace containing all their variants
 func inferAppSpace(workloads []WorkloadInfo, defaultSpace string) string {
 	if defaultSpace != "" {
 		return defaultSpace
@@ -519,8 +519,8 @@ func inferAppSpace(workloads []WorkloadInfo, defaultSpace string) string {
 
 // Print displays the Hub/App Space suggestion
 func (s *HubAppSpaceSuggestion) Print() {
-	fmt.Printf("Suggested structure (Hub/App Space model):\n")
-	fmt.Printf("  App Space: %s\n", s.AppSpace)
+	fmt.Printf("Suggested structure (App model):\n")
+	fmt.Printf("  App: %s\n", s.AppSpace)
 	fmt.Println()
 
 	// Group by app for display
@@ -894,7 +894,7 @@ func suggestReconciliationRules(variants map[string]bool) []ReconciliationRule {
 // Print displays the full proposal
 func (p *FullProposal) Print() {
 	fmt.Println("┌─────────────────────────────────────────────────────────────┐")
-	fmt.Println("│ PROPOSED HUB/APP SPACE MODEL                                │")
+	fmt.Println("│ PROPOSED APP MODEL                                           │")
 	fmt.Println("└─────────────────────────────────────────────────────────────┘")
 
 	// Hub Bases
@@ -906,7 +906,7 @@ func (p *FullProposal) Print() {
 	}
 
 	// App Space
-	fmt.Printf("\n  APP SPACE: %s\n", p.AppSpace)
+	fmt.Printf("\n  APP: %s\n", p.AppSpace)
 
 	// Deployer
 	if p.Deployer != "" {

--- a/cmd/cub-scout/tree.go
+++ b/cmd/cub-scout/tree.go
@@ -50,7 +50,7 @@ cub-scout tree provides different perspectives on your infrastructure:
 
   CONFIGHUB VIEWS (wraps 'cub unit tree'):
     config      ConfigHub Unit inheritance (--edge clone) or dependencies (--edge link)
-    suggest     Suggested Hub/AppSpace organization based on cluster workloads
+    suggest     Suggested App model organization based on cluster workloads
 
 Examples:
   # Show runtime hierarchy (Deployment -> ReplicaSet -> Pod)
@@ -1174,7 +1174,7 @@ func runTreeSuggest(ctx context.Context) error {
 	}
 
 	// Print suggestion
-	fmt.Printf("%sHub/AppSpace Suggestion%s\n", colorBold, colorReset)
+	fmt.Printf("%sApp Model Suggestion%s\n", colorBold, colorReset)
 	fmt.Println(strings.Repeat("─", 60))
 	fmt.Println()
 	fmt.Println("Based on cluster workloads, here's a suggested ConfigHub structure:")

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,28 +31,35 @@ New to cub-scout? Start here:
 
 ## How-To Guides
 
-Task-based guides:
+### v1.0 Standalone
 
 | Task | Guide |
 |------|-------|
 | Find orphan resources | [howto/find-orphans.md](howto/find-orphans.md) |
 | Trace ownership chains | [howto/trace-ownership.md](howto/trace-ownership.md) |
-| Crossplane walkthrough | [howto/crossplane-walkthrough.md](howto/crossplane-walkthrough.md) |
 | Query resources | [howto/query-resources.md](howto/query-resources.md) |
-| Fleet queries | [howto/fleet-queries.md](howto/fleet-queries.md) |
-| Tree hierarchies | [howto/tree-hierarchies.md](howto/tree-hierarchies.md) |
-| Scan for risk issues | [howto/scan-for-risks.md](howto/scan-for-risks.md) |
 | Ownership detection | [howto/ownership-detection.md](howto/ownership-detection.md) |
-| Import to ConfigHub | [howto/import-to-confighub.md](howto/import-to-confighub.md) |
+| Scan for risk issues | [howto/scan-for-risks.md](howto/scan-for-risks.md) |
+| Tree hierarchies | [howto/tree-hierarchies.md](howto/tree-hierarchies.md) |
 | Advanced queries | [howto/advanced-queries.md](howto/advanced-queries.md) |
+| Crossplane walkthrough | [howto/crossplane-walkthrough.md](howto/crossplane-walkthrough.md) |
 | Run demos | [howto/running-demos.md](howto/running-demos.md) |
 | Extending cub-scout | [howto/extending.md](howto/extending.md) |
+
+### 1.x Connected *(requires ConfigHub)*
+
+| Task | Guide |
+|------|-------|
+| Import to ConfigHub | [howto/import-to-confighub.md](howto/import-to-confighub.md) |
+| Import from live cluster | [howto/import-from-live.md](howto/import-from-live.md) |
+| Migration playbook | [howto/migration-playbook.md](howto/migration-playbook.md) |
+| Fleet queries | [howto/fleet-queries.md](howto/fleet-queries.md) |
 
 ---
 
 ## Reference
 
-Complete reference documentation:
+### v1.0 Standalone
 
 | Topic | Reference |
 |-------|-----------|
@@ -64,7 +71,6 @@ Complete reference documentation:
 | **Ownership & Precedence** | [reference/ownership-precedence.md](reference/ownership-precedence.md) |
 | **Health & Failure States** | [reference/health-failure-states.md](reference/health-failure-states.md) |
 | **CLI Contract** | [reference/cli-contract.md](reference/cli-contract.md) |
-| Import docs crosswalk | [reference/import-docs-crosswalk.md](reference/import-docs-crosswalk.md) |
 | Query syntax | [reference/query-syntax.md](reference/query-syntax.md) |
 | Query library | [reference/query-library.md](reference/query-library.md) |
 | GSF schema | [reference/gsf-schema.md](reference/gsf-schema.md) |
@@ -72,18 +78,24 @@ Complete reference documentation:
 | Keybindings | [reference/keybindings.md](reference/keybindings.md) |
 | GitOps patterns | [reference/gitops-patterns.md](reference/gitops-patterns.md) |
 | GitOps repo structures | [reference/gitops-repo-structures.md](reference/gitops-repo-structures.md) |
-| Rendered Manifest + Argo guide | [reference/rendered-manifest-and-argo-product-guide.md](reference/rendered-manifest-and-argo-product-guide.md) |
-| Connected tiers + views guide | [reference/connected-tiers-and-views-product-guide.md](reference/connected-tiers-and-views-product-guide.md) |
-| Resolver pattern | [reference/resolver-pattern.md](reference/resolver-pattern.md) |
-| Hub/AppSpace examples | [reference/hub-appspace-examples.md](reference/hub-appspace-examples.md) |
 | Map PRD | [reference/map-prd.md](reference/map-prd.md) |
-| GitOps checkpoint PRD (proposal) | [reference/gitops-checkpoint-prd.md](reference/gitops-checkpoint-prd.md) |
-| GitOps checkpoint schemas | [reference/gitops-checkpoint-schemas.md](reference/gitops-checkpoint-schemas.md) |
-| Stored in Git vs ConfigHub (DRY vs WET) | [reference/stored-in-git-vs-confighub.md](reference/stored-in-git-vs-confighub.md) |
 | Command matrix | [reference/command-matrix.md](reference/command-matrix.md) |
 | Glossary | [reference/glossary.md](reference/glossary.md) |
 | Testing guide | [reference/testing.md](reference/testing.md) |
 | CLI guide | [../CLI-GUIDE.md](../CLI-GUIDE.md) |
+
+### 1.x Connected *(requires ConfigHub)*
+
+| Topic | Reference |
+|-------|-----------|
+| Import docs crosswalk | [reference/import-docs-crosswalk.md](reference/import-docs-crosswalk.md) |
+| Connected tiers + views guide | [reference/connected-tiers-and-views-product-guide.md](reference/connected-tiers-and-views-product-guide.md) |
+| App model examples | [reference/hub-appspace-examples.md](reference/hub-appspace-examples.md) |
+| Rendered Manifest + Argo guide | [reference/rendered-manifest-and-argo-product-guide.md](reference/rendered-manifest-and-argo-product-guide.md) |
+| Stored in Git vs ConfigHub | [reference/stored-in-git-vs-confighub.md](reference/stored-in-git-vs-confighub.md) |
+| Resolver pattern | [reference/resolver-pattern.md](reference/resolver-pattern.md) |
+| GitOps checkpoint PRD (proposal) | [reference/gitops-checkpoint-prd.md](reference/gitops-checkpoint-prd.md) |
+| GitOps checkpoint schemas | [reference/gitops-checkpoint-schemas.md](reference/gitops-checkpoint-schemas.md) |
 
 ---
 

--- a/docs/getting-started/checklist.md
+++ b/docs/getting-started/checklist.md
@@ -69,9 +69,13 @@ A friendly guide to getting comfortable with cub-scout. These are suggestions, n
   cub-scout demo quick
   ```
 
+- [ ] **Explore the CLI reference** — [CLI-GUIDE.md](../../CLI-GUIDE.md) has everything
+
 ---
 
-## First Hour
+## Ready for Connected Mode? *(1.x)*
+
+> These steps require a ConfigHub account. Everything above works standalone.
 
 - [ ] **Connect to ConfigHub** — Free account, unlocks import and fleet features
   ```bash
@@ -86,13 +90,7 @@ A friendly guide to getting comfortable with cub-scout. These are suggestions, n
 
 - [ ] **See the full walkthrough** — [First Import guide](first-import.md) (10 minutes)
 
----
-
-## When You're Comfortable
-
 - [ ] **Import more namespaces** — Follow the [Migration Playbook](../howto/migration-playbook.md)
-
-- [ ] **Explore the CLI reference** — [CLI-GUIDE.md](../../CLI-GUIDE.md) has everything
 
 - [ ] **Learn why connected matters** — [WHY_CONNECTED_MODE.md](../WHY_CONNECTED_MODE.md)
 

--- a/docs/getting-started/first-import.md
+++ b/docs/getting-started/first-import.md
@@ -1,5 +1,8 @@
 # First Import: Connect and Import in 10 Minutes
 
+> **1.x Connected** — This guide requires a ConfigHub account.
+> For standalone features (no account needed), see [First Map](first-map.md).
+
 **Time:** 10 minutes
 **Goal:** Connect to ConfigHub, import one namespace, see what you unlock
 
@@ -61,25 +64,22 @@ Pick a namespace you know well. Preview what cub-scout will propose:
 ```
 Discovered 4 workloads in payments-prod:
 
-  App: payments
-  Components:
+  App: payments-team
+
+  Deployments:
     payment-api      Deployment   owner=ArgoCD   variant=prod
     order-svc        Deployment   owner=ArgoCD   variant=prod
     redis            StatefulSet  owner=Helm     variant=prod
-    debug-config     ConfigMap    owner=Native   (unmanaged)
 
-  Proposed mapping:
-    Space: payments-team
-    Units: payment-api, order-svc, redis
-    Labels: app=payments, variant=prod
+  Labels: app=payments, variant=prod
 
   Skipped: debug-config (Native/unmanaged — import separately if desired)
 
 No changes made. Use without --dry-run to import.
 ```
 
-> **API note:** The output says "Space" and "Units" — those are the current CLI names.
-> Read them as: Space = where this App lives, Unit = a component of the App.
+> **API note:** The `cub` CLI currently uses `--space` and `unit` commands while the
+> API evolves. Read them as: Space = App, Unit = Deployment.
 
 **What to check:**
 - Do the component names make sense to your team?
@@ -100,8 +100,8 @@ If the proposal looks right:
 
 ```
 Imported 3 workloads to ConfigHub:
-  Space: payments-team
-  Units: payment-api, order-svc, redis
+  App: payments-team
+  Deployments: payment-api, order-svc, redis
 
 Your existing deployer (ArgoCD, Helm) is still running.
 ConfigHub is now aware of these workloads.


### PR DESCRIPTION
## Summary
- **Docs**: Badge `first-import.md` as 1.x Connected, restructure `checklist.md` to separate standalone vs connected sections, reorganize `docs/README.md` with v1.0/1.x splits for How-To and Reference tables
- **CLI**: Rename user-facing strings across 15 source files — "App Space" → "App", "unit" → "deployment", "Hub/AppSpace" → "App model"
- Internal struct/function names and JSON field names unchanged (API compatibility)

## Test plan
- [x] `go build ./cmd/cub-scout` compiles
- [x] `go test ./...` — all 33 packages pass
- [x] `./cub-scout import --help` shows new terminology
- [x] `./cub-scout app-space --help` shows "Manage Apps"
- [ ] Manual: `./cub-scout import -n guestbook -y` output uses "App" / "deployment" (needs cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)