### PR TITLE
combined: add Git↔Git compare mode

### DIFF
--- a/cmd/cub-scout/combined.go
+++ b/cmd/cub-scout/combined.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/confighub/cub-scout/pkg/gitops"
@@ -16,22 +17,25 @@ import (
 )
 
 var (
-	combinedGitURL    string
-	combinedGitPath   string
-	combinedNamespace string
-	combinedBundle    string
-	combinedJSON      bool
-	combinedSuggest   bool
-	combinedApply     bool
-	combinedDryRun    bool
+	combinedGitURL         string
+	combinedGitPath        string
+	combinedGitURLCompare  string
+	combinedGitPathCompare string
+	combinedNamespace      string
+	combinedBundle         string
+	combinedJSON           bool
+	combinedSuggest        bool
+	combinedApply          bool
+	combinedDryRun         bool
 )
 
 // CombinedResult shows Git repo structure + Cluster workloads together
 type CombinedResult struct {
-	GitRepo   *gitops.RepoStructure `json:"gitRepo,omitempty"`
-	Cluster   *ImportResult         `json:"cluster,omitempty"`
-	Alignment []AlignmentEntry      `json:"alignment,omitempty"`
-	Proposal  *FullProposal         `json:"proposal,omitempty"` // App model proposal
+	GitRepo    *gitops.RepoStructure `json:"gitRepo,omitempty"`
+	GitCompare []GitCompareEntry     `json:"gitCompare,omitempty"`
+	Cluster    *ImportResult         `json:"cluster,omitempty"`
+	Alignment  []AlignmentEntry      `json:"alignment,omitempty"`
+	Proposal   *FullProposal         `json:"proposal,omitempty"` // App model proposal
 }
 
 // AlignmentEntry shows how Git apps align with cluster workloads
