### PR TITLE
patterns: canonicalize flux_kustomization_paths ID

### DIFF
--- a/docs/reference/gitops-patterns.md
+++ b/docs/reference/gitops-patterns.md
@@ -121,7 +121,7 @@ See [Patterns Contract Reference](patterns-contract.md#git-aware-patterns-v010) 
 | Pattern ID | Type | Status | Description |
 |------------|------|--------|-------------|
 | `gitops.argocd.applicationset_generators` | Hybrid | Implemented | Summarizes ApplicationSet generators; enriched with repo data when `--git-root` provided |
-| `gitops.flux_kustomization_paths` | Hybrid | Planned | Correlates Flux Kustomization paths; validates against repo when `--git-root` provided |
+| `gitops.flux_kustomization_paths` | Hybrid | Implemented | Correlates Flux Kustomization paths; validates against repo when `--git-root` provided |
 
 **Hybrid patterns** run in both modes:
 - **Without `--git-root`**: PASS with info findings from graph-visible data only

--- a/docs/reference/patterns-contract.md
+++ b/docs/reference/patterns-contract.md
@@ -665,7 +665,7 @@ enriched when `--git-root` is provided.
 
 ---
 
-### gitops.flux_kustomization_paths (v0.10+, planned)
+### gitops.flux_kustomization_paths (v0.10+)
 
 **Category:** gitops
 **Type:** Hybrid

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,7 +51,7 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 ### Pattern Contract (`reference/patterns-contract.md`)
 
 - [x] `gitops.argocd.applicationset_generators` pattern (implemented; doc ID drift fixed in #153)
-- [ ] `gitops.flux_kustomization_paths` pattern (planned, not implemented)
+- [x] `gitops.flux_kustomization_paths` pattern (implemented)
 
 ### Connected Mode Ideas
 

--- a/internal/patterns/pattern_git_aware.go
+++ b/internal/patterns/pattern_git_aware.go
@@ -9,10 +9,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	patternIDApplicationSetGenerators     = "gitops.argocd.applicationset_generators"
+	patternIDFluxKustomizationPaths       = "gitops.flux_kustomization_paths"
+	legacyPatternIDFluxKustomizationPaths = "gitops.flux.kustomization_paths"
+)
+
 func init() {
 	// ApplicationSet generators pattern (Hybrid)
 	Register(Pattern{
-		ID:          "gitops.argocd.applicationset_generators",
+		ID:          patternIDApplicationSetGenerators,
 		Name:        "ApplicationSet Generator Summary",
 		Description: "Summarizes ApplicationSet generators. Runs without --git-root with reduced evidence; enriched when --git-root is provided.",
 		Category:    "gitops",
@@ -25,7 +31,7 @@ func init() {
 
 	// Flux Kustomization paths pattern (Hybrid)
 	Register(Pattern{
-		ID:          "gitops.flux.kustomization_paths",
+		ID:          patternIDFluxKustomizationPaths,
 		Name:        "Flux Kustomization Paths",
 		Description: "Correlates Flux Kustomization paths with Git repository structure. Runs without --git-root with reduced evidence; enriched when --git-root is provided.",
 		Category:    "gitops",
@@ -35,6 +41,9 @@ func init() {
 		},
 		DetectWithGit: detectFluxKustomizationPaths,
 	})
+
+	// Backward compatibility for legacy dotted ID.
+	RegisterAlias(legacyPatternIDFluxKustomizationPaths, patternIDFluxKustomizationPaths)
 }
 
 // detectApplicationSetGenerators analyzes ApplicationSet generators.
@@ -54,7 +63,7 @@ func detectApplicationSetGenerators(ctx *DetectContext) ([]Finding, Status) {
 	// Note: invalid git context is handled by engine (SKIP), so we only check for nil
 	if ctx.Git == nil {
 		findings = append(findings, Finding{
-			Pattern:  "gitops.argocd.applicationset_generators",
+			Pattern:  patternIDApplicationSetGenerators,
 			Severity: SeverityInfo,
 			Message:  fmt.Sprintf("ApplicationSets in graph: %d (use --git-root for generator details)", appSetCount),
 		})
@@ -112,7 +121,7 @@ func detectApplicationSetGenerators(ctx *DetectContext) ([]Finding, Status) {
 
 		sort.Strings(refs)
 		findings = append(findings, Finding{
-			Pattern:  "gitops.argocd.applicationset_generators",
+			Pattern:  patternIDApplicationSetGenerators,
 			Severity: SeverityInfo,
 			Message:  fmt.Sprintf("ApplicationSet generators: %s", strings.Join(parts, " ")),
 			Refs:     refs,
@@ -121,7 +130,7 @@ func detectApplicationSetGenerators(ctx *DetectContext) ([]Finding, Status) {
 
 	// Also report graph count
 	findings = append(findings, Finding{
-		Pattern:  "gitops.argocd.applicationset_generators",
+		Pattern:  patternIDApplicationSetGenerators,
 		Severity: SeverityInfo,
 		Message:  fmt.Sprintf("ApplicationSets in graph: %d", appSetCount),
 	})
@@ -146,7 +155,7 @@ func detectFluxKustomizationPaths(ctx *DetectContext) ([]Finding, Status) {
 	// Note: invalid git context is handled by engine (SKIP), so we only check for nil
 	if ctx.Git == nil {
 		findings = append(findings, Finding{
-			Pattern:  "gitops.flux.kustomization_paths",
+			Pattern:  patternIDFluxKustomizationPaths,
 			Severity: SeverityInfo,
 			Message:  fmt.Sprintf("Flux Kustomizations in graph: %d (use --git-root for path details)", kustomizationCount),
 		})
@@ -198,7 +207,7 @@ func detectFluxKustomizationPaths(ctx *DetectContext) ([]Finding, Status) {
 
 		sort.Strings(refs)
 		findings = append(findings, Finding{
-			Pattern:  "gitops.flux.kustomization_paths",
+			Pattern:  patternIDFluxKustomizationPaths,
 			Severity: SeverityInfo,
 			Message:  fmt.Sprintf("Kustomization paths: %s", strings.Join(paths, ", ")),
 			Refs:     refs,
@@ -207,7 +216,7 @@ func detectFluxKustomizationPaths(ctx *DetectContext) ([]Finding, Status) {
 
 	// Report cluster count
 	findings = append(findings, Finding{
-		Pattern:  "gitops.flux.kustomization_paths",
+		Pattern:  patternIDFluxKustomizationPaths,
 		Severity: SeverityInfo,
 		Message:  fmt.Sprintf("Flux Kustomizations in graph: %d", kustomizationCount),
 	})

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -631,6 +631,7 @@ func TestRenderJSON_OmitsAbsentFields(t *testing.T) {
 		t.Error("should not include remediation when nil")
 	}
 }
+
 // Tests for Track J prerequisites (v0.9+)
 
 func TestCheckPrerequisites_NoPrereqs(t *testing.T) {
@@ -1137,7 +1138,7 @@ func TestFluxKustomizationPaths_ReducedEvidence(t *testing.T) {
 	})
 
 	// Without git context - should run in reduced evidence mode
-	pr := DetectOneWithGit(g, nil, "gitops.flux.kustomization_paths")
+	pr := DetectOneWithGit(g, nil, "gitops.flux_kustomization_paths")
 	if pr == nil {
 		t.Fatal("expected result")
 	}
@@ -1159,11 +1160,53 @@ func TestFluxKustomizationPaths_ReducedEvidence(t *testing.T) {
 	}
 }
 
+func TestFluxKustomizationPaths_UnderscoreID(t *testing.T) {
+	g := graph.NewGraph("test-cluster")
+
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/flux-system/Kustomization/flux-system",
+		Cluster:    "test-cluster",
+		Namespace:  "flux-system",
+		Kind:       "Kustomization",
+		Name:       "flux-system",
+		APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+	})
+
+	pr := DetectOneWithGit(g, nil, "gitops.flux_kustomization_paths")
+	if pr == nil {
+		t.Fatal("expected result for underscore pattern ID")
+	}
+	if pr.ID != "gitops.flux_kustomization_paths" {
+		t.Fatalf("expected canonical underscore ID, got %q", pr.ID)
+	}
+}
+
+func TestFluxKustomizationPaths_LegacyIDAlias(t *testing.T) {
+	g := graph.NewGraph("test-cluster")
+
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/flux-system/Kustomization/flux-system",
+		Cluster:    "test-cluster",
+		Namespace:  "flux-system",
+		Kind:       "Kustomization",
+		Name:       "flux-system",
+		APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+	})
+
+	pr := DetectOneWithGit(g, nil, "gitops.flux.kustomization_paths")
+	if pr == nil {
+		t.Fatal("expected result for legacy dotted pattern ID alias")
+	}
+	if pr.ID != "gitops.flux_kustomization_paths" {
+		t.Fatalf("expected canonical underscore ID from alias lookup, got %q", pr.ID)
+	}
+}
+
 func TestFluxKustomizationPaths_Skipped_NoPrereqs(t *testing.T) {
 	g := graph.NewGraph("test-cluster")
 	// Empty graph - no Kustomizations
 
-	pr := DetectOneWithGit(g, nil, "gitops.flux.kustomization_paths")
+	pr := DetectOneWithGit(g, nil, "gitops.flux_kustomization_paths")
 	if pr == nil {
 		t.Fatal("expected result")
 	}
@@ -1265,7 +1308,7 @@ func TestFluxKustomizationPaths_EnrichedWithGitContext(t *testing.T) {
 		t.Skipf("git context not valid: %v", gitCtx)
 	}
 
-	pr := DetectOneWithGit(g, gitCtx, "gitops.flux.kustomization_paths")
+	pr := DetectOneWithGit(g, gitCtx, "gitops.flux_kustomization_paths")
 	if pr == nil {
 		t.Fatal("expected result")
 	}

--- a/internal/patterns/registry.go
+++ b/internal/patterns/registry.go
@@ -4,6 +4,7 @@ import "sort"
 
 // registry holds all registered patterns.
 var registry = make(map[string]Pattern)
+var aliases = make(map[string]string)
 
 // Register adds a pattern to the registry.
 // Panics if a pattern with the same ID is already registered.
@@ -11,11 +12,35 @@ func Register(p Pattern) {
 	if _, exists := registry[p.ID]; exists {
 		panic("pattern already registered: " + p.ID)
 	}
+	if _, exists := aliases[p.ID]; exists {
+		panic("pattern ID collides with alias: " + p.ID)
+	}
 	registry[p.ID] = p
+}
+
+// RegisterAlias maps a legacy pattern ID to a canonical pattern ID.
+// Panics if alias collides with a registered pattern or existing alias.
+func RegisterAlias(alias, canonical string) {
+	if alias == "" || canonical == "" {
+		panic("alias and canonical must be non-empty")
+	}
+	if alias == canonical {
+		return
+	}
+	if _, exists := registry[alias]; exists {
+		panic("alias collides with pattern ID: " + alias)
+	}
+	if _, exists := aliases[alias]; exists {
+		panic("alias already registered: " + alias)
+	}
+	aliases[alias] = canonical
 }
 
 // Get returns a pattern by ID, or nil if not found.
 func Get(id string) *Pattern {
+	if canonical, ok := aliases[id]; ok {
+		id = canonical
+	}
 	if p, ok := registry[id]; ok {
 		return &p
 	}

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-auth-required.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-auth-required.golden.txt
@@ -46,16 +46,16 @@ Schema: patterns.v1
       evidence (1):
         - 1 Kustomization(s)
 
-[SKIP] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  skip_reason: git_source authentication required
-  findings (0):
-    (none)
-
 [PASS] gitops.flux.resources_present
   Flux Resources Present
   findings (1):
     - [info] Flux Kustomizations detected: 1
+
+[SKIP] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source authentication required
+  findings (0):
+    (none)
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.json
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.json
@@ -85,26 +85,6 @@
       ]
     },
     {
-      "id": "gitops.flux.kustomization_paths",
-      "name": "Flux Kustomization Paths",
-      "status": "pass",
-      "findings": [
-        {
-          "pattern": "gitops.flux.kustomization_paths",
-          "severity": "info",
-          "message": "Flux Kustomizations in graph: 1"
-        },
-        {
-          "pattern": "gitops.flux.kustomization_paths",
-          "severity": "info",
-          "message": "Kustomization paths: ./clusters/prod",
-          "refs": [
-            "git:path:flux/kustomization.yaml"
-          ]
-        }
-      ]
-    },
-    {
       "id": "gitops.flux.resources_present",
       "name": "Flux Resources Present",
       "status": "pass",
@@ -113,6 +93,26 @@
           "pattern": "gitops.flux.resources_present",
           "severity": "info",
           "message": "Flux Kustomizations detected: 1"
+        }
+      ]
+    },
+    {
+      "id": "gitops.flux_kustomization_paths",
+      "name": "Flux Kustomization Paths",
+      "status": "pass",
+      "findings": [
+        {
+          "pattern": "gitops.flux_kustomization_paths",
+          "severity": "info",
+          "message": "Flux Kustomizations in graph: 1"
+        },
+        {
+          "pattern": "gitops.flux_kustomization_paths",
+          "severity": "info",
+          "message": "Kustomization paths: ./clusters/prod",
+          "refs": [
+            "git:path:flux/kustomization.yaml"
+          ]
         }
       ]
     },

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.txt
@@ -46,16 +46,16 @@ Schema: patterns.v1
       evidence (1):
         - 1 Kustomization(s)
 
-[PASS] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  findings (2):
-    - [info] Flux Kustomizations in graph: 1
-    - [info] Kustomization paths: ./clusters/prod
-
 [PASS] gitops.flux.resources_present
   Flux Resources Present
   findings (1):
     - [info] Flux Kustomizations detected: 1
+
+[PASS] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  findings (2):
+    - [info] Flux Kustomizations in graph: 1
+    - [info] Kustomization paths: ./clusters/prod
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-fetch-failed.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-fetch-failed.golden.txt
@@ -46,16 +46,16 @@ Schema: patterns.v1
       evidence (1):
         - 1 Kustomization(s)
 
-[SKIP] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  skip_reason: git_source fetch failed
-  findings (0):
-    (none)
-
 [PASS] gitops.flux.resources_present
   Flux Resources Present
   findings (1):
     - [info] Flux Kustomizations detected: 1
+
+[SKIP] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source fetch failed
+  findings (0):
+    (none)
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-rate-limited.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-rate-limited.golden.txt
@@ -46,16 +46,16 @@ Schema: patterns.v1
       evidence (1):
         - 1 Kustomization(s)
 
-[SKIP] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  skip_reason: git_source rate limited
-  findings (0):
-    (none)
-
 [PASS] gitops.flux.resources_present
   Flux Resources Present
   findings (1):
     - [info] Flux Kustomizations detected: 1
+
+[SKIP] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source rate limited
+  findings (0):
+    (none)
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-ref-not-found.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-ref-not-found.golden.txt
@@ -46,16 +46,16 @@ Schema: patterns.v1
       evidence (1):
         - 1 Kustomization(s)
 
-[SKIP] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  skip_reason: git_source ref not found
-  findings (0):
-    (none)
-
 [PASS] gitops.flux.resources_present
   Flux Resources Present
   findings (1):
     - [info] Flux Kustomizations detected: 1
+
+[SKIP] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source ref not found
+  findings (0):
+    (none)
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-repo-not-found.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-repo-not-found.golden.txt
@@ -46,16 +46,16 @@ Schema: patterns.v1
       evidence (1):
         - 1 Kustomization(s)
 
-[SKIP] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  skip_reason: git_source repository not found
-  findings (0):
-    (none)
-
 [PASS] gitops.flux.resources_present
   Flux Resources Present
   findings (1):
     - [info] Flux Kustomizations detected: 1
+
+[SKIP] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source repository not found
+  findings (0):
+    (none)
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-tarball-invalid.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-tarball-invalid.golden.txt
@@ -46,16 +46,16 @@ Schema: patterns.v1
       evidence (1):
         - 1 Kustomization(s)
 
-[SKIP] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  skip_reason: git_source tarball invalid
-  findings (0):
-    (none)
-
 [PASS] gitops.flux.resources_present
   Flux Resources Present
   findings (1):
     - [info] Flux Kustomizations detected: 1
+
+[SKIP] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: git_source tarball invalid
+  findings (0):
+    (none)
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.json
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.json
@@ -74,17 +74,17 @@
       ]
     },
     {
-      "id": "gitops.flux.kustomization_paths",
-      "name": "Flux Kustomization Paths",
-      "status": "skip",
-      "skip_reason": "no Kustomization nodes in graph",
-      "findings": []
-    },
-    {
       "id": "gitops.flux.resources_present",
       "name": "Flux Resources Present",
       "status": "skip",
       "skip_reason": "no Kustomization/HelmRelease/GitRepository nodes in graph",
+      "findings": []
+    },
+    {
+      "id": "gitops.flux_kustomization_paths",
+      "name": "Flux Kustomization Paths",
+      "status": "skip",
+      "skip_reason": "no Kustomization nodes in graph",
       "findings": []
     },
     {

--- a/test/golden/patterns-detect/testdata/detect-empty.golden.txt
+++ b/test/golden/patterns-detect/testdata/detect-empty.golden.txt
@@ -53,15 +53,15 @@ Schema: patterns.v1
         - https://argo-cd.readthedocs.io/en/stable/getting_started/
         - https://fluxcd.io/flux/get-started/
 
-[SKIP] gitops.flux.kustomization_paths
-  Flux Kustomization Paths
-  skip_reason: no Kustomization nodes in graph
-  findings (0):
-    (none)
-
 [SKIP] gitops.flux.resources_present
   Flux Resources Present
   skip_reason: no Kustomization/HelmRelease/GitRepository nodes in graph
+  findings (0):
+    (none)
+
+[SKIP] gitops.flux_kustomization_paths
+  Flux Kustomization Paths
+  skip_reason: no Kustomization nodes in graph
   findings (0):
     (none)
 
@@ -70,3 +70,4 @@ Schema: patterns.v1
   skip_reason: no Deployment/ReplicaSet/Pod nodes in graph
   findings (0):
     (none)
+

--- a/test/golden/patterns-explain/testdata/explain-unknown.golden.txt
+++ b/test/golden/patterns-explain/testdata/explain-unknown.golden.txt
@@ -8,6 +8,6 @@ Available patterns:
   - gitops.argocd.applicationset_generators
   - gitops.argocd.resources_present
   - gitops.controller_presence
-  - gitops.flux.kustomization_paths
   - gitops.flux.resources_present
+  - gitops.flux_kustomization_paths
   - k8s.ownership_chain_complete

--- a/test/golden/patterns-list/testdata/list.golden.txt
+++ b/test/golden/patterns-list/testdata/list.golden.txt
@@ -16,9 +16,9 @@ Registered patterns (10):
     Argo CD Resources Present
   - gitops.controller_presence
     GitOps Controller Presence
-  - gitops.flux.kustomization_paths
-    Flux Kustomization Paths
   - gitops.flux.resources_present
     Flux Resources Present
+  - gitops.flux_kustomization_paths
+    Flux Kustomization Paths
   - k8s.ownership_chain_complete
     Kubernetes Ownership Chain Complete


### PR DESCRIPTION
## Summary
- canonicalize Flux hybrid pattern ID to `gitops.flux_kustomization_paths`
- keep backward compatibility by resolving legacy `gitops.flux.kustomization_paths` as an alias
- ensure findings emit the canonical pattern ID consistently
- update pattern docs/roadmap status to implemented
- refresh pattern goldens (list/detect/explain + connected detect snapshots) for canonical ID and sorted-order output

## Proof-first workflow
- added failing tests first for underscore ID + alias behavior:
  - `TestFluxKustomizationPaths_UnderscoreID`
  - `TestFluxKustomizationPaths_LegacyIDAlias`
- implemented alias registry + canonical ID migration
- iterated until stable reruns

## Scoped proofs (iterative)
- `go test ./internal/patterns -run 'TestFluxKustomizationPaths_(UnderscoreID|LegacyIDAlias|ReducedEvidence|Skipped_NoPrereqs|EnrichedWithGitContext)' -count=1`
  - repeated stable reruns: pass
- `go test ./test/golden/patterns-list ./test/golden/patterns-detect ./test/golden/patterns-explain -count=1`
  - repeated stable reruns: pass

## Broader regression
- `go test ./internal/patterns -count=1` pass
- `go test ./cmd/cub-scout -count=1` pass

## Environment note
- full execution of `test/golden/patterns-detect-connected` is socket-restricted in this sandbox (localhost bind denied)
- compile-only check was run: `go test ./test/golden/patterns-detect-connected -run '^$' -count=1`
