### PR TITLE
ci: enforce total coverage threshold in unit job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,20 @@ jobs:
         run: ./scripts/check-readonly.sh
 
       - name: Run unit tests
-        run: go test ./... -v
+        run: go test ./... -v -covermode=atomic -coverprofile=coverage.out
+
+      - name: Enforce coverage gate
+        run: ./scripts/ci/check-coverage.sh coverage.out
+        env:
+          COVERAGE_MIN_PERCENT: "15.0"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.out
+            coverage-summary.txt
 
       - name: Verify real examples catalog
         run: go test -tags=integration ./test/integration/... -run '^TestRealExamplesCatalog$' -count=1 -v

--- a/scripts/ci/check-coverage.sh
+++ b/scripts/ci/check-coverage.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+coverage_file="${1:-coverage.out}"
+min_percent="${COVERAGE_MIN_PERCENT:-15.0}"
+summary_path="${COVERAGE_SUMMARY_PATH:-coverage-summary.txt}"
+
+observed=""
+
+if [[ -n "${COVERAGE_TOTAL_OVERRIDE:-}" ]]; then
+  observed="${COVERAGE_TOTAL_OVERRIDE}"
+else
+  if [[ ! -f "${coverage_file}" ]]; then
+    echo "coverage profile not found: ${coverage_file}" >&2
+    exit 1
+  fi
+
+  summary="$(go tool cover -func="${coverage_file}")"
+  printf "%s\n" "${summary}" > "${summary_path}"
+
+  observed="$(printf "%s\n" "${summary}" | awk '/^total:/{gsub("%","",$3); print $3}')"
+fi
+
+if [[ -z "${observed}" ]]; then
+  echo "could not determine total coverage from ${coverage_file}" >&2
+  exit 1
+fi
+
+if awk "BEGIN {exit !(${observed}+0 >= ${min_percent}+0)}"; then
+  echo "Coverage gate passed: observed=${observed}% required>=${min_percent}%"
+  exit 0
+fi
+
+echo "Coverage gate failed: observed=${observed}% required>=${min_percent}%" >&2
+exit 1

--- a/scripts/ci/check_coverage_test.go
+++ b/scripts/ci/check_coverage_test.go
@@ -1,0 +1,50 @@
+package ci
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCheckCoverage_PassesWhenAtOrAboveThreshold(t *testing.T) {
+	cmd := exec.Command("bash", "./check-coverage.sh", "unused.cover")
+	cmd.Env = append(os.Environ(),
+		"COVERAGE_TOTAL_OVERRIDE=25.5",
+		"COVERAGE_MIN_PERCENT=20.0",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check-coverage expected success, got error: %v\n%s", err, string(output))
+	}
+	if !strings.Contains(string(output), "Coverage gate passed") {
+		t.Fatalf("expected pass message, got:\n%s", string(output))
+	}
+}
+
+func TestCheckCoverage_FailsWhenBelowThreshold(t *testing.T) {
+	cmd := exec.Command("bash", "./check-coverage.sh", "unused.cover")
+	cmd.Env = append(os.Environ(),
+		"COVERAGE_TOTAL_OVERRIDE=12.0",
+		"COVERAGE_MIN_PERCENT=20.0",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("check-coverage expected failure, got success:\n%s", string(output))
+	}
+	if !strings.Contains(string(output), "Coverage gate failed") {
+		t.Fatalf("expected failure message, got:\n%s", string(output))
+	}
+}
+
+func TestCheckCoverage_FailsOnMissingInputWithoutOverride(t *testing.T) {
+	cmd := exec.Command("bash", "./check-coverage.sh", "missing.cover")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected missing-input failure, got success:\n%s", string(output))
+	}
+	if !strings.Contains(string(output), "coverage profile not found") {
+		t.Fatalf("expected missing-input message, got:\n%s", string(output))
+	}
+}
+


### PR DESCRIPTION
## Scope
- Adds CI coverage gate script: `scripts/ci/check-coverage.sh`.
- Adds deterministic tests for coverage gate pass/fail behavior: `scripts/ci/check_coverage_test.go`.
- Updates CI unit job to:
  - run coverage profile generation (`coverage.out`),
  - enforce minimum total coverage threshold,
  - upload coverage artifacts.

## Contract
- CI now fails if total coverage in unit job is below `COVERAGE_MIN_PERCENT` (currently `15.0`).
- Coverage artifacts are uploaded as `coverage-report` (`coverage.out`, `coverage-summary.txt`).
- No runtime CLI behavior changes.

## Proof-First Evidence
- Red first:
  - `go test ./scripts/ci -run 'TestCheckCoverage_' -count=1`
- Green loop:
  - run #1/#2/#3: `go test ./scripts/ci -run 'TestCheckCoverage_' -count=1`
- Broader checks:
  - `go test ./scripts/ci -count=1`
  - `go test ./cmd/cub-scout -count=1`

Evidence logs:
- `/tmp/cub-scout-regression/m4/m4-t2/run0-red.log`
- `/tmp/cub-scout-regression/m4/m4-t2/run1.log`
- `/tmp/cub-scout-regression/m4/m4-t2/run2.log`
- `/tmp/cub-scout-regression/m4/m4-t2/run3.log`
- `/tmp/cub-scout-regression/m4/m4-t2/scripts-ci-all.log`
- `/tmp/cub-scout-regression/m4/m4-t2/cmd-cub-scout.log`
