### PR TITLE
feat: v1.1.0 — connected foundation + roadmap triage

### DIFF
--- a/cmd/cub-scout/localcluster.go
+++ b/cmd/cub-scout/localcluster.go
@@ -19,6 +19,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/confighub/cub-scout/internal/mapsvc"
+	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/confighub/cub-scout/pkg/hub"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -5237,8 +5238,14 @@ func (m LocalClusterModel) runTrace(item TraceItem) tea.Cmd {
 					out, cmdErr = cmd.CombinedOutput()
 					output = string(out)
 				}
-				if cmdErr != nil && output == "" {
-					err = cmdErr
+				if cmdErr != nil {
+					// Detect context/connectivity issues and provide remediation
+					if help, ok := agent.FormatFluxContextError(output); ok {
+						err = fmt.Errorf("%s", help)
+						output = ""
+					} else if output == "" {
+						err = cmdErr
+					}
 				}
 			}
 
@@ -5249,7 +5256,13 @@ func (m LocalClusterModel) runTrace(item TraceItem) tea.Cmd {
 				out, cmdErr := cmd.CombinedOutput()
 				output = string(out)
 				if cmdErr != nil {
-					err = cmdErr
+					// Detect context/connectivity issues and provide remediation
+					if help, ok := agent.FormatArgoContextError(output); ok {
+						err = fmt.Errorf("%s", help)
+						output = ""
+					} else {
+						err = cmdErr
+					}
 				}
 			} else {
 				// For workloads, try to find the parent Application
@@ -5473,7 +5486,16 @@ func (m LocalClusterModel) renderTrace() string {
 
 	// Show error if any
 	if m.traceError != nil {
-		b.WriteString(lcErrStyle.Render("Error: "+m.traceError.Error()) + "\n")
+		errMsg := m.traceError.Error()
+		if strings.Contains(errMsg, "Trace context troubleshooting:") {
+			// Structured remediation — render each line clearly
+			b.WriteString(lcErrStyle.Render("⚠ Context Issue Detected") + "\n\n")
+			for _, line := range strings.Split(errMsg, "\n") {
+				b.WriteString("  " + line + "\n")
+			}
+		} else {
+			b.WriteString(lcErrStyle.Render("Error: "+errMsg) + "\n")
+		}
 		b.WriteString("\n" + lcDimStyle.Render("Press any key to continue") + "\n")
 		return b.String()
 	}

--- a/cmd/cub-scout/main.go
+++ b/cmd/cub-scout/main.go
@@ -22,8 +22,10 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "cub-scout",
-	Short: "Explore and map GitOps in your clusters",
+	Use:           "cub-scout",
+	Short:         "Explore and map GitOps in your clusters",
+	SilenceErrors: true, // We print errors in main() — don't let cobra duplicate them
+	SilenceUsage:  true, // Don't print usage on runtime errors
 	Long: `cub-scout - explore and map GitOps in your clusters
 
 Offline-first, deterministic, read-only cluster explorer for Kubernetes and GitOps.

--- a/cmd/cub-scout/trace.go
+++ b/cmd/cub-scout/trace.go
@@ -252,10 +252,16 @@ func runTrace(cmd *cobra.Command, args []string) error {
 		// Get k8s client for Helm tracing (reads release secrets)
 		cfg, cfgErr := buildConfig()
 		if cfgErr != nil {
+			if help, ok := agent.FormatHelmContextError(cfgErr.Error()); ok {
+				return fmt.Errorf("%s", help)
+			}
 			return fmt.Errorf("failed to build kubeconfig: %w", cfgErr)
 		}
 		clientset, clientErr := kubernetes.NewForConfig(cfg)
 		if clientErr != nil {
+			if help, ok := agent.FormatHelmContextError(clientErr.Error()); ok {
+				return fmt.Errorf("%s", help)
+			}
 			return fmt.Errorf("failed to create kubernetes client: %w", clientErr)
 		}
 		tracer := agent.NewHelmTracer(clientset)
@@ -263,6 +269,11 @@ func runTrace(cmd *cobra.Command, args []string) error {
 			result, err = tracer.TraceRelease(ctx, ownership.Name, traceNamespace)
 		} else {
 			result, err = tracer.Trace(ctx, kind, name, traceNamespace)
+		}
+		if err != nil {
+			if help, ok := agent.FormatHelmContextError(err.Error()); ok {
+				return fmt.Errorf("%s", help)
+			}
 		}
 
 	default:

--- a/docs/EXAMPLES-OVERVIEW.md
+++ b/docs/EXAMPLES-OVERVIEW.md
@@ -1,203 +1,22 @@
 # Examples Overview
 
-Central reference for all cub-scout examples, demos, and integrations.
+> **This file is a redirect.** The canonical examples index is [`examples/README.md`](../examples/README.md).
 
-> **Looking for examples?** All examples live in [examples/](../examples/).
+All examples, demos, integrations, and scripts are documented in one place:
 
----
+**[`examples/README.md`](../examples/README.md)**
 
 ## Quick Links
 
 | What You Want | Where It Is |
 |---------------|-------------|
+| All examples and demos | [`examples/README.md`](../examples/README.md) |
+| Demo walkthroughs | [`examples/demos/README.md`](../examples/demos/README.md) |
 | Run a demo | `./cub-scout demo list` |
 | Full CLI reference | [CLI-GUIDE.md](../CLI-GUIDE.md) |
-| Try on your cluster | [examples/README.md](../examples/README.md) |
 | Fleet query examples | [howto/fleet-queries.md](howto/fleet-queries.md) |
 | Conference demo | [examples/impressive-demo/](../examples/impressive-demo/) |
 
 ---
 
-## Demos (Built-in)
-
-cub-scout includes built-in demos. Run `./cub-scout demo list` to see all available.
-
-```bash
-# Quick demos
-./cub-scout demo quick              # Ownership detection (~30 sec)
-./cub-scout demo risk               # RISK-2025-0027 (~2 min)
-./cub-scout demo query              # Query language filtering (~1 min)
-
-# Scenarios
-./cub-scout demo scenario bigbank-incident  # BIGBANK incident
-./cub-scout demo scenario break-glass       # Emergency kubectl workflow
-
-# Cleanup
-./cub-scout demo quick --cleanup
-```
-
-See [demos/README.md](demos/README.md) for detailed walkthroughs.
-
----
-
-## Examples by Category
-
-### TUI Showcase Demos
-
-Multi-service demos designed to showcase TUI views:
-
-| Demo | Services | Status | Best For |
-|------|----------|--------|----------|
-| [flux-boutique/](../examples/flux-boutique/) | 5 | Working | TUI view showcase, trace demo |
-| [platform-example/](../examples/platform-example/) | ~35 | Working | Full GitOps learning environment |
-| [orphans/](../examples/orphans/) | ~20 | Working | Orphan detection demo |
-
-**Platform Example (Recommended for learning):**
-```bash
-cd examples/platform-example
-./setup.sh                              # Deploy Flux + orphans to kind cluster
-./cub-scout map                         # Explore with TUI
-./cub-scout trace deploy/podinfo -n podinfo  # Trace to Git source
-./cleanup.sh                            # Remove everything
-```
-
-### Drift Detection Examples
-
-| Example | Shows |
-|---------|-------|
-| [drift/env-var-drift/](../examples/drift/env-var-drift/) | Environment variable drift |
-| [drift/resource-drift/](../examples/drift/resource-drift/) | Resource requests/limits drift |
-| [drift/image-policy-drift/](../examples/drift/image-policy-drift/) | Image pull policy drift |
-
-### App-Deployment-Target Examples
-
-| Example | Shows |
-|---------|-------|
-| [demo-data/](../examples/demo-data/) | 6 apps × 2 targets with ConfigHub labels, version skew, bridge patterns |
-
-```bash
-# Scan manifests (no cluster required)
-./cub-scout scan --file examples/demo-data/manifests.yaml
-
-# Apply and explore
-kubectl apply -f examples/demo-data/manifests.yaml
-./cub-scout map workloads
-./cub-scout patterns detect
-```
-
-### Crossplane Examples
-
-| Example | Shows |
-|---------|-------|
-| [crossplane-system/](../examples/crossplane-system/) | Crossplane ownership detection |
-
-### Lifecycle Hazards Examples
-
-| Example | Shows |
-|---------|-------|
-| [lifecycle-hazards/](../examples/lifecycle-hazards/) | Helm hooks under ArgoCD, phase mapping |
-
-```bash
-# List hooks and their ArgoCD phase mapping
-./cub-scout map hooks --file examples/lifecycle-hazards/helm-hooks.yaml
-
-# Scan for lifecycle hazards
-./cub-scout scan --file examples/lifecycle-hazards/helm-hooks.yaml --lifecycle-hazards
-```
-
-### Integration Examples
-
-| Integration | Status | Description |
-|-------------|--------|-------------|
-| [argocd-extension/](../examples/integrations/argocd-extension/) | Working | Scan tab in Argo CD UI |
-| [flux-operator/](../examples/integrations/flux-operator/) | Working | Metrics exporter |
-| [flux9s/](../examples/integrations/flux9s/) | Proposal | K9s-style TUI for Flux |
-| [confighub-oci/](../examples/integrations/confighub-oci/) | Working | ConfigHub OCI integration |
-
-### Import & Discovery Examples
-
-| Example | Pattern | Shows |
-|---------|---------|-------|
-| [import-from-live/](../examples/import-from-live/) | ArgoCD | Cluster-only discovery — no Git required |
-| [combined-git-live/](../examples/combined-git-live/) | Flux | Git repo + cluster alignment |
-| [fleet-import/](../examples/fleet-import/) | Multi-cluster | Aggregating imports from 2 clusters |
-| [demo-data-adt/](../examples/demo-data-adt/) | App-Deployment-Target | Multi-app × multi-env with version skew |
-
-### Real-World Examples
-
-#### Apptique (Google Online Boutique)
-
-Multiple GitOps patterns using the Online Boutique app:
-
-| Pattern | Directory | Shows |
-|---------|-----------|-------|
-| Flux Monorepo | [apptique-examples/](../examples/apptique-examples/) | Kustomize + HelmRelease |
-| Drift Detection | [apptique-examples/scenarios/drift-detection/](../examples/apptique-examples/scenarios/drift-detection/) | Drift scenarios |
-
-#### ArgoCD Patterns (rm-demos-argocd)
-
-Repository patterns for ArgoCD:
-
-| Pattern | Directory |
-|---------|-----------|
-| Monorepo | [rm-demos-argocd/repo-patterns/monorepo/](../examples/rm-demos-argocd/repo-patterns/monorepo/) |
-| Multi-repo | [rm-demos-argocd/repo-patterns/multi-repo/](../examples/rm-demos-argocd/repo-patterns/multi-repo/) |
-| ApplicationSets | [rm-demos-argocd/repo-patterns/applicationsets/](../examples/rm-demos-argocd/repo-patterns/applicationsets/) |
-| Helm Umbrella | [rm-demos-argocd/repo-patterns/helm-umbrella/](../examples/rm-demos-argocd/repo-patterns/helm-umbrella/) |
-
----
-
-## Map Subcommands
-
-The map command supports multiple subcommands:
-
-```bash
-# Interactive TUI
-./cub-scout map              # Full dashboard (interactive TUI)
-./cub-scout map --hub        # ConfigHub hierarchy TUI (Connected mode)
-
-# CLI Output
-./cub-scout map list         # Plain text resource list
-./cub-scout map status       # One-line health check
-./cub-scout map workloads    # List workloads by owner
-./cub-scout map orphans      # Unmanaged (Native) resources
-./cub-scout map drift        # Desired vs actual state
-```
-
-### TUI Views
-
-Press these keys in the interactive TUI to switch views:
-
-| Key | View | Description |
-|-----|------|-------------|
-| `s` | Status | Dashboard overview |
-| `w` | Workloads | Workloads by owner |
-| `p` | Pipelines | Deployers |
-| `d` | Drift | Resources diverged from desired state |
-| `o` | Orphans | Native resources (not GitOps-managed) |
-| `c` | Crashes | Failing pods |
-| `i` | Issues | Unhealthy resources |
-| `T` | Trace | GitOps trace |
-| `?` | Help | Keybindings |
-
----
-
-## JSON Output
-
-All commands support `--json` for tooling:
-
-```bash
-./cub-scout map list --json | jq '.[] | select(.owner == "Flux")'
-./cub-scout scan --json | jq '.findings[] | select(.severity == "critical")'
-```
-
----
-
-## See Also
-
-| Doc | Content |
-|-----|---------|
-| [README.md](../README.md) | Project overview |
-| [CLI-GUIDE.md](../CLI-GUIDE.md) | Complete CLI reference |
-| [demos/README.md](demos/README.md) | Demo walkthroughs |
-| [FAQ.md](FAQ.md) | Frequently asked questions |
+*Previously this file duplicated content from `examples/README.md`. It is now a redirect to eliminate the sync burden. See `examples/README.md` for the complete catalog.*

--- a/docs/WHY_CONNECTED_MODE.md
+++ b/docs/WHY_CONNECTED_MODE.md
@@ -1,5 +1,7 @@
 # Why Connect cub-scout to ConfigHub
 
+> **Note:** This content has been integrated into the canonical roadmap at [`docs/roadmap.md`](roadmap.md) (v1.1+ Connected Mode section). This file is retained for historical reference but the roadmap is the authoritative source.
+
 ## TL;DR
 
 `cub-scout` is a free, read-only cluster explorer.

--- a/docs/howto/ascii-vs-json.md
+++ b/docs/howto/ascii-vs-json.md
@@ -1,0 +1,186 @@
+# ASCII vs JSON: What Each Output Gives You
+
+cub-scout produces two output formats for most commands. They contain the same facts but serve different purposes.
+
+---
+
+## Quick Summary
+
+| Format | Purpose | Audience | Stable? |
+|--------|---------|----------|---------|
+| `--format ascii` (default) | Human-readable explanation | Operators, on-call, demos | Layout may evolve |
+| `--format json` | Machine-readable data | Scripts, CI/CD, automation | Field names are stable |
+
+**Rule of thumb:** Read ASCII when debugging. Parse JSON when automating.
+
+---
+
+## What ASCII Gives You
+
+ASCII output is designed for human comprehension. It:
+
+- Groups resources by owner, namespace, or status
+- Adds headings, icons, and color for quick scanning
+- Orders items by importance (critical issues first)
+- Summarizes counts and highlights anomalies
+- Tells the debugging story: what happened, why, and what to do
+
+```bash
+# Human-readable ownership map
+./cub-scout map list
+
+# Human-readable trace chain
+./cub-scout trace deploy/web -n prod
+```
+
+ASCII is the default format. It is what you see in the terminal and TUI.
+
+**What ASCII is NOT:** ASCII is not a data contract. The layout, grouping, and ordering may change between versions to improve readability. Do not parse ASCII with `grep` or `awk` for automation — use JSON instead.
+
+---
+
+## What JSON Gives You
+
+JSON output is the canonical data contract. It:
+
+- Contains every structural fact cub-scout knows
+- Uses stable field names (documented per command)
+- Is deterministic: same input produces the same output
+- Is lossless: nothing is grouped, summarized, or hidden
+
+```bash
+# Machine-readable ownership map
+./cub-scout map list --format json
+
+# Machine-readable trace chain
+./cub-scout trace deploy/web -n prod --format json
+
+# Pipe to jq for filtering
+./cub-scout map list --format json | jq '.resources[] | select(.owner == "Native")'
+```
+
+**What JSON is NOT:** JSON does not include narrative explanations, debugging guidance, or visual emphasis. For those, use ASCII.
+
+---
+
+## Same Facts, Different Views
+
+Both formats derive from the same internal model. The relationship is:
+
+```
+ASCII = render(JSON facts) + narrative
+```
+
+Every fact in the ASCII output has a corresponding field in the JSON output. ASCII adds narrative (headings, grouping, emphasis) to make the facts readable.
+
+### Example: Map List
+
+**ASCII** groups by owner and adds status indicators:
+
+```
+Flux (3 resources)
+  ✓ deploy/payment-api     prod     Synced
+  ✓ deploy/auth-service    prod     Synced
+  ⚠ deploy/notification    staging  Suspended
+
+Native (1 resource)
+  ? deploy/hotfix-cache    prod     Unknown
+```
+
+**JSON** lists every resource with explicit fields:
+
+```json
+{
+  "resources": [
+    {"kind": "Deployment", "name": "payment-api", "namespace": "prod", "owner": "Flux", "status": "Synced"},
+    {"kind": "Deployment", "name": "auth-service", "namespace": "prod", "owner": "Flux", "status": "Synced"},
+    {"kind": "Deployment", "name": "notification", "namespace": "staging", "owner": "Flux", "status": "Suspended"},
+    {"kind": "Deployment", "name": "hotfix-cache", "namespace": "prod", "owner": "Native", "status": "Unknown"}
+  ]
+}
+```
+
+Same four resources, same ownership, same status — just different presentations.
+
+---
+
+## When to Use Which
+
+| Scenario | Use |
+|----------|-----|
+| Investigating an incident | ASCII |
+| Running in CI/CD pipeline | JSON |
+| Demo or presentation | ASCII |
+| Feeding data to another tool | JSON |
+| Alerting on orphan count | JSON |
+| Understanding a trace chain | ASCII |
+| Comparing two clusters | JSON |
+| Weekly team review | ASCII |
+
+---
+
+## Common Patterns
+
+### Count orphans in CI
+
+```bash
+ORPHAN_COUNT=$(./cub-scout map list --format json \
+  | jq '[.resources[] | select(.owner == "Native")] | length')
+
+if [ "$ORPHAN_COUNT" -gt 0 ]; then
+  echo "WARNING: $ORPHAN_COUNT orphan resources detected"
+  exit 1
+fi
+```
+
+### Extract trace chain as JSON
+
+```bash
+./cub-scout trace deploy/web -n prod --format json \
+  | jq '.chain[] | {kind, name, ready, status}'
+```
+
+### Filter by owner in a script
+
+```bash
+./cub-scout map list --format json \
+  | jq '.resources[] | select(.owner == "Flux") | .name'
+```
+
+---
+
+## Markdown Format
+
+Some commands also support `--format md` for Markdown output, useful for:
+
+- Pasting into GitHub issues or PRs
+- Generating reports
+- Slack messages (via code blocks)
+
+```bash
+./cub-scout map list --format md
+./cub-scout gitops status --format md
+```
+
+---
+
+## Field Naming Conventions
+
+JSON field names follow per-surface conventions:
+
+| Surface | Convention | Example |
+|---------|------------|---------|
+| CLI commands (map, trace) | camelCase | `formatVersion`, `capturedAt` |
+| Debug bundle metadata | camelCase | `cubScoutVersion`, `createdAt` |
+| Versioned schemas (graph, catalog) | snake_case | `schema_version`, `join_mode` |
+
+Field names within each surface are frozen — they will not change in future versions.
+
+---
+
+## See Also
+
+- [Semantic Contract](../semantic-contract.md) — Technical specification (R1-R6 rules)
+- [JSON Contracts](../reference/json-contracts.md) — Field naming and schema references
+- [CLI Contract](../reference/cli-contract.md) — Command stability guarantees
+- [Query Resources](query-resources.md) — Query syntax for filtering

--- a/docs/howto/break-glass-to-managed.md
+++ b/docs/howto/break-glass-to-managed.md
@@ -1,0 +1,257 @@
+# Break-Glass to Managed
+
+Step-by-step guide for handling emergency `kubectl apply` resources and transitioning them back under GitOps management.
+
+---
+
+## When You Need This
+
+Someone ran `kubectl apply` during an incident, bypassing GitOps. Now the cluster has resources that:
+
+- Are not tracked in Git
+- Will be lost on cluster rebuild
+- May conflict with the next GitOps reconciliation
+- Have no audit trail
+
+This guide walks through detection, assessment, and resolution.
+
+---
+
+## Prerequisites
+
+```bash
+# Build cub-scout
+go build ./cmd/cub-scout
+
+# Verify cluster access
+kubectl cluster-info
+```
+
+For the import step (optional): ConfigHub connected mode (`cub auth login`).
+
+---
+
+## Step 1: Detect Orphan Resources
+
+Orphan resources have no GitOps owner — cub-scout classifies them as **Native**.
+
+```bash
+# Quick orphan check
+./cub-scout map orphans
+
+# Or use query syntax
+./cub-scout map list -q "owner=Native"
+
+# Filter to a specific namespace
+./cub-scout map list -q "owner=Native AND namespace=production"
+```
+
+**What to look for:** Any resource with `Owner: Native` that wasn't intentionally left unmanaged. Common break-glass indicators:
+
+- Resources with `break-glass/*` annotations
+- Resources without standard GitOps labels (`kustomize.toolkit.fluxcd.io/*`, `argocd.argoproj.io/*`, `app.kubernetes.io/managed-by`)
+- Resources created recently during an incident window
+
+---
+
+## Step 2: Inspect the Resource
+
+Before deciding what to do, understand what was deployed and why.
+
+```bash
+# Check annotations for incident context
+kubectl get deploy/<name> -n <namespace> -o yaml | grep -A5 "annotations:"
+
+# Look for break-glass markers
+kubectl get deploy/<name> -n <namespace> \
+  -o jsonpath='{.metadata.annotations}' | jq .
+```
+
+Common break-glass annotations to look for:
+
+| Annotation | Meaning |
+|------------|---------|
+| `break-glass/incident` | Incident ticket ID |
+| `break-glass/applied-by` | Who applied the hotfix |
+| `break-glass/applied-at` | When it was applied |
+| `break-glass/reason` | Why it was needed |
+
+---
+
+## Step 3: Trace Ownership
+
+Use `trace` to confirm the resource is truly unmanaged and see what cub-scout knows about it.
+
+```bash
+./cub-scout trace deploy/<name> -n <namespace>
+```
+
+**Expected output for a break-glass resource:**
+- Tool: none (not Flux, ArgoCD, or Helm)
+- No ownership chain
+- Resource appears as standalone
+
+If trace shows an unexpected owner (e.g., Flux), the resource may have been reconciled already — check GitOps status before proceeding.
+
+---
+
+## Step 4: Decide
+
+Three outcomes are available. Choose based on your team's incident review.
+
+### Option A: Accept — Bring Under Management
+
+The break-glass change was correct and should be permanent.
+
+**With ConfigHub (connected mode):**
+
+```bash
+# Preview what would be imported
+./cub-scout import -n <namespace> --dry-run
+
+# Import the resource to ConfigHub
+./cub-scout import deploy/<name> -n <namespace>
+```
+
+This creates a ConfigHub Unit, publishes an OCI artifact, and Flux/ArgoCD reconciles from ConfigHub. The resource is now versioned and repeatable.
+
+**Without ConfigHub (standalone):**
+
+```bash
+# Export the resource manifest
+kubectl get deploy/<name> -n <namespace> -o yaml > manifests/<name>.yaml
+
+# Remove runtime fields (status, managedFields, resourceVersion, uid, etc.)
+# Add to your Git repo under the appropriate Kustomization/HelmRelease path
+# Commit, push, and let GitOps reconcile
+```
+
+### Option B: Reject — Remove the Hotfix
+
+The break-glass change was temporary or the proper fix is now in Git.
+
+```bash
+# Delete the orphan resource
+kubectl delete deploy/<name> -n <namespace>
+
+# Verify GitOps reconciles the correct state
+flux reconcile kustomization <name> --with-source
+# or
+argocd app sync <app-name>
+```
+
+### Option C: Defer — Track for Later
+
+You need more time to decide, but want visibility.
+
+```bash
+# Add a tracking label
+kubectl label deploy/<name> -n <namespace> \
+  break-glass/tracked="true" \
+  break-glass/review-by="2026-03-01"
+
+# Find tracked break-glass resources later
+./cub-scout map list -q "owner=Native"
+kubectl get deploy -l break-glass/tracked=true --all-namespaces
+```
+
+---
+
+## Step 5: Verify
+
+After taking action, confirm the cluster is in the expected state.
+
+```bash
+# Re-check for orphans
+./cub-scout map orphans
+
+# Verify GitOps status
+./cub-scout gitops status
+
+# If using ConfigHub, verify import
+cub unit list --space <space>
+```
+
+---
+
+## Guided Testing: Break-Glass Demo
+
+cub-scout includes a break-glass demo scenario with pre-built fixtures.
+
+### Run the Demo
+
+```bash
+# Apply break-glass fixtures
+./cub-scout demo scenario break-glass
+
+# What it creates:
+#   break-glass-demo namespace with:
+#   - payment-api (Flux-managed, with Kustomization labels)
+#   - hotfix-cache (Native/orphan, with break-glass annotations)
+```
+
+### Verify Detection
+
+```bash
+# payment-api should show as Flux-owned
+./cub-scout map list -n break-glass-demo
+
+# hotfix-cache should appear as orphan
+./cub-scout map orphans
+```
+
+### Validate Ownership
+
+```bash
+# Flux-managed resource
+./cub-scout trace deploy/payment-api -n break-glass-demo
+# Expected: Owner=Flux, Kustomization=payment-api
+
+# Break-glass resource
+./cub-scout trace deploy/hotfix-cache -n break-glass-demo
+# Expected: Owner=Native (no GitOps chain)
+```
+
+### Clean Up
+
+```bash
+./cub-scout demo scenario break-glass --cleanup
+```
+
+---
+
+## Graceful Degradation
+
+| Scenario | Behavior |
+|----------|----------|
+| No GitOps CRDs installed | Orphan detection still works (all resources show as Native) |
+| ConfigHub not connected | Detection and assessment work; import requires connected mode |
+| Cluster unreachable | cub-scout reports connection error with remediation steps |
+| Break-glass annotations missing | Resource still detected as orphan; less context available |
+
+---
+
+## Weekly Audit
+
+Establish a recurring check for break-glass resources:
+
+```bash
+# Monday morning orphan check
+./cub-scout map orphans
+
+# Alert if orphans exist in production
+if [ "$(./cub-scout map list -q 'owner=Native AND namespace=production' --count 2>/dev/null)" -gt 0 ]; then
+  echo "WARNING: Orphan resources in production"
+fi
+```
+
+---
+
+## See Also
+
+- [Find Orphans](find-orphans.md) — Orphan detection reference
+- [Import to ConfigHub](import-to-confighub.md) — Full import path
+- [Import from Live](import-from-live.md) — Cluster-only discovery
+- [Trace Ownership](trace-ownership.md) — Ownership chain tracing
+- [Break-Glass Scenarios](../outcomes/break-glass-scenarios.md) — Conceptual overview
+- [Trace Context Troubleshooting](trace-context-troubleshooting.md) — When trace fails

--- a/docs/howto/trace-context-troubleshooting.md
+++ b/docs/howto/trace-context-troubleshooting.md
@@ -1,8 +1,37 @@
-# Trace Context Troubleshooting (ArgoCD)
+# Trace Context Troubleshooting
 
-Use this when `cub-scout trace` fails because the local `argocd` context points to a stale or invalid endpoint.
+Use this when `cub-scout trace` fails because the local context for a GitOps tool points to a stale or invalid endpoint, or when ConfigHub connected enrichment is unavailable.
 
-## Inspect and reset path
+cub-scout detects common context issues automatically and prints remediation steps. This guide documents the full troubleshooting path for each tool.
+
+---
+
+## Graceful Degradation
+
+cub-scout follows a strict graceful degradation policy for trace:
+
+| Scenario | Behavior |
+|----------|----------|
+| Flux context stale | Error with numbered remediation steps |
+| ArgoCD context stale | Error with numbered remediation steps |
+| Helm kubeconfig invalid | Error with numbered remediation steps |
+| ConfigHub auth expired | **Warning only** — standalone trace succeeds |
+| ConfigHub API unreachable | **Warning only** — standalone trace succeeds |
+| ConfigHub space not found | **Warning only** — standalone trace succeeds |
+
+**Key principle:** ConfigHub enrichment failure never blocks trace. Standalone trace always completes. Context diagnostics appear as warnings on stderr (CLI) or as a structured remediation box (TUI).
+
+---
+
+## ArgoCD
+
+### Symptoms
+
+- `argocd context appears stale or invalid`
+- `authentication required`, `token is expired`, `unauthorized`
+- `connection refused`, `i/o timeout`, `dial tcp`
+
+### Inspect and reset path
 
 1. Inspect current context:
 
@@ -33,3 +62,171 @@ argocd login <server>
 ```bash
 cub-scout trace --app <app-name>
 ```
+
+---
+
+## Flux
+
+### Symptoms
+
+- `flux context appears stale or invalid`
+- `no matches for kind`, `the server doesn't have a resource type`
+- `connection refused`, `i/o timeout`, `x509:`
+
+### Inspect and reset path
+
+1. Verify cluster connectivity:
+
+```bash
+kubectl cluster-info
+```
+
+2. Check Flux installation:
+
+```bash
+flux check
+```
+
+3. Install or reinstall Flux if needed:
+
+```bash
+flux install
+```
+
+4. Switch to the correct cluster context:
+
+```bash
+kubectl config use-context <context>
+```
+
+5. Retry trace:
+
+```bash
+cub-scout trace <kind>/<name> -n <namespace>
+```
+
+---
+
+## Helm
+
+### Symptoms
+
+- `helm trace context appears stale or invalid`
+- `connection refused`, `i/o timeout`, `x509:`
+- `secrets is forbidden`, `cannot list resource`
+
+### Inspect and reset path
+
+1. Verify cluster connectivity:
+
+```bash
+kubectl cluster-info
+```
+
+2. Check permissions to read Helm release secrets:
+
+```bash
+kubectl auth can-i list secrets -n <namespace>
+```
+
+3. Switch to the correct cluster context:
+
+```bash
+kubectl config use-context <context>
+```
+
+4. Verify Helm releases are visible:
+
+```bash
+helm list -n <namespace>
+```
+
+5. Retry trace:
+
+```bash
+cub-scout trace <kind>/<name> -n <namespace>
+```
+
+---
+
+## ConfigHub Connected Mode
+
+### Symptoms
+
+- `ConfigHub enrichment failed`
+- `unauthorized`, `401`, `token expired`, `forbidden`
+- `connection refused`, `timeout`, `no such host`
+- `space not found`, `unit not found`, `no worker`
+
+### Important
+
+ConfigHub errors are **warnings only**. Standalone trace always completes with cluster-local data. Connected metadata (unit slug, space, drift detection, remediation URL) will be missing, but the ownership chain and health status are still accurate.
+
+### Inspect and reset path
+
+1. Check authentication status:
+
+```bash
+cub auth status
+```
+
+2. Re-authenticate:
+
+```bash
+cub auth login
+```
+
+3. Verify active context:
+
+```bash
+cub context get
+```
+
+4. Check worker status:
+
+```bash
+cub worker list
+```
+
+5. Retry trace:
+
+```bash
+cub-scout trace <kind>/<name> -n <namespace>
+```
+
+---
+
+## TUI Trace Diagnostics
+
+When trace fails in the TUI (interactive `cub-scout map` mode), context errors are displayed as structured remediation boxes instead of raw error strings.
+
+The TUI detects context issues for both Flux and ArgoCD and displays numbered steps to resolve the issue. Press any key to dismiss the error and return to the resource list.
+
+### What the TUI shows
+
+- **Context issue detected**: A structured box with the reason and numbered remediation steps
+- **Normal errors**: Standard error message (e.g., "resource not managed by Flux")
+- **ConfigHub warnings**: Appear on stderr in CLI mode; in TUI mode, connected metadata fields will be absent but trace succeeds
+
+---
+
+## Detection Patterns
+
+cub-scout detects context issues by pattern-matching on error output. The following patterns trigger remediation messages:
+
+### ArgoCD
+- Auth: `server address unspecified`, `not logged in`, `authentication required`, `unauthorized`, `token is expired`
+- Network: `connection refused`, `i/o timeout`, `dial tcp`, `no such host`, `x509:`, `tls:`, `rpc error: code = unavailable`
+
+### Flux
+- Missing CRDs: `no matches for kind`, `the server doesn't have a resource type`, `no flux object found`, `flux is not installed`
+- Network: `connection refused`, `i/o timeout`, `dial tcp`, `x509:`, `tls:`, `no such host`
+
+### Helm
+- Network: `connection refused`, `i/o timeout`, `dial tcp`, `x509:`, `tls:`, `no such host`
+- Permissions: `forbidden`, `cannot list resource`, `secrets is forbidden`, `unauthorized`
+
+### ConfigHub
+- Auth: `unauthorized`, `401`, `token expired`, `forbidden`, `403`, `authentication required`
+- Network: `connection refused`, `timeout`, `no such host`, `dial tcp`
+- Context: `space not found`, `unit not found`, `no active space`, `no worker`

--- a/docs/outcomes/break-glass-scenarios.md
+++ b/docs/outcomes/break-glass-scenarios.md
@@ -203,6 +203,7 @@ LIVE (cluster)     CONFIGUB (store)     OCI (transport)     FLUX/ARGO
 
 ## See Also
 
+- [Break-Glass to Managed](../howto/break-glass-to-managed.md) — Step-by-step guide with guided testing
 - [Ownership Visibility](ownership-visibility.md) — The Native bucket insight
 - [Find Orphans](../howto/find-orphans.md) — How to find unmanaged resources
 - [Import to ConfigHub](../howto/import-to-confighub.md) — Adopting resources

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -1,0 +1,100 @@
+# v1.1.0 Release Notes
+
+> **Status:** Pending release.
+> Predecessor: `v1.0.0` (2026-02-20).
+
+**Theme:** *Connected foundation — making connected mode clearly better than standalone for single-cluster operations.*
+
+This release completes Phase A (trust hardening) and Phase B (connected foundation) of the 1.x roadmap.
+
+---
+
+## What's New
+
+### Connected Hierarchy Navigation
+
+Connected mode now provides smarter defaults:
+- **Cluster-aware filtering** — auto-scopes views to the connected cluster context
+- **Mode-aware query presets** — different default queries for Standalone vs Connected
+- **Auto-navigation** — TUI navigates to App Hierarchy when connected
+
+### Mode State Visibility
+
+The TUI now clearly displays operating mode:
+- **QuickMode** for instant mode detection without API calls
+- **Offline / Standalone / Connected** distinction visible in status bar
+- No ambiguity about what data sources are active
+
+### Trace Context Diagnostics
+
+When trace fails due to stale context, cub-scout now provides structured remediation:
+
+```
+Flux context error detected
+
+  Flux CRDs or controllers may not be installed in this cluster.
+
+  Remediation:
+    1. Verify cluster access:    kubectl cluster-info
+    2. Check Flux installation:  flux check
+    3. Install Flux if missing:  flux install
+    4. Switch context if needed: kubectl config use-context <name>
+    5. Retry:                    cub-scout trace <resource>
+```
+
+Supported tools: **Flux, Helm, ArgoCD, ConfigHub**. ConfigHub enrichment failures never block standalone trace.
+
+See: `docs/howto/trace-context-troubleshooting.md`
+
+### Migration Playbook
+
+Canonical guide for moving from Argo/Helm to ConfigHub:
+
+See: `docs/howto/migration-playbook.md`
+
+### Break-Glass to Managed
+
+Step-by-step guide for handling emergency `kubectl apply` resources:
+detect orphan → inspect annotations → trace ownership → decide (accept/reject/defer) → verify.
+
+See: `docs/howto/break-glass-to-managed.md`
+
+### ASCII vs JSON Explainer
+
+User-facing guide explaining when to use `--format json` vs default ASCII output, common automation patterns, and field naming conventions.
+
+See: `docs/howto/ascii-vs-json.md`
+
+---
+
+## Bug Fixes
+
+- **Duplicate CLI error output** — cobra's default printed errors twice (error + usage, then main() again). Fixed with `SilenceErrors` and `SilenceUsage` on root command.
+
+---
+
+## Documentation
+
+- **Examples index consolidated** — `docs/EXAMPLES-OVERVIEW.md` is now a thin redirect to `examples/README.md` (single source of truth). Removed 6 stale "keep in sync" maintainer notes.
+- **WHY_CONNECTED_MODE.md integrated** — key substance (standalone ceiling, connected unlocks, interface boundaries, paid value boundary) is now inline in the roadmap.
+- **Roadmap cleanup** — backlog checklist synced with actual issue status, trapped-in-prose items added, stale references fixed.
+
+---
+
+## Upgrading
+
+```bash
+brew upgrade confighub/tap/cub-scout
+```
+
+Or from source:
+```bash
+git pull && go build ./cmd/cub-scout
+```
+
+---
+
+## What's Next
+
+- **Phase C (v1.2):** Argo hierarchy intelligence — App-of-Apps parent/child lineage, ApplicationSet generator→instance lineage
+- **Phase D (v1.3):** Fleet and governance expansion — multi-cluster topology, revision history, incident views

--- a/docs/roadmap-1x-connected-upsell.md
+++ b/docs/roadmap-1x-connected-upsell.md
@@ -43,41 +43,38 @@ The goal is to sequence 1.x so we:
 
 ## 1.x roadmap (execution order)
 
-### Phase A: 1.0.x trust hardening (now)
+### Phase A: 1.0.x trust hardening — Complete
 
-Scope:
-- Close P0s before broad connected expansion.
+**Status:** Complete (all issues closed)
 
-Primary issues:
+Primary issues (all closed):
 - #125 regression audit for Argo tree/appset/app-of-apps
 - #126 pipeline semantics (`unknown -> ...`)
 - #127 trace context hardening
 - #129 workload scope definition
 
-Exit criteria:
-- Reproducible v0.4.0 vs v0.19.6 comparison report exists and is linked from docs.
-- Known behavior gaps are classified as intentional or regression.
-- Map/trace UX has no unresolved “what does this mean?” dead ends.
+### Phase B: 1.1 connected foundation — Complete
 
-### Phase B: 1.1 connected foundation (next)
+**Status:** Complete (PR #177)
 
-Scope:
-- Make connected mode clearly better than OSS for single-cluster operations.
+Delivered:
+- Connected hierarchy navigation defaults (cluster-aware filtering, mode-aware presets)
+- Mode state visibility in TUI (QuickMode, Offline/Standalone/Connected)
+- First-class trace context diagnostics (Flux, Helm, ConfigHub) with TUI remediation
+- Canonical migration guide from Argo/Helm to ConfigHub (#130)
+- Break-glass to managed flow documentation and guided testing
+- ASCII vs JSON model explainer
+- WHY_CONNECTED_MODE.md integrated into roadmap
+- Examples index consolidated
+- Duplicate CLI error output fixed
 
-Deliverables:
-- Better connected hierarchy navigation defaults (cluster-aware filtering and clear mode state).
-- First-class trace context diagnostics and reset path in connected workflows.
-- Canonical migration guide from Argo/Helm to ConfigHub (#130), promoted out of archive.
-- Update all "why connected" docs and roadmap sections to be consistent and complete
-
-Exit criteria:
-- A user can import one real cluster and understand Hub/App Space/Unit mapping without external guidance.
+Exit criteria met:
+- User can import one real cluster and understand Hub/App Space/Unit mapping without external guidance.
 - “Break-glass to managed” flow is documented and testable in one guided path.
 
-### Phase C: 1.2 Argo hierarchy intelligence (next)
+### Phase C: 1.2 Argo hierarchy intelligence — Scoped
 
-Scope:
-- Resolve App-of-Apps/ApplicationSet visibility gap and unify tree mental model.
+**Status:** Scoped (issues #128, #132 closed as scope definitions; runtime implementation is future work)
 
 Deliverables:
 - Ownership/tree lineage support for:
@@ -89,10 +86,9 @@ Deliverables:
 Exit criteria:
 - Argo users can answer “who generated this app?” and “what is parent of this app?” in one command/view.
 
-### Phase D: 1.3 fleet and governance expansion (later)
+### Phase D: 1.3 fleet and governance expansion — Scoped
 
-Scope:
-- Fleet-level workflows and governance surfaces that justify paid tiers.
+**Status:** Scoped (issues #131, #133 closed as scope definitions)
 
 Deliverables:
 - Multi-cluster topology view and scoped roadmap implementation (#131).
@@ -158,14 +154,16 @@ Exit criteria:
 - Risk: Complex connected story dilutes OSS value.
   - Mitigation: keep OSS reflexes sharp (map, trace, scan) and additive messaging.
 
-## Near-term actions (next 2 sprints)
+## Near-term actions — Complete
 
-1. Complete #125 and publish comparison report.
-2. Land #126 + #127 with tests and docs.
-3. Finalize workload scope contract (#129).
-4. Draft and publish canonical migration path (#130).
-5. Start lineage fixture implementation for #128.
-6. Add a clear user-facing explainer for the ASCII vs JSON model (what is canonical data vs presentation).
+All 6 original near-term actions are done:
+
+1. ~~Complete #125 and publish comparison report.~~ Done
+2. ~~Land #126 + #127 with tests and docs.~~ Done
+3. ~~Finalize workload scope contract (#129).~~ Done
+4. ~~Draft and publish canonical migration path (#130).~~ Done (#172–#177)
+5. ~~Start lineage fixture implementation for #128.~~ Scoped (#128 closed)
+6. ~~Add a clear user-facing explainer for the ASCII vs JSON model.~~ Done (`docs/howto/ascii-vs-json.md`)
 
 ## Source references
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,7 +73,7 @@ Tracking issue: **#154** (master backlog tracking)
 - [x] Connected hierarchy navigation defaults (cluster-aware filtering, auto-nav to App Hierarchy when connected, mode-aware query presets)
 - [x] Mode state visibility in TUI (QuickMode for instant display, Offline/Standalone/Connected distinction)
 - [x] Canonical migration guide from Argo/Helm to ConfigHub (`docs/howto/migration-playbook.md`)
-- [ ] Trace context diagnostics and documented reset path for connected workflows
+- [x] Trace context diagnostics and documented reset path for connected workflows
 - [ ] "Break-glass to managed" flow documentation and guided testing
 - [ ] User-facing explainer for ASCII vs JSON model (canonical data vs presentation)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,6 +65,7 @@ Tracking issue: **#154** (master backlog tracking)
 
 - [x] Production-scale E2E testing (500+ resources, mixed ownership, deep hierarchies) — resolved by #155, #156
 - [x] TUI performance profiling at scale (500+ resources) — resolved by #157
+- [x] Testing best practices cookbook (`docs/testing/BEST-PRACTICES.md`) — build tag standards, fixture conventions, golden patterns, cluster lifecycle, example-driven testing (#176)
 - [ ] CI-enforced coverage metrics
 
 ### 1.x Connected Upsell (`roadmap-1x-connected-upsell.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@ Tracking issue: **#154** (master backlog tracking)
 - [x] Canonical migration guide from Argo/Helm to ConfigHub (`docs/howto/migration-playbook.md`)
 - [x] Trace context diagnostics and documented reset path for connected workflows
 - [x] "Break-glass to managed" flow documentation and guided testing
-- [ ] User-facing explainer for ASCII vs JSON model (canonical data vs presentation)
+- [x] User-facing explainer for ASCII vs JSON model (canonical data vs presentation)
 
 ### Documentation Gaps (`NEXT-PLAN.md`)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,23 +15,20 @@
 
 ## Untracked Backlog Checklist
 
-The planning docs below contain future ideas not yet tracked as GitHub issues.
-This checklist prevents ideas from being forgotten during sprint planning.
-When an item graduates to real work, file a dedicated issue and remove it here.
+This checklist tracks ideas from planning docs. Items marked "scoped" had issues filed and
+closed as scope definitions — the contract/design was documented but runtime implementation
+remains future work. Items marked "resolved" had issues filed, implemented, and closed.
 
-Tracking issue: **#154** (master backlog tracking)
+Tracking: issue **#154** is closed. This checklist is now the live tracker.
 
 ### Rendered Manifest + Argo (`roadmap-rendered-manifest-and-argo.md`)
 
-- [ ] Workstream A: Distinguish "ConfigHub via OCI" ownership in trace outputs
-- [ ] Workstream A: Show explicit `source → render → OCI → deployer → workload` chain
+- [ ] Workstream A: Distinguish "ConfigHub via OCI" ownership in trace outputs (relates to [ConfigHub rendered manifests](https://docs.confighub.com/guide/rendered-manifests/))
+- [x] Workstream A: Show explicit `source → render → OCI → deployer → workload` chain — scoped in #149
 - [ ] Workstream A: Source staleness/sync signals where evidence is available
-- [ ] Workstream B: Source inventory view — broader vision beyond `map sources` (#148)
-- [ ] Workstream C: Schema extension for `rendered_from` / `original_source` (beyond #150)
-- [ ] Workstream D: Bridge pattern — Git→Flux→cluster (beyond #151)
-- [ ] Workstream D: Bridge pattern — Git→Argo→cluster
-- [ ] Workstream D: Bridge pattern — Git→ConfigHub→OCI→deployer
-- [ ] Workstream D: Bridge pattern — Live import→ConfigHub→OCI→deployer
+- [x] Workstream B: Source inventory view — resolved #148
+- [x] Workstream C: Schema extension for `rendered_from` / `original_source` — scoped in #150
+- [x] Workstream D: Bridge patterns (Git→Flux, Git→Argo, Git→ConfigHub→OCI, Live→ConfigHub→OCI) — scoped in #151
 - [ ] Workstream E: Orphan detection for broken ApplicationSet generator links
 - [ ] Workstream F: Fleet query ergonomics and provenance readability
 - [ ] Workstream F: Impact analysis ergonomics and multi-cluster context clarity
@@ -40,7 +37,7 @@ Tracking issue: **#154** (master backlog tracking)
 ### Connected Views + Launch (`roadmap-connected-views-and-launch.md`)
 
 - [ ] Workstream A: Navigation-first messaging and "aha in seconds" walkthrough
-- [ ] Workstream B: Scale-real demo assets (realistic many-workload examples)
+- [x] Workstream B: Scale-real demo assets — resolved #158
 - [ ] Workstream B: Expected-output snapshots for core navigation flows
 - [ ] Workstream C: WET-LIVE panel clarity and causality messaging
 - [ ] Workstream C: Break-glass decision ergonomics and audit visibility
@@ -54,12 +51,21 @@ Tracking issue: **#154** (master backlog tracking)
 - [x] `gitops.argocd.applicationset_generators` pattern (implemented; doc ID drift fixed in #153)
 - [ ] `gitops.flux_kustomization_paths` pattern (planned, not implemented)
 
-### Connected Mode Ideas (`NEXT-PLAN.md`, `WHY_CONNECTED_MODE.md`)
+### Connected Mode Ideas
 
 - [ ] ConfigHub summary storage and Slack integration for drift/sync notifications
 - [ ] Connected import flows (`cub-scout connected import bundle/git/cluster`)
 - [ ] Intent vs render vs observed three-way comparison
 - [ ] Hook compatibility verifier
+- [ ] Import wizard with auto-detection (`--wizard` flag, from `gitops-repo-structures.md`)
+- [ ] Snapshot enrichment with ConfigHub intent/history metadata (from `state-and-snapshots.md`)
+
+### Extension & Integration Ideas (`howto/extending.md`)
+
+- [ ] Webhook event streaming (entry/drift/finding events)
+- [ ] Output plugin architecture (Kafka, custom destinations)
+- [ ] Config-based custom ownership detectors (YAML, no Go required)
+- [ ] Config-based CRD watching (YAML status extraction)
 
 ### Scale and Testing
 
@@ -68,7 +74,7 @@ Tracking issue: **#154** (master backlog tracking)
 - [x] Testing best practices cookbook (`docs/testing/BEST-PRACTICES.md`) — build tag standards, fixture conventions, golden patterns, cluster lifecycle, example-driven testing (#176)
 - [ ] CI-enforced coverage metrics
 
-### 1.x Connected Upsell (`roadmap-1x-connected-upsell.md`)
+### 1.x Connected Upsell (`roadmap-1x-connected-upsell.md`) — Complete
 
 - [x] Connected hierarchy navigation defaults (cluster-aware filtering, auto-nav to App Hierarchy when connected, mode-aware query presets)
 - [x] Mode state visibility in TUI (QuickMode for instant display, Offline/Standalone/Connected distinction)
@@ -77,7 +83,7 @@ Tracking issue: **#154** (master backlog tracking)
 - [x] "Break-glass to managed" flow documentation and guided testing
 - [x] User-facing explainer for ASCII vs JSON model (canonical data vs presentation)
 
-### Documentation Gaps (`NEXT-PLAN.md`)
+### Documentation Gaps (`NEXT-PLAN.md`) — Complete
 
 - [x] Unified examples index (consolidate EXAMPLES-OVERVIEW.md, examples/README.md, demos/README.md)
 - [x] Integrate WHY_CONNECTED_MODE.md content into roadmap v1.x section with concrete issues
@@ -484,9 +490,9 @@ Connected Mode does **not** introduce:
 ## Summary
 
 * v0.x is **complete**
-* v0.18 fulfilled the original "why connected" *operationally*
-* v0.19 locked UX, behavior, and performance
-* Open issues #3/#21 (kro), #149-#151 (delivery chain), #158 (connected example), #163-#166 (experiments/evidence), and #183-#186 (docs/contract alignment) remain for future work
+* v1.0.0 is the stable contract baseline (2026-02-20)
+* v1.1 Phase A (trust hardening) and Phase B (connected foundation) are **complete**
+* Open issues: #3/#21 (kro), #149-#151 (delivery chain), #163-#166 (experiments/evidence), #183-#186 (docs/contract alignment)
 * The remaining roadmap is **Connected Mode with ConfigHub**:
 
   * import

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,8 +79,8 @@ Tracking issue: **#154** (master backlog tracking)
 
 ### Documentation Gaps (`NEXT-PLAN.md`)
 
-- [ ] Unified examples index (consolidate EXAMPLES-OVERVIEW.md, examples/README.md, demos/README.md)
-- [ ] Integrate WHY_CONNECTED_MODE.md content into roadmap v1.x section with concrete issues
+- [x] Unified examples index (consolidate EXAMPLES-OVERVIEW.md, examples/README.md, demos/README.md)
+- [x] Integrate WHY_CONNECTED_MODE.md content into roadmap v1.x section with concrete issues
 
 ### Patterns (`reference/patterns-contract.md`)
 
@@ -334,7 +334,40 @@ Nothing here represents unfinished 0.x promises.
 
 Connected Mode integrates cub-scout with **ConfigHub**, the system of record for configuration intent, history, and fleets.
 
-This work is explicitly motivated by `WHY_CONNECTED_MODE.md`.
+### Why Connected Mode Exists
+
+Standalone cub-scout answers: *what exists now, who owns it, and what looks risky.*
+
+Connected mode answers: *what should exist, what changed over time, and what this affects across environments.*
+
+A cluster API can only show current observed state. It cannot reliably answer what changed last week, whether one cluster is an outlier, what should happen before a rollout, or how imported state maps to org structure. Those require durable history, indexing, and cross-environment context outside a single cluster.
+
+Connected mode adds context, not control. cub-scout remains read-only.
+
+### What Connected Mode Unlocks
+
+* Intent context (DRY/WET/LIVE)
+* Change history and timeline correlations
+* Fleet comparison and outlier detection
+* Import/adoption workflows (break-glass to managed)
+* Dependency-aware impact analysis
+* Governance context and approvals metadata
+
+### Interface Boundaries
+
+* `cub` CLI is the external interface contract for connected workflows
+* `confighub-agent` depends on `cub` command behavior (arguments, exit codes, JSON shape)
+* `cub-scout` connected mode depends on `cub auth login` for credential/session management
+* Standalone `cub-scout` must continue to function without `cub`
+
+Ownership split:
+
+* **cub-scout:** deterministic discovery, explanation, evidence export
+* **ConfigHub:** system of record, lifecycle state, migration semantics
+
+### Paid Value Boundary
+
+Connected value is paid because it requires hosted platform capabilities: durable multi-tenant storage, cross-cluster indexing, fleet/governance APIs, retention and auditability at scale. The CLI remains free and safe to run offline.
 
 ### Definition
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,7 +74,7 @@ Tracking issue: **#154** (master backlog tracking)
 - [x] Mode state visibility in TUI (QuickMode for instant display, Offline/Standalone/Connected distinction)
 - [x] Canonical migration guide from Argo/Helm to ConfigHub (`docs/howto/migration-playbook.md`)
 - [x] Trace context diagnostics and documented reset path for connected workflows
-- [ ] "Break-glass to managed" flow documentation and guided testing
+- [x] "Break-glass to managed" flow documentation and guided testing
 - [ ] User-facing explainer for ASCII vs JSON model (canonical data vs presentation)
 
 ### Documentation Gaps (`NEXT-PLAN.md`)

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 All examples, demos, and integration code in one place.
 
-> **Maintainer note:** When updating this file, also update [docs/EXAMPLES-OVERVIEW.md](../docs/EXAMPLES-OVERVIEW.md).
+> **This is the canonical examples index.** `docs/EXAMPLES-OVERVIEW.md` redirects here.
 
 ## Status Legend
 
@@ -387,7 +387,6 @@ $ cub-scout map --json | jq '.workloads[] | select(.owner == "ConfigHub")'
 
 | Doc | What's in it |
 |-----|--------------|
-| [docs/EXAMPLES-OVERVIEW.md](../docs/EXAMPLES-OVERVIEW.md) | Central examples overview |
 | [CLI-GUIDE.md](../CLI-GUIDE.md) | Complete CLI reference (14 commands, 17 subcommands) |
 | [docs/reference/command-matrix.md](../docs/reference/command-matrix.md) | Full command/option matrix |
 | [docs/howto/import-to-confighub.md](../docs/howto/import-to-confighub.md) | Import workloads into ConfigHub |

--- a/examples/demos/README.md
+++ b/examples/demos/README.md
@@ -2,8 +2,6 @@
 
 **Status: Working** — All demos apply real Kubernetes resources and run on your cluster.
 
-> **Maintainer note:** When updating this file, also update [docs/EXAMPLES-OVERVIEW.md](../../docs/EXAMPLES-OVERVIEW.md).
-
 Demos that create resources, show problems, and let you explore.
 
 ## Running Demos

--- a/examples/demos/walkthrough.md
+++ b/examples/demos/walkthrough.md
@@ -2,8 +2,6 @@
 
 **Status: Working** — Step-by-step walkthrough with expected output at each step.
 
-> **Maintainer note:** When updating this file, also update [docs/EXAMPLES-OVERVIEW.md](../../docs/EXAMPLES-OVERVIEW.md).
-
 This example creates a realistic multi-owner cluster with ConfigHub-managed resources, introduces problems and risk issues, shows how to diagnose them using the map tool, then fixes them.
 
 ---

--- a/examples/integrations/MOCKUPS.md
+++ b/examples/integrations/MOCKUPS.md
@@ -2,8 +2,6 @@
 
 **Status: Mockups Only** — UI designs for discussion, not working code.
 
-> **Maintainer note:** When updating this file, also update [docs/EXAMPLES-OVERVIEW.md](../../docs/EXAMPLES-OVERVIEW.md).
-
 The cub-scout exposes a standardized API that can be consumed by GUI tools. These mockups show how integrations could look.
 
 ---

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -2,8 +2,6 @@
 
 Plugins and extensions for popular Kubernetes tools.
 
-> **Maintainer note:** When updating this file, also update [docs/EXAMPLES-OVERVIEW.md](../../docs/EXAMPLES-OVERVIEW.md).
-
 ## Status Legend
 
 | Status | Meaning |

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -2,8 +2,6 @@
 
 **Status: Working** — Copy-paste scripts for integrating cub-scout into your workflow.
 
-> **Maintainer note:** When updating this file, also update [docs/EXAMPLES-OVERVIEW.md](../../docs/EXAMPLES-OVERVIEW.md).
-
 ## k9s Plugin
 
 Add map/scan commands to k9s:

--- a/pkg/agent/flux_trace.go
+++ b/pkg/agent/flux_trace.go
@@ -101,6 +101,9 @@ func (f *FluxTracer) Trace(ctx context.Context, kind, name, namespace string) (*
 	}
 
 	if err != nil {
+		if help, ok := FormatFluxContextError(errorOutput); ok {
+			return nil, fmt.Errorf("%s", help)
+		}
 		return nil, fmt.Errorf("flux trace failed: %w: %s", err, stderrStr)
 	}
 
@@ -313,6 +316,59 @@ func extractRevision(rev string) string {
 	}
 
 	return rev
+}
+
+// FormatFluxContextError detects stale/invalid Flux context errors and
+// returns a remediation-focused message. The bool return is true when a
+// context issue was detected.
+func FormatFluxContextError(output string) (string, bool) {
+	out := strings.ToLower(output)
+
+	containsAny := func(parts ...string) bool {
+		for _, p := range parts {
+			if strings.Contains(out, p) {
+				return true
+			}
+		}
+		return false
+	}
+
+	reason := ""
+	switch {
+	case containsAny(
+		"no matches for kind",
+		"the server doesn't have a resource type",
+		"no flux object found",
+		"unable to recognize",
+		"flux is not installed",
+	):
+		reason = "Flux CRDs or controllers are not installed"
+	case containsAny(
+		"connection refused",
+		"i/o timeout",
+		"dial tcp",
+		"x509:",
+		"certificate signed by unknown authority",
+		"tls:",
+		"no such host",
+	):
+		reason = "cluster endpoint is unreachable or certificate is invalid"
+	default:
+		return "", false
+	}
+
+	msg := fmt.Sprintf(
+		"flux context appears stale or invalid (%s).\n\n"+
+			"Trace context troubleshooting:\n"+
+			"  1) kubectl cluster-info\n"+
+			"  2) flux check\n"+
+			"  3) flux install\n"+
+			"  4) kubectl config use-context <context>\n\n"+
+			"Then retry:\n"+
+			"  cub-scout trace <kind>/<name> -n <namespace>",
+		reason,
+	)
+	return msg, true
 }
 
 // fluxResource represents the JSON structure of a Flux Kustomization or HelmRelease

--- a/pkg/agent/flux_trace_test.go
+++ b/pkg/agent/flux_trace_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -463,5 +464,91 @@ func TestFluxHistoryWithEmptyArray(t *testing.T) {
 
 	if len(history) != 0 {
 		t.Errorf("Expected empty history, got %d entries", len(history))
+	}
+}
+
+func TestFormatFluxContextError(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantMatch  bool
+		wantReason string
+	}{
+		{
+			name:       "CRD absent",
+			output:     "error: no matches for kind \"Kustomization\" in version \"kustomize.toolkit.fluxcd.io/v1\"",
+			wantMatch:  true,
+			wantReason: "CRDs or controllers are not installed",
+		},
+		{
+			name:       "server resource type missing",
+			output:     "the server doesn't have a resource type \"Kustomization\"",
+			wantMatch:  true,
+			wantReason: "CRDs or controllers are not installed",
+		},
+		{
+			name:       "no flux object found",
+			output:     "✗ no flux object found for Deployment/nginx in namespace demo",
+			wantMatch:  true,
+			wantReason: "CRDs or controllers are not installed",
+		},
+		{
+			name:       "connection refused",
+			output:     "dial tcp 10.0.0.1:6443: connect: connection refused",
+			wantMatch:  true,
+			wantReason: "cluster endpoint is unreachable",
+		},
+		{
+			name:       "TLS error",
+			output:     "x509: certificate signed by unknown authority",
+			wantMatch:  true,
+			wantReason: "cluster endpoint is unreachable",
+		},
+		{
+			name:       "i/o timeout",
+			output:     "dial tcp 192.168.1.100:6443: i/o timeout",
+			wantMatch:  true,
+			wantReason: "cluster endpoint is unreachable",
+		},
+		{
+			name:      "normal output not matched",
+			output:    "Object: Deployment/nginx\nNamespace: demo\nStatus: Managed by Flux",
+			wantMatch: false,
+		},
+		{
+			name:      "resource not managed (not a context error)",
+			output:    "object not managed by Flux",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := FormatFluxContextError(tt.output)
+			if ok != tt.wantMatch {
+				t.Fatalf("FormatFluxContextError() match = %v, want %v (msg=%q)", ok, tt.wantMatch, got)
+			}
+			if !tt.wantMatch {
+				return
+			}
+
+			// Ensure remediation path is present and actionable.
+			required := []string{
+				"kubectl cluster-info",
+				"flux check",
+				"flux install",
+				"kubectl config use-context",
+				"cub-scout trace",
+			}
+			for _, r := range required {
+				if !strings.Contains(got, r) {
+					t.Fatalf("expected remediation command %q in message: %s", r, got)
+				}
+			}
+
+			if !strings.Contains(got, tt.wantReason) {
+				t.Fatalf("expected reason fragment %q in message: %s", tt.wantReason, got)
+			}
+		})
 	}
 }

--- a/pkg/agent/helm_trace.go
+++ b/pkg/agent/helm_trace.go
@@ -335,6 +335,58 @@ func (h *HelmTracer) buildTraceResult(release *helmRelease, kind, name, namespac
 	return result, nil
 }
 
+// FormatHelmContextError detects cluster connectivity or permission errors
+// during Helm tracing and returns a remediation-focused message. The bool
+// return is true when a context issue was detected.
+func FormatHelmContextError(output string) (string, bool) {
+	out := strings.ToLower(output)
+
+	containsAny := func(parts ...string) bool {
+		for _, p := range parts {
+			if strings.Contains(out, p) {
+				return true
+			}
+		}
+		return false
+	}
+
+	reason := ""
+	switch {
+	case containsAny(
+		"connection refused",
+		"i/o timeout",
+		"dial tcp",
+		"x509:",
+		"certificate signed by unknown authority",
+		"tls:",
+		"no such host",
+	):
+		reason = "cluster endpoint is unreachable or certificate is invalid"
+	case containsAny(
+		"forbidden",
+		"cannot list resource",
+		"secrets is forbidden",
+		"unauthorized",
+	):
+		reason = "insufficient permissions to read Helm release secrets"
+	default:
+		return "", false
+	}
+
+	msg := fmt.Sprintf(
+		"helm trace context appears stale or invalid (%s).\n\n"+
+			"Trace context troubleshooting:\n"+
+			"  1) kubectl cluster-info\n"+
+			"  2) kubectl auth can-i list secrets -n <namespace>\n"+
+			"  3) kubectl config use-context <context>\n"+
+			"  4) helm list -n <namespace>\n\n"+
+			"Then retry:\n"+
+			"  cub-scout trace <kind>/<name> -n <namespace>",
+		reason,
+	)
+	return msg, true
+}
+
 // TraceByOwnership traces a resource by its Helm ownership labels
 func (h *HelmTracer) TraceByOwnership(ctx context.Context, ownership Ownership) (*TraceResult, error) {
 	if ownership.Type != OwnerHelm {

--- a/pkg/agent/helm_trace_test.go
+++ b/pkg/agent/helm_trace_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -503,5 +504,85 @@ func TestHelmHistoryNoRelease(t *testing.T) {
 
 	if len(history) != 0 {
 		t.Errorf("Expected empty history, got %d entries", len(history))
+	}
+}
+
+func TestFormatHelmContextError(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantMatch  bool
+		wantReason string
+	}{
+		{
+			name:       "connection refused",
+			output:     "dial tcp 10.0.0.1:6443: connect: connection refused",
+			wantMatch:  true,
+			wantReason: "cluster endpoint is unreachable",
+		},
+		{
+			name:       "TLS error",
+			output:     "x509: certificate signed by unknown authority",
+			wantMatch:  true,
+			wantReason: "cluster endpoint is unreachable",
+		},
+		{
+			name:       "i/o timeout",
+			output:     "dial tcp 192.168.1.100:6443: i/o timeout",
+			wantMatch:  true,
+			wantReason: "cluster endpoint is unreachable",
+		},
+		{
+			name:       "secrets forbidden",
+			output:     "secrets is forbidden: User \"system:serviceaccount:default:default\" cannot list resource \"secrets\"",
+			wantMatch:  true,
+			wantReason: "insufficient permissions",
+		},
+		{
+			name:       "cannot list resource",
+			output:     "cannot list resource \"secrets\" in API group \"\" in the namespace \"kube-system\"",
+			wantMatch:  true,
+			wantReason: "insufficient permissions",
+		},
+		{
+			name:      "normal output not matched",
+			output:    "release nginx found in namespace default",
+			wantMatch: false,
+		},
+		{
+			name:      "no release found (not a context error)",
+			output:    "no Helm release found managing this resource",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := FormatHelmContextError(tt.output)
+			if ok != tt.wantMatch {
+				t.Fatalf("FormatHelmContextError() match = %v, want %v (msg=%q)", ok, tt.wantMatch, got)
+			}
+			if !tt.wantMatch {
+				return
+			}
+
+			// Ensure remediation path is present and actionable.
+			required := []string{
+				"kubectl cluster-info",
+				"kubectl auth can-i list secrets",
+				"kubectl config use-context",
+				"helm list",
+				"cub-scout trace",
+			}
+			for _, r := range required {
+				if !strings.Contains(got, r) {
+					t.Fatalf("expected remediation command %q in message: %s", r, got)
+				}
+			}
+
+			if !strings.Contains(got, tt.wantReason) {
+				t.Fatalf("expected reason fragment %q in message: %s", tt.wantReason, got)
+			}
+		})
 	}
 }

--- a/pkg/agent/ownership_test.go
+++ b/pkg/agent/ownership_test.go
@@ -770,6 +770,89 @@ func TestDetectOwnership_Priority(t *testing.T) {
 }
 
 // Benchmark tests for ownership detection
+// TestDetectOwnership_BreakGlass verifies the ownership detection for
+// the break-glass scenario: a Flux-managed resource alongside a Native
+// orphan created via kubectl during an incident. This matches the fixture
+// in examples/demos/break-glass.yaml.
+func TestDetectOwnership_BreakGlass(t *testing.T) {
+	t.Run("Flux-managed payment-api", func(t *testing.T) {
+		resource := newTestResource("break-glass-demo", "payment-api", map[string]string{
+			"app":                                  "payment-api",
+			"kustomize.toolkit.fluxcd.io/name":      "payment-api",
+			"kustomize.toolkit.fluxcd.io/namespace": "break-glass-demo",
+		}, map[string]string{
+			"confighub.com/revision":    "42",
+			"confighub.com/deployed-by": "flux",
+			"confighub.com/deployed-at": "2026-01-14T12:15:00Z",
+		})
+		ownership := DetectOwnership(resource)
+
+		if ownership.Type != OwnerFlux {
+			t.Errorf("payment-api: Type = %q, want %q", ownership.Type, OwnerFlux)
+		}
+		if ownership.SubType != "kustomization" {
+			t.Errorf("payment-api: SubType = %q, want %q", ownership.SubType, "kustomization")
+		}
+		if ownership.Name != "payment-api" {
+			t.Errorf("payment-api: Name = %q, want %q", ownership.Name, "payment-api")
+		}
+		if ownership.Confidence != "high" {
+			t.Errorf("payment-api: Confidence = %q, want %q", ownership.Confidence, "high")
+		}
+	})
+
+	t.Run("Native hotfix-cache (break-glass orphan)", func(t *testing.T) {
+		// hotfix-cache has NO GitOps labels — only break-glass annotations
+		resource := newTestResource("break-glass-demo", "hotfix-cache", map[string]string{
+			"app": "hotfix-cache",
+			// NO flux/argo/helm/terraform/confighub labels
+		}, map[string]string{
+			"break-glass/incident":  "INC-4521",
+			"break-glass/applied-by": "admin",
+			"break-glass/applied-at": "2026-01-14T14:23:00Z",
+			"break-glass/reason":     "Emergency cache fix for payment processing failures",
+		})
+		ownership := DetectOwnership(resource)
+
+		if ownership.Type != OwnerUnknown {
+			t.Errorf("hotfix-cache: Type = %q, want %q (should be orphan/Native)", ownership.Type, OwnerUnknown)
+		}
+	})
+
+	t.Run("Native hotfix-cache-config (break-glass ConfigMap)", func(t *testing.T) {
+		resource := newTestResource("break-glass-demo", "hotfix-cache-config", map[string]string{
+			"app": "hotfix-cache",
+		}, map[string]string{
+			"break-glass/incident":  "INC-4521",
+			"break-glass/applied-by": "admin",
+		})
+		ownership := DetectOwnership(resource)
+
+		if ownership.Type != OwnerUnknown {
+			t.Errorf("hotfix-cache-config: Type = %q, want %q (should be orphan/Native)", ownership.Type, OwnerUnknown)
+		}
+	})
+
+	t.Run("Break-glass annotations do not confer ownership", func(t *testing.T) {
+		// Even with many annotations, if no GitOps label is present,
+		// the resource must be classified as unknown (Native).
+		resource := newTestResource("prod", "emergency-fix", map[string]string{
+			"app":         "emergency-fix",
+			"team":        "platform",
+			"environment": "production",
+		}, map[string]string{
+			"break-glass/incident":  "INC-9999",
+			"break-glass/applied-by": "oncall",
+			"kubectl.kubernetes.io/last-applied-configuration": "{}",
+		})
+		ownership := DetectOwnership(resource)
+
+		if ownership.Type != OwnerUnknown {
+			t.Errorf("emergency-fix: Type = %q, want %q", ownership.Type, OwnerUnknown)
+		}
+	})
+}
+
 func BenchmarkDetectOwnership_Flux(b *testing.B) {
 	resource := newTestResource("test-ns", "test", map[string]string{
 		"kustomize.toolkit.fluxcd.io/name":      "my-app",

--- a/pkg/agent/trace.go
+++ b/pkg/agent/trace.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -296,4 +297,67 @@ func (r *TraceResult) EnrichWithConfigHub(labels, annotations map[string]string)
 	}
 
 	r.ConfigHub = ch
+}
+
+// FormatConfigHubContextError detects ConfigHub connectivity/auth errors and
+// returns a remediation-focused message. The bool return is true when a
+// context issue was detected.
+//
+// ConfigHub errors are treated as warnings — standalone trace always proceeds.
+func FormatConfigHubContextError(output string) (string, bool) {
+	out := strings.ToLower(output)
+
+	containsAny := func(parts ...string) bool {
+		for _, p := range parts {
+			if strings.Contains(out, p) {
+				return true
+			}
+		}
+		return false
+	}
+
+	reason := ""
+	switch {
+	case containsAny(
+		"unauthorized",
+		"401",
+		"token expired",
+		"token is expired",
+		"forbidden",
+		"403",
+		"authentication required",
+	):
+		reason = "ConfigHub authentication is missing or expired"
+	case containsAny(
+		"connection refused",
+		"timeout",
+		"no such host",
+		"dial tcp",
+		"i/o timeout",
+	):
+		reason = "ConfigHub API is unreachable"
+	case containsAny(
+		"space not found",
+		"unit not found",
+		"no active space",
+		"no worker",
+	):
+		reason = "ConfigHub space or unit context is invalid"
+	default:
+		return "", false
+	}
+
+	msg := fmt.Sprintf(
+		"ConfigHub enrichment failed (%s).\n"+
+			"Standalone trace completed successfully — connected metadata unavailable.\n\n"+
+			"Trace context troubleshooting:\n"+
+			"  1) cub auth status\n"+
+			"  2) cub auth login\n"+
+			"  3) cub context get\n"+
+			"  4) cub worker list\n\n"+
+			"Then retry:\n"+
+			"  cub-scout trace <kind>/<name> -n <namespace>",
+		reason,
+	)
+	return msg, true
 }

--- a/pkg/agent/trace_test.go
+++ b/pkg/agent/trace_test.go
@@ -473,3 +473,100 @@ func TestEnrichWithConfigHub(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatConfigHubContextError(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantMatch  bool
+		wantReason string
+	}{
+		{
+			name:       "auth expired",
+			output:     "HTTP 401: token expired",
+			wantMatch:  true,
+			wantReason: "authentication is missing or expired",
+		},
+		{
+			name:       "unauthorized",
+			output:     "request failed: unauthorized",
+			wantMatch:  true,
+			wantReason: "authentication is missing or expired",
+		},
+		{
+			name:       "forbidden",
+			output:     "403 Forbidden",
+			wantMatch:  true,
+			wantReason: "authentication is missing or expired",
+		},
+		{
+			name:       "API unreachable",
+			output:     "dial tcp 10.0.0.1:443: connection refused",
+			wantMatch:  true,
+			wantReason: "API is unreachable",
+		},
+		{
+			name:       "timeout",
+			output:     "context deadline exceeded: timeout",
+			wantMatch:  true,
+			wantReason: "API is unreachable",
+		},
+		{
+			name:       "space not found",
+			output:     "space not found: production",
+			wantMatch:  true,
+			wantReason: "space or unit context is invalid",
+		},
+		{
+			name:       "no worker",
+			output:     "no worker running for space",
+			wantMatch:  true,
+			wantReason: "space or unit context is invalid",
+		},
+		{
+			name:      "normal output not matched",
+			output:    "enrichment complete: unit=payment-api space=production",
+			wantMatch: false,
+		},
+		{
+			name:      "empty output not matched",
+			output:    "",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := FormatConfigHubContextError(tt.output)
+			if ok != tt.wantMatch {
+				t.Fatalf("FormatConfigHubContextError() match = %v, want %v (msg=%q)", ok, tt.wantMatch, got)
+			}
+			if !tt.wantMatch {
+				return
+			}
+
+			// Ensure remediation path is present and actionable.
+			required := []string{
+				"cub auth status",
+				"cub auth login",
+				"cub context get",
+				"cub worker list",
+				"cub-scout trace",
+			}
+			for _, r := range required {
+				if !strings.Contains(got, r) {
+					t.Fatalf("expected remediation command %q in message: %s", r, got)
+				}
+			}
+
+			if !strings.Contains(got, tt.wantReason) {
+				t.Fatalf("expected reason fragment %q in message: %s", tt.wantReason, got)
+			}
+
+			// ConfigHub errors must indicate standalone trace still succeeds
+			if !strings.Contains(got, "Standalone trace completed successfully") {
+				t.Fatalf("expected graceful degradation note in message: %s", got)
+			}
+		})
+	}
+}

--- a/test/e2e/break-glass-guided-test.sh
+++ b/test/e2e/break-glass-guided-test.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# Break-Glass Guided Test
+#
+# Validates the break-glass-to-managed flow end-to-end:
+#   1. Applies break-glass fixture (Flux-managed + Native orphan)
+#   2. Verifies ownership detection (payment-api=Flux, hotfix-cache=Native)
+#   3. Verifies orphan detection via map
+#   4. Verifies trace output for both resources
+#   5. Cleans up
+#
+# Prerequisites:
+#   - kubectl access to a cluster
+#   - Flux CRDs installed (for Flux ownership labels)
+#   - cub-scout binary built (go build ./cmd/cub-scout)
+#
+# Usage:
+#   ./test/e2e/break-glass-guided-test.sh
+#   ./test/e2e/break-glass-guided-test.sh --cleanup   # Remove fixtures only
+#
+# See: docs/howto/break-glass-to-managed.md
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE="$REPO_ROOT/examples/demos/break-glass.yaml"
+BINARY="$REPO_ROOT/cub-scout"
+NAMESPACE="break-glass-demo"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC} $*"; }
+fail() { echo -e "${RED}FAIL${NC} $*"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${CYAN}INFO${NC} $*"; }
+step() { echo -e "\n${BOLD}Step $1:${NC} $2"; }
+
+FAILURES=0
+TESTS=0
+
+assert_contains() {
+    local label="$1"
+    local haystack="$2"
+    local needle="$3"
+    TESTS=$((TESTS + 1))
+    if echo "$haystack" | grep -qi "$needle"; then
+        pass "$label"
+    else
+        fail "$label (expected '$needle' in output)"
+    fi
+}
+
+assert_not_contains() {
+    local label="$1"
+    local haystack="$2"
+    local needle="$3"
+    TESTS=$((TESTS + 1))
+    if echo "$haystack" | grep -qi "$needle"; then
+        fail "$label (unexpected '$needle' in output)"
+    else
+        pass "$label"
+    fi
+}
+
+cleanup() {
+    info "Cleaning up break-glass fixtures..."
+    kubectl delete -f "$FIXTURE" --ignore-not-found=true 2>/dev/null || true
+    kubectl delete namespace "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+    info "Cleanup complete"
+}
+
+# Handle --cleanup flag
+if [[ "${1:-}" == "--cleanup" ]]; then
+    cleanup
+    exit 0
+fi
+
+echo -e "${BOLD}Break-Glass Guided Test${NC}"
+echo -e "${DIM}Validates the break-glass-to-managed flow end-to-end${NC}"
+echo ""
+
+# Pre-flight checks
+step 0 "Pre-flight checks"
+
+if [[ ! -f "$BINARY" ]]; then
+    fail "cub-scout binary not found at $BINARY"
+    echo "  Run: go build ./cmd/cub-scout"
+    exit 1
+fi
+pass "cub-scout binary exists"
+TESTS=$((TESTS + 1))
+
+if ! kubectl cluster-info &>/dev/null 2>&1; then
+    fail "Cannot connect to cluster"
+    echo "  Check your kubeconfig"
+    exit 1
+fi
+pass "Cluster is reachable"
+TESTS=$((TESTS + 1))
+
+# Step 1: Apply fixtures
+step 1 "Apply break-glass fixtures"
+
+kubectl apply -f "$FIXTURE" 2>/dev/null
+sleep 2
+info "Waiting for resources to settle..."
+kubectl wait --for=condition=Available deployment/payment-api -n "$NAMESPACE" --timeout=60s 2>/dev/null || true
+kubectl wait --for=condition=Available deployment/hotfix-cache -n "$NAMESPACE" --timeout=60s 2>/dev/null || true
+
+DEPLOYMENTS=$(kubectl get deployments -n "$NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+TESTS=$((TESTS + 1))
+if [[ "$DEPLOYMENTS" -ge 2 ]]; then
+    pass "Both deployments exist in $NAMESPACE ($DEPLOYMENTS found)"
+else
+    fail "Expected at least 2 deployments, found $DEPLOYMENTS"
+fi
+
+# Step 2: Verify ownership detection via map list
+step 2 "Verify ownership detection"
+
+MAP_OUTPUT=$("$BINARY" map list -n "$NAMESPACE" 2>/dev/null || echo "MAP_FAILED")
+
+if [[ "$MAP_OUTPUT" == "MAP_FAILED" ]]; then
+    fail "cub-scout map list failed"
+else
+    # payment-api should be detected as Flux-owned
+    assert_contains "payment-api appears in map output" "$MAP_OUTPUT" "payment-api"
+
+    # hotfix-cache should appear
+    assert_contains "hotfix-cache appears in map output" "$MAP_OUTPUT" "hotfix-cache"
+fi
+
+# Step 3: Verify orphan detection
+step 3 "Verify orphan detection"
+
+# Check that hotfix-cache has no GitOps labels
+HOTFIX_LABELS=$(kubectl get deployment hotfix-cache -n "$NAMESPACE" -o jsonpath='{.metadata.labels}' 2>/dev/null)
+assert_not_contains "hotfix-cache has no Flux labels" "$HOTFIX_LABELS" "kustomize.toolkit.fluxcd.io"
+assert_not_contains "hotfix-cache has no ArgoCD labels" "$HOTFIX_LABELS" "argocd.argoproj.io"
+assert_not_contains "hotfix-cache has no Helm managed-by" "$HOTFIX_LABELS" "managed-by.*Helm"
+
+# Check that payment-api HAS Flux labels
+PAYMENT_LABELS=$(kubectl get deployment payment-api -n "$NAMESPACE" -o jsonpath='{.metadata.labels}' 2>/dev/null)
+assert_contains "payment-api has Flux labels" "$PAYMENT_LABELS" "kustomize.toolkit.fluxcd.io"
+
+# Step 4: Verify break-glass annotations
+step 4 "Verify break-glass annotations"
+
+HOTFIX_ANNOTATIONS=$(kubectl get deployment hotfix-cache -n "$NAMESPACE" -o jsonpath='{.metadata.annotations}' 2>/dev/null)
+assert_contains "hotfix-cache has incident annotation" "$HOTFIX_ANNOTATIONS" "INC-4521"
+assert_contains "hotfix-cache has applied-by annotation" "$HOTFIX_ANNOTATIONS" "admin"
+assert_contains "hotfix-cache has reason annotation" "$HOTFIX_ANNOTATIONS" "Emergency cache fix"
+
+# Step 5: Verify trace (if Flux CRDs are available)
+step 5 "Verify trace output"
+
+# Try tracing the Flux-managed resource
+TRACE_PAYMENT=$("$BINARY" trace deploy/payment-api -n "$NAMESPACE" 2>&1 || echo "TRACE_FAILED")
+
+if [[ "$TRACE_PAYMENT" == *"TRACE_FAILED"* ]] || [[ "$TRACE_PAYMENT" == *"context appears stale"* ]]; then
+    info "Trace for payment-api not fully available (Flux controllers may not be running)"
+    info "  This is expected in test environments without active Flux controllers"
+else
+    assert_contains "payment-api trace mentions Flux" "$TRACE_PAYMENT" "flux\|Kustomization\|kustomize"
+fi
+
+# Try tracing the orphan
+TRACE_HOTFIX=$("$BINARY" trace deploy/hotfix-cache -n "$NAMESPACE" 2>&1 || echo "TRACE_FAILED")
+
+if [[ "$TRACE_HOTFIX" == *"TRACE_FAILED"* ]]; then
+    info "Trace for hotfix-cache not available"
+else
+    # The orphan should not have a Flux/Argo/Helm trace result
+    assert_not_contains "hotfix-cache trace has no Flux chain" "$TRACE_HOTFIX" "Kustomization.*payment"
+fi
+
+# Step 6: Cleanup
+step 6 "Cleanup"
+cleanup
+
+# Summary
+echo ""
+echo -e "${BOLD}Results:${NC}"
+echo -e "  Tests run: $TESTS"
+echo -e "  Passed:    $((TESTS - FAILURES))"
+echo -e "  Failed:    $FAILURES"
+echo ""
+
+if [[ $FAILURES -gt 0 ]]; then
+    echo -e "${RED}${BOLD}$FAILURES test(s) failed${NC}"
+    exit 1
+else
+    echo -e "${GREEN}${BOLD}All tests passed${NC}"
+    exit 0
+fi

--- a/test/golden/trace/testdata/invalid-format.golden.txt
+++ b/test/golden/trace/testdata/invalid-format.golden.txt
@@ -1,17 +1,1 @@
 Error: invalid resource format: use kind/name (e.g., deployment/nginx)
-Usage:
-  cub-scout trace <kind/name> or <kind> <name> [flags]
-
-Flags:
-      --app string         Trace Argo CD application by name
-      --artifacts          Include source artifact provenance (url/revision/digest/update time)
-  -d, --diff               Show diff between live state and desired state from Git
-      --explain            Show explanatory content to help learn GitOps concepts
-      --format string      Output format: ascii, json, md (default "ascii")
-  -h, --help               help for trace
-      --history            Show deployment history (who deployed what, when)
-      --limit int          Limit number of history entries (default: 10) (default 10)
-  -n, --namespace string   Namespace of the resource (default: flux-system)
-  -r, --reverse            Reverse trace - walk ownerReferences up to find GitOps source
-
-Error: invalid resource format: use kind/name (e.g., deployment/nginx)

--- a/test/golden/trace/testdata/usage-error.golden.txt
+++ b/test/golden/trace/testdata/usage-error.golden.txt
@@ -1,17 +1,1 @@
 Error: usage: cub-scout trace <kind/name> or cub-scout trace <kind> <name>
-Usage:
-  cub-scout trace <kind/name> or <kind> <name> [flags]
-
-Flags:
-      --app string         Trace Argo CD application by name
-      --artifacts          Include source artifact provenance (url/revision/digest/update time)
-  -d, --diff               Show diff between live state and desired state from Git
-      --explain            Show explanatory content to help learn GitOps concepts
-      --format string      Output format: ascii, json, md (default "ascii")
-  -h, --help               help for trace
-      --history            Show deployment history (who deployed what, when)
-      --limit int          Limit number of history entries (default: 10) (default 10)
-  -n, --namespace string   Namespace of the resource (default: flux-system)
-  -r, --reverse            Reverse trace - walk ownerReferences up to find GitOps source
-
-Error: usage: cub-scout trace <kind/name> or cub-scout trace <kind> <name>


### PR DESCRIPTION
## Summary

Completes Phase B (connected foundation) of the 1.x roadmap, fixes a CLI bug, consolidates documentation, and does a full roadmap triage.

### Phase B Deliverables
- **Trace context diagnostics** — `FormatFluxContextError()`, `FormatHelmContextError()`, `FormatConfigHubContextError()` with 27 test cases. TUI renders structured remediation boxes.
- **Break-glass to managed** — step-by-step howto guide, 4 ownership tests, e2e validation script
- **ASCII vs JSON explainer** — user-facing guide for when/how to use each format

### CLI Bug Fix
- `SilenceErrors: true` + `SilenceUsage: true` on root cobra command — eliminates duplicate/triple error output

### Documentation Consolidation
- `docs/EXAMPLES-OVERVIEW.md` → thin redirect to `examples/README.md` (single source of truth)
- `WHY_CONNECTED_MODE.md` substance integrated into roadmap v1.1+ section

### Roadmap Triage
- Synced backlog checklist with actual issue status (all 15 issues #125–#158 confirmed CLOSED)
- Marked resolved/scoped items, added trapped-in-prose items (webhooks, plugins, import wizard, etc.)
- Stamped Phase A + B as Complete, Phase C + D as Scoped in upsell doc
- Added `docs/releases/v1.1.0.md` release notes

## Commits (6)
1. `3eec5bc` feat: first-class trace context diagnostics for Flux, Helm, and ConfigHub
2. `4cc322e` feat: break-glass to managed flow documentation and guided testing
3. `ef5c20d` docs: user-facing ASCII vs JSON explainer
4. `522d86f` fix: eliminate duplicate error output from CLI commands
5. `4fad076` docs: consolidate examples index and integrate WHY_CONNECTED_MODE into roadmap
6. `46147bf` docs: roadmap triage, backlog sync, and v1.1.0 release notes

## Roadmap impact
- [x] 1.x Connected Upsell: 6/6 complete
- [x] Documentation Gaps: 2/2 complete
- [x] Backlog checklist synced with issue reality
- [x] Phase A + B marked complete
- [x] Release notes written

## Test plan
- [x] 27 trace context diagnostic test cases pass
- [x] 4 break-glass ownership test cases pass
- [x] Full test suite passes (`go test ./...` — 33 packages)
- [x] All 15 referenced issues confirmed CLOSED via `gh issue view`

🤖 Generated with [Claude Code](https://claude.com/claude-code)