### PR TITLE
M2/M3: bundle import contract + evidence + git↔bundle compare primitive

### DIFF
--- a/cmd/cub-scout/combined.go
+++ b/cmd/cub-scout/combined.go
@@ -19,6 +19,7 @@ var (
 	combinedGitURL    string
 	combinedGitPath   string
 	combinedNamespace string
+	combinedBundle    string
 	combinedJSON      bool
 	combinedSuggest   bool
 	combinedApply     bool
@@ -70,6 +71,9 @@ Examples:
 
   # Use local Git repo with JSON output
   cub-scout combined --git-path ./my-repo --namespace demo --suggest --json
+
+  # Offline Git ↔ cluster compare from a debug bundle
+  cub-scout combined --git-path ./my-repo --bundle ./debug-bundle --json
 `,
 	RunE: runCombined,
 }
@@ -78,6 +82,7 @@ func init() {
 	combinedCmd.Flags().StringVar(&combinedGitURL, "git-url", "", "Git repository URL to parse")
 	combinedCmd.Flags().StringVar(&combinedGitPath, "git-path", "", "Local path to Git repository")
 	combinedCmd.Flags().StringVarP(&combinedNamespace, "namespace", "n", "", "Namespace to scan in cluster")
+	combinedCmd.Flags().StringVar(&combinedBundle, "bundle", "", "Debug bundle directory to use as cluster snapshot (offline)")
 	combinedCmd.Flags().BoolVar(&combinedJSON, "json", false, "Output as JSON")
 	combinedCmd.Flags().BoolVar(&combinedSuggest, "suggest", false, "Generate App model proposal")
 	combinedCmd.Flags().BoolVar(&combinedApply, "apply", false, "Create App and Deployments in ConfigHub")
@@ -125,20 +130,17 @@ func runCombined(cmd *cobra.Command, args []string) error {
 		result.GitRepo = repo
 	}
 
-	// Scan cluster if namespace provided
-	var workloads []WorkloadInfo
-	if combinedNamespace != "" {
-		var err error
-		workloads, err = discoverWorkloads(combinedNamespace)
-		if err != nil {
-			return fmt.Errorf("discover workloads: %w", err)
-		}
-
+	// Collect cluster-side workloads from live namespace OR bundle snapshot.
+	workloads, clusterNamespace, err := resolveCombinedWorkloadsSource(combinedNamespace, combinedBundle)
+	if err != nil {
+		return err
+	}
+	if len(workloads) > 0 || clusterNamespace != "" {
 		suggestion := SuggestHubAppSpaceStructure(workloads, "")
 		suggestionJSON := convertToSuggestionJSON(&suggestion)
 
 		result.Cluster = &ImportResult{
-			Namespace:  combinedNamespace,
+			Namespace:  clusterNamespace,
 			Model:      "hub-appspace",
 			Workloads:  convertToWorkloadJSON(workloads),
 			Suggestion: suggestionJSON,
@@ -184,6 +186,34 @@ func runCombined(cmd *cobra.Command, args []string) error {
 		printCombinedResult(result)
 	}
 	return nil
+}
+
+func resolveCombinedWorkloadsSource(namespace, bundlePath string) ([]WorkloadInfo, string, error) {
+	if namespace != "" && bundlePath != "" {
+		return nil, "", fmt.Errorf("--namespace and --bundle cannot be used together")
+	}
+
+	if bundlePath != "" {
+		_, workloads, namespaces, err := buildImportFromBundlePreview(bundlePath)
+		if err != nil {
+			return nil, "", fmt.Errorf("load bundle workloads: %w", err)
+		}
+		clusterNamespace := ""
+		if len(namespaces) > 0 {
+			clusterNamespace = namespaces[0]
+		}
+		return workloads, clusterNamespace, nil
+	}
+
+	if namespace != "" {
+		workloads, err := discoverWorkloads(namespace)
+		if err != nil {
+			return nil, "", fmt.Errorf("discover workloads: %w", err)
+		}
+		return workloads, namespace, nil
+	}
+
+	return []WorkloadInfo{}, "", nil
 }
 
 func buildAlignment(repo *gitops.RepoStructure, cluster *ImportResult) []AlignmentEntry {

--- a/cmd/cub-scout/combined_bundle_test.go
+++ b/cmd/cub-scout/combined_bundle_test.go
@@ -1,0 +1,199 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestResolveCombinedWorkloadsSource_FromBundle(t *testing.T) {
+	bundleDir := t.TempDir()
+	writer := agent.NewBundleWriter("test")
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "api",
+				Namespace: "payments",
+			},
+		},
+		Session: &agent.DebugSessionData{
+			StartedAt: time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC),
+			WorkloadHealth: &agent.WorkloadHealthSnapshot{
+				Kind:          "Deployment",
+				Name:          "api",
+				Namespace:     "payments",
+				Replicas:      2,
+				ReadyReplicas: 2,
+			},
+		},
+	}
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	workloads, namespace, err := resolveCombinedWorkloadsSource("", bundleDir)
+	if err != nil {
+		t.Fatalf("resolveCombinedWorkloadsSource() error = %v", err)
+	}
+	if namespace != "payments" {
+		t.Fatalf("namespace = %q, want payments", namespace)
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("len(workloads) = %d, want 1", len(workloads))
+	}
+	if workloads[0].Name != "api" {
+		t.Fatalf("workload name = %q, want api", workloads[0].Name)
+	}
+}
+
+func TestResolveCombinedWorkloadsSource_Conflict(t *testing.T) {
+	_, _, err := resolveCombinedWorkloadsSource("default", "/tmp/test-bundle")
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+}
+
+func TestResolveCombinedWorkloadsSource_Empty(t *testing.T) {
+	workloads, namespace, err := resolveCombinedWorkloadsSource("", "")
+	if err != nil {
+		t.Fatalf("resolveCombinedWorkloadsSource() error = %v", err)
+	}
+	if namespace != "" {
+		t.Fatalf("namespace = %q, want empty", namespace)
+	}
+	if len(workloads) != 0 {
+		t.Fatalf("len(workloads) = %d, want 0", len(workloads))
+	}
+}
+
+func TestRunCombined_GitPathWithBundleJSON(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, "apps", "base", "api"), 0o755); err != nil {
+		t.Fatalf("mkdir base app: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "apps", "prod"), 0o755); err != nil {
+		t.Fatalf("mkdir prod: %v", err)
+	}
+	baseKustomization := []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n")
+	if err := os.WriteFile(filepath.Join(repoDir, "apps", "base", "api", "kustomization.yaml"), baseKustomization, 0o644); err != nil {
+		t.Fatalf("write base kustomization: %v", err)
+	}
+	prodKustomization := []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n- ../base/api\n")
+	if err := os.WriteFile(filepath.Join(repoDir, "apps", "prod", "kustomization.yaml"), prodKustomization, 0o644); err != nil {
+		t.Fatalf("write prod kustomization: %v", err)
+	}
+
+	bundleDir := t.TempDir()
+	writer := agent.NewBundleWriter("test")
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "api",
+				Namespace: "payments",
+			},
+		},
+		Session: &agent.DebugSessionData{
+			WorkloadHealth: &agent.WorkloadHealthSnapshot{
+				Kind:          "Deployment",
+				Name:          "api",
+				Namespace:     "payments",
+				Replicas:      1,
+				ReadyReplicas: 1,
+			},
+		},
+	}
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	restore := setCombinedFlagState(combinedFlagState{
+		gitPath: repoDir,
+		bundle:  bundleDir,
+		json:    true,
+	})
+	defer restore()
+
+	output := captureStdout(t, func() {
+		if err := runCombined(nil, nil); err != nil {
+			t.Fatalf("runCombined() error = %v", err)
+		}
+	})
+
+	var result CombinedResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("parse combined JSON: %v\n%s", err, output)
+	}
+
+	if result.Cluster == nil {
+		t.Fatal("cluster result is nil")
+	}
+	if result.Cluster.Namespace != "payments" {
+		t.Fatalf("cluster namespace = %q, want payments", result.Cluster.Namespace)
+	}
+	if len(result.Alignment) == 0 {
+		t.Fatal("alignment is empty")
+	}
+	foundAligned := false
+	for _, a := range result.Alignment {
+		if a.App == "api" && a.Status == "aligned" {
+			foundAligned = true
+			break
+		}
+	}
+	if !foundAligned {
+		t.Fatalf("expected aligned entry for app=api, got %+v", result.Alignment)
+	}
+}
+
+type combinedFlagState struct {
+	gitURL    string
+	gitPath   string
+	namespace string
+	bundle    string
+	json      bool
+	suggest   bool
+	apply     bool
+	dryRun    bool
+}
+
+func setCombinedFlagState(next combinedFlagState) func() {
+	prev := combinedFlagState{
+		gitURL:    combinedGitURL,
+		gitPath:   combinedGitPath,
+		namespace: combinedNamespace,
+		bundle:    combinedBundle,
+		json:      combinedJSON,
+		suggest:   combinedSuggest,
+		apply:     combinedApply,
+		dryRun:    combinedDryRun,
+	}
+
+	combinedGitURL = next.gitURL
+	combinedGitPath = next.gitPath
+	combinedNamespace = next.namespace
+	combinedBundle = next.bundle
+	combinedJSON = next.json
+	combinedSuggest = next.suggest
+	combinedApply = next.apply
+	combinedDryRun = next.dryRun
+
+	return func() {
+		combinedGitURL = prev.gitURL
+		combinedGitPath = prev.gitPath
+		combinedNamespace = prev.namespace
+		combinedBundle = prev.bundle
+		combinedJSON = prev.json
+		combinedSuggest = prev.suggest
+		combinedApply = prev.apply
+		combinedDryRun = prev.dryRun
+	}
+}

--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -24,14 +25,15 @@ import (
 )
 
 var (
-	importNamespace string
-	importDryRun    bool
-	importYes       bool
-	importJSON      bool
-	importNoLog     bool
-	importWizard    bool
-	importConnect   bool
-	importNoConnect bool
+	importNamespace  string
+	importDryRun     bool
+	importYes        bool
+	importJSON       bool
+	importNoLog      bool
+	importWizard     bool
+	importConnect    bool
+	importNoConnect  bool
+	importFromBundle string
 )
 
 type cubTargetRef struct {
@@ -121,6 +123,11 @@ type UnitJSON struct {
 	Workloads []string `json:"workloads"`
 }
 
+type importEvidenceJSON struct {
+	Source     string `json:"source"`
+	BundlePath string `json:"bundlePath,omitempty"`
+}
+
 var importCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Import workloads into ConfigHub",
@@ -157,6 +164,9 @@ Examples:
   # JSON output (for GUI integration)
   cub-scout import --json
 
+  # Preview import proposal from an existing debug bundle
+  cub-scout import --from-bundle ./debug-bundle --dry-run --json
+
   # Interactive TUI wizard (recommended)
   cub-scout import --wizard
 
@@ -175,6 +185,7 @@ func init() {
 	importCmd.Flags().BoolVarP(&importWizard, "wizard", "w", false, "Launch interactive TUI wizard")
 	importCmd.Flags().BoolVar(&importConnect, "connect", false, "After import, start worker and set targets")
 	importCmd.Flags().BoolVar(&importNoConnect, "no-connect", false, "Do not start worker/targets after import")
+	importCmd.Flags().StringVar(&importFromBundle, "from-bundle", "", "Import from a debug bundle directory instead of live cluster discovery")
 
 	rootCmd.AddCommand(importCmd)
 }
@@ -186,12 +197,20 @@ func runImport(cmd *cobra.Command, args []string) error {
 
 	// Wizard mode - launch interactive TUI
 	if importWizard {
+		if importFromBundle != "" {
+			return fmt.Errorf("--wizard cannot be used with --from-bundle")
+		}
 		return RunImportWizard()
 	}
 
 	// JSON mode = dry-run (never change anything when outputting JSON)
 	if importJSON {
 		importDryRun = true
+	}
+
+	// Bundle import path bypasses live cluster discovery.
+	if importFromBundle != "" {
+		return runImportFromBundle(importFromBundle)
 	}
 
 	// Initialize logger (unless disabled or JSON mode)
@@ -367,6 +386,230 @@ func runImport(cmd *cobra.Command, args []string) error {
 	}
 
 	return applyImportWithLogger(proposalToApply, scoutWorkloads, logger, shouldConnect)
+}
+
+func runImportFromBundle(bundlePath string) error {
+	if importNamespace != "" {
+		return fmt.Errorf("--namespace cannot be used with --from-bundle")
+	}
+
+	proposal, workloads, namespaces, err := buildImportFromBundlePreview(bundlePath)
+	if err != nil {
+		return err
+	}
+
+	if len(workloads) == 0 {
+		if importJSON {
+			return outputEmptyJSON()
+		}
+		fmt.Println("No workloads found in bundle.")
+		return nil
+	}
+
+	if importJSON {
+		return outputProposalJSON(proposal, workloads, namespaces)
+	}
+
+	printDiscovery(namespaces, workloads, proposal)
+
+	if importDryRun {
+		fmt.Println("\n(dry-run mode - no changes made)")
+		fmt.Println("Run without --dry-run to import.")
+		return nil
+	}
+
+	if !importYes {
+		fmt.Printf("\nImport this into ConfigHub? [y/N] ")
+		if !confirm() {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	// Connection behavior:
+	// - Interactive confirmation defaults to connect now
+	// - Non-interactive (-y) preserves legacy behavior unless --connect is set
+	shouldConnect := importConnect
+	if !importYes && !importNoConnect && !importConnect {
+		shouldConnect = true
+	}
+	if importNoConnect {
+		shouldConnect = false
+	}
+
+	return applyImportWithLogger(proposal, workloads, nil, shouldConnect)
+}
+
+func buildImportFromBundlePreview(bundlePath string) (*FullProposal, []WorkloadInfo, []string, error) {
+	reader := agent.NewBundleReader()
+	bundle, err := reader.Read(bundlePath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("read bundle %q: %w", bundlePath, err)
+	}
+
+	workload, err := workloadFromBundle(bundle)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	workloads := []WorkloadInfo{workload}
+	namespaces := collectNamespacesFromWorkloads(workloads, bundle.Metadata.Target.Namespace)
+	proposal := SuggestFullProposal(nil, workloads, "")
+	return proposal, workloads, namespaces, nil
+}
+
+func workloadFromBundle(bundle *agent.DebugBundle) (WorkloadInfo, error) {
+	kind := strings.TrimSpace(bundle.Metadata.Target.Kind)
+	name := strings.TrimSpace(bundle.Metadata.Target.Name)
+	namespace := strings.TrimSpace(bundle.Metadata.Target.Namespace)
+
+	workload := WorkloadInfo{
+		Kind:      kind,
+		Name:      name,
+		Namespace: namespace,
+		Owner:     "Native",
+		Replicas:  0,
+		Ready:     false,
+	}
+
+	if bundle.Session != nil {
+		if health := bundle.Session.WorkloadHealth; health != nil {
+			if strings.TrimSpace(health.Kind) != "" {
+				workload.Kind = strings.TrimSpace(health.Kind)
+			}
+			if strings.TrimSpace(health.Name) != "" {
+				workload.Name = strings.TrimSpace(health.Name)
+			}
+			if strings.TrimSpace(health.Namespace) != "" {
+				workload.Namespace = strings.TrimSpace(health.Namespace)
+			}
+			workload.Replicas = health.Replicas
+			workload.Ready = health.ReadyReplicas == health.Replicas
+		}
+
+		owner := inferOwnerFromBundleSession(bundle.Session)
+		if owner != "" {
+			workload.Owner = owner
+		}
+
+		workload.KustomizationPath, workload.ApplicationPath = inferPathsFromBundleSession(bundle.Session)
+		if bundle.Session.SourceStatus != nil {
+			workload.SourceRepo = strings.TrimSpace(bundle.Session.SourceStatus.URL)
+		}
+	}
+
+	if workload.Kind == "" || workload.Name == "" {
+		return WorkloadInfo{}, fmt.Errorf("bundle target is missing required kind/name")
+	}
+
+	return workload, nil
+}
+
+func inferOwnerFromBundleSession(session *agent.DebugSessionData) string {
+	if session == nil {
+		return "Native"
+	}
+
+	if session.OwnershipChain != nil {
+		if owner := normalizeOwnerFromBundle(session.OwnershipChain.Owner); owner != "" {
+			return owner
+		}
+		for _, link := range session.OwnershipChain.GitOpsChain {
+			if owner := ownerFromDeployerKind(link.Kind); owner != "" {
+				return owner
+			}
+		}
+	}
+
+	if session.DeployerStatus != nil {
+		if owner := ownerFromDeployerKind(session.DeployerStatus.Kind); owner != "" {
+			return owner
+		}
+	}
+
+	return "Native"
+}
+
+func inferPathsFromBundleSession(session *agent.DebugSessionData) (string, string) {
+	if session == nil || session.OwnershipChain == nil {
+		return "", ""
+	}
+
+	var kustomizationPath, applicationPath string
+	for _, link := range session.OwnershipChain.GitOpsChain {
+		path := strings.TrimSpace(link.Path)
+		if path == "" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(link.Kind)) {
+		case "kustomization":
+			if kustomizationPath == "" {
+				kustomizationPath = path
+			}
+		case "application":
+			if applicationPath == "" {
+				applicationPath = path
+			}
+		}
+	}
+	return kustomizationPath, applicationPath
+}
+
+func normalizeOwnerFromBundle(owner string) string {
+	switch strings.ToLower(strings.TrimSpace(owner)) {
+	case "":
+		return ""
+	case "argocd", "argo", "argo cd":
+		return "ArgoCD"
+	case "flux":
+		return "Flux"
+	case "helm":
+		return "Helm"
+	case "native":
+		return "Native"
+	case "confighub", "config hub":
+		return "ConfigHub"
+	case "terraform":
+		return "Terraform"
+	case "crossplane":
+		return "Crossplane"
+	default:
+		return strings.TrimSpace(owner)
+	}
+}
+
+func ownerFromDeployerKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "application", "applicationset":
+		return "ArgoCD"
+	case "kustomization", "helmrelease":
+		return "Flux"
+	default:
+		return ""
+	}
+}
+
+func collectNamespacesFromWorkloads(workloads []WorkloadInfo, fallback string) []string {
+	nsSet := make(map[string]struct{})
+	for _, w := range workloads {
+		ns := strings.TrimSpace(w.Namespace)
+		if ns != "" {
+			nsSet[ns] = struct{}{}
+		}
+	}
+
+	if len(nsSet) == 0 {
+		if fallback = strings.TrimSpace(fallback); fallback != "" {
+			nsSet[fallback] = struct{}{}
+		}
+	}
+
+	namespaces := make([]string, 0, len(nsSet))
+	for ns := range nsSet {
+		namespaces = append(namespaces, ns)
+	}
+	sort.Strings(namespaces)
+	return namespaces
 }
 
 // discoverNamespacesWithWorkloads finds all namespaces that have Deployments, StatefulSets, or DaemonSets
@@ -1404,6 +1647,7 @@ func outputEmptyJSON() error {
 		"namespaces": []string{},
 		"workloads":  []WorkloadJSON{},
 		"proposal":   nil,
+		"evidence":   buildImportEvidenceJSON(),
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
@@ -1432,11 +1676,24 @@ func outputProposalJSON(proposal *FullProposal, workloads []WorkloadInfo, namesp
 		"namespaces": namespaces,
 		"workloads":  wJSON,
 		"proposal":   proposal,
+		"evidence":   buildImportEvidenceJSON(),
 	}
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(result)
+}
+
+func buildImportEvidenceJSON() importEvidenceJSON {
+	if strings.TrimSpace(importFromBundle) != "" {
+		return importEvidenceJSON{
+			Source:     "bundle",
+			BundlePath: importFromBundle,
+		}
+	}
+	return importEvidenceJSON{
+		Source: "cluster",
+	}
 }
 
 // createUnitWithConfig creates a unit with initial configuration from stdin

--- a/cmd/cub-scout/import_bundle_test.go
+++ b/cmd/cub-scout/import_bundle_test.go
@@ -1,0 +1,445 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestBuildImportFromBundlePreview_BasicContract(t *testing.T) {
+	bundleDir := t.TempDir()
+	writer := agent.NewBundleWriter("test")
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "payments-api",
+				Namespace: "payments",
+				Cluster:   "kind-dev",
+			},
+		},
+		Session: &agent.DebugSessionData{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "payments-api",
+				Namespace: "payments",
+			},
+			StartedAt:   time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC),
+			CompletedAt: time.Date(2026, 2, 1, 10, 0, 5, 0, time.UTC),
+			WorkloadHealth: &agent.WorkloadHealthSnapshot{
+				Kind:          "Deployment",
+				Name:          "payments-api",
+				Namespace:     "payments",
+				Replicas:      3,
+				ReadyReplicas: 3,
+			},
+			OwnershipChain: &agent.OwnershipSnapshot{
+				Owner: "ArgoCD",
+			},
+			DeployerStatus: &agent.DeployerSnapshot{
+				Kind:      "Application",
+				Name:      "payments-prod",
+				Namespace: "argocd",
+				Ready:     true,
+			},
+		},
+	}
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	proposal, workloads, namespaces, err := buildImportFromBundlePreview(bundleDir)
+	if err != nil {
+		t.Fatalf("buildImportFromBundlePreview() error = %v", err)
+	}
+
+	if proposal == nil {
+		t.Fatal("proposal is nil")
+	}
+	if proposal.AppSpace == "" {
+		t.Error("proposal.appSpace is empty")
+	}
+	if len(proposal.Units) == 0 {
+		t.Error("proposal.units should not be empty")
+	}
+
+	if !reflect.DeepEqual(namespaces, []string{"payments"}) {
+		t.Fatalf("namespaces = %v, want [payments]", namespaces)
+	}
+
+	if len(workloads) != 1 {
+		t.Fatalf("len(workloads) = %d, want 1", len(workloads))
+	}
+	w := workloads[0]
+	if w.Kind != "Deployment" || w.Name != "payments-api" || w.Namespace != "payments" {
+		t.Fatalf("unexpected workload identity: %+v", w)
+	}
+	if w.Owner != "ArgoCD" {
+		t.Fatalf("workload owner = %q, want ArgoCD", w.Owner)
+	}
+	if w.Replicas != 3 {
+		t.Fatalf("workload replicas = %d, want 3", w.Replicas)
+	}
+	if !w.Ready {
+		t.Fatal("workload ready = false, want true")
+	}
+}
+
+func TestBuildImportFromBundlePreview_GracefulFallback(t *testing.T) {
+	bundleDir := t.TempDir()
+	writer := agent.NewBundleWriter("test")
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "StatefulSet",
+				Name:      "ledger",
+				Namespace: "finance",
+			},
+		},
+	}
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	proposal, workloads, namespaces, err := buildImportFromBundlePreview(bundleDir)
+	if err != nil {
+		t.Fatalf("buildImportFromBundlePreview() error = %v", err)
+	}
+	if proposal == nil {
+		t.Fatal("proposal is nil")
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("len(workloads) = %d, want 1", len(workloads))
+	}
+	if !reflect.DeepEqual(namespaces, []string{"finance"}) {
+		t.Fatalf("namespaces = %v, want [finance]", namespaces)
+	}
+
+	w := workloads[0]
+	if w.Owner != "Native" {
+		t.Fatalf("fallback owner = %q, want Native", w.Owner)
+	}
+	if w.Replicas != 0 {
+		t.Fatalf("fallback replicas = %d, want 0", w.Replicas)
+	}
+	if w.Ready {
+		t.Fatal("fallback ready = true, want false")
+	}
+}
+
+func TestBuildImportFromBundlePreview_InvalidTarget(t *testing.T) {
+	bundleDir := t.TempDir()
+	writer := agent.NewBundleWriter("test")
+	bundle := &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "",
+				Namespace: "payments",
+			},
+		},
+	}
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	_, _, _, err := buildImportFromBundlePreview(bundleDir)
+	if err == nil {
+		t.Fatal("expected error for invalid target, got nil")
+	}
+	if !strings.Contains(err.Error(), "target") {
+		t.Fatalf("error = %v, want target validation message", err)
+	}
+}
+
+func TestRunImport_FromBundleJSONContract(t *testing.T) {
+	bundleDir := writeImportBundleFixture(t, &agent.DebugBundle{
+		Metadata: agent.BundleMetadata{
+			Target: agent.BundleTarget{
+				Kind:      "Deployment",
+				Name:      "orders-api",
+				Namespace: "orders",
+			},
+		},
+		Session: &agent.DebugSessionData{
+			WorkloadHealth: &agent.WorkloadHealthSnapshot{
+				Kind:          "Deployment",
+				Name:          "orders-api",
+				Namespace:     "orders",
+				Replicas:      2,
+				ReadyReplicas: 2,
+			},
+			OwnershipChain: &agent.OwnershipSnapshot{
+				Owner: "Flux",
+			},
+		},
+	})
+
+	restore := setImportFlagState(importFlagState{
+		fromBundle: bundleDir,
+		json:       true,
+		noLog:      true,
+	})
+	defer restore()
+
+	output := captureStdout(t, func() {
+		if err := runImport(nil, nil); err != nil {
+			t.Fatalf("runImport() error = %v", err)
+		}
+	})
+
+	var result struct {
+		Namespaces []string       `json:"namespaces"`
+		Workloads  []WorkloadJSON `json:"workloads"`
+		Proposal   *FullProposal  `json:"proposal"`
+		Evidence   struct {
+			Source     string `json:"source"`
+			BundlePath string `json:"bundlePath,omitempty"`
+		} `json:"evidence"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput=%s", err, output)
+	}
+
+	if !reflect.DeepEqual(result.Namespaces, []string{"orders"}) {
+		t.Fatalf("namespaces = %v, want [orders]", result.Namespaces)
+	}
+	if len(result.Workloads) != 1 {
+		t.Fatalf("len(workloads) = %d, want 1", len(result.Workloads))
+	}
+	if result.Workloads[0].Owner != "Flux" {
+		t.Fatalf("owner = %q, want Flux", result.Workloads[0].Owner)
+	}
+	if result.Proposal == nil || result.Proposal.AppSpace == "" {
+		t.Fatalf("proposal missing or empty: %+v", result.Proposal)
+	}
+	if result.Evidence.Source != "bundle" {
+		t.Fatalf("evidence.source = %q, want bundle", result.Evidence.Source)
+	}
+	if result.Evidence.BundlePath != bundleDir {
+		t.Fatalf("evidence.bundlePath = %q, want %q", result.Evidence.BundlePath, bundleDir)
+	}
+}
+
+func TestRunImport_FromBundleNamespaceConflict(t *testing.T) {
+	restore := setImportFlagState(importFlagState{
+		fromBundle: "/tmp/example-bundle",
+		namespace:  "payments",
+		noLog:      true,
+	})
+	defer restore()
+
+	err := runImport(nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--namespace cannot be used with --from-bundle") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunImport_FromBundleWizardConflict(t *testing.T) {
+	restore := setImportFlagState(importFlagState{
+		fromBundle: "/tmp/example-bundle",
+		wizard:     true,
+		noLog:      true,
+	})
+	defer restore()
+
+	err := runImport(nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--wizard cannot be used with --from-bundle") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunImport_FromBundleJSONGolden(t *testing.T) {
+	restore := setImportFlagState(importFlagState{
+		fromBundle: filepath.Join("..", "..", "examples", "workflows", "fleet-demo", "bundles", "dev"),
+		json:       true,
+		noLog:      true,
+	})
+	defer restore()
+
+	actualOutput := captureStdout(t, func() {
+		if err := runImport(nil, nil); err != nil {
+			t.Fatalf("runImport() error = %v", err)
+		}
+	})
+
+	expectedPath := filepath.Join("..", "..", "examples", "import-from-bundle", "expected-output", "suggestion.json")
+	expectedOutput, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read expected output: %v", err)
+	}
+
+	var actual interface{}
+	if err := json.Unmarshal([]byte(actualOutput), &actual); err != nil {
+		t.Fatalf("parse actual JSON: %v\n%s", err, actualOutput)
+	}
+	var expected interface{}
+	if err := json.Unmarshal(expectedOutput, &expected); err != nil {
+		t.Fatalf("parse expected JSON: %v", err)
+	}
+	normalizeBundlePath(actual)
+	normalizeBundlePath(expected)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bundle import JSON does not match golden\nexpected=%s\nactual=%s", string(expectedOutput), actualOutput)
+	}
+}
+
+func TestOutputProposalJSON_ClusterEvidenceSource(t *testing.T) {
+	restore := setImportFlagState(importFlagState{
+		fromBundle: "",
+		noLog:      true,
+	})
+	defer restore()
+
+	proposal := &FullProposal{
+		AppSpace: "test-space",
+		Units: []UnitProposal{
+			{
+				Slug:    "test-unit",
+				App:     "test",
+				Variant: "default",
+				Status:  "cluster-only",
+			},
+		},
+	}
+	output := captureStdout(t, func() {
+		if err := outputProposalJSON(proposal, nil, []string{"default"}); err != nil {
+			t.Fatalf("outputProposalJSON() error = %v", err)
+		}
+	})
+
+	var result struct {
+		Evidence struct {
+			Source string `json:"source"`
+		} `json:"evidence"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, output)
+	}
+	if result.Evidence.Source != "cluster" {
+		t.Fatalf("evidence.source = %q, want cluster", result.Evidence.Source)
+	}
+}
+
+type importFlagState struct {
+	namespace  string
+	dryRun     bool
+	yes        bool
+	json       bool
+	noLog      bool
+	wizard     bool
+	connect    bool
+	noConnect  bool
+	fromBundle string
+}
+
+func setImportFlagState(next importFlagState) func() {
+	prev := importFlagState{
+		namespace:  importNamespace,
+		dryRun:     importDryRun,
+		yes:        importYes,
+		json:       importJSON,
+		noLog:      importNoLog,
+		wizard:     importWizard,
+		connect:    importConnect,
+		noConnect:  importNoConnect,
+		fromBundle: importFromBundle,
+	}
+
+	importNamespace = next.namespace
+	importDryRun = next.dryRun
+	importYes = next.yes
+	importJSON = next.json
+	importNoLog = next.noLog
+	importWizard = next.wizard
+	importConnect = next.connect
+	importNoConnect = next.noConnect
+	importFromBundle = next.fromBundle
+
+	return func() {
+		importNamespace = prev.namespace
+		importDryRun = prev.dryRun
+		importYes = prev.yes
+		importJSON = prev.json
+		importNoLog = prev.noLog
+		importWizard = prev.wizard
+		importConnect = prev.connect
+		importNoConnect = prev.noConnect
+		importFromBundle = prev.fromBundle
+	}
+}
+
+func writeImportBundleFixture(t *testing.T, bundle *agent.DebugBundle) string {
+	t.Helper()
+	bundleDir := t.TempDir()
+	writer := agent.NewBundleWriter("test")
+	if err := writer.Write(bundle, bundleDir); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return bundleDir
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+
+	os.Stdout = writePipe
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	fn()
+
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("close write pipe: %v", err)
+	}
+	out, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	if err := readPipe.Close(); err != nil {
+		t.Fatalf("close read pipe: %v", err)
+	}
+	return string(out)
+}
+
+func normalizeBundlePath(v interface{}) {
+	switch typed := v.(type) {
+	case map[string]interface{}:
+		for key, value := range typed {
+			if key == "bundlePath" {
+				if _, ok := value.(string); ok {
+					typed[key] = "<BUNDLE_PATH>"
+				}
+				continue
+			}
+			normalizeBundlePath(value)
+		}
+	case []interface{}:
+		for _, item := range typed {
+			normalizeBundlePath(item)
+		}
+	}
+}

--- a/docs/howto/import-to-confighub.md
+++ b/docs/howto/import-to-confighub.md
@@ -19,6 +19,8 @@ cub-scout is read-only in discovery mode (`--dry-run`). Non-dry-run import creat
 
 For cluster-only discovery (no Git required), see [Import from Live](import-from-live.md).
 
+For bundle-based import previews (no cluster discovery), see [Import from Bundle Example](../../examples/import-from-bundle/).
+
 > **API note:** The `cub` CLI currently uses Space/Unit commands while APIs evolve
 > toward App/Deployment language. See [Glossary](../reference/glossary.md) for the mapping.
 
@@ -148,8 +150,9 @@ Rollback is safe: import creates ConfigHub state only — it does not modify wor
 
 ## Notes
 
-- `cub-scout import --json` is for proposal automation and GUI workflows.
+- `cub-scout import --json` is for proposal automation and GUI workflows (`evidence.source` shows `cluster` vs `bundle`).
 - `cub-scout import --wizard` runs the interactive TUI wizard.
+- `cub-scout import --from-bundle <path>` uses bundle facts instead of live cluster discovery.
 - `cub-scout import` now performs connected delegation for Argo/Flux when available, then imports leftovers.
 - This path prioritizes predictable migration over fast migration.
 
@@ -170,6 +173,7 @@ make test-import-delegation
 - [Flux Import Demo](../../examples/flux-import-confighub-demo/) — Management + discovery on real Flux cluster with D2 pattern (kind)
 - [Import from Live](import-from-live.md) — Cluster-only discovery (no Git required)
 - [Import from Live Example](../../examples/import-from-live/) — Worked example with fixtures
+- [Import from Bundle Example](../../examples/import-from-bundle/) — Worked example with expected dry-run JSON output
 - [Combined Git+Live Example](../../examples/combined-git-live/) — Git repo + cluster alignment
 - [Fleet Import Example](../../examples/fleet-import/) — Multi-cluster aggregation
 - [Business Outcomes](../outcomes/README.md) — Why ConfigHub import matters

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -620,6 +620,7 @@ cub-scout import [flags]
 | `--json` | Output proposal JSON (implies dry-run) |
 | `--no-log` | Disable local import log file |
 | `-w, --wizard` | Launch interactive import wizard |
+| `--from-bundle` | Import proposal/apply from a debug bundle directory (offline path, no cluster discovery) |
 
 ### Canonical Migration Path
 
@@ -640,7 +641,14 @@ cub-scout import -n payments-prod -y
 
 # Proposal JSON for automation/GUI
 cub-scout import -n payments-prod --json
+
+# Proposal JSON from a debug bundle (offline)
+cub-scout import --from-bundle ./debug-bundle --dry-run --json
 ```
+
+`import --json` output includes an `evidence` block:
+- `evidence.source`: `cluster` or `bundle`
+- `evidence.bundlePath`: set when source is `bundle`
 
 ---
 

--- a/docs/reference/dual-approval-gitops-gh-pr-and-ch-mr.md
+++ b/docs/reference/dual-approval-gitops-gh-pr-and-ch-mr.md
@@ -8,10 +8,11 @@ Last updated: 2026-02-28
 Define a bidirectional workflow where:
 
 1. Teams can start from GitHub PRs or from ConfigHub Merge Requests (MRs).
-2. GitHub remains the source merge authority.
-3. ConfigHub remains the governed execution authority.
-4. Flux/Argo remain reconcilers.
-5. OCI is the default WET transport.
+2. Teams can also start from live-cluster observations captured as ConfigHub MR proposals.
+3. GitHub remains the source merge authority.
+4. ConfigHub remains the governed execution authority.
+5. Flux/Argo remain reconcilers.
+6. OCI is the default WET transport.
 
 This gives users both entry points without split-brain approvals.
 
@@ -22,6 +23,7 @@ This gives users both entry points without split-brain approvals.
 3. ConfigHub `ALLOW|ESCALATE|BLOCK` is required for governed apply.
 4. One canonical `change_id` links all artifacts across systems.
 5. One canonical content commit (`merged_sha`) is the source truth.
+6. Nothing observed from live state silently overwrites DRY intent.
 
 ## Authority Boundary
 
@@ -79,6 +81,17 @@ decision:
 7. Flux/Argo reconcile published WET artifact.
 8. ConfigHub finalizes attestation and outcome receipts.
 
+### Path C: LIVE observation -> ConfigHub MR proposal
+
+1. Observer tooling detects live mutation or drift (`cub-scout`/evidence adapters).
+2. ConfigHub creates a proposal MR from live evidence using a new `change_id`.
+3. Proposal includes live snapshot, drift class, and suggested DRY patch; no source is overwritten automatically.
+4. Reviewer decides to either discard/revert live state or accept and continue as a source change.
+5. If accepted, ConfigHub opens/updates paired GitHub PR (or internal source branch) with proposed DRY edits.
+6. Source merge happens through normal approval policy.
+7. ConfigHub applies governed decision (`ALLOW|ESCALATE|BLOCK`) for execution/promotion.
+8. Attestation links live evidence, source merge, and outcome under one `change_id`.
+
 ## State Machine (Single Logical Change)
 
 ```mermaid
@@ -115,13 +128,15 @@ Execution gating rule:
    `pull_request.opened`, `pull_request.synchronize`, `pull_request.closed`, `pull_request.merged`.
 2. ConfigHub webhook/status callback:
    `mr.created`, `mr.updated`, `decision.updated`, `execution.completed`, `attestation.recorded`.
-3. Idempotent upsert endpoint:
+3. Live observation ingest:
+   `live.observed`, `live.drift_detected`, `live.proposal_created`.
+4. Idempotent upsert endpoint:
    `POST /v1/changes/upsert` keyed by `change_id`.
-4. Link endpoint:
+5. Link endpoint:
    `POST /v1/changes/{change_id}/links` for PR/MR/card references.
-5. Decision endpoint:
+6. Decision endpoint:
    `POST /v1/changes/{change_id}/decision` with `ALLOW|ESCALATE|BLOCK`.
-6. Execution endpoint:
+7. Execution endpoint:
    `POST /v1/changes/{change_id}/execute` requiring prior allow state.
 
 ## Conflict Rules
@@ -131,12 +146,13 @@ Execution gating rule:
 3. If GitHub PR closes unmerged, CH MR moves to `abandoned`.
 4. If CH MR is withdrawn, bot closes PR unless explicitly detached.
 5. If two CH MRs target same app/env and overlapping fields, require serialization.
+6. If live state changes again while proposal MR is open, mark MR stale and require refresh/re-evaluation.
 
 ## Data Placement (DRY/WET)
 
 1. GitHub stores source commits, PR review history, and optional compact receipts.
 2. OCI stores WET deployment artifacts (digest-pinned).
-3. ConfigHub stores decision graph, approvals, execution telemetry, and attestation.
+3. ConfigHub stores live observation evidence, decision graph, approvals, execution telemetry, and attestation.
 4. Shared IDs and digests are written back to both sides for traceability.
 
 ## Flux/Argo Compatibility
@@ -150,7 +166,8 @@ Execution gating rule:
 
 1. Phase 1: GitHub-first (`PR -> CH evaluate -> status checks`).
 2. Phase 2: ConfigHub-authoring (`CH MR -> bot PR`).
-3. Phase 3: full dual-entry with single state machine and strict gate enforcement.
+3. Phase 3: live-observation proposals (`LIVE -> CH MR`) with explicit review before write-back.
+4. Phase 4: full multi-entry state machine with strict gate enforcement.
 
 ## Positioning Line
 

--- a/docs/reference/next-gen-gitops-ai-era.md
+++ b/docs/reference/next-gen-gitops-ai-era.md
@@ -65,6 +65,21 @@ Combined result:
 
 1. app intent and agent behavior are linked in one audit path.
 
+## LIVE-Origin Change Path (Kargo-Style, Governed)
+
+Live changes can enter the same model without breaking intent control:
+
+1. observer detects live mutation/drift,
+2. ConfigHub creates a proposal MR from live evidence,
+3. reviewers decide accept or revert (no silent overwrite),
+4. accepted proposal becomes DRY source change (paired PR/MR),
+5. governed decision (`ALLOW|ESCALATE|BLOCK`) gates execution,
+6. attestation links live evidence -> source change -> runtime outcome.
+
+Rule:
+
+1. live is evidence and proposal input, never automatic source-of-truth replacement.
+
 ## Practical Boundary by Component
 
 1. `cub-track`: Git-native mutation ledger (`enable`, `explain`, `search`)

--- a/docs/reference/scoredev-dry-wet-unit-worked-example.md
+++ b/docs/reference/scoredev-dry-wet-unit-worked-example.md
@@ -392,16 +392,26 @@ attestation:
 This is the recommended promotion path when an app-level change should become a
 platform default:
 
-1. App team edits app-owned DRY fields (`score.yaml` or app overlay unit) and opens a GitHub PR.
-2. ConfigHub links the PR to a change card/MR using a shared `change_id`.
-3. Platform engineer reviews and merge-approves the app PR in GitHub.
-4. ConfigHub evaluates policy and allows execution only on `ALLOW` (or approved `ESCALATE`).
-5. After successful rollout, ConfigHub opens a promotion PR against platform DRY/base defaults.
-6. Platform maintainers merge the upstream DRY promotion PR.
-7. App-specific override is reduced or removed to avoid long-lived drift.
+1. App team edits app-owned DRY fields (`score.yaml` or app overlay unit).
+2. ConfigHub renders/evaluates candidate WET, posts evidence, and opens/updates a ConfigHub MR (plus paired Git PR if mirror is enabled).
+3. Platform engineer reviews and merge-approves the app change in ConfigHub.
+4. ConfigHub enforces governed deploy decision (`ALLOW|ESCALATE|BLOCK`) for that merged change.
+5. On `ALLOW` (or approved `ESCALATE`), execution runs with scoped token, then verification and attestation are recorded.
+6. After successful rollout, ConfigHub opens a promotion PR/MR to upstream Platform DRY/Base Unit when reusable, if not done already.
+7. After required upstream approvals, ConfigHub merges the promotion PR in Git.
+8. App-specific override is reduced or removed to avoid long-lived drift.
 
 This keeps team velocity high while still converging reusable behavior into the
 platform's main DRY contract.
+
+Guardrail:
+
+1. Do not auto-write directly to platform main DRY without separate upstream review/merge.
+
+Live-origin variant:
+
+1. If observer tooling detects a live-only Score-related change, ConfigHub creates a proposal MR from live evidence.
+2. Accepted proposals are converted into DRY source edits and follow the same promotion path above.
 
 ---
 

--- a/docs/reference/stored-in-git-vs-confighub.md
+++ b/docs/reference/stored-in-git-vs-confighub.md
@@ -58,6 +58,7 @@ Use commit trailers + compact receipt objects.
 5. Pre/post scan detailed findings and evidence links
 6. Adapter-normalized evidence and cross-repo indexes
 7. Retention-governed sensitive data (e.g., optional transcripts)
+8. Live observation/drift evidence and proposal MR lineage (`LIVE -> CH MR`)
 
 ### WET constraints
 
@@ -81,6 +82,7 @@ Each receipt references authoritative WET records in ConfigHub by ID and digest.
 2. Writing token values or sensitive auth material to Git
 3. Treating Git as the primary runtime telemetry store
 4. Storing mutable indexes/search state in Git
+5. Silently overwriting DRY intent from live observations without explicit review
 
 ## Practical Rule
 

--- a/docs/reference/traefik-helm-dry-wet-unit-worked-example.md
+++ b/docs/reference/traefik-helm-dry-wet-unit-worked-example.md
@@ -176,13 +176,24 @@ spec:
 This is the key promotion path:
 
 1. App team adds a feature/config change in app DRY unit (for example new middleware rule).
-2. Platform engineer reviews and merge-approves source PR in GitHub.
-3. ConfigHub policy decides `ALLOW|ESCALATE|BLOCK` for deploy execution.
-4. On allowed execution, rollout and verification complete.
-5. If broadly useful, ConfigHub opens a separate promotion PR to platform base DRY.
-6. Platform team merges upstream promotion and app unit override is minimized.
+2. ConfigHub renders/evaluates candidate WET, posts evidence, and opens/updates a ConfigHub MR (plus paired Git PR if mirror is enabled).
+3. Platform engineer reviews and merge-approves the app change in ConfigHub.
+4. ConfigHub decision gate enforces `ALLOW|ESCALATE|BLOCK` for that merged change.
+5. On `ALLOW` (or approved `ESCALATE`), rollout executes with scoped token, then verification and attestation complete.
+6. After successful rollout, ConfigHub opens a promotion PR/MR to upstream Platform DRY/Base Unit when reusable, if not done already.
+7. After required upstream approvals, ConfigHub merges the promotion PR in Git.
+8. App unit override is minimized to avoid long-term drift.
 
 This avoids permanent app forks while preserving app-team velocity.
+
+Guardrail:
+
+1. Never auto-write directly to platform main DRY without separate upstream review/merge.
+
+Live-origin variant:
+
+1. If observer tooling detects a live Traefik/config drift event, ConfigHub creates a proposal MR from live evidence.
+2. Accepted proposals become DRY edits and continue through the same governed promotion path.
 
 ---
 

--- a/examples/import-from-bundle/README.md
+++ b/examples/import-from-bundle/README.md
@@ -1,0 +1,28 @@
+# Import from Bundle
+
+Import proposal generation from an existing debug bundle, without cluster access.
+
+This example demonstrates the `--from-bundle` path added to `cub-scout import`.
+It reuses the sample bundle in:
+
+`examples/workflows/fleet-demo/bundles/dev`
+
+## Run
+
+```bash
+./cub-scout import --from-bundle examples/workflows/fleet-demo/bundles/dev --dry-run --json
+```
+
+## Expected Output
+
+Expected JSON is committed at:
+
+`examples/import-from-bundle/expected-output/suggestion.json`
+
+The output shape is identical to live-cluster dry-run JSON:
+- `namespaces[]`
+- `workloads[]`
+- `proposal`
+- `evidence` (`source=bundle`, `bundlePath=<path>`)
+
+Only the source of facts changes (`bundle` vs `live cluster`).

--- a/examples/import-from-bundle/expected-output/suggestion.json
+++ b/examples/import-from-bundle/expected-output/suggestion.json
@@ -1,0 +1,48 @@
+{
+  "evidence": {
+    "source": "bundle",
+    "bundlePath": "examples/workflows/fleet-demo/bundles/dev"
+  },
+  "namespaces": [
+    "api"
+  ],
+  "proposal": {
+    "appSpace": "api-team",
+    "units": [
+      {
+        "slug": "api",
+        "app": "api",
+        "variant": "default",
+        "workloads": [
+          "api/api-server"
+        ],
+        "status": "cluster-only",
+        "labels": {
+          "app": "api",
+          "team": "api",
+          "variant": "default"
+        }
+      }
+    ],
+    "clusterOnly": [
+      {
+        "app": "api",
+        "workloads": [
+          "api/api-server"
+        ],
+        "owner": "Native"
+      }
+    ]
+  },
+  "workloads": [
+    {
+      "kind": "Deployment",
+      "namespace": "api",
+      "name": "api-server",
+      "owner": "Native",
+      "connected": false,
+      "ready": false,
+      "replicas": 0
+    }
+  ]
+}

--- a/test/integration/import_e2e_test.go
+++ b/test/integration/import_e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -155,6 +156,7 @@ type importDryRunResult struct {
 	Namespaces []string         `json:"namespaces"`
 	Proposal   *importProposal  `json:"proposal"`
 	Workloads  []importWorkload `json:"workloads"`
+	Evidence   *importEvidence  `json:"evidence,omitempty"`
 }
 
 // importProposal matches the "proposal" object in the JSON output.
@@ -192,6 +194,11 @@ type importWorkload struct {
 	Ready     bool              `json:"ready"`
 	Replicas  int32             `json:"replicas"`
 	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+type importEvidence struct {
+	Source     string `json:"source"`
+	BundlePath string `json:"bundlePath,omitempty"`
 }
 
 // =============================================================================
@@ -337,6 +344,36 @@ func TestImportDryRunSuggestionContract(t *testing.T) {
 
 	t.Logf("Contract check passed: %d workloads, %d units",
 		len(result.Workloads), len(result.Proposal.Units))
+}
+
+// TestImportFromBundleDryRunJSONConnectedContract verifies bundle-driven import
+// JSON contract in connected environments (skip when not authenticated).
+func TestImportFromBundleDryRunJSONConnectedContract(t *testing.T) {
+	skipIfNotConnected(t)
+
+	bundlePath := filepath.Join("..", "..", "examples", "workflows", "fleet-demo", "bundles", "dev")
+	output := runCubAgent(t, "import", "--from-bundle", bundlePath, "--dry-run", "--json")
+
+	var result importDryRunResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("Failed to parse import bundle JSON output: %v", err)
+	}
+
+	if result.Evidence == nil {
+		t.Fatal("Expected evidence block in JSON output")
+	}
+	if result.Evidence.Source != "bundle" {
+		t.Fatalf("evidence.source = %q, want bundle", result.Evidence.Source)
+	}
+	if result.Evidence.BundlePath != bundlePath {
+		t.Fatalf("evidence.bundlePath = %q, want %q", result.Evidence.BundlePath, bundlePath)
+	}
+	if result.Proposal == nil || result.Proposal.AppSpace == "" {
+		t.Fatal("Expected non-empty proposal.appSpace for bundle import dry-run")
+	}
+	if len(result.Workloads) == 0 {
+		t.Fatal("Expected at least one workload from bundle import dry-run")
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- add `cub-scout import --from-bundle PATH` as an explicit bundle entrypoint with dry-run/json/apply flow parity
- extend import JSON contract with `evidence` metadata (`source=cluster|bundle`, `bundlePath` for bundle source)
- add offline compare primitive in `combined` via `--bundle` (mutually exclusive with `--namespace`) so Git↔cluster alignment can run from bundle snapshots
- add worked example and expected output for import-from-bundle
- include the additional reference doc edits requested in this branch

## Proof / Tests
- `go test ./...`
- `go test ./cmd/cub-scout -run "Test(BuildImportFromBundlePreview|RunImport_FromBundle|OutputProposalJSON_ClusterEvidenceSource|ResolveCombinedWorkloadsSource|RunCombined_GitPathWithBundleJSON)" -count=1` (run repeatedly for stability)
- `go test -tags=integration ./test/integration/... -run TestImportFromBundleDryRunJSONConnectedContract -count=1` (connected-gated, passed in this environment)

## Notes
- left existing untracked `.claude/` worktree directory untouched
- this PR intentionally includes the additional doc updates you asked to keep