@@ -41,6 +45,15 @@ type AlignmentEntry struct {
 	LivePath   string   `json:"livePath,omitempty"`   // From cluster deployer
 	Status     string   `json:"status"`               // "aligned", "git-only", "cluster-only"
 	Workloads  []string `json:"workloads,omitempty"`
+}
+
+// GitCompareEntry represents a Git↔Git comparison row.
+type GitCompareEntry struct {
+	App       string `json:"app"`
+	Variant   string `json:"variant,omitempty"`
+	Status    string `json:"status"` // "aligned", "left-only", "right-only"
+	LeftPath  string `json:"leftPath,omitempty"`
+	RightPath string `json:"rightPath,omitempty"`
 }
 
 var combinedCmd = &cobra.Command{
@@ -74,6 +87,9 @@ Examples:
 
   # Offline Git ↔ cluster compare from a debug bundle
   cub-scout combined --git-path ./my-repo --bundle ./debug-bundle --json
+
+  # Git ↔ Git compare (left vs right repo)
+  cub-scout combined --git-path ./repo-a --git-path-compare ./repo-b --json
 `,
 	RunE: runCombined,
 }
@@ -81,6 +97,8 @@ Examples:
 func init() {
 	combinedCmd.Flags().StringVar(&combinedGitURL, "git-url", "", "Git repository URL to parse")
 	combinedCmd.Flags().StringVar(&combinedGitPath, "git-path", "", "Local path to Git repository")
+	combinedCmd.Flags().StringVar(&combinedGitURLCompare, "git-url-compare", "", "Right-side Git repository URL for Git↔Git compare")
+	combinedCmd.Flags().StringVar(&combinedGitPathCompare, "git-path-compare", "", "Right-side local Git repository path for Git↔Git compare")
 	combinedCmd.Flags().StringVarP(&combinedNamespace, "namespace", "n", "", "Namespace to scan in cluster")
 	combinedCmd.Flags().StringVar(&combinedBundle, "bundle", "", "Debug bundle directory to use as cluster snapshot (offline)")
 	combinedCmd.Flags().BoolVar(&combinedJSON, "json", false, "Output as JSON")
@@ -94,40 +112,29 @@ func init() {
 func runCombined(cmd *cobra.Command, args []string) error {
 	result := &CombinedResult{}
 
-	// Parse Git repo if provided
-	if combinedGitURL != "" || combinedGitPath != "" {
-		var repoPath string
-		var cleanup func()
+	// Parse left-side Git repo (primary).
+	leftRepo, leftCleanup, err := loadCombinedRepoSource(combinedGitURL, combinedGitPath)
+	if err != nil {
+		return err
+	}
+	if leftCleanup != nil {
+		defer leftCleanup()
+	}
+	result.GitRepo = leftRepo
 
-		if combinedGitURL != "" {
-			tmpDir, err := os.MkdirTemp("", "gitops-combined-*")
-			if err != nil {
-				return fmt.Errorf("create temp dir: %w", err)
-			}
-			cleanup = func() { os.RemoveAll(tmpDir) }
-
-			if !combinedJSON {
-				fmt.Fprintf(os.Stderr, "Cloning %s...\n", combinedGitURL)
-			}
-			gitCmd := exec.Command("git", "clone", "--depth=1", combinedGitURL, tmpDir)
-			if output, err := gitCmd.CombinedOutput(); err != nil {
-				cleanup()
-				return fmt.Errorf("clone failed: %w\n%s", err, output)
-			}
-			repoPath = tmpDir
-		} else {
-			repoPath = combinedGitPath
-		}
-
-		if cleanup != nil {
-			defer cleanup()
-		}
-
-		repo, err := gitops.ParseRepo(repoPath)
-		if err != nil {
-			return fmt.Errorf("parse repo: %w", err)
-		}
-		result.GitRepo = repo
+	// Parse right-side Git repo (compare).
+	rightRepo, rightCleanup, err := loadCombinedRepoSource(combinedGitURLCompare, combinedGitPathCompare)
+	if err != nil {
+		return err
+	}
+	if rightCleanup != nil {
+		defer rightCleanup()
+	}
+	if rightRepo != nil && leftRepo == nil {
+		return fmt.Errorf("--git-url-compare/--git-path-compare requires --git-url or --git-path")
+	}
+	if leftRepo != nil && rightRepo != nil {
+		result.GitCompare = buildGitComparison(leftRepo, rightRepo)
 	}
 
 	// Collect cluster-side workloads from live namespace OR bundle snapshot.
@@ -148,13 +155,13 @@ func runCombined(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build alignment if we have both
-	if result.GitRepo != nil && result.Cluster != nil {
-		result.Alignment = buildAlignment(result.GitRepo, result.Cluster)
+	if leftRepo != nil && result.Cluster != nil {
+		result.Alignment = buildAlignment(leftRepo, result.Cluster)
 	}
 
 	// Build full App model proposal if --suggest
-	if combinedSuggest && result.GitRepo != nil {
-		result.Proposal = SuggestFullProposal(result.GitRepo.Apps, workloads, "")
+	if combinedSuggest && leftRepo != nil {
+		result.Proposal = SuggestFullProposal(leftRepo.Apps, workloads, "")
 	}
 
 	// Build proposal from cluster-only if no Git repo
@@ -188,6 +195,51 @@ func runCombined(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func loadCombinedRepoSource(gitURL, gitPath string) (*gitops.RepoStructure, func(), error) {
+	gitURL = strings.TrimSpace(gitURL)
+	gitPath = strings.TrimSpace(gitPath)
+
+	if gitURL == "" && gitPath == "" {
+		return nil, nil, nil
+	}
+	if gitURL != "" && gitPath != "" {
+		return nil, nil, fmt.Errorf("--git-url and --git-path cannot be used together")
+	}
+
+	var (
+		repoPath string
+		cleanup  func()
+	)
+	if gitURL != "" {
+		tmpDir, err := os.MkdirTemp("", "gitops-combined-*")
+		if err != nil {
+			return nil, nil, fmt.Errorf("create temp dir: %w", err)
+		}
+		cleanup = func() { os.RemoveAll(tmpDir) }
+
+		if !combinedJSON {
+			fmt.Fprintf(os.Stderr, "Cloning %s...\n", gitURL)
+		}
+		gitCmd := exec.Command("git", "clone", "--depth=1", gitURL, tmpDir)
+		if output, err := gitCmd.CombinedOutput(); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("clone failed: %w\n%s", err, output)
+		}
+		repoPath = tmpDir
+	} else {
+		repoPath = gitPath
+	}
+
+	repo, err := gitops.ParseRepo(repoPath)
+	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, nil, fmt.Errorf("parse repo: %w", err)
+	}
+	return repo, cleanup, nil
+}
+
 func resolveCombinedWorkloadsSource(namespace, bundlePath string) ([]WorkloadInfo, string, error) {
 	if namespace != "" && bundlePath != "" {
 		return nil, "", fmt.Errorf("--namespace and --bundle cannot be used together")
@@ -214,6 +266,109 @@ func resolveCombinedWorkloadsSource(namespace, bundlePath string) ([]WorkloadInf
 	}
 
 	return []WorkloadInfo{}, "", nil
+}
+
+func buildGitComparison(left, right *gitops.RepoStructure) []GitCompareEntry {
+	if left == nil || right == nil {
+		return nil
+	}
+
+	leftIndex := indexRepoAppsForCompare(left)
+	rightIndex := indexRepoAppsForCompare(right)
+
+	keySet := make(map[gitCompareKey]struct{}, len(leftIndex)+len(rightIndex))
+	for k := range leftIndex {
+		keySet[k] = struct{}{}
+	}
+	for k := range rightIndex {
+		keySet[k] = struct{}{}
+	}
+
+	keys := make([]gitCompareKey, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].App != keys[j].App {
+			return keys[i].App < keys[j].App
+		}
+		return keys[i].Variant < keys[j].Variant
+	})
+
+	entries := make([]GitCompareEntry, 0, len(keys))
+	for _, key := range keys {
+		leftPath, leftOK := leftIndex[key]
+		rightPath, rightOK := rightIndex[key]
+		entry := GitCompareEntry{
+			App:       key.App,
+			Variant:   key.Variant,
+			LeftPath:  leftPath,
+			RightPath: rightPath,
+		}
+		switch {
+		case leftOK && rightOK:
+			entry.Status = "aligned"
+		case leftOK:
+			entry.Status = "left-only"
+		default:
+			entry.Status = "right-only"
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+type gitCompareKey struct {
+	App     string
+	Variant string
+}
+
+func indexRepoAppsForCompare(repo *gitops.RepoStructure) map[gitCompareKey]string {
+	index := make(map[gitCompareKey]string)
+	for _, app := range repo.Apps {
+		appName := strings.TrimSpace(app.Name)
+		if appName == "" {
+			continue
+		}
+		if len(app.Variants) == 0 {
+			key := gitCompareKey{
+				App:     appName,
+				Variant: "default",
+			}
+			setComparePath(index, key, app.BasePath)
+			continue
+		}
+
+		for _, variant := range app.Variants {
+			variantName := strings.TrimSpace(variant.Name)
+			if variantName == "" {
+				variantName = "default"
+			}
+			path := strings.TrimSpace(variant.Path)
+			if path == "" {
+				path = app.BasePath
+			}
+			key := gitCompareKey{
+				App:     appName,
+				Variant: variantName,
+			}
+			setComparePath(index, key, path)
+		}
+	}
+	return index
+}
+
+func setComparePath(index map[gitCompareKey]string, key gitCompareKey, path string) {
+	current, exists := index[key]
+	path = strings.TrimSpace(path)
+	if !exists {
+		index[key] = path
+		return
+	}
+	// Keep deterministic tie-breaking for duplicate app/variant rows.
+	if current == "" || (path != "" && path < current) {
+		index[key] = path
+	}
 }
 
 func buildAlignment(repo *gitops.RepoStructure, cluster *ImportResult) []AlignmentEntry {
@@ -332,6 +487,30 @@ func printCombinedResult(r *CombinedResult) {
 			}
 			if a.LivePath != "" {
 				fmt.Printf(" [path: %s]", a.LivePath)
+			}
+			fmt.Println()
+		}
+		fmt.Println()
+	}
+
+	if len(r.GitCompare) > 0 {
+		fmt.Println("┌─────────────────────────────────────────────────────────────┐")
+		fmt.Println("│ GIT COMPARE                                                 │")
+		fmt.Println("└─────────────────────────────────────────────────────────────┘")
+		for _, c := range r.GitCompare {
+			status := SymOK
+			if c.Status == "left-only" || c.Status == "right-only" {
+				status = "⚠ " + c.Status
+			}
+			fmt.Printf("  %s %s", status, c.App)
+			if c.Variant != "" {
+				fmt.Printf(" (variant=%s)", c.Variant)
+			}
+			if c.LeftPath != "" {
+				fmt.Printf(" [left: %s]", c.LeftPath)
+			}
+			if c.RightPath != "" {
+				fmt.Printf(" [right: %s]", c.RightPath)
 			}
 			fmt.Println()
 		}

--- a/cmd/cub-scout/combined_bundle_test.go
+++ b/cmd/cub-scout/combined_bundle_test.go
@@ -155,30 +155,36 @@ func TestRunCombined_GitPathWithBundleJSON(t *testing.T) {
 }
 
 type combinedFlagState struct {
-	gitURL    string
-	gitPath   string
-	namespace string
-	bundle    string
-	json      bool
-	suggest   bool
-	apply     bool
-	dryRun    bool
+	gitURL         string
+	gitPath        string
+	gitURLCompare  string
+	gitPathCompare string
+	namespace      string
+	bundle         string
+	json           bool
+	suggest        bool
+	apply          bool
+	dryRun         bool
 }
 
 func setCombinedFlagState(next combinedFlagState) func() {
 	prev := combinedFlagState{
-		gitURL:    combinedGitURL,
-		gitPath:   combinedGitPath,
-		namespace: combinedNamespace,
-		bundle:    combinedBundle,
-		json:      combinedJSON,
-		suggest:   combinedSuggest,
-		apply:     combinedApply,
-		dryRun:    combinedDryRun,
+		gitURL:         combinedGitURL,
+		gitPath:        combinedGitPath,
+		gitURLCompare:  combinedGitURLCompare,
+		gitPathCompare: combinedGitPathCompare,
+		namespace:      combinedNamespace,
+		bundle:         combinedBundle,
+		json:           combinedJSON,
+		suggest:        combinedSuggest,
+		apply:          combinedApply,
+		dryRun:         combinedDryRun,
 	}
 
 	combinedGitURL = next.gitURL
 	combinedGitPath = next.gitPath
+	combinedGitURLCompare = next.gitURLCompare
+	combinedGitPathCompare = next.gitPathCompare
 	combinedNamespace = next.namespace
 	combinedBundle = next.bundle
 	combinedJSON = next.json
@@ -189,6 +195,8 @@ func setCombinedFlagState(next combinedFlagState) func() {
 	return func() {
 		combinedGitURL = prev.gitURL
 		combinedGitPath = prev.gitPath
+		combinedGitURLCompare = prev.gitURLCompare
+		combinedGitPathCompare = prev.gitPathCompare
 		combinedNamespace = prev.namespace
 		combinedBundle = prev.bundle
 		combinedJSON = prev.json

--- a/cmd/cub-scout/combined_git_compare_test.go
+++ b/cmd/cub-scout/combined_git_compare_test.go
@@ -1,0 +1,172 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/gitops"
+)
+
+func TestBuildGitComparison_Deterministic(t *testing.T) {
+	left := &gitops.RepoStructure{
+		Apps: []gitops.AppDefinition{
+			{
+				Name: "api",
+				Variants: []gitops.VariantDefinition{
+					{Name: "prod", Path: "apps/prod"},
+				},
+			},
+			{
+				Name: "worker",
+				Variants: []gitops.VariantDefinition{
+					{Name: "prod", Path: "apps/prod"},
+				},
+			},
+		},
+	}
+	right := &gitops.RepoStructure{
+		Apps: []gitops.AppDefinition{
+			{
+				Name: "api",
+				Variants: []gitops.VariantDefinition{
+					{Name: "prod", Path: "apps/prod"},
+				},
+			},
+			{
+				Name: "billing",
+				Variants: []gitops.VariantDefinition{
+					{Name: "prod", Path: "apps/prod"},
+				},
+			},
+		},
+	}
+
+	got := buildGitComparison(left, right)
+	want := []GitCompareEntry{
+		{
+			App:       "api",
+			Variant:   "prod",
+			Status:    "aligned",
+			LeftPath:  "apps/prod",
+			RightPath: "apps/prod",
+		},
+		{
+			App:       "billing",
+			Variant:   "prod",
+			Status:    "right-only",
+			RightPath: "apps/prod",
+		},
+		{
+			App:      "worker",
+			Variant:  "prod",
+			Status:   "left-only",
+			LeftPath: "apps/prod",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildGitComparison() mismatch\nwant=%+v\ngot=%+v", want, got)
+	}
+}
+
+func TestRunCombined_GitPathCompareJSON(t *testing.T) {
+	leftRepo := createCompareRepoFixture(t, []string{"api", "worker"})
+	rightRepo := createCompareRepoFixture(t, []string{"api", "billing"})
+
+	restore := setCombinedFlagState(combinedFlagState{
+		gitPath:        leftRepo,
+		gitPathCompare: rightRepo,
+		json:           true,
+	})
+	defer restore()
+
+	output := captureStdout(t, func() {
+		if err := runCombined(nil, nil); err != nil {
+			t.Fatalf("runCombined() error = %v", err)
+		}
+	})
+
+	var result struct {
+		GitCompare []GitCompareEntry `json:"gitCompare"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("parse combined JSON: %v\n%s", err, output)
+	}
+	if len(result.GitCompare) == 0 {
+		t.Fatal("gitCompare output is empty")
+	}
+
+	hasAlignedAPI := false
+	hasLeftOnlyWorker := false
+	hasRightOnlyBilling := false
+	for _, entry := range result.GitCompare {
+		if entry.App == "api" && entry.Status == "aligned" {
+			hasAlignedAPI = true
+		}
+		if entry.App == "worker" && entry.Status == "left-only" {
+			hasLeftOnlyWorker = true
+		}
+		if entry.App == "billing" && entry.Status == "right-only" {
+			hasRightOnlyBilling = true
+		}
+	}
+	if !hasAlignedAPI || !hasLeftOnlyWorker || !hasRightOnlyBilling {
+		t.Fatalf("unexpected gitCompare entries: %+v", result.GitCompare)
+	}
+}
+
+func TestRunCombined_GitCompareRequiresPrimary(t *testing.T) {
+	rightRepo := createCompareRepoFixture(t, []string{"api"})
+
+	restore := setCombinedFlagState(combinedFlagState{
+		gitPathCompare: rightRepo,
+		json:           true,
+	})
+	defer restore()
+
+	err := runCombined(nil, nil)
+	if err == nil {
+		t.Fatal("expected error when compare repo is set without primary repo")
+	}
+	if !strings.Contains(err.Error(), "requires --git-url or --git-path") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func createCompareRepoFixture(t *testing.T, apps []string) string {
+	t.Helper()
+	repoDir := t.TempDir()
+
+	for _, app := range apps {
+		baseDir := filepath.Join(repoDir, "apps", "base", app)
+		if err := os.MkdirAll(baseDir, 0o755); err != nil {
+			t.Fatalf("mkdir base dir: %v", err)
+		}
+		baseKustomization := []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n")
+		if err := os.WriteFile(filepath.Join(baseDir, "kustomization.yaml"), baseKustomization, 0o644); err != nil {
+			t.Fatalf("write base kustomization: %v", err)
+		}
+	}
+
+	prodDir := filepath.Join(repoDir, "apps", "prod")
+	if err := os.MkdirAll(prodDir, 0o755); err != nil {
+		t.Fatalf("mkdir prod dir: %v", err)
+	}
+
+	var resources strings.Builder
+	for _, app := range apps {
+		resources.WriteString("- ../base/" + app + "\n")
+	}
+	prodKustomization := []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n" + resources.String())
+	if err := os.WriteFile(filepath.Join(prodDir, "kustomization.yaml"), prodKustomization, 0o644); err != nil {
+		t.Fatalf("write prod kustomization: %v", err)
+	}
+
+	return repoDir
+}

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -230,7 +230,10 @@ Complete reference of all commands, options, TUI keys, and availability.
 |--------|-------------|
 | `--git-url` | Git repository URL |
 | `--git-path` | Local path to Git repo |
+| `--git-url-compare` | Right-side Git repository URL for Git↔Git compare |
+| `--git-path-compare` | Right-side local Git repository path for Git↔Git compare |
 | `-n, --namespace` | Namespace to scan |
+| `--bundle` | Debug bundle directory as offline cluster snapshot |
 | `--suggest` | Generate Hub/App Space proposal |
 | `--apply` | Create App Space and Units |
 | `--dry-run` | Show without making changes |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -27,6 +27,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD | v0.19 |
 | `tree` | Hierarchical resource views | v0.5 |
 | `import` | Import workloads into ConfigHub | v1.0 |
+| `combined` | Compare Git and cluster/bundle structures | v1.0 |
 | `discover` | Scout-style workload discovery | v0.5 |
 | `health` | Scout-style health check | v0.5 |
 | `status` | Show connection status and cluster info | v1.0 |
@@ -649,6 +650,44 @@ cub-scout import --from-bundle ./debug-bundle --dry-run --json
 `import --json` output includes an `evidence` block:
 - `evidence.source`: `cluster` or `bundle`
 - `evidence.bundlePath`: set when source is `bundle`
+
+---
+
+## combined
+
+Show alignment across Git, live cluster, bundle snapshots, and Git↔Git compare.
+
+```bash
+cub-scout combined [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--git-url` | Left-side Git repository URL |
+| `--git-path` | Left-side local Git repository path |
+| `--git-url-compare` | Right-side Git repository URL for Git↔Git compare |
+| `--git-path-compare` | Right-side local Git repository path for Git↔Git compare |
+| `-n, --namespace` | Namespace to scan from live cluster |
+| `--bundle` | Use debug bundle directory as offline cluster snapshot |
+| `--suggest` | Generate App model proposal |
+| `--apply` | Apply proposal to ConfigHub |
+| `--dry-run` | Preview apply behavior without making changes |
+| `--json` | Output JSON |
+
+### Examples
+
+```bash
+# Git ↔ live cluster compare
+cub-scout combined --git-path ./repo --namespace payments --json
+
+# Git ↔ bundle (offline cluster snapshot) compare
+cub-scout combined --git-path ./repo --bundle ./debug-bundle --json
+
+# Git ↔ Git compare (left vs right)
+cub-scout combined --git-path ./repo-a --git-path-compare ./repo-b --json
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- add right-side compare flags to `cub-scout combined`: `--git-url-compare` and `--git-path-compare`
- compute deterministic Git↔Git comparison rows in JSON and ASCII output
- keep existing Git↔cluster/bundle alignment behavior and validate compare-only misuse
- document the new compare mode in command reference and command matrix

## Test-first proofs
- added failing tests first in `cmd/cub-scout/combined_git_compare_test.go`
- implemented minimal code to satisfy tests, then repeated proof runs

## Tests run
- `go test ./cmd/cub-scout -run "Test(BuildGitComparison_Deterministic|RunCombined_GitPathCompareJSON|RunCombined_GitCompareRequiresPrimary)" -count=1`
- `go test ./cmd/cub-scout`
