### PR TITLE
patterns: validate flux kustomization paths against repo

### DIFF
--- a/internal/patterns/pattern_git_aware.go
+++ b/internal/patterns/pattern_git_aware.go
@@ -164,9 +164,12 @@ func detectFluxKustomizationPaths(ctx *DetectContext) ([]Finding, Status) {
 
 	// Mode 2: With valid git context (enriched)
 	pathCounts := make(map[string]int)
+	existingPaths := make(map[string]struct{})
+	missingPaths := make(map[string]struct{})
 	var refs []string
 
 	files := ctx.Git.Files()
+	repoPathSet := buildRepoPathSet(files)
 	for _, file := range files {
 		if !isYAMLFile(file) {
 			continue
@@ -188,6 +191,11 @@ func detectFluxKustomizationPaths(ctx *DetectContext) ([]Finding, Status) {
 			path := extractSpecPath(doc)
 			if path != "" {
 				pathCounts[path]++
+				if repoPathExists(repoPathSet, path) {
+					existingPaths[path] = struct{}{}
+				} else {
+					missingPaths[path] = struct{}{}
+				}
 			}
 
 			// Add repo-relative ref (bounded to first 10)
@@ -212,6 +220,21 @@ func detectFluxKustomizationPaths(ctx *DetectContext) ([]Finding, Status) {
 			Message:  fmt.Sprintf("Kustomization paths: %s", strings.Join(paths, ", ")),
 			Refs:     refs,
 		})
+
+		findings = append(findings, Finding{
+			Pattern:  patternIDFluxKustomizationPaths,
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Path validation: existing=%d missing=%d", len(existingPaths), len(missingPaths)),
+		})
+
+		if len(missingPaths) > 0 {
+			missing := sortedSetKeys(missingPaths)
+			findings = append(findings, Finding{
+				Pattern:  patternIDFluxKustomizationPaths,
+				Severity: SeverityInfo,
+				Message:  fmt.Sprintf("Missing repo paths: %s", strings.Join(missing, ", ")),
+			})
+		}
 	}
 
 	// Report cluster count
@@ -301,4 +324,58 @@ func extractSpecPath(doc map[string]interface{}) string {
 
 	path, _ := spec["path"].(string)
 	return path
+}
+
+func buildRepoPathSet(files []string) map[string]struct{} {
+	paths := make(map[string]struct{})
+	for _, file := range files {
+		normalized := normalizeRepoPath(file)
+		if normalized == "" {
+			continue
+		}
+		paths[normalized] = struct{}{}
+
+		dir := filepath.ToSlash(filepath.Dir(normalized))
+		for dir != "" && dir != "." && dir != "/" {
+			paths[dir] = struct{}{}
+			next := filepath.ToSlash(filepath.Dir(dir))
+			if next == dir {
+				break
+			}
+			dir = next
+		}
+	}
+	return paths
+}
+
+func repoPathExists(repoPaths map[string]struct{}, specPath string) bool {
+	normalized := normalizeRepoPath(specPath)
+	if normalized == "" {
+		return false
+	}
+	_, exists := repoPaths[normalized]
+	return exists
+}
+
+func normalizeRepoPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = filepath.ToSlash(filepath.Clean(path))
+	path = strings.TrimPrefix(path, "./")
+	path = strings.TrimPrefix(path, "/")
+	if path == "." {
+		return ""
+	}
+	return path
+}
+
+func sortedSetKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -1,6 +1,7 @@
 package patterns
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -1340,6 +1341,81 @@ func TestFluxKustomizationPaths_EnrichedWithGitContext(t *testing.T) {
 	}
 	if !hasRefs {
 		t.Error("expected refs with git:path: prefix in enriched mode")
+	}
+}
+
+func TestFluxKustomizationPaths_EnrichedValidationSummary(t *testing.T) {
+	g := graph.NewGraph("test-cluster")
+
+	g.AddNode(graph.Node{
+		ID:         "test-cluster/flux-system/Kustomization/flux-system",
+		Cluster:    "test-cluster",
+		Namespace:  "flux-system",
+		Kind:       "Kustomization",
+		Name:       "flux-system",
+		APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+	})
+
+	gitRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(gitRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(gitRoot, "flux"), 0o755); err != nil {
+		t.Fatalf("mkdir flux: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(gitRoot, "clusters", "prod"), 0o755); err != nil {
+		t.Fatalf("mkdir existing path: %v", err)
+	}
+
+	// Existing path
+	if err := os.WriteFile(filepath.Join(gitRoot, "clusters", "prod", "kustomization.yaml"), []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n"), 0o644); err != nil {
+		t.Fatalf("write existing kustomization: %v", err)
+	}
+	// Flux manifest that points at both an existing and missing path.
+	manifest := []byte(
+		"apiVersion: kustomize.toolkit.fluxcd.io/v1\n" +
+			"kind: Kustomization\n" +
+			"metadata:\n" +
+			"  name: existing\n" +
+			"spec:\n" +
+			"  path: ./clusters/prod\n" +
+			"---\n" +
+			"apiVersion: kustomize.toolkit.fluxcd.io/v1\n" +
+			"kind: Kustomization\n" +
+			"metadata:\n" +
+			"  name: missing\n" +
+			"spec:\n" +
+			"  path: ./apps/backend\n",
+	)
+	if err := os.WriteFile(filepath.Join(gitRoot, "flux", "kustomization.yaml"), manifest, 0o644); err != nil {
+		t.Fatalf("write flux manifest: %v", err)
+	}
+
+	gitCtx := gitctx.OpenGitRoot(gitRoot)
+	if gitCtx == nil || !gitCtx.Valid {
+		t.Fatalf("git context not valid: %+v", gitCtx)
+	}
+
+	pr := DetectOneWithGit(g, gitCtx, "gitops.flux_kustomization_paths")
+	if pr == nil {
+		t.Fatal("expected result")
+	}
+
+	hasValidationSummary := false
+	hasMissingPathList := false
+	for _, f := range pr.Findings {
+		if strings.Contains(f.Message, "Path validation: existing=1 missing=1") {
+			hasValidationSummary = true
+		}
+		if strings.Contains(f.Message, "Missing repo paths:") && strings.Contains(f.Message, "./apps/backend") {
+			hasMissingPathList = true
+		}
+	}
+	if !hasValidationSummary {
+		t.Fatal("expected enriched validation summary finding")
+	}
+	if !hasMissingPathList {
+		t.Fatal("expected missing path list finding")
 	}
 }
 

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.json
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.json
@@ -113,6 +113,11 @@
           "refs": [
             "git:path:flux/kustomization.yaml"
           ]
+        },
+        {
+          "pattern": "gitops.flux_kustomization_paths",
+          "severity": "info",
+          "message": "Path validation: existing=1 missing=0"
         }
       ]
     },

--- a/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.txt
+++ b/test/golden/patterns-detect-connected/testdata/detect-connected-equivalence.golden.txt
@@ -53,9 +53,10 @@ Schema: patterns.v1
 
 [PASS] gitops.flux_kustomization_paths
   Flux Kustomization Paths
-  findings (2):
+  findings (3):
     - [info] Flux Kustomizations in graph: 1
     - [info] Kustomization paths: ./clusters/prod
+    - [info] Path validation: existing=1 missing=0
 
 [SKIP] k8s.ownership_chain_complete
   Kubernetes Ownership Chain Complete


### PR DESCRIPTION
## Summary
- add real repo-path validation to `gitops.flux_kustomization_paths` in enriched (`--git-root`) mode
- keep existing path summary finding, then add validation finding: `existing=N missing=M`
- add explicit missing-path finding when unresolved paths exist
- refresh connected-equivalence goldens to include validation output

## Proof-first
- added failing test first: `TestFluxKustomizationPaths_EnrichedValidationSummary`
- implemented minimal path-set validation helpers and detection wiring
- reran scoped proofs to stability

## Scoped proofs
- `go test ./internal/patterns -run 'TestFluxKustomizationPaths_(EnrichedValidationSummary|UnderscoreID|LegacyIDAlias|ReducedEvidence|Skipped_NoPrereqs|EnrichedWithGitContext)' -count=1`
  - repeated runs passed
- `go test ./test/golden/patterns-list ./test/golden/patterns-detect ./test/golden/patterns-explain -count=1`
  - pass

## Broader checks
- `go test ./test/golden/patterns-detect-connected -run '^$' -count=1` (compile-only in sandbox)
- `go test ./cmd/cub-scout -count=1` pass

## Environment note
- full execution of connected golden tests remains socket-restricted in this sandbox (localhost bind denied), so compile-only validation is included here.
