### PR TITLE
map fleet: show source space provenance per target

### DIFF
--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -1333,8 +1333,12 @@ func runMapFleet(cmd *cobra.Command, args []string) error {
 				if target == "" {
 					target = u.Space
 				}
+				spaceProvenance := u.Space
+				if spaceProvenance == "" {
+					spaceProvenance = "unknown"
+				}
 
-				fmt.Printf("  %s %s %s %s\n", unitPrefix, icon, target, revStatus)
+				fmt.Printf("  %s %s %s %s [space=%s]\n", unitPrefix, icon, target, revStatus, spaceProvenance)
 			}
 		}
 		fmt.Println()

--- a/test/ascii/map/fleet/basic.txt
+++ b/test/ascii/map/fleet/basic.txt
@@ -4,17 +4,17 @@ Impact: 3 apps, 6 targets, 1 behind, 1 drifted, 1 failed
 
   billing-api
   └── variant: dev
-      └── ✓ eu-west-1 @ rev 12
+      └── ✓ eu-west-1 @ rev 12 [space=billing-team]
 
   checkout
   ├── variant: dev
-  │   └── ✓ dev-1 @ rev 9
+  │   └── ✓ dev-1 @ rev 9 [space=checkout-team-dev]
   └── variant: prod
-      ├── ✗ prod-ap @ rev 42
-      ├── ⚠ prod-eu @ rev 42
-      └── ⚠ prod-us @ rev 40 ← behind!
+      ├── ✗ prod-ap @ rev 42 [space=checkout-team]
+      ├── ⚠ prod-eu @ rev 42 [space=checkout-team]
+      └── ⚠ prod-us @ rev 40 ← behind! [space=checkout-team]
 
   ops
   └── variant: prod
-      └── ✓ ops-team @ rev 5
+      └── ✓ ops-team @ rev 5 [space=ops-team]
 


### PR DESCRIPTION
## Scope
- Improves fleet provenance readability in ASCII output.
- Appends source App Space provenance to each target line in `map fleet`.

## Contract
- `map fleet` ASCII lines now include ` [space=<slug>]`.
- JSON output unchanged.
- No flag/schema changes.

## Proof-First Evidence
- Red first:
  - `go test ./test/ascii -run 'TestMapFleet_Basic' -count=1`
- Green loop:
  - run #1/#2/#3 same command
- Broader checks:
  - `go test ./test/ascii -count=1`
  - `go test ./cmd/cub-scout -count=1`

Evidence logs: `/tmp/cub-scout-regression/m3/m3-t6/`
