### PR TITLE
map: add deterministic fleet view snapshot coverage

### DIFF
--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -1088,6 +1088,38 @@ func loadMapEntriesFromJSON(path string) ([]MapEntry, error) {
 	return entries, nil
 }
 
+// loadFleetUnitsFromJSON loads a []FleetUnit fixture used by ASCII golden tests.
+// This is only used when CUB_SCOUT_TEST_MAP_FLEET_JSON is set.
+func loadFleetUnitsFromJSON(path, space, appFilter string) ([]FleetUnit, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read map fleet fixture: %w", err)
+	}
+	var units []FleetUnit
+	if err := json.Unmarshal(b, &units); err != nil {
+		return nil, fmt.Errorf("parse map fleet fixture: %w", err)
+	}
+
+	filtered := make([]FleetUnit, 0, len(units))
+	for _, u := range units {
+		// Keep semantics aligned with live path: app label is required.
+		if strings.TrimSpace(u.App) == "" {
+			continue
+		}
+		if space != "" && u.Space != space {
+			continue
+		}
+		if appFilter != "" && u.App != appFilter {
+			continue
+		}
+		if strings.TrimSpace(u.Variant) == "" {
+			u.Variant = "default"
+		}
+		filtered = append(filtered, u)
+	}
+	return filtered, nil
+}
+
 type mapStatusFixture struct {
 	DeployersReady int `json:"deployersReady"`
 	DeployersTotal int `json:"deployersTotal"`
@@ -1274,6 +1306,10 @@ func runMapFleet(cmd *cobra.Command, args []string) error {
 }
 
 func fetchFleetUnits(space, appFilter string) ([]FleetUnit, error) {
+	if fixture := os.Getenv("CUB_SCOUT_TEST_MAP_FLEET_JSON"); fixture != "" {
+		return loadFleetUnitsFromJSON(fixture, space, appFilter)
+	}
+
 	// Build cub command to list units
 	args := []string{"unit", "list", "--json"}
 	if space != "" {

--- a/test/ascii/map/fleet/basic.json.golden
+++ b/test/ascii/map/fleet/basic.json.golden
@@ -1,0 +1,62 @@
+[
+  {
+    "Slug": "billing-dev-eu",
+    "Space": "billing-team",
+    "App": "billing-api",
+    "Variant": "dev",
+    "Revision": 12,
+    "LiveRevision": 12,
+    "Status": "Healthy",
+    "Target": "eu-west-1"
+  },
+  {
+    "Slug": "checkout-prod-us",
+    "Space": "checkout-team",
+    "App": "checkout",
+    "Variant": "prod",
+    "Revision": 42,
+    "LiveRevision": 40,
+    "Status": "Healthy",
+    "Target": "prod-us"
+  },
+  {
+    "Slug": "checkout-prod-eu",
+    "Space": "checkout-team",
+    "App": "checkout",
+    "Variant": "prod",
+    "Revision": 42,
+    "LiveRevision": 42,
+    "Status": "Drifted",
+    "Target": "prod-eu"
+  },
+  {
+    "Slug": "checkout-dev",
+    "Space": "checkout-team-dev",
+    "App": "checkout",
+    "Variant": "dev",
+    "Revision": 9,
+    "LiveRevision": 9,
+    "Status": "Healthy",
+    "Target": "dev-1"
+  },
+  {
+    "Slug": "checkout-prod-ap",
+    "Space": "checkout-team",
+    "App": "checkout",
+    "Variant": "prod",
+    "Revision": 42,
+    "LiveRevision": 0,
+    "Status": "Failed",
+    "Target": "prod-ap"
+  },
+  {
+    "Slug": "ops-prod",
+    "Space": "ops-team",
+    "App": "ops",
+    "Variant": "prod",
+    "Revision": 5,
+    "LiveRevision": 5,
+    "Status": "Healthy",
+    "Target": ""
+  }
+]

--- a/test/ascii/map/fleet/basic.txt
+++ b/test/ascii/map/fleet/basic.txt
@@ -1,0 +1,19 @@
+ConfigHub Fleet View (App Model)
+Hierarchy: Application → Variant → Target
+
+  billing-api
+  └── variant: dev
+      └── ✓ eu-west-1 @ rev 12
+
+  checkout
+  ├── variant: dev
+  │   └── ✓ dev-1 @ rev 9
+  └── variant: prod
+      ├── ⚠ prod-us @ rev 40 ← behind!
+      ├── ⚠ prod-eu @ rev 42
+      └── ✗ prod-ap @ rev 42
+
+  ops
+  └── variant: prod
+      └── ✓ ops-team @ rev 5
+

--- a/test/ascii/map/fleet/testdata/basic.json
+++ b/test/ascii/map/fleet/testdata/basic.json
@@ -1,0 +1,62 @@
+[
+  {
+    "Slug": "billing-dev-eu",
+    "Space": "billing-team",
+    "App": "billing-api",
+    "Variant": "dev",
+    "Revision": 12,
+    "LiveRevision": 12,
+    "Status": "Healthy",
+    "Target": "eu-west-1"
+  },
+  {
+    "Slug": "checkout-prod-us",
+    "Space": "checkout-team",
+    "App": "checkout",
+    "Variant": "prod",
+    "Revision": 42,
+    "LiveRevision": 40,
+    "Status": "Healthy",
+    "Target": "prod-us"
+  },
+  {
+    "Slug": "checkout-prod-eu",
+    "Space": "checkout-team",
+    "App": "checkout",
+    "Variant": "prod",
+    "Revision": 42,
+    "LiveRevision": 42,
+    "Status": "Drifted",
+    "Target": "prod-eu"
+  },
+  {
+    "Slug": "checkout-dev",
+    "Space": "checkout-team-dev",
+    "App": "checkout",
+    "Variant": "dev",
+    "Revision": 9,
+    "LiveRevision": 9,
+    "Status": "Healthy",
+    "Target": "dev-1"
+  },
+  {
+    "Slug": "checkout-prod-ap",
+    "Space": "checkout-team",
+    "App": "checkout",
+    "Variant": "prod",
+    "Revision": 42,
+    "LiveRevision": 0,
+    "Status": "Failed",
+    "Target": "prod-ap"
+  },
+  {
+    "Slug": "ops-prod",
+    "Space": "ops-team",
+    "App": "ops",
+    "Variant": "prod",
+    "Revision": 5,
+    "LiveRevision": 5,
+    "Status": "Healthy",
+    "Target": ""
+  }
+]

--- a/test/ascii/map_fleet_test.go
+++ b/test/ascii/map_fleet_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package ascii_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/confighub/cub-scout/test/ascii/golden"
+	"github.com/confighub/cub-scout/test/ascii/runner"
+)
+
+func TestMapFleet_Basic(t *testing.T) {
+	repoRoot := runner.RepoRoot(t)
+	fixture := filepath.Join(repoRoot, "test", "ascii", "map", "fleet", "testdata", "basic.json")
+
+	out := runner.RunWithEnv(t, repoRoot, map[string]string{
+		"CUB_SCOUT_TEST_MAP_FLEET_JSON": fixture,
+	}, "map", "fleet")
+
+	goldenPath := filepath.Join(repoRoot, "test", "ascii", "map", "fleet", "basic.txt")
+	golden.AssertGolden(t, out, goldenPath)
+}
+
+func TestMapFleet_JSON(t *testing.T) {
+	repoRoot := runner.RepoRoot(t)
+	fixture := filepath.Join(repoRoot, "test", "ascii", "map", "fleet", "testdata", "basic.json")
+
+	out := runner.RunWithEnv(t, repoRoot, map[string]string{
+		"CUB_SCOUT_TEST_MAP_FLEET_JSON": fixture,
+	}, "map", "fleet", "--json")
+
+	goldenPath := filepath.Join(repoRoot, "test", "ascii", "map", "fleet", "basic.json.golden")
+	golden.AssertGolden(t, out, goldenPath)
+}


### PR DESCRIPTION
## Scope
- Adds deterministic offline snapshot coverage for `cub-scout map fleet` (ascii + json).
- Adds test-only fixture hook `CUB_SCOUT_TEST_MAP_FLEET_JSON` in fleet unit loading path.

## Contract
- No user-facing flag/schema changes.
- Normal runtime behavior unchanged when the test hook is not set.
- Fixture parse errors fail safely with explicit error.

## Tests
- Added `test/ascii/map_fleet_test.go`
- Added fleet fixtures/goldens under `test/ascii/map/fleet/`

## Proof Runs
- `go test ./test/ascii -run 'TestMapFleet_' -count=1` (red first, then 3 consecutive green)
- `go test ./cmd/cub-scout -count=1`
- `go test ./test/ascii -count=1`

Local evidence: `/tmp/cub-scout-regression/m3/m3-t2/`
