### PR TITLE
fix: integration test bugs found by real cluster verification

### DIFF
--- a/test/integration/scan_provider_test.go
+++ b/test/integration/scan_provider_test.go
@@ -25,7 +25,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -122,10 +121,11 @@ func TestScanProvider_FileScan_WithFakeCubScan(t *testing.T) {
 	}
 
 	// Verify finding IDs match what fake binary returns
+	// JSON output uses snake_case: ccve_id (from StaticFinding.CCVEID json tag)
 	if len(findings) >= 1 {
 		f0, _ := findings[0].(map[string]interface{})
-		if ccve, _ := f0["ccveId"].(string); ccve != "CCVE-2025-0244" {
-			t.Errorf("findings[0].ccveId = %q, want CCVE-2025-0244", ccve)
+		if ccve, _ := f0["ccve_id"].(string); ccve != "CCVE-2025-0244" {
+			t.Errorf("findings[0].ccve_id = %q, want CCVE-2025-0244", ccve)
 		}
 	}
 }

--- a/test/integration/trace_lineage_test.go
+++ b/test/integration/trace_lineage_test.go
@@ -47,7 +47,7 @@ func TestTraceLineage_JSONContractShape(t *testing.T) {
 	ns, name := parts[0], parts[1]
 
 	// Run trace --json
-	output := runCubAgentAllowFailures(t, "trace", "deploy/"+name, "-n", ns, "--json")
+	output := runCubAgentAllowFailures(t, "trace", "deploy/"+name, "-n", ns, "--format", "json")
 
 	// Parse JSON
 	var result map[string]interface{}
@@ -126,7 +126,7 @@ func TestTraceLineage_ArgoAppWithParent(t *testing.T) {
 	}
 
 	// Trace the child application
-	output := runCubAgentAllowFailures(t, "trace", "application/"+targetName, "-n", targetNS, "--json")
+	output := runCubAgentAllowFailures(t, "trace", "application/"+targetName, "-n", targetNS, "--format", "json")
 
 	var result map[string]interface{}
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
@@ -196,7 +196,7 @@ func TestTraceLineage_ArgoAppFromApplicationSet(t *testing.T) {
 	}
 
 	// Trace the generated application
-	output := runCubAgentAllowFailures(t, "trace", "application/"+targetName, "-n", targetNS, "--json")
+	output := runCubAgentAllowFailures(t, "trace", "application/"+targetName, "-n", targetNS, "--format", "json")
 
 	var result map[string]interface{}
 	if err := json.Unmarshal([]byte(output), &result); err != nil {

--- a/test/prove-it-works.sh
+++ b/test/prove-it-works.sh
@@ -225,9 +225,10 @@ if [[ $CURRENT_IDX -ge 2 ]]; then
         run_test "scan --json" "./cub-scout scan --json"
 
         subsection "Scan Provider Selection (v1.2)"
-        run_test "scan --file (legacy override)" "CUB_SCOUT_SCAN_PROVIDER=legacy ./cub-scout scan --file test/golden/scan-file/testdata/inputs/misconfigured-deployment.yaml --json > /dev/null"
+        # scan --file exits 1 when findings exist (by design), so use clean fixture for provider tests
+        run_test "scan --file (legacy override)" "CUB_SCOUT_SCAN_PROVIDER=legacy ./cub-scout scan --file test/golden/scan-file/testdata/inputs/clean-deployment.yaml --json > /dev/null"
         if command -v confighub-scan > /dev/null 2>&1 || command -v cub-scan > /dev/null 2>&1; then
-            run_test "scan --file (cub-scan detected)" "./cub-scout scan --file test/golden/scan-file/testdata/inputs/misconfigured-deployment.yaml --json > /dev/null"
+            run_test "scan --file (cub-scan detected)" "./cub-scout scan --file test/golden/scan-file/testdata/inputs/clean-deployment.yaml --json > /dev/null"
         else
             skip_test "scan --file (cub-scan)" "confighub-scan/cub-scan not on PATH"
         fi
@@ -304,11 +305,11 @@ EOF"
         run_test "trace flux app" "./cub-scout trace deployment/cart -n boutique"
 
         subsection "Trace Lineage (v1.2)"
-        # Verify trace --json includes lineage fields in schema (even if empty)
-        run_test "trace --json schema" "./cub-scout trace deployment/cart -n boutique --json 2>/dev/null | python3 -c 'import sys,json; d=json.load(sys.stdin); assert \"object\" in d, \"missing object field\"' 2>/dev/null || true"
+        # Verify trace --format json includes lineage fields in schema (even if empty)
+        run_test "trace json schema" "./cub-scout trace deployment/cart -n boutique --format json 2>/dev/null | python3 -c 'import sys,json; d=json.load(sys.stdin); assert \"object\" in d, \"missing object field\"' 2>/dev/null || true"
         # If ArgoCD app exists, verify lineage fields
         if kubectl get application guestbook -n argocd > /dev/null 2>&1; then
-            run_test "trace argo lineage" "./cub-scout trace application/guestbook -n argocd --json 2>/dev/null | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"lineage:\", d.get(\"parentApplication\",\"\"), d.get(\"generatedByApplicationSet\",\"\"), d.get(\"lineageConfidence\",\"\"))'"
+            run_test "trace argo lineage" "./cub-scout trace application/guestbook -n argocd --format json 2>/dev/null | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"lineage:\", d.get(\"parentApplication\",\"\"), d.get(\"generatedByApplicationSet\",\"\"), d.get(\"lineageConfidence\",\"\"))'"
         fi
 
         subsection "Deep Dive"


### PR DESCRIPTION
## Summary

Bugs found by running `prove-it-works.sh --level=integration` against a real cluster:

- **scan_provider_test**: `ccveId` → `ccve_id` (JSON output uses snake_case)
- **scan_provider_test**: unused `"strings"` import (only compiles with `-tags=integration`)
- **trace_lineage_test**: `--json` → `--format json` (`--json` is deprecated)
- **prove-it-works.sh**: use `clean-deployment.yaml` for provider test (misconfigured exits 1)
- **prove-it-works.sh**: `--json` → `--format json` in trace lineage section

## Verification results on real cluster

| Test | Result |
|------|--------|
| `prove-it-works.sh --level=integration` | ✓ 14/14 pass (1 skip: no cub-scan binary) |
| `go test -tags=integration` (scan provider + trace lineage) | ✓ 5 pass, 2 skip (no App-of-Apps/AppSet on cluster) |
| `import --dry-run -n monitoring` | ✓ Discovers 2 workloads, correct proposal |
| `map list --json` | ✓ 57 resources, owners: [Flux, Native] |
| `scan` | ✓ No issues found |

## Test plan

- [x] `go test ./...` passes
- [x] `go test -tags=integration ./test/integration/... -run "TestScanProvider|TestTraceLineage"` passes on real cluster
- [x] `prove-it-works.sh --level=integration` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)