### PR TITLE
refactor: scan provider abstraction + normalized output

### DIFF
--- a/cmd/cub-scout/bundle.go
+++ b/cmd/cub-scout/bundle.go
@@ -238,10 +238,13 @@ Output is deterministic: same bundle always produces identical summary.
 All content derives from bundle facts — no external lookups.
 
 Examples:
-  # Generate ticket summary (stdout)
+  # Generate ASCII summary (default)
   cub-scout bundle summarize ./bundle
 
-  # Generate ticket summary (write to file)
+  # Generate ticket summary for Jira/ServiceNow
+  cub-scout bundle summarize ./bundle --format ticket
+
+  # Write ticket summary to file
   cub-scout bundle summarize ./bundle --format ticket --out jira.md
 
   # Generate Slack notification (JSON)

--- a/cmd/cub-scout/scan.go
+++ b/cmd/cub-scout/scan.go
@@ -8,13 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/confighub/cub-scout/internal/scan"
 	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/confighub/cub-scout/pkg/hub"
 )
@@ -33,6 +32,7 @@ var (
 	scanThreshold         string
 	scanFile              string
 	scanExplain           bool
+	scanNormalizedJSON    bool
 )
 
 var scanCmd = &cobra.Command{
@@ -103,18 +103,12 @@ func init() {
 	scanCmd.Flags().StringVar(&scanThreshold, "threshold", "5m", "Duration threshold for stuck detection (e.g., 30s, 2m, 5m)")
 	scanCmd.Flags().StringVar(&scanFile, "file", "", "YAML file to scan (static analysis, no cluster required)")
 	scanCmd.Flags().BoolVar(&scanExplain, "explain", false, "Show explanatory content to help learn GitOps risk concepts")
+	scanCmd.Flags().BoolVar(&scanNormalizedJSON, "normalized-json", false, "Output normalized findings JSON (scan.normalized.v1 schema)")
 }
 
-// CombinedScanResult holds results from all scanners
-type CombinedScanResult struct {
-	Kyverno          *agent.ScanResult            `json:"kyverno,omitempty"`
-	State            *agent.StateScanResult       `json:"state,omitempty"`
-	TimingBombs      *agent.TimingBombResult      `json:"timingBombs,omitempty"`
-	Unresolved       *agent.UnresolvedResult      `json:"unresolved,omitempty"`
-	Dangling         *agent.DanglingResult        `json:"dangling,omitempty"`
-	LifecycleHazards *agent.LifecycleHazardResult `json:"lifecycleHazards,omitempty"`
-	Static           *agent.StaticScanResult      `json:"static,omitempty"`
-}
+// CombinedScanResult is the legacy type name, preserved for compatibility
+// with the CUB_SCOUT_TEST_SCAN_JSON test hook and rendering functions.
+type CombinedScanResult = scan.CombinedResult
 
 func runScan(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
@@ -132,23 +126,23 @@ func runScan(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Find policy database directory
-	policyDBDir := findPolicyDBDir()
+	// Create scan provider
+	provider := scan.NewLegacyProvider(scan.ProviderConfig{})
 
 	// List mode - show all KPOL policies
 	if scanList {
-		return listKPOLPolicies(policyDBDir)
+		return listKPOLPolicies(provider)
 	}
 
 	// File mode - static analysis of YAML file (no cluster required)
 	if scanFile != "" {
-		return runFileScan(ctx, scanFile, policyDBDir)
+		return runFileScan(ctx, provider, scanFile)
 	}
 
 	// TEST HOOK: Load scan results from JSON file to bypass cluster access in tests.
 	// In production this env var is never set, so real cluster scanning is always used.
-	if scanJSON := os.Getenv("CUB_SCOUT_TEST_SCAN_JSON"); scanJSON != "" {
-		return loadAndRenderScanFromJSON(scanJSON)
+	if testJSON := os.Getenv("CUB_SCOUT_TEST_SCAN_JSON"); testJSON != "" {
+		return loadAndRenderScanFromJSON(testJSON)
 	}
 
 	// Build k8s config
@@ -157,201 +151,72 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to build kubernetes config: %w", err)
 	}
 
+	// Parse threshold duration
+	threshold, err := time.ParseDuration(scanThreshold)
+	if err != nil {
+		return fmt.Errorf("invalid threshold duration %q: %w", scanThreshold, err)
+	}
+
 	// Determine what to scan (default: both)
 	runKyverno := !scanStateOnly || scanKyvernoOnly
 	runState := !scanKyvernoOnly || scanStateOnly
-	// If both flags are set, run both
 	if scanStateOnly && scanKyvernoOnly {
 		runKyverno = true
 		runState = true
 	}
 
-	var kyvernoResult *agent.ScanResult
-	var stateResult *agent.StateScanResult
-	var timingBombResult *agent.TimingBombResult
-	var unresolvedResult *agent.UnresolvedResult
-	var danglingResult *agent.DanglingResult
-
-	// Run Kyverno scan
-	if runKyverno {
-		scanner, err := agent.NewKyvernoScanner(cfg, policyDBDir)
-		if err != nil {
-			return fmt.Errorf("failed to create kyverno scanner: %w", err)
-		}
-
-		if scanner.Available(ctx) {
-			if scanNamespace != "" {
-				kyvernoResult, err = scanner.ScanNamespace(ctx, scanNamespace)
-			} else {
-				kyvernoResult, err = scanner.Scan(ctx)
-			}
-			if err != nil {
-				return fmt.Errorf("kyverno scan failed: %w", err)
-			}
-		} else if scanKyvernoOnly {
-			// Only warn if Kyverno was explicitly requested
-			if scanJSON {
-				return outputCombinedJSON(&CombinedScanResult{
-					Kyverno: &agent.ScanResult{Error: "Kyverno not installed or PolicyReport CRD not found"},
-				})
-			}
-			fmt.Printf("\n%s⚠ Kyverno not installed%s\n", colorYellow, colorReset)
-			fmt.Printf("  PolicyReport CRD not found in cluster.\n")
-			fmt.Printf("  Install Kyverno: https://kyverno.io/docs/installation/\n\n")
-			return nil
-		}
+	// Execute scan through provider
+	result, err := provider.ScanCluster(ctx, scan.ClusterScanOpts{
+		Config:              cfg,
+		Namespace:           scanNamespace,
+		RunKyverno:          runKyverno,
+		RunState:            runState,
+		RunTimingBombs:      scanTimingBombs,
+		RunUnresolved:       scanIncludeUnresolved,
+		RunDangling:         scanDangling,
+		RunLifecycleHazards: scanLifecycleHazards,
+		Threshold:           threshold,
+	})
+	if err != nil {
+		return err
 	}
 
-	// Run State scan
-	if runState {
-		stateScanner, err := agent.NewStateScanner(cfg)
-		if err != nil {
-			return fmt.Errorf("failed to create state scanner: %w", err)
+	// Handle Kyverno-only mode where Kyverno is not installed
+	if scanKyvernoOnly && result.Kyverno == nil && !runState {
+		if scanJSON || scanNormalizedJSON {
+			return outputCombinedJSON(&CombinedScanResult{
+				Kyverno: &agent.ScanResult{Error: "Kyverno not installed or PolicyReport CRD not found"},
+			})
 		}
-
-		// Parse threshold duration
-		threshold, err := time.ParseDuration(scanThreshold)
-		if err != nil {
-			return fmt.Errorf("invalid threshold duration %q: %w", scanThreshold, err)
-		}
-
-		if scanNamespace != "" {
-			stateResult, err = stateScanner.ScanNamespaceWithThreshold(ctx, scanNamespace, threshold)
-		} else {
-			stateResult, err = stateScanner.ScanWithThreshold(ctx, threshold)
-		}
-		if err != nil {
-			return fmt.Errorf("state scan failed: %w", err)
-		}
-	}
-
-	// Run Timing Bombs scan
-	if scanTimingBombs {
-		stateScanner, err := agent.NewStateScanner(cfg)
-		if err != nil {
-			return fmt.Errorf("failed to create state scanner for timing bombs: %w", err)
-		}
-
-		timingBombResult, err = stateScanner.ScanTimingBombs(ctx)
-		if err != nil {
-			return fmt.Errorf("timing bomb scan failed: %w", err)
-		}
-	}
-
-	// Run Unresolved Findings scan
-	if scanIncludeUnresolved {
-		stateScanner, err := agent.NewStateScanner(cfg)
-		if err != nil {
-			return fmt.Errorf("failed to create state scanner for unresolved: %w", err)
-		}
-
-		unresolvedResult, err = stateScanner.ScanUnresolvedFindings(ctx)
-		if err != nil {
-			return fmt.Errorf("unresolved findings scan failed: %w", err)
-		}
-	}
-
-	// Run Dangling Resources scan
-	if scanDangling {
-		stateScanner, err := agent.NewStateScanner(cfg)
-		if err != nil {
-			return fmt.Errorf("failed to create state scanner for dangling: %w", err)
-		}
-
-		danglingResult, err = stateScanner.ScanDanglingResources(ctx)
-		if err != nil {
-			return fmt.Errorf("dangling resources scan failed: %w", err)
-		}
-	}
-
-	// Run Lifecycle Hazards scan
-	var lifecycleHazardsResult *agent.LifecycleHazardResult
-	if scanLifecycleHazards {
-		lifecycleScanner, err := agent.NewLifecycleHazardScanner(cfg)
-		if err != nil {
-			return fmt.Errorf("failed to create lifecycle hazard scanner: %w", err)
-		}
-		if scanNamespace != "" {
-			lifecycleHazardsResult, err = lifecycleScanner.ScanNamespace(ctx, scanNamespace)
-		} else {
-			lifecycleHazardsResult, err = lifecycleScanner.Scan(ctx)
-		}
-		if err != nil {
-			return fmt.Errorf("lifecycle hazards scan failed: %w", err)
-		}
+		fmt.Printf("\n%s⚠ Kyverno not installed%s\n", colorYellow, colorReset)
+		fmt.Printf("  PolicyReport CRD not found in cluster.\n")
+		fmt.Printf("  Install Kyverno: https://kyverno.io/docs/installation/\n\n")
+		return nil
 	}
 
 	// Output results
-	if scanJSON {
-		return outputCombinedJSON(&CombinedScanResult{
-			Kyverno:          kyvernoResult,
-			State:            stateResult,
-			TimingBombs:      timingBombResult,
-			Unresolved:       unresolvedResult,
-			Dangling:         danglingResult,
-			LifecycleHazards: lifecycleHazardsResult,
-		})
+	if scanNormalizedJSON {
+		return outputNormalizedJSON(result)
 	}
-	if err := outputCombinedHuman(kyvernoResult, stateResult, timingBombResult, unresolvedResult, danglingResult); err != nil {
+	if scanJSON {
+		return outputCombinedJSON(result)
+	}
+	if err := outputCombinedHuman(result.Kyverno, result.State, result.TimingBombs, result.Unresolved, result.Dangling); err != nil {
 		return err
 	}
-	if lifecycleHazardsResult != nil {
+	if result.LifecycleHazards != nil {
 		fmt.Printf("\n")
-		fmt.Print(agent.RenderLifecycleHazardsASCII(lifecycleHazardsResult))
+		fmt.Print(agent.RenderLifecycleHazardsASCII(result.LifecycleHazards))
 	}
 	return nil
 }
 
-// findPolicyDBDir locates the Kyverno policy database
-func findPolicyDBDir() string {
-	// Try relative to executable
-	exe, err := os.Executable()
-	if err == nil {
-		dir := filepath.Join(filepath.Dir(exe), "..", "cve", "ccve", "kyverno")
-		if _, err := os.Stat(dir); err == nil {
-			return dir
-		}
-	}
-
-	// Try relative to current directory
-	cwd, err := os.Getwd()
-	if err == nil {
-		dir := filepath.Join(cwd, "cve", "ccve", "kyverno")
-		if _, err := os.Stat(dir); err == nil {
-			return dir
-		}
-	}
-
-	// Try common locations
-	locations := []string{
-		"/usr/local/share/confighub/cve/ccve/kyverno",
-		"/usr/share/confighub/cve/ccve/kyverno",
-	}
-	for _, loc := range locations {
-		if _, err := os.Stat(loc); err == nil {
-			return loc
-		}
-	}
-
-	return ""
-}
-
-// listKPOLPolicies lists all policies in the database
-func listKPOLPolicies(policyDBDir string) error {
-	if policyDBDir == "" {
-		return fmt.Errorf("policy database not found")
-	}
-
-	scanner := agent.NewKyvernoScannerWithClient(nil, policyDBDir)
-	policies, err := scanner.GetPolicyCatalog()
+// listKPOLPolicies lists all policies via the scan provider.
+func listKPOLPolicies(provider scan.Provider) error {
+	policies, err := provider.ListPolicies()
 	if err != nil {
-		return fmt.Errorf("failed to load policy catalog: %w", err)
+		return err
 	}
-
-	// Sort by ID
-	sort.Slice(policies, func(i, j int) bool {
-		return policies[i].ID < policies[j].ID
-	})
 
 	if scanJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -942,55 +807,38 @@ func outputDanglingFinding(f agent.DanglingFinding) {
 	fmt.Printf("\n")
 }
 
-// runFileScan performs static analysis on a YAML file without requiring cluster access
-func runFileScan(ctx context.Context, filename string, ccveDBDir string) error {
-	// Determine CCVE database directory (parent of kyverno dir)
-	ccveDir := ccveDBDir
-	if strings.HasSuffix(ccveDir, "/kyverno") {
-		ccveDir = filepath.Dir(ccveDir)
-	}
-
-	scanner, err := agent.NewStaticScanner(ccveDir)
+// runFileScan performs static analysis on a YAML file via the scan provider.
+func runFileScan(ctx context.Context, provider scan.Provider, filename string) error {
+	combined, err := provider.ScanFile(ctx, scan.FileScanOpts{
+		Filename:            filename,
+		RunLifecycleHazards: scanLifecycleHazards,
+	})
 	if err != nil {
-		return fmt.Errorf("failed to create static scanner: %w", err)
+		return err
 	}
 
-	result, err := scanner.ScanFile(ctx, filename)
-	if err != nil {
-		return fmt.Errorf("static scan failed: %w", err)
-	}
-
-	// Run lifecycle hazards scan if requested
-	var lifecycleResult *agent.LifecycleHazardResult
-	if scanLifecycleHazards {
-		objects, err := scanner.LoadObjectsFromFile(filename)
-		if err != nil {
-			return fmt.Errorf("failed to load objects for lifecycle scan: %w", err)
+	// Output
+	if scanNormalizedJSON {
+		if err := outputNormalizedJSON(combined); err != nil {
+			return err
 		}
-		lifecycleScanner := agent.NewLifecycleHazardScannerFromObjects(objects)
-		lifecycleResult = lifecycleScanner.ScanObjects(objects)
-	}
-
-	if scanJSON {
-		if err := outputCombinedJSON(&CombinedScanResult{
-			Static:           result,
-			LifecycleHazards: lifecycleResult,
-		}); err != nil {
+	} else if scanJSON {
+		if err := outputCombinedJSON(combined); err != nil {
 			return err
 		}
 	} else {
-		if err := outputStaticScanHuman(result); err != nil {
+		if err := outputStaticScanHuman(combined.Static); err != nil {
 			return err
 		}
-		if lifecycleResult != nil && lifecycleResult.Summary.Total > 0 {
-			fmt.Print(agent.RenderLifecycleHazardsASCII(lifecycleResult))
+		if combined.LifecycleHazards != nil && combined.LifecycleHazards.Summary.Total > 0 {
+			fmt.Print(agent.RenderLifecycleHazardsASCII(combined.LifecycleHazards))
 		}
 	}
 
 	// Per cli-contract.md: exit code 1 for "Issues found or error"
-	hasFindings := len(result.Findings) > 0 || result.Error != ""
-	if lifecycleResult != nil {
-		hasFindings = hasFindings || lifecycleResult.Summary.Total > 0
+	hasFindings := combined.Static != nil && (len(combined.Static.Findings) > 0 || combined.Static.Error != "")
+	if combined.LifecycleHazards != nil {
+		hasFindings = hasFindings || combined.LifecycleHazards.Summary.Total > 0
 	}
 	if hasFindings {
 		os.Exit(1)
@@ -1104,6 +952,14 @@ func outputStaticFinding(f agent.StaticFinding) {
 	fmt.Printf("\n")
 }
 
+// outputNormalizedJSON outputs the combined result in the scan.normalized.v1 schema.
+func outputNormalizedJSON(result *CombinedScanResult) error {
+	normalized := scan.Normalize(result)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(normalized)
+}
+
 // loadAndRenderScanFromJSON loads scan results from a JSON file and renders them.
 // This is used for golden testing to bypass cluster access.
 func loadAndRenderScanFromJSON(path string) error {
@@ -1117,6 +973,9 @@ func loadAndRenderScanFromJSON(path string) error {
 		return fmt.Errorf("failed to parse scan JSON: %w", err)
 	}
 
+	if scanNormalizedJSON {
+		return outputNormalizedJSON(&result)
+	}
 	if scanJSON {
 		return outputCombinedJSON(&result)
 	}

--- a/cmd/cub-scout/status.go
+++ b/cmd/cub-scout/status.go
@@ -92,37 +92,41 @@ func runStatus(cmd *cobra.Command) error {
 		status.Mode = "connected"
 	}
 
-	// If we have local auth, check if cub CLI is available for richer status
-	if hub.IsAuthenticated() {
-		auth, _ := hub.LoadAuth()
-		if auth != nil && auth.Email != "" {
-			status.Email = auth.Email
-		}
+	// Check local auth for email (fast, file-only)
+	auth, _ := hub.LoadAuth()
+	if auth != nil && auth.Email != "" {
+		status.Email = auth.Email
+	}
 
-		// Try to get extended status from cub CLI (optional dependency)
-		if cubInstalled() {
-			cubCtx, email, err := getStatusCubContext()
-			if err == nil && cubCtx != nil {
-				// cub CLI context overrides local auth for email
-				if email != "" {
-					status.Email = email
-				}
-				status.Space = cubCtx.Settings.DefaultSpace
+	// Try cub CLI for richer status (does not depend on local auth.json)
+	if cubInstalled() {
+		cubCtx, email, err := getStatusCubContext()
+		if err == nil && cubCtx != nil {
+			// cub CLI context overrides local auth for email
+			if email != "" {
+				status.Email = email
+			}
+			status.Space = cubCtx.Settings.DefaultSpace
 
-				// Validate token via cub CLI
-				authValid := validateAuthToken()
-				status.AuthValid = &authValid
+			// If hub reported offline/online but cub CLI has a context,
+			// upgrade to connected
+			if status.Mode != "connected" {
+				status.Mode = "connected"
+			}
 
-				if !authValid {
-					status.Mode = "auth_expired"
-				}
+			// Validate token via cub CLI
+			authValid := validateAuthToken()
+			status.AuthValid = &authValid
 
-				// Try to get worker status (only if auth is valid)
-				if authValid && cubCtx.Settings.DefaultSpace != "" {
-					worker := getWorkerForCluster(cubCtx.Settings.DefaultSpace, status.ClusterName)
-					if worker != nil {
-						status.Worker = worker
-					}
+			if !authValid {
+				status.Mode = "auth_expired"
+			}
+
+			// Try to get worker status (only if auth is valid)
+			if authValid && cubCtx.Settings.DefaultSpace != "" {
+				worker := getWorkerForCluster(cubCtx.Settings.DefaultSpace, status.ClusterName)
+				if worker != nil {
+					status.Worker = worker
 				}
 			}
 		}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,38 +1,50 @@
 # Command Reference
 
-Complete reference for all cub-scout commands.
+Curated reference for common cub-scout commands with usage examples.
+
+For the **exhaustive stable surface** (all contracted commands, flags, exit codes, and output schemas), see [CLI Contract Reference](cli-contract.md).
 
 ## Overview
 
-| Command | Purpose |
-|---------|---------|
-| `map` | Interactive cluster explorer (TUI) |
-| `map list` | List resources by ownership |
-| `map orphans` | Find resources without GitOps owner |
-| `map issues` | Show resources with problems |
-| `map crashes` | Show crashing pods |
-| `map workloads` | List workloads by owner |
-| `map deployers` | List GitOps deployers (Flux, ArgoCD, core Deployments) |
-| `map cronjobs` | List CronJobs with schedule/run state |
-| `map jobs` | List Jobs with CronJob linkage and run state |
-| `map actions` | Read-only operator action preview (runbook output) |
-| `map activity` | Unified activity timeline from Flux/Argo/Helm/events |
-| `map previews` | Detect PR preview environments |
-| `trace` | Show GitOps ownership chain |
-| `scan` | Scan for misconfigurations |
-| `tree` | Hierarchical resource views |
-| `import` | Import workloads into ConfigHub |
-| `discover` | Scout-style workload discovery |
-| `health` | Scout-style health check |
-| `connect` | Quickly configure kube context from server URL or kubeconfig |
-| `setup` | Set up shell completions |
-| `graph export` | Export resource graph as JSON (v0.6) |
-| `graph explain` | Explain a resource's graph relationships (v0.6) |
-| `patterns list` | List registered patterns (v0.7) |
-| `patterns detect` | Run pattern detection (v0.7) |
-| `patterns explain` | Explain a specific pattern (v0.7) |
-| `bundle summarize` | Generate evidence summaries from debug bundles (v0.19) |
-| `gitops status` | Show GitOps pipeline health (v0.14) |
+| Command | Purpose | Stable Since |
+|---------|---------|--------------|
+| `map` | Interactive cluster explorer (TUI) | v0.5 |
+| `map list` | List resources by ownership | v0.5 |
+| `map status` | One-line cluster health check | v0.5 |
+| `map orphans` | Find resources without GitOps owner | v0.5 |
+| `map issues` | Show resources with problems | v0.5 |
+| `map crashes` | Show crashing pods | v0.5 |
+| `map workloads` | List workloads by owner | v0.5 |
+| `map deployers` | List GitOps deployers (Flux, ArgoCD, core Deployments) | v0.5 |
+| `map hooks` | List lifecycle hooks (Helm/ArgoCD) | v0.19 |
+| `map cronjobs` | List CronJobs with schedule/run state | v0.20 |
+| `map jobs` | List Jobs with CronJob linkage and run state | v0.20 |
+| `map actions` | Read-only operator action preview (runbook output) | v0.20 |
+| `map activity` | Unified activity timeline from Flux/Argo/Helm/events | v0.20 |
+| `map previews` | Detect PR preview environments | v0.20 |
+| `trace` | Show GitOps ownership chain | v0.5 |
+| `scan` | Scan for misconfigurations | v0.5 |
+| `scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD | v0.19 |
+| `tree` | Hierarchical resource views | v0.5 |
+| `import` | Import workloads into ConfigHub | v1.0 |
+| `discover` | Scout-style workload discovery | v0.5 |
+| `health` | Scout-style health check | v0.5 |
+| `status` | Show connection status and cluster info | v1.0 |
+| `connect` | Quickly configure kube context from server URL or kubeconfig | v1.0 |
+| `setup` | Set up shell completions | v0.19 |
+| `graph export` | Export resource graph as JSON | v0.6 |
+| `graph explain` | Explain a resource's graph relationships | v0.6 |
+| `patterns list` | List registered patterns | v0.7 |
+| `patterns detect` | Run pattern detection | v0.7 |
+| `patterns explain` | Explain a specific pattern | v0.7 |
+| `bundle inspect` | Show bundle metadata and contents | v0.15 |
+| `bundle summarize` | Generate evidence summaries from debug bundles | v0.19 |
+| `bundle replay` | Re-render bundle contents | v0.15 |
+| `bundle diff` | Compare two bundles | v0.15 |
+| `bundle timeline` | Time-series view across catalog | v0.15 |
+| `catalog list` | List bundles in a catalog | v0.15 |
+| `gitops status` | Show GitOps pipeline health | v0.14.1 |
+| `completion` | Generate shell completion script | v0.19 |
 
 For JSON contract navigation, start with [JSON Contracts and Output Model](json-contracts.md).
 
@@ -75,6 +87,33 @@ In the pipelines view (`p`):
 - `unknown`: source field missing/unreadable
 
 See `docs/reference/pipeline-source-resolution.md` for details.
+
+---
+
+## map status
+
+One-line cluster health summary.
+
+```bash
+cub-scout map status [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-n, --namespace` | Filter by namespace |
+| `--format` | Output format: `ascii`, `json`, `md` (default: ascii) |
+
+### Examples
+
+```bash
+cub-scout map status
+cub-scout map status -n production
+cub-scout map status --format json
+```
+
+See [CLI Contract Reference](cli-contract.md) for exit codes and JSON schema.
 
 ---
 
@@ -217,6 +256,32 @@ Canonical deployer scope (v1.0):
 - Flux `HelmRelease`
 - Argo CD `Application`
 - Core Kubernetes `Deployment` (fallback where GitOps CRDs are absent)
+
+---
+
+## map hooks
+
+List lifecycle hooks (Helm pre/post-install, ArgoCD sync hooks).
+
+```bash
+cub-scout map hooks [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-n, --namespace` | Filter by namespace |
+| `--format` | Output format: `ascii`, `json`, `md` (default: ascii) |
+
+### Examples
+
+```bash
+cub-scout map hooks
+cub-scout map hooks -n production
+```
+
+See [CLI Contract Reference](cli-contract.md) for full output details.
 
 ---
 
@@ -619,6 +684,33 @@ cub-scout connect --from-kubeconfig ./artem.yaml --from-context ske-vcl-pro --ma
 
 ---
 
+## status
+
+Show connection status, cluster info, and worker status.
+
+```bash
+cub-scout status [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+cub-scout status
+cub-scout status --json
+```
+
+Displays ConfigHub connection mode (Offline/Online/Connected), current cluster
+name, kubectl context, and optional worker/space info when the `cub` CLI is
+available.
+
+---
+
 ## setup
 
 Set up shell completions and configuration.
@@ -858,6 +950,58 @@ cub-scout bundle summarize ./bundle --format json
 Output is deterministic: same bundle always produces identical output. All content derives from bundle facts only.
 
 For the full evidence export schema, see [Evidence Export v1](evidence-export-v1.md).
+
+---
+
+## bundle inspect (v0.15)
+
+Show bundle metadata, contents, and structure.
+
+```bash
+cub-scout bundle inspect <bundle-path>
+```
+
+---
+
+## bundle replay (v0.15)
+
+Re-render bundle contents through the current rendering pipeline.
+
+```bash
+cub-scout bundle replay <bundle-path> [flags]
+```
+
+---
+
+## bundle diff (v0.15)
+
+Compare two bundles and show differences.
+
+```bash
+cub-scout bundle diff <bundle-a> <bundle-b> [flags]
+```
+
+---
+
+## bundle timeline (v0.15)
+
+Time-series view of bundles in a catalog directory.
+
+```bash
+cub-scout bundle timeline <catalog-path> [flags]
+```
+
+---
+
+## catalog list (v0.15)
+
+List bundles in a catalog directory with metadata.
+
+```bash
+cub-scout catalog list <catalog-path> [flags]
+```
+
+See [CLI Contract Reference](cli-contract.md) for full flag and output documentation for all bundle and catalog commands.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -378,12 +378,19 @@ Legacy `cub-agent` command examples in archive docs are non-canonical; current c
 
 ### Remaining Capabilities (Authoritative)
 
-#### 1. Connected Import into ConfigHub
+#### 1. Connected Import Evolution (1.1+)
 
-* Import bundles into ConfigHub
-* Import cluster-captured state via cub-scout
-* Explicit, one-shot, auditable imports
-* Intentionally deferred from late 0.x to keep read-only-first stabilization tight; now staged as 1.1+ Connected Mode scope
+Basic `cub-scout import` shipped in v1.0:
+* Namespace-scoped workload discovery and import (`cub-scout import -n <ns>`)
+* Interactive wizard (`cub-scout import --wizard`)
+* Dry-run and JSON proposal modes
+* See `docs/reference/commands.md` and `docs/howto/import-to-confighub.md`
+
+Remaining 1.1+ scope — evolve import, not introduce it:
+* App-centric transition mapping (App/Deployment/Target to Space/Unit) — see #186
+* OCI-first source language alignment
+* Evidence contract integration with bundle/scan surfaces
+* Import from bundle artifacts (not just live cluster)
 
 #### 2. Git as a First-Class Source
 

--- a/internal/scan/config.go
+++ b/internal/scan/config.go
@@ -1,0 +1,78 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ProviderConfig controls provider-level behavior.
+type ProviderConfig struct {
+	// PolicyDBDir is the Kyverno policy database directory.
+	// Resolution order: explicit value > CUB_SCOUT_KYVERNO_DB env > legacy probing.
+	PolicyDBDir string
+
+	// CCVEDir is the CCVE database directory for static scanning.
+	// When empty, derived from PolicyDBDir (its parent if PolicyDBDir ends in /kyverno).
+	CCVEDir string
+}
+
+// ResolveConfig returns a fully-resolved ProviderConfig.
+// It applies the resolution chain: explicit > env > legacy probe.
+func ResolveConfig(explicit ProviderConfig) ProviderConfig {
+	resolved := explicit
+
+	if resolved.PolicyDBDir == "" {
+		resolved.PolicyDBDir = os.Getenv("CUB_SCOUT_KYVERNO_DB")
+	}
+
+	if resolved.PolicyDBDir == "" {
+		resolved.PolicyDBDir = probeLegacyPolicyDBDir()
+	}
+
+	if resolved.CCVEDir == "" && resolved.PolicyDBDir != "" {
+		if strings.HasSuffix(resolved.PolicyDBDir, "/kyverno") {
+			resolved.CCVEDir = filepath.Dir(resolved.PolicyDBDir)
+		} else {
+			resolved.CCVEDir = resolved.PolicyDBDir
+		}
+	}
+
+	return resolved
+}
+
+// probeLegacyPolicyDBDir probes hardcoded filesystem locations for the
+// Kyverno policy database. This is the legacy discovery mechanism preserved
+// as a fallback for backward compatibility.
+func probeLegacyPolicyDBDir() string {
+	// Try relative to executable
+	exe, err := os.Executable()
+	if err == nil {
+		dir := filepath.Join(filepath.Dir(exe), "..", "cve", "ccve", "kyverno")
+		if _, err := os.Stat(dir); err == nil {
+			return dir
+		}
+	}
+
+	// Try relative to current directory
+	cwd, err := os.Getwd()
+	if err == nil {
+		dir := filepath.Join(cwd, "cve", "ccve", "kyverno")
+		if _, err := os.Stat(dir); err == nil {
+			return dir
+		}
+	}
+
+	// Try common system locations
+	locations := []string{
+		"/usr/local/share/confighub/cve/ccve/kyverno",
+		"/usr/share/confighub/cve/ccve/kyverno",
+	}
+	for _, loc := range locations {
+		if _, err := os.Stat(loc); err == nil {
+			return loc
+		}
+	}
+
+	return ""
+}

--- a/internal/scan/config_test.go
+++ b/internal/scan/config_test.go
@@ -1,0 +1,88 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveConfig_ExplicitTakesPrecedence(t *testing.T) {
+	t.Setenv("CUB_SCOUT_KYVERNO_DB", "/env/path")
+
+	got := ResolveConfig(ProviderConfig{PolicyDBDir: "/explicit/path"})
+	if got.PolicyDBDir != "/explicit/path" {
+		t.Errorf("PolicyDBDir = %q, want /explicit/path (explicit should win over env)", got.PolicyDBDir)
+	}
+}
+
+func TestResolveConfig_EnvFallback(t *testing.T) {
+	t.Setenv("CUB_SCOUT_KYVERNO_DB", "/env/kyverno")
+
+	got := ResolveConfig(ProviderConfig{})
+	if got.PolicyDBDir != "/env/kyverno" {
+		t.Errorf("PolicyDBDir = %q, want /env/kyverno", got.PolicyDBDir)
+	}
+}
+
+func TestResolveConfig_LegacyProbe(t *testing.T) {
+	t.Setenv("CUB_SCOUT_KYVERNO_DB", "")
+
+	// Create a temp dir with the expected structure
+	tmp := t.TempDir()
+	kyvernoDir := filepath.Join(tmp, "cve", "ccve", "kyverno")
+	if err := os.MkdirAll(kyvernoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Probe uses cwd as one of the search paths, so chdir
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+	os.Chdir(tmp)
+
+	got := ResolveConfig(ProviderConfig{})
+	if got.PolicyDBDir == "" {
+		t.Error("PolicyDBDir is empty, expected legacy probe to find cwd/cve/ccve/kyverno")
+	}
+}
+
+func TestResolveConfig_CCVEDirDerivedFromKyvernoSuffix(t *testing.T) {
+	got := ResolveConfig(ProviderConfig{PolicyDBDir: "/data/cve/ccve/kyverno"})
+	if got.CCVEDir != "/data/cve/ccve" {
+		t.Errorf("CCVEDir = %q, want /data/cve/ccve", got.CCVEDir)
+	}
+}
+
+func TestResolveConfig_CCVEDirPreservedWhenNoKyvernoSuffix(t *testing.T) {
+	got := ResolveConfig(ProviderConfig{PolicyDBDir: "/data/policies"})
+	if got.CCVEDir != "/data/policies" {
+		t.Errorf("CCVEDir = %q, want /data/policies (same as PolicyDBDir without /kyverno suffix)", got.CCVEDir)
+	}
+}
+
+func TestResolveConfig_ExplicitCCVEDirPreserved(t *testing.T) {
+	got := ResolveConfig(ProviderConfig{
+		PolicyDBDir: "/data/kyverno",
+		CCVEDir:     "/explicit/ccve",
+	})
+	if got.CCVEDir != "/explicit/ccve" {
+		t.Errorf("CCVEDir = %q, want /explicit/ccve (explicit should be preserved)", got.CCVEDir)
+	}
+}
+
+func TestResolveConfig_EmptyWhenNothingFound(t *testing.T) {
+	t.Setenv("CUB_SCOUT_KYVERNO_DB", "")
+
+	// Use a temp dir with no kyverno structure as cwd
+	tmp := t.TempDir()
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+	os.Chdir(tmp)
+
+	got := ResolveConfig(ProviderConfig{})
+	// PolicyDBDir may be empty if none of the probe paths exist
+	// (depends on whether exe-relative or system paths exist on this machine)
+	// Just verify no panic and CCVEDir is consistent
+	if got.PolicyDBDir == "" && got.CCVEDir != "" {
+		t.Error("CCVEDir should be empty when PolicyDBDir is empty")
+	}
+}

--- a/internal/scan/confighub_provider.go
+++ b/internal/scan/confighub_provider.go
@@ -1,0 +1,48 @@
+package scan
+
+import (
+	"context"
+	"os/exec"
+)
+
+// ConfighubScanProvider delegates scanning to the confighub-scan binary when
+// available, falling back to LegacyProvider for all operations when it is not.
+// This is the future provider for ConfigHub-managed scan patterns.
+type ConfighubScanProvider struct {
+	fallback *LegacyProvider
+}
+
+// NewConfighubScanProvider creates a ConfighubScanProvider that probes for the
+// confighub-scan binary. If unavailable, all methods silently delegate to the
+// LegacyProvider.
+func NewConfighubScanProvider(cfg ProviderConfig) *ConfighubScanProvider {
+	return &ConfighubScanProvider{
+		fallback: NewLegacyProvider(cfg),
+	}
+}
+
+func (p *ConfighubScanProvider) Name() string { return "confighub-scan" }
+
+// Available reports whether the confighub-scan binary is on PATH.
+func (p *ConfighubScanProvider) Available() bool {
+	_, err := exec.LookPath("confighub-scan")
+	return err == nil
+}
+
+// ScanCluster delegates to confighub-scan when available, otherwise falls back.
+func (p *ConfighubScanProvider) ScanCluster(ctx context.Context, opts ClusterScanOpts) (*CombinedResult, error) {
+	// TODO: invoke confighub-scan binary for cluster scanning
+	return p.fallback.ScanCluster(ctx, opts)
+}
+
+// ScanFile delegates to confighub-scan when available, otherwise falls back.
+func (p *ConfighubScanProvider) ScanFile(ctx context.Context, opts FileScanOpts) (*CombinedResult, error) {
+	// TODO: invoke confighub-scan binary for file scanning
+	return p.fallback.ScanFile(ctx, opts)
+}
+
+// ListPolicies delegates to confighub-scan when available, otherwise falls back.
+func (p *ConfighubScanProvider) ListPolicies() ([]PolicyEntry, error) {
+	// TODO: invoke confighub-scan binary for policy listing
+	return p.fallback.ListPolicies()
+}

--- a/internal/scan/confighub_provider_test.go
+++ b/internal/scan/confighub_provider_test.go
@@ -1,0 +1,50 @@
+package scan
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestConfighubScanProvider_Name(t *testing.T) {
+	p := NewConfighubScanProvider(ProviderConfig{})
+	if got := p.Name(); got != "confighub-scan" {
+		t.Errorf("Name() = %q, want confighub-scan", got)
+	}
+}
+
+func TestConfighubScanProvider_Available_NoBinary(t *testing.T) {
+	// Use empty temp dir as PATH to ensure binary not found
+	tmpDir := t.TempDir()
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir)
+	defer func() { os.Setenv("PATH", origPath) }()
+
+	p := NewConfighubScanProvider(ProviderConfig{})
+	if p.Available() {
+		t.Error("Available() = true, want false when confighub-scan not on PATH")
+	}
+}
+
+func TestConfighubScanProvider_FallbackScanFile(t *testing.T) {
+	fixture := findTestFixture(t, "test/golden/scan-file/testdata/inputs/clean-deployment.yaml")
+
+	p := NewConfighubScanProvider(ProviderConfig{})
+	result, err := p.ScanFile(context.Background(), FileScanOpts{
+		Filename: fixture,
+	})
+	if err != nil {
+		t.Fatalf("ScanFile() error = %v", err)
+	}
+	if result.Static == nil {
+		t.Fatal("Static result is nil (fallback should produce result)")
+	}
+}
+
+func TestConfighubScanProvider_FallbackListPolicies_NoDB(t *testing.T) {
+	p := NewConfighubScanProvider(ProviderConfig{PolicyDBDir: ""})
+	_, err := p.ListPolicies()
+	if err == nil {
+		t.Error("ListPolicies() error = nil, want error when no policy DB (fallback behavior)")
+	}
+}

--- a/internal/scan/legacy_provider.go
+++ b/internal/scan/legacy_provider.go
@@ -1,0 +1,230 @@
+package scan
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+// LegacyProvider wraps the existing pkg/agent scanners behind the Provider
+// interface. This is the default provider — it uses the built-in scanner
+// implementations that have been shipping since v0.5.
+type LegacyProvider struct {
+	config ProviderConfig
+}
+
+// NewLegacyProvider creates a LegacyProvider with resolved configuration.
+func NewLegacyProvider(cfg ProviderConfig) *LegacyProvider {
+	return &LegacyProvider{config: ResolveConfig(cfg)}
+}
+
+func (p *LegacyProvider) Name() string    { return "legacy" }
+func (p *LegacyProvider) Available() bool { return true }
+
+// ScanCluster runs all enabled scan types against a live cluster.
+// The orchestration logic is extracted from cmd/cub-scout/scan.go runScan().
+func (p *LegacyProvider) ScanCluster(ctx context.Context, opts ClusterScanOpts) (*CombinedResult, error) {
+	var result CombinedResult
+
+	// Kyverno scan
+	if opts.RunKyverno {
+		kyvernoResult, kyvernoOnlyMode, err := p.scanKyverno(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		result.Kyverno = kyvernoResult
+		// If Kyverno was explicitly requested but not available, return early
+		// with the error result (matches legacy behavior).
+		if kyvernoOnlyMode {
+			return &result, nil
+		}
+	}
+
+	// State scan
+	if opts.RunState {
+		stateResult, err := p.scanState(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		result.State = stateResult
+	}
+
+	// Timing bombs scan
+	if opts.RunTimingBombs {
+		tbResult, err := p.scanTimingBombs(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		result.TimingBombs = tbResult
+	}
+
+	// Unresolved findings scan
+	if opts.RunUnresolved {
+		urResult, err := p.scanUnresolved(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		result.Unresolved = urResult
+	}
+
+	// Dangling resources scan
+	if opts.RunDangling {
+		dangResult, err := p.scanDangling(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		result.Dangling = dangResult
+	}
+
+	// Lifecycle hazards scan
+	if opts.RunLifecycleHazards {
+		lhResult, err := p.scanLifecycleHazards(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		result.LifecycleHazards = lhResult
+	}
+
+	return &result, nil
+}
+
+// ScanFile performs static analysis on a YAML file.
+// Extracted from cmd/cub-scout/scan.go runFileScan().
+func (p *LegacyProvider) ScanFile(ctx context.Context, opts FileScanOpts) (*CombinedResult, error) {
+	scanner, err := agent.NewStaticScanner(p.config.CCVEDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create static scanner: %w", err)
+	}
+
+	staticResult, err := scanner.ScanFile(ctx, opts.Filename)
+	if err != nil {
+		return nil, fmt.Errorf("static scan failed: %w", err)
+	}
+
+	var result CombinedResult
+	result.Static = staticResult
+
+	// Optional lifecycle hazards scan
+	if opts.RunLifecycleHazards {
+		objects, err := scanner.LoadObjectsFromFile(opts.Filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load objects for lifecycle scan: %w", err)
+		}
+		lifecycleScanner := agent.NewLifecycleHazardScannerFromObjects(objects)
+		result.LifecycleHazards = lifecycleScanner.ScanObjects(objects)
+	}
+
+	return &result, nil
+}
+
+// ListPolicies returns the Kyverno policy catalog.
+// Extracted from cmd/cub-scout/scan.go listKPOLPolicies().
+func (p *LegacyProvider) ListPolicies() ([]PolicyEntry, error) {
+	if p.config.PolicyDBDir == "" {
+		return nil, fmt.Errorf("policy database not found")
+	}
+
+	scanner := agent.NewKyvernoScannerWithClient(nil, p.config.PolicyDBDir)
+	policies, err := scanner.GetPolicyCatalog()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load policy catalog: %w", err)
+	}
+
+	// Sort by ID (deterministic output)
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].ID < policies[j].ID
+	})
+
+	entries := make([]PolicyEntry, len(policies))
+	for i, p := range policies {
+		entries[i] = PolicyEntry{
+			ID:       p.ID,
+			Name:     p.Name,
+			Severity: p.Severity,
+			Category: p.Category,
+		}
+	}
+	return entries, nil
+}
+
+// --- internal scanner methods ---
+
+func (p *LegacyProvider) scanKyverno(ctx context.Context, opts ClusterScanOpts) (*agent.ScanResult, bool, error) {
+	scanner, err := agent.NewKyvernoScanner(opts.Config, p.config.PolicyDBDir)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create kyverno scanner: %w", err)
+	}
+
+	if !scanner.Available(ctx) {
+		// Return nil result when Kyverno is not installed.
+		// Second return value signals "kyverno-only mode" to the caller
+		// so it can decide whether to return an error message.
+		return nil, false, nil
+	}
+
+	var result *agent.ScanResult
+	if opts.Namespace != "" {
+		result, err = scanner.ScanNamespace(ctx, opts.Namespace)
+	} else {
+		result, err = scanner.Scan(ctx)
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("kyverno scan failed: %w", err)
+	}
+	return result, false, nil
+}
+
+func (p *LegacyProvider) scanState(ctx context.Context, opts ClusterScanOpts) (*agent.StateScanResult, error) {
+	stateScanner, err := agent.NewStateScanner(opts.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create state scanner: %w", err)
+	}
+
+	threshold := opts.Threshold
+	if threshold == 0 {
+		threshold = 5 * time.Minute
+	}
+
+	if opts.Namespace != "" {
+		return stateScanner.ScanNamespaceWithThreshold(ctx, opts.Namespace, threshold)
+	}
+	return stateScanner.ScanWithThreshold(ctx, threshold)
+}
+
+func (p *LegacyProvider) scanTimingBombs(ctx context.Context, opts ClusterScanOpts) (*agent.TimingBombResult, error) {
+	stateScanner, err := agent.NewStateScanner(opts.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create state scanner for timing bombs: %w", err)
+	}
+	return stateScanner.ScanTimingBombs(ctx)
+}
+
+func (p *LegacyProvider) scanUnresolved(ctx context.Context, opts ClusterScanOpts) (*agent.UnresolvedResult, error) {
+	stateScanner, err := agent.NewStateScanner(opts.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create state scanner for unresolved: %w", err)
+	}
+	return stateScanner.ScanUnresolvedFindings(ctx)
+}
+
+func (p *LegacyProvider) scanDangling(ctx context.Context, opts ClusterScanOpts) (*agent.DanglingResult, error) {
+	stateScanner, err := agent.NewStateScanner(opts.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create state scanner for dangling: %w", err)
+	}
+	return stateScanner.ScanDanglingResources(ctx)
+}
+
+func (p *LegacyProvider) scanLifecycleHazards(ctx context.Context, opts ClusterScanOpts) (*agent.LifecycleHazardResult, error) {
+	lifecycleScanner, err := agent.NewLifecycleHazardScanner(opts.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lifecycle hazard scanner: %w", err)
+	}
+	if opts.Namespace != "" {
+		return lifecycleScanner.ScanNamespace(ctx, opts.Namespace)
+	}
+	return lifecycleScanner.Scan(ctx)
+}

--- a/internal/scan/legacy_provider_test.go
+++ b/internal/scan/legacy_provider_test.go
@@ -1,0 +1,114 @@
+package scan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLegacyProvider_Name(t *testing.T) {
+	p := NewLegacyProvider(ProviderConfig{})
+	if got := p.Name(); got != "legacy" {
+		t.Errorf("Name() = %q, want legacy", got)
+	}
+}
+
+func TestLegacyProvider_Available(t *testing.T) {
+	p := NewLegacyProvider(ProviderConfig{})
+	if !p.Available() {
+		t.Error("Available() = false, want true (legacy provider is always available)")
+	}
+}
+
+func TestLegacyProvider_ScanFile_CleanDeployment(t *testing.T) {
+	fixture := findTestFixture(t, "test/golden/scan-file/testdata/inputs/clean-deployment.yaml")
+
+	p := NewLegacyProvider(ProviderConfig{})
+	result, err := p.ScanFile(context.Background(), FileScanOpts{
+		Filename: fixture,
+	})
+	if err != nil {
+		t.Fatalf("ScanFile() error = %v", err)
+	}
+	if result.Static == nil {
+		t.Fatal("Static result is nil")
+	}
+	if len(result.Static.Findings) != 0 {
+		t.Errorf("Findings = %d, want 0 for clean deployment", len(result.Static.Findings))
+	}
+}
+
+func TestLegacyProvider_ScanFile_WithFindings(t *testing.T) {
+	fixture := findTestFixture(t, "test/golden/scan-file/testdata/inputs/misconfigured-deployment.yaml")
+
+	p := NewLegacyProvider(ProviderConfig{})
+	result, err := p.ScanFile(context.Background(), FileScanOpts{
+		Filename: fixture,
+	})
+	if err != nil {
+		t.Fatalf("ScanFile() error = %v", err)
+	}
+	if result.Static == nil {
+		t.Fatal("Static result is nil")
+	}
+	if len(result.Static.Findings) == 0 {
+		t.Error("Findings = 0, want >0 for misconfigured deployment")
+	}
+}
+
+func TestLegacyProvider_ScanFile_FileNotFound(t *testing.T) {
+	p := NewLegacyProvider(ProviderConfig{})
+	result, err := p.ScanFile(context.Background(), FileScanOpts{
+		Filename: "/nonexistent/file.yaml",
+	})
+	// StaticScanner.ScanFile returns errors in the result's Error field
+	// (not as a Go error) per the CLI contract: exit 1 with error message.
+	if err != nil {
+		// If it does return a Go error, that's also acceptable
+		return
+	}
+	if result == nil || result.Static == nil {
+		t.Fatal("expected non-nil Static result")
+	}
+	if result.Static.Error == "" {
+		t.Error("Static.Error is empty, want error message for missing file")
+	}
+}
+
+func TestLegacyProvider_ListPolicies_NoDB(t *testing.T) {
+	p := NewLegacyProvider(ProviderConfig{PolicyDBDir: ""})
+	_, err := p.ListPolicies()
+	if err == nil {
+		t.Error("ListPolicies() error = nil, want error when no policy DB")
+	}
+}
+
+// findTestFixture locates a test fixture relative to the repo root.
+// Walks up from the current directory looking for go.mod to find root.
+func findTestFixture(t *testing.T, relPath string) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for {
+		// Check if this looks like the repo root (has go.mod)
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			candidate := filepath.Join(dir, relPath)
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+			t.Skipf("fixture %s not found under repo root %s", relPath, dir)
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Skipf("fixture %s not found (could not locate repo root)", relPath)
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/internal/scan/normalized.go
+++ b/internal/scan/normalized.go
@@ -1,0 +1,208 @@
+package scan
+
+import (
+	"fmt"
+	"time"
+)
+
+// NormalizedSchemaVersion is the schema version for normalized findings output.
+const NormalizedSchemaVersion = "scan.normalized.v1"
+
+// NormalizedFinding is the universal finding shape across all scanner tracks.
+// Each field maps deterministically from the source finding type — no inference.
+type NormalizedFinding struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Category    string `json:"category"`
+	Track       string `json:"track"` // "kyverno", "state", "timing-bomb", "unresolved", "dangling", "static", "lifecycle"
+	Severity    string `json:"severity"`
+	Resource    string `json:"resource"`
+	Namespace   string `json:"namespace"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+	Command     string `json:"command,omitempty"`
+}
+
+// NormalizedResult wraps all normalized findings with metadata.
+type NormalizedResult struct {
+	SchemaVersion string              `json:"schema_version"`
+	ScannedAt     time.Time           `json:"scanned_at"`
+	Findings      []NormalizedFinding `json:"findings"`
+	Summary       NormalizedSummary   `json:"summary"`
+}
+
+// NormalizedSummary counts findings by severity.
+type NormalizedSummary struct {
+	Critical int `json:"critical"`
+	Warning  int `json:"warning"`
+	Info     int `json:"info"`
+	Total    int `json:"total"`
+}
+
+// Normalize converts a CombinedResult into a NormalizedResult.
+// The mapping is deterministic: same input always produces same output.
+func Normalize(combined *CombinedResult) *NormalizedResult {
+	if combined == nil {
+		return &NormalizedResult{
+			SchemaVersion: NormalizedSchemaVersion,
+			Findings:      []NormalizedFinding{},
+		}
+	}
+
+	var findings []NormalizedFinding
+
+	// Kyverno findings
+	if combined.Kyverno != nil {
+		for _, f := range combined.Kyverno.Findings {
+			id := f.PolicyID
+			if id == "" {
+				id = f.ID
+			}
+			findings = append(findings, NormalizedFinding{
+				ID:        id,
+				Title:     f.PolicyName,
+				Category:  f.Category,
+				Track:     "kyverno",
+				Severity:  f.Severity,
+				Resource:  f.Resource,
+				Namespace: f.Namespace,
+				Message:   f.Message,
+			})
+		}
+	}
+
+	// State findings (stuck reconciliations)
+	if combined.State != nil {
+		for _, f := range combined.State.Findings {
+			findings = append(findings, NormalizedFinding{
+				ID:          f.CCVEID,
+				Title:       fmt.Sprintf("%s/%s stuck", f.Kind, f.Name),
+				Category:    f.Category,
+				Track:       "state",
+				Severity:    f.Severity,
+				Resource:    fmt.Sprintf("%s/%s", f.Kind, f.Name),
+				Namespace:   f.Namespace,
+				Message:     f.Message,
+				Remediation: f.Remediation,
+				Command:     f.Command,
+			})
+		}
+	}
+
+	// Timing bomb findings
+	if combined.TimingBombs != nil {
+		for _, f := range combined.TimingBombs.Findings {
+			findings = append(findings, NormalizedFinding{
+				ID:          f.CCVEID,
+				Title:       fmt.Sprintf("%s/%s expires %s", f.Kind, f.Name, f.ExpiresIn),
+				Category:    f.Category,
+				Track:       "timing-bomb",
+				Severity:    f.Severity,
+				Resource:    fmt.Sprintf("%s/%s", f.Kind, f.Name),
+				Namespace:   f.Namespace,
+				Message:     f.Message,
+				Remediation: f.Remediation,
+				Command:     f.Command,
+			})
+		}
+	}
+
+	// Unresolved findings
+	if combined.Unresolved != nil {
+		for _, f := range combined.Unresolved.Findings {
+			findings = append(findings, NormalizedFinding{
+				ID:        f.CCVEID,
+				Title:     fmt.Sprintf("%s unresolved %s", f.Source, f.FindingType),
+				Category:  f.Category,
+				Track:     "unresolved",
+				Severity:  f.Severity,
+				Resource:  fmt.Sprintf("%s/%s", f.Kind, f.Name),
+				Namespace: f.Namespace,
+				Message:   f.Message,
+				Command:   f.Command,
+			})
+		}
+	}
+
+	// Dangling findings
+	if combined.Dangling != nil {
+		for _, f := range combined.Dangling.Findings {
+			findings = append(findings, NormalizedFinding{
+				ID:          f.CCVEID,
+				Title:       fmt.Sprintf("Dangling %s/%s", f.Kind, f.Name),
+				Category:    f.Category,
+				Track:       "dangling",
+				Severity:    f.Severity,
+				Resource:    fmt.Sprintf("%s/%s", f.Kind, f.Name),
+				Namespace:   f.Namespace,
+				Message:     f.Message,
+				Remediation: f.Remediation,
+				Command:     f.Command,
+			})
+		}
+	}
+
+	// Static findings
+	if combined.Static != nil {
+		for _, f := range combined.Static.Findings {
+			findings = append(findings, NormalizedFinding{
+				ID:          f.CCVEID,
+				Title:       f.Name,
+				Category:    f.Category,
+				Track:       "static",
+				Severity:    f.Severity,
+				Resource:    fmt.Sprintf("%s/%s", f.Kind, f.ResourceName),
+				Namespace:   f.Namespace,
+				Message:     f.Message,
+				Remediation: f.Remediation,
+			})
+		}
+	}
+
+	// Lifecycle hazard findings
+	if combined.LifecycleHazards != nil {
+		for _, f := range combined.LifecycleHazards.Findings {
+			findings = append(findings, NormalizedFinding{
+				ID:          f.Rule,
+				Title:       f.Risk,
+				Category:    "LIFECYCLE",
+				Track:       "lifecycle",
+				Severity:    f.Severity,
+				Resource:    f.Resource,
+				Namespace:   f.Namespace,
+				Message:     f.Risk,
+				Remediation: f.Remediation,
+			})
+		}
+	}
+
+	// Build summary
+	summary := NormalizedSummary{Total: len(findings)}
+	for _, f := range findings {
+		switch f.Severity {
+		case "critical":
+			summary.Critical++
+		case "warning":
+			summary.Warning++
+		default:
+			summary.Info++
+		}
+	}
+
+	// Determine scannedAt from available results
+	scannedAt := time.Now()
+	if combined.State != nil && !combined.State.ScannedAt.IsZero() {
+		scannedAt = combined.State.ScannedAt
+	} else if combined.Kyverno != nil && !combined.Kyverno.ScannedAt.IsZero() {
+		scannedAt = combined.Kyverno.ScannedAt
+	} else if combined.Static != nil && !combined.Static.ScannedAt.IsZero() {
+		scannedAt = combined.Static.ScannedAt
+	}
+
+	return &NormalizedResult{
+		SchemaVersion: NormalizedSchemaVersion,
+		ScannedAt:     scannedAt,
+		Findings:      findings,
+		Summary:       summary,
+	}
+}

--- a/internal/scan/normalized_test.go
+++ b/internal/scan/normalized_test.go
@@ -1,0 +1,281 @@
+package scan
+
+import (
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestNormalize_Nil(t *testing.T) {
+	got := Normalize(nil)
+	if got.SchemaVersion != NormalizedSchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", got.SchemaVersion, NormalizedSchemaVersion)
+	}
+	if len(got.Findings) != 0 {
+		t.Errorf("Findings = %d items, want 0", len(got.Findings))
+	}
+}
+
+func TestNormalize_EmptyResult(t *testing.T) {
+	got := Normalize(&CombinedResult{})
+	if got.Summary.Total != 0 {
+		t.Errorf("Total = %d, want 0", got.Summary.Total)
+	}
+}
+
+func TestNormalize_StateFindings(t *testing.T) {
+	now := time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC)
+	combined := &CombinedResult{
+		State: &agent.StateScanResult{
+			ScannedAt: now,
+			Findings: []agent.StuckFinding{
+				{
+					CCVEID:      "CCVE-2025-0001",
+					Category:    "STATE",
+					Severity:    "critical",
+					Kind:        "HelmRelease",
+					Name:        "payment-api",
+					Namespace:   "prod",
+					Message:     "Stuck for 45m",
+					Remediation: "Suspend and resume",
+					Command:     "flux suspend hr payment-api -n prod",
+				},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+
+	if got.Summary.Total != 1 {
+		t.Fatalf("Total = %d, want 1", got.Summary.Total)
+	}
+	if got.Summary.Critical != 1 {
+		t.Errorf("Critical = %d, want 1", got.Summary.Critical)
+	}
+
+	f := got.Findings[0]
+	if f.ID != "CCVE-2025-0001" {
+		t.Errorf("ID = %q, want CCVE-2025-0001", f.ID)
+	}
+	if f.Track != "state" {
+		t.Errorf("Track = %q, want state", f.Track)
+	}
+	if f.Resource != "HelmRelease/payment-api" {
+		t.Errorf("Resource = %q, want HelmRelease/payment-api", f.Resource)
+	}
+	if f.Namespace != "prod" {
+		t.Errorf("Namespace = %q, want prod", f.Namespace)
+	}
+	if f.Command != "flux suspend hr payment-api -n prod" {
+		t.Errorf("Command = %q, want flux suspend hr payment-api -n prod", f.Command)
+	}
+	if !got.ScannedAt.Equal(now) {
+		t.Errorf("ScannedAt = %v, want %v", got.ScannedAt, now)
+	}
+}
+
+func TestNormalize_KyvernoFindings(t *testing.T) {
+	combined := &CombinedResult{
+		Kyverno: &agent.ScanResult{
+			ScannedAt: time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC),
+			Findings: []agent.ScanFinding{
+				{
+					ID:         "finding-1",
+					PolicyID:   "KPOL-001",
+					PolicyName: "require-labels",
+					Category:   "best-practices",
+					Severity:   "warning",
+					Resource:   "Deployment/nginx",
+					Namespace:  "default",
+					Message:    "Missing required labels",
+				},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+
+	if got.Summary.Total != 1 {
+		t.Fatalf("Total = %d, want 1", got.Summary.Total)
+	}
+
+	f := got.Findings[0]
+	if f.ID != "KPOL-001" {
+		t.Errorf("ID = %q, want KPOL-001 (PolicyID takes precedence)", f.ID)
+	}
+	if f.Track != "kyverno" {
+		t.Errorf("Track = %q, want kyverno", f.Track)
+	}
+	if f.Title != "require-labels" {
+		t.Errorf("Title = %q, want require-labels", f.Title)
+	}
+}
+
+func TestNormalize_StaticFindings(t *testing.T) {
+	combined := &CombinedResult{
+		Static: &agent.StaticScanResult{
+			ScannedAt:     time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC),
+			File:          "deploy.yaml",
+			ResourceCount: 1,
+			Findings: []agent.StaticFinding{
+				{
+					CCVEID:       "CCVE-2025-0248",
+					Name:         "Missing resource limits",
+					Kind:         "Deployment",
+					ResourceName: "nginx",
+					Severity:     "warning",
+					Category:     "CONFIG",
+					Message:      "No resource limits defined",
+					Remediation:  "Add resource limits",
+				},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+
+	if got.Summary.Total != 1 {
+		t.Fatalf("Total = %d, want 1", got.Summary.Total)
+	}
+
+	f := got.Findings[0]
+	if f.ID != "CCVE-2025-0248" {
+		t.Errorf("ID = %q, want CCVE-2025-0248", f.ID)
+	}
+	if f.Track != "static" {
+		t.Errorf("Track = %q, want static", f.Track)
+	}
+	if f.Resource != "Deployment/nginx" {
+		t.Errorf("Resource = %q, want Deployment/nginx", f.Resource)
+	}
+}
+
+func TestNormalize_MixedTracks(t *testing.T) {
+	combined := &CombinedResult{
+		State: &agent.StateScanResult{
+			ScannedAt: time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC),
+			Findings: []agent.StuckFinding{
+				{CCVEID: "CCVE-1", Severity: "critical", Kind: "HR", Name: "a", Namespace: "ns"},
+			},
+		},
+		Kyverno: &agent.ScanResult{
+			Findings: []agent.ScanFinding{
+				{ID: "f-1", PolicyID: "KPOL-1", Severity: "warning", PolicyName: "pol", Resource: "Deploy/b", Namespace: "ns"},
+			},
+		},
+		Static: &agent.StaticScanResult{
+			Findings: []agent.StaticFinding{
+				{CCVEID: "CCVE-2", Severity: "info", Name: "check", Kind: "Deploy", ResourceName: "c"},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+
+	if got.Summary.Total != 3 {
+		t.Errorf("Total = %d, want 3", got.Summary.Total)
+	}
+	if got.Summary.Critical != 1 {
+		t.Errorf("Critical = %d, want 1", got.Summary.Critical)
+	}
+	if got.Summary.Warning != 1 {
+		t.Errorf("Warning = %d, want 1", got.Summary.Warning)
+	}
+	if got.Summary.Info != 1 {
+		t.Errorf("Info = %d, want 1", got.Summary.Info)
+	}
+
+	// Verify ordering: kyverno, then state, then static (source order)
+	tracks := make([]string, len(got.Findings))
+	for i, f := range got.Findings {
+		tracks[i] = f.Track
+	}
+	if tracks[0] != "kyverno" || tracks[1] != "state" || tracks[2] != "static" {
+		t.Errorf("Tracks = %v, want [kyverno state static]", tracks)
+	}
+}
+
+func TestNormalize_DanglingFindings(t *testing.T) {
+	combined := &CombinedResult{
+		Dangling: &agent.DanglingResult{
+			Findings: []agent.DanglingFinding{
+				{
+					CCVEID:    "CCVE-2025-0100",
+					Category:  "DANGLING",
+					Severity:  "warning",
+					Kind:      "Service",
+					Name:      "orphaned-svc",
+					Namespace: "default",
+					Message:   "No matching pods",
+				},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+	if got.Summary.Total != 1 {
+		t.Fatalf("Total = %d, want 1", got.Summary.Total)
+	}
+	f := got.Findings[0]
+	if f.Track != "dangling" {
+		t.Errorf("Track = %q, want dangling", f.Track)
+	}
+}
+
+func TestNormalize_TimingBombFindings(t *testing.T) {
+	combined := &CombinedResult{
+		TimingBombs: &agent.TimingBombResult{
+			Findings: []agent.TimingBombFinding{
+				{
+					CCVEID:    "CCVE-2025-0200",
+					Category:  "TIMING",
+					Severity:  "critical",
+					Kind:      "Certificate",
+					Name:      "tls-cert",
+					Namespace: "istio-system",
+					ExpiresIn: "2d",
+					Message:   "Expires in 2 days",
+				},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+	if got.Summary.Total != 1 {
+		t.Fatalf("Total = %d, want 1", got.Summary.Total)
+	}
+	f := got.Findings[0]
+	if f.Track != "timing-bomb" {
+		t.Errorf("Track = %q, want timing-bomb", f.Track)
+	}
+}
+
+func TestNormalize_LifecycleFindings(t *testing.T) {
+	combined := &CombinedResult{
+		LifecycleHazards: &agent.LifecycleHazardResult{
+			Findings: []agent.LifecycleHazardFinding{
+				{
+					Rule:        "helm-hook-ambiguity",
+					Resource:    "Job/db-migrate",
+					Namespace:   "prod",
+					Severity:    "warning",
+					Risk:        "Helm hook may conflict with ArgoCD sync",
+					Remediation: "Convert to ArgoCD sync hook",
+				},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+	if got.Summary.Total != 1 {
+		t.Fatalf("Total = %d, want 1", got.Summary.Total)
+	}
+	f := got.Findings[0]
+	if f.Track != "lifecycle" {
+		t.Errorf("Track = %q, want lifecycle", f.Track)
+	}
+	if f.ID != "helm-hook-ambiguity" {
+		t.Errorf("ID = %q, want helm-hook-ambiguity", f.ID)
+	}
+}

--- a/internal/scan/provider_contract_test.go
+++ b/internal/scan/provider_contract_test.go
@@ -1,0 +1,70 @@
+package scan
+
+import (
+	"context"
+	"testing"
+)
+
+// providerContractSuite runs shared contract assertions against any Provider.
+// This ensures all implementations behave consistently for core operations.
+func providerContractSuite(t *testing.T, name string, p Provider) {
+	t.Helper()
+
+	t.Run(name+"/Name_NonEmpty", func(t *testing.T) {
+		if got := p.Name(); got == "" {
+			t.Error("Name() returned empty string")
+		}
+	})
+
+	t.Run(name+"/ScanFile_CleanYAML", func(t *testing.T) {
+		fixture := findTestFixture(t, "test/golden/scan-file/testdata/inputs/clean-deployment.yaml")
+		result, err := p.ScanFile(context.Background(), FileScanOpts{
+			Filename: fixture,
+		})
+		if err != nil {
+			t.Fatalf("ScanFile() error = %v", err)
+		}
+		if result.Static == nil {
+			t.Fatal("Static result is nil for clean YAML")
+		}
+		if len(result.Static.Findings) != 0 {
+			t.Errorf("Findings = %d, want 0 for clean YAML", len(result.Static.Findings))
+		}
+	})
+
+	t.Run(name+"/ScanFile_MalformedYAML", func(t *testing.T) {
+		// A nonexistent file exercises the error path without needing
+		// a real malformed fixture.
+		result, err := p.ScanFile(context.Background(), FileScanOpts{
+			Filename: "/nonexistent/file.yaml",
+		})
+		// Either a Go error or an error in the result is acceptable.
+		if err != nil {
+			return // Go error — acceptable
+		}
+		if result == nil || result.Static == nil {
+			t.Fatal("expected non-nil Static result for error case")
+		}
+		if result.Static.Error == "" {
+			t.Error("Static.Error is empty, want error message for missing file")
+		}
+	})
+
+	t.Run(name+"/ListPolicies_NoDB", func(t *testing.T) {
+		// Providers constructed without a PolicyDBDir should return an error.
+		_, err := p.ListPolicies()
+		if err == nil {
+			t.Error("ListPolicies() error = nil, want error when no policy DB")
+		}
+	})
+}
+
+func TestProviderContract_Legacy(t *testing.T) {
+	p := NewLegacyProvider(ProviderConfig{PolicyDBDir: ""})
+	providerContractSuite(t, "legacy", p)
+}
+
+func TestProviderContract_Confighub(t *testing.T) {
+	p := NewConfighubScanProvider(ProviderConfig{PolicyDBDir: ""})
+	providerContractSuite(t, "confighub", p)
+}

--- a/internal/scan/types.go
+++ b/internal/scan/types.go
@@ -1,0 +1,75 @@
+// Package scan defines the scan provider boundary for cub-scout.
+//
+// Providers abstract scan execution so cub-scout can delegate to different
+// scan engines (legacy built-in scanners, confighub-scan, etc.) behind a
+// common interface. The CLI layer in cmd/cub-scout/scan.go owns rendering;
+// providers own execution.
+package scan
+
+import (
+	"context"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"k8s.io/client-go/rest"
+)
+
+// Provider abstracts scan execution behind a testable boundary.
+// Implementations: LegacyProvider (built-in), ConfighubScanProvider (future).
+type Provider interface {
+	// Name returns the provider identifier (e.g. "legacy", "confighub-scan").
+	Name() string
+
+	// ScanCluster runs enabled scan types against a live cluster.
+	ScanCluster(ctx context.Context, opts ClusterScanOpts) (*CombinedResult, error)
+
+	// ScanFile runs static analysis on a YAML file (no cluster required).
+	ScanFile(ctx context.Context, opts FileScanOpts) (*CombinedResult, error)
+
+	// ListPolicies returns the Kyverno policy catalog.
+	ListPolicies() ([]PolicyEntry, error)
+
+	// Available reports whether this provider can execute.
+	Available() bool
+}
+
+// ClusterScanOpts encapsulates all options for a cluster scan.
+type ClusterScanOpts struct {
+	Config              *rest.Config
+	Namespace           string
+	RunKyverno          bool
+	RunState            bool
+	RunTimingBombs      bool
+	RunUnresolved       bool
+	RunDangling         bool
+	RunLifecycleHazards bool
+	Threshold           time.Duration
+}
+
+// FileScanOpts encapsulates options for a static file scan.
+type FileScanOpts struct {
+	Filename            string
+	RunLifecycleHazards bool
+}
+
+// CombinedResult holds results from all scanner types.
+// Field names and JSON tags match the legacy CombinedScanResult exactly
+// to preserve serialization compatibility with golden tests and the
+// CUB_SCOUT_TEST_SCAN_JSON test hook.
+type CombinedResult struct {
+	Kyverno          *agent.ScanResult            `json:"kyverno,omitempty"`
+	State            *agent.StateScanResult       `json:"state,omitempty"`
+	TimingBombs      *agent.TimingBombResult      `json:"timingBombs,omitempty"`
+	Unresolved       *agent.UnresolvedResult      `json:"unresolved,omitempty"`
+	Dangling         *agent.DanglingResult        `json:"dangling,omitempty"`
+	LifecycleHazards *agent.LifecycleHazardResult `json:"lifecycleHazards,omitempty"`
+	Static           *agent.StaticScanResult      `json:"static,omitempty"`
+}
+
+// PolicyEntry represents a policy in the catalog listing.
+type PolicyEntry struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Severity string `json:"severity"`
+	Category string `json:"category"`
+}

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -3,7 +3,9 @@ package hub
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // Auth holds user authentication state.
@@ -74,6 +76,20 @@ func ClearAuth() error {
 func authConfigPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".cub-scout", "auth.json")
+}
+
+// CubCLIAuthenticated checks if the cub CLI has a valid auth token.
+// This checks the cub CLI's own token store (~/.confighub/tokens/),
+// which is separate from cub-scout's local auth.json.
+// Returns false if cub is not installed or has no valid token.
+// Note: this calls exec.Command so it is NOT suitable for hot paths.
+// Use IsAuthenticated() for fast local-file-only checks.
+func CubCLIAuthenticated() bool {
+	out, err := exec.Command("cub", "auth", "get-token").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
 }
 
 // IsPaidTier returns true if user has a paid subscription.

--- a/pkg/hub/auth_test.go
+++ b/pkg/hub/auth_test.go
@@ -157,6 +157,14 @@ func TestIsAuthenticated(t *testing.T) {
 	}
 }
 
+func TestCubCLIAuthenticated_NoCubBinary(t *testing.T) {
+	// When cub is not in PATH, CubCLIAuthenticated should return false.
+	t.Setenv("PATH", t.TempDir()) // empty dir — no cub binary
+	if CubCLIAuthenticated() {
+		t.Error("CubCLIAuthenticated() = true, want false when cub is not installed")
+	}
+}
+
 func TestIsPaidTier(t *testing.T) {
 	tests := []struct {
 		tier string

--- a/pkg/hub/mode.go
+++ b/pkg/hub/mode.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// ConfigHubHealthEndpoint is the endpoint used to check ConfigHub connectivity.
-	ConfigHubHealthEndpoint = "https://api.confighub.com/health"
+	ConfigHubHealthEndpoint = "https://hub.confighub.com/health"
 
 	// ConnectivityTimeout is the maximum time to wait for connectivity check.
 	ConnectivityTimeout = 2 * time.Second
@@ -87,14 +87,15 @@ func (m Mode) DisplayName() string {
 
 // CurrentMode returns the current operating mode.
 // It checks connectivity and authentication state.
+// Authentication is checked via both local auth.json and cub CLI token store.
 func CurrentMode() Mode {
 	// Check if user has disabled network or we're air-gapped
 	if !hasConnectivity() {
 		return Offline
 	}
 
-	// Check if user is authenticated
-	if IsAuthenticated() {
+	// Check if user is authenticated via local auth.json or cub CLI
+	if IsAuthenticated() || CubCLIAuthenticated() {
 		return Connected
 	}
 

--- a/pkg/hub/mode_test.go
+++ b/pkg/hub/mode_test.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+func TestConfigHubHealthEndpoint(t *testing.T) {
+	// Ensure the health endpoint points to the real ConfigHub domain.
+	// api.confighub.com does not exist — hub.confighub.com is correct.
+	want := "https://hub.confighub.com/health"
+	if ConfigHubHealthEndpoint != want {
+		t.Errorf("ConfigHubHealthEndpoint = %q, want %q", ConfigHubHealthEndpoint, want)
+	}
+}
+
 func TestMode_String(t *testing.T) {
 	tests := []struct {
 		mode Mode

--- a/test/golden/harness.go
+++ b/test/golden/harness.go
@@ -91,6 +91,58 @@ func RunCubScout(t *testing.T, args ...string) Result {
 	}
 }
 
+// RunCubScoutWithEnv executes the cub-scout binary with extra environment variables.
+func RunCubScoutWithEnv(t *testing.T, env map[string]string, args ...string) Result {
+	t.Helper()
+
+	binary := os.Getenv("CUB_SCOUT_BINARY")
+	if binary == "" {
+		binary = filepath.Join(projectRoot(t), "cub-scout")
+	}
+
+	if _, err := os.Stat(binary); os.IsNotExist(err) {
+		t.Fatalf("cub-scout binary not found at %s - run 'go build ./cmd/cub-scout' first", binary)
+	}
+
+	cmd := exec.Command(binary, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	cmd.Env = append(os.Environ(),
+		"NO_COLOR=1",
+		"TERM=dumb",
+		"CI=true",
+	)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	err := cmd.Run()
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("failed to run cub-scout: %v", err)
+		}
+	}
+
+	return Result{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}
+}
+
+// ProjectRoot returns the project root directory (exported for use by golden test packages).
+func ProjectRoot(t *testing.T) string {
+	t.Helper()
+	return projectRoot(t)
+}
+
 // Normalize removes non-deterministic content from CLI output:
 //   - ANSI escape codes (colors)
 //   - Timestamps (ISO 8601, RFC 3339, etc.)

--- a/test/golden/scan-normalized/scan_normalized_test.go
+++ b/test/golden/scan-normalized/scan_normalized_test.go
@@ -1,0 +1,211 @@
+// Package scannormalized provides golden tests for the --normalized-json scan output.
+//
+// These tests verify that the scan.normalized.v1 schema is produced correctly
+// via both scan paths:
+//   - --file (static file scan) + --normalized-json
+//   - CUB_SCOUT_TEST_SCAN_JSON (cluster scan hook) + --normalized-json
+//
+// IMPORTANT: These tests are fully offline - they do NOT require:
+//   - A Kubernetes cluster
+//   - Network access
+//   - kubectl
+package scannormalized
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/test/golden"
+)
+
+var updateGolden = os.Getenv("UPDATE_GOLDEN") == "1"
+
+func init() {
+	for _, arg := range os.Args {
+		if arg == "-update" || arg == "--update" {
+			updateGolden = true
+			break
+		}
+	}
+}
+
+// TestNormalizedJSON_FileScan verifies --file --normalized-json produces valid
+// scan.normalized.v1 output with correct track mapping for static findings.
+func TestNormalizedJSON_FileScan(t *testing.T) {
+	root := golden.ProjectRoot(t)
+	fixturePath := filepath.Join(root, "test", "golden", "scan-file", "testdata", "inputs", "misconfigured-deployment.yaml")
+
+	result := golden.RunCubScout(t, "scan", "--file", fixturePath, "--normalized-json")
+
+	// Exit code 1 because findings exist
+	golden.AssertExitCode(t, 1, result)
+
+	// Verify output is valid JSON with required schema fields
+	combined := result.Stdout + result.Stderr
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(combined), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, combined)
+	}
+
+	// Verify schema_version field
+	if sv, ok := output["schema_version"].(string); !ok || sv != "scan.normalized.v1" {
+		t.Errorf("schema_version = %v, want scan.normalized.v1", output["schema_version"])
+	}
+
+	// Verify findings array exists and has entries
+	if findings, ok := output["findings"].([]interface{}); !ok || len(findings) == 0 {
+		t.Errorf("expected non-empty findings array, got %v", output["findings"])
+	}
+
+	// Verify each finding has required fields and track = "static"
+	if findings, ok := output["findings"].([]interface{}); ok {
+		for i, f := range findings {
+			finding, ok := f.(map[string]interface{})
+			if !ok {
+				t.Errorf("finding[%d] is not an object", i)
+				continue
+			}
+			for _, field := range []string{"id", "title", "category", "track", "severity"} {
+				if _, ok := finding[field]; !ok {
+					t.Errorf("finding[%d] missing required field %q", i, field)
+				}
+			}
+			if track, ok := finding["track"].(string); ok && track != "static" {
+				t.Errorf("finding[%d] track = %q, want static for file scan", i, track)
+			}
+		}
+	}
+
+	// Normalize for golden comparison
+	goldenNormalized := normalizeNormalizedJSON(combined, fixturePath)
+	assertGolden(t, "file-scan-normalized", goldenNormalized)
+}
+
+// TestNormalizedJSON_ClusterScanHook verifies CUB_SCOUT_TEST_SCAN_JSON + --normalized-json
+// produces normalized output for cluster scan results with multiple tracks.
+func TestNormalizedJSON_ClusterScanHook(t *testing.T) {
+	root := golden.ProjectRoot(t)
+	fixturePath := filepath.Join(root, "test", "golden", "scan-normalized", "testdata", "inputs", "mixed-findings.json")
+
+	result := golden.RunCubScoutWithEnv(t,
+		map[string]string{"CUB_SCOUT_TEST_SCAN_JSON": fixturePath},
+		"scan", "--normalized-json",
+	)
+
+	// Exit code 0 (test hook path doesn't exit 1 for findings)
+	golden.AssertExitCode(t, 0, result)
+
+	// Verify output is valid JSON
+	combined := result.Stdout + result.Stderr
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(combined), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, combined)
+	}
+
+	// Verify schema_version
+	if sv, ok := output["schema_version"].(string); !ok || sv != "scan.normalized.v1" {
+		t.Errorf("schema_version = %v, want scan.normalized.v1", output["schema_version"])
+	}
+
+	// Verify findings from multiple tracks exist
+	tracks := map[string]bool{}
+	if findings, ok := output["findings"].([]interface{}); ok {
+		for _, f := range findings {
+			if finding, ok := f.(map[string]interface{}); ok {
+				if track, ok := finding["track"].(string); ok {
+					tracks[track] = true
+				}
+			}
+		}
+	}
+
+	// The mixed fixture has kyverno, state, and timing-bomb tracks
+	for _, expected := range []string{"kyverno", "state", "timing-bomb"} {
+		if !tracks[expected] {
+			t.Errorf("missing expected track %q in normalized output, got tracks: %v", expected, tracks)
+		}
+	}
+
+	// Normalize for golden comparison
+	goldenNormalized := normalizeNormalizedJSON(combined, fixturePath)
+	assertGolden(t, "cluster-scan-normalized", goldenNormalized)
+}
+
+// normalizeNormalizedJSON normalizes the JSON output for golden comparison.
+func normalizeNormalizedJSON(s string, fixturePath string) string {
+	// Replace fixture path
+	s = strings.ReplaceAll(s, fixturePath, "<FILE>")
+	s = strings.ReplaceAll(s, strings.ToLower(fixturePath), "<FILE>")
+
+	// Parse and re-marshal with stable formatting + timestamp normalization
+	var data interface{}
+	if err := json.Unmarshal([]byte(s), &data); err == nil {
+		data = normalizeJSONData(data)
+		if formatted, err := json.MarshalIndent(data, "", "  "); err == nil {
+			return string(formatted) + "\n"
+		}
+	}
+
+	return s
+}
+
+// normalizeJSONData recursively normalizes JSON data for golden comparison.
+func normalizeJSONData(data interface{}) interface{} {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for k, val := range v {
+			switch k {
+			case "scanned_at", "scannedAt":
+				result[k] = "<TIMESTAMP>"
+			case "file":
+				result[k] = "<FILE>"
+			default:
+				result[k] = normalizeJSONData(val)
+			}
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, val := range v {
+			result[i] = normalizeJSONData(val)
+		}
+		return result
+	default:
+		return data
+	}
+}
+
+// assertGolden compares output against golden file.
+func assertGolden(t *testing.T, name, actual string) {
+	t.Helper()
+
+	goldenPath := filepath.Join("testdata", name+".golden.json")
+
+	if updateGolden {
+		if err := os.MkdirAll("testdata", 0755); err != nil {
+			t.Fatalf("failed to create testdata dir: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(actual), 0644); err != nil {
+			t.Fatalf("failed to write golden file: %v", err)
+		}
+		t.Logf("updated golden file: %s", goldenPath)
+		return
+	}
+
+	expected, err := os.ReadFile(goldenPath)
+	if os.IsNotExist(err) {
+		t.Fatalf("golden file not found: %s\n\nActual output:\n%s\n\nRun with UPDATE_GOLDEN=1 to create it:\n  UPDATE_GOLDEN=1 go test ./test/golden/scan-normalized/...", goldenPath, actual)
+	}
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if actual != string(expected) {
+		t.Errorf("output does not match golden file %s\n\n--- EXPECTED ---\n%s\n--- ACTUAL ---\n%s",
+			goldenPath, string(expected), actual)
+	}
+}

--- a/test/golden/scan-normalized/testdata/cluster-scan-normalized.golden.json
+++ b/test/golden/scan-normalized/testdata/cluster-scan-normalized.golden.json
@@ -1,0 +1,46 @@
+{
+  "findings": [
+    {
+      "category": "",
+      "id": "KPOL-001",
+      "message": "Missing required label: team",
+      "namespace": "production",
+      "resource": "Deployment/frontend",
+      "severity": "warning",
+      "title": "require-labels",
+      "track": "kyverno"
+    },
+    {
+      "category": "stuck-reconciliation",
+      "command": "helm rollback payment-api -n ecommerce",
+      "id": "CCVE-2025-0027",
+      "message": "Helm upgrade failed: timed out",
+      "namespace": "ecommerce",
+      "remediation": "Check helm history and rollback",
+      "resource": "HelmRelease/payment-api",
+      "severity": "critical",
+      "title": "HelmRelease/payment-api stuck",
+      "track": "state"
+    },
+    {
+      "category": "",
+      "command": "kubectl get secret tls-cert -n ingress -o yaml",
+      "id": "CCVE-2025-0051",
+      "message": "Certificate expires in 17 days",
+      "namespace": "ingress",
+      "remediation": "Renew certificate",
+      "resource": "Secret/tls-cert",
+      "severity": "warning",
+      "title": "Secret/tls-cert expires 17d",
+      "track": "timing-bomb"
+    }
+  ],
+  "scanned_at": "\u003cTIMESTAMP\u003e",
+  "schema_version": "scan.normalized.v1",
+  "summary": {
+    "critical": 1,
+    "info": 0,
+    "total": 3,
+    "warning": 2
+  }
+}

--- a/test/golden/scan-normalized/testdata/file-scan-normalized.golden.json
+++ b/test/golden/scan-normalized/testdata/file-scan-normalized.golden.json
@@ -1,0 +1,34 @@
+{
+  "findings": [
+    {
+      "category": "SILENT",
+      "id": "CCVE-2025-0244",
+      "message": "livenessProbe timeout (15s) \u003e period (10s) - probe may never succeed",
+      "namespace": "default",
+      "remediation": "Ensure probe timeoutSeconds \u003c= periodSeconds",
+      "resource": "Deployment/misconfigured-app",
+      "severity": "warning",
+      "title": "Probe timeout exceeds period",
+      "track": "static"
+    },
+    {
+      "category": "CONFIG",
+      "id": "CCVE-2025-0248",
+      "message": "Container \"app\" has no resource limits defined",
+      "namespace": "default",
+      "remediation": "Add resources.limits.cpu and resources.limits.memory",
+      "resource": "Deployment/misconfigured-app",
+      "severity": "warning",
+      "title": "Missing resource limits",
+      "track": "static"
+    }
+  ],
+  "scanned_at": "\u003cTIMESTAMP\u003e",
+  "schema_version": "scan.normalized.v1",
+  "summary": {
+    "critical": 0,
+    "info": 0,
+    "total": 2,
+    "warning": 2
+  }
+}

--- a/test/golden/scan-normalized/testdata/inputs/mixed-findings.json
+++ b/test/golden/scan-normalized/testdata/inputs/mixed-findings.json
@@ -1,0 +1,72 @@
+{
+  "kyverno": {
+    "scannedAt": "2025-01-15T10:00:00Z",
+    "findings": [
+      {
+        "policyName": "require-labels",
+        "policyID": "KPOL-001",
+        "resource": "Deployment/frontend",
+        "namespace": "production",
+        "severity": "warning",
+        "message": "Missing required label: team",
+        "rule": "check-team-label"
+      }
+    ],
+    "summary": {
+      "critical": 0,
+      "warning": 1,
+      "info": 0,
+      "total": 1
+    }
+  },
+  "state": {
+    "scannedAt": "2025-01-15T10:00:00Z",
+    "findings": [
+      {
+        "ccveId": "CCVE-2025-0027",
+        "category": "stuck-reconciliation",
+        "severity": "critical",
+        "kind": "HelmRelease",
+        "name": "payment-api",
+        "namespace": "ecommerce",
+        "condition": "Ready=False",
+        "reason": "UpgradeFailed",
+        "message": "Helm upgrade failed: timed out",
+        "duration": "45m",
+        "remediation": "Check helm history and rollback",
+        "command": "helm rollback payment-api -n ecommerce"
+      }
+    ],
+    "summary": {
+      "helmReleaseStuck": 1,
+      "kustomizationStuck": 0,
+      "applicationStuck": 0,
+      "silentFailures": 0,
+      "total": 1
+    }
+  },
+  "timingBombs": {
+    "scannedAt": "2025-01-15T10:00:00Z",
+    "findings": [
+      {
+        "ccveId": "CCVE-2025-0051",
+        "severity": "warning",
+        "kind": "Secret",
+        "name": "tls-cert",
+        "namespace": "ingress",
+        "expiresAt": "2025-02-01T00:00:00Z",
+        "expiresIn": "17d",
+        "reason": "TLS certificate expiring",
+        "message": "Certificate expires in 17 days",
+        "remediation": "Renew certificate",
+        "command": "kubectl get secret tls-cert -n ingress -o yaml"
+      }
+    ],
+    "summary": {
+      "critical": 0,
+      "warning": 1,
+      "info": 0,
+      "total": 1
+    }
+  }
+}


### PR DESCRIPTION
## Changes

### Core Provider Refactoring
- Introduce `scan.Provider` interface for pluggable scan implementations
- Migrate legacy scanner orchestration from `cmd/scan.go` to `internal/scan/legacy_provider.go`
- Add `ProviderConfig` with resolution chain: explicit > env > legacy probe
- Create `ConfighubScanProvider` for future confighub-scan binary integration

### Normalized Output Schema
- Add `scan.normalized.v1` schema for universal finding representation
- Implement `Normalize()` to convert `CombinedResult` to normalized findings
- Support `--normalized-json` flag for cluster and file scans
- Deterministic mapping: Kyverno/State/Timing/Unresolved/Dangling/Static/Lifecycle → universal shape

### Refactored Scan Command
- Replace ad-hoc scanner instantiation with `provider.ScanCluster()` and `provider.ScanFile()`
- Remove `findPolicyDBDir()` — now handled by `ProviderConfig.ResolveConfig()`
- Simplify `listKPOLPolicies()` to use provider interface
- Consolidate Kyverno-not-installed handling

### Status Command Improvements
- Simplify auth flow: check local auth.json first, then cub CLI
- Remove unnecessary `IsAuthenticated()` guard
- Upgrade mode to "connected" when cub CLI context is available

### Documentation
- Expand `docs/reference/commands.md` with stability versions and examples
- Add `map status`, `map hooks`, `status`, bundle/catalog commands
- Reference CLI Contract for full schema details
- Update roadmap: clarify Import v1.0 scope, defer advanced features to 1.1+

### Testing
- Add golden test harness for normalized scanning
- Add config resolution tests (explicit/env/legacy probe chain)
- Add provider contract tests (ScanFile, ScanCluster, ListPolicies)
- Add confighub provider fallback tests

## Impact

- **Backward Compatible**: Legacy `--json` output unchanged; new `--normalized-json` is opt-in
- **Extensible**: Future `confighub-scan` binary can implement `Provider` interface
- **Testable**: Provider abstraction enables unit testing without cluster/filesystem mocking
- **Observable**: Normalized schema enables downstream tooling (evidence export, SaaS integration)