### PR TITLE
docs: v1.2 milestone scope and roadmap update

### DIFF
--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -116,5 +116,8 @@ git pull && go build ./cmd/cub-scout
 
 ## What's Next
 
-- **Phase C (v1.2):** Argo hierarchy intelligence — App-of-Apps parent/child lineage, ApplicationSet generator→instance lineage
-- **Phase D (v1.3):** Fleet and governance expansion — multi-cluster topology, revision history, incident views
+- **v1.2:** cub-scan integration + Argo hierarchy intelligence
+  - Wire `ConfighubScanProvider` to `cub-scan` binary (#190, #191, #192, #193)
+  - App-of-Apps parent/child lineage (#194)
+  - ApplicationSet generator→instance lineage (#195)
+- **v1.3:** Fleet and governance expansion — multi-cluster topology, revision history, incident views

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -469,12 +469,21 @@ Connected Mode does **not** introduce:
 
 ---
 
-### Linked v1.1 Issues (Docs + Contract Alignment)
+### Linked v1.1 Issues (Docs + Contract Alignment) — All Closed
 
-* #183 — align connected-import roadmap scope with shipped `cub-scout import`
-* #184 — reconcile `commands.md` completeness claim with actual coverage
-* #185 — fix `bundle summarize` default-format help mismatch
-* #186 — add app-centric transition mapping (App/Deployment/Target ↔ Space/Unit)
+* ~~#183~~ — align connected-import roadmap scope with shipped `cub-scout import`
+* ~~#184~~ — reconcile `commands.md` completeness claim with actual coverage
+* ~~#185~~ — fix `bundle summarize` default-format help mismatch
+* ~~#186~~ — add app-centric transition mapping (App/Deployment/Target ↔ Space/Unit)
+
+### v1.2 — cub-scan Integration + Argo Hierarchy (In Progress)
+
+* #190 — wire `ConfighubScanProvider.ScanFile()` to `cub-scan` binary
+* #191 — wire `ListPolicies()` to `risk-catalog-v1.json`
+* #192 — schema parity tests between `cub-scan Finding` and `scan.normalized.v1`
+* #193 — provider selection logic (auto-detect cub-scan)
+* #194 — Argo App-of-Apps parent/child lineage
+* #195 — ApplicationSet → generated Application lineage
 
 ---
 
@@ -491,8 +500,9 @@ Connected Mode does **not** introduce:
 
 * v0.x is **complete**
 * v1.0.0 is the stable contract baseline (2026-02-20)
-* v1.1 Phase A (trust hardening) and Phase B (connected foundation) are **complete**
-* Open issues: #3/#21 (kro), #149-#151 (delivery chain), #163-#166 (experiments/evidence), #183-#186 (docs/contract alignment)
+* v1.1.0 released (2026-02-25) — connected foundation, scan provider boundary, docs alignment
+* v1.2 in progress — cub-scan integration (#190-#193), Argo hierarchy (#194-#195)
+* Open backlog: #3/#21 (kro), #149-#151 (delivery chain), #163-#165 (experiments)
 * The remaining roadmap is **Connected Mode with ConfigHub**:
 
   * import


### PR DESCRIPTION
## Summary
- Updated `docs/roadmap.md` with v1.2 milestone scope (issues #190-#195)
- Updated `docs/releases/v1.1.0.md` "What's Next" section with v1.2 issue references
- Marked v1.1 issues as closed in roadmap

## Context
v1.1.0 was just released and tagged. This PR captures the v1.2 planning artifacts:
- #190: Wire ScanFile to cub-scan binary
- #191: Wire ListPolicies to risk catalog
- #192: Schema parity tests
- #193: Provider selection logic
- #194: Argo App-of-Apps lineage
- #195: ApplicationSet lineage

🤖 Generated with [Claude Code](https://claude.com/claude-code)