### PR TITLE
map fleet: add per-app impact context summary

### DIFF
--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -1257,6 +1257,25 @@ func runMapFleet(cmd *cobra.Command, args []string) error {
 	for _, appName := range appNames {
 		variants := apps[appName]
 		fmt.Printf("  %s\n", appName)
+		appTargets := 0
+		appBehind := 0
+		appDrifted := 0
+		appFailed := 0
+		for _, appUnits := range variants {
+			for _, u := range appUnits {
+				appTargets++
+				if u.LiveRevision > 0 && u.LiveRevision < u.Revision {
+					appBehind++
+				}
+				if u.Status == "Drifted" {
+					appDrifted++
+				}
+				if u.Status == "Failed" || u.Status == "Error" {
+					appFailed++
+				}
+			}
+		}
+		fmt.Printf("    impact: %d targets, %d behind, %d drifted, %d failed\n", appTargets, appBehind, appDrifted, appFailed)
 
 		// Sort variant names
 		variantNames := make([]string, 0, len(variants))

--- a/test/ascii/map/fleet/basic.txt
+++ b/test/ascii/map/fleet/basic.txt
@@ -3,10 +3,12 @@ Hierarchy: Application → Variant → Target
 Impact: 3 apps, 6 targets, 1 behind, 1 drifted, 1 failed
 
   billing-api
+    impact: 1 targets, 0 behind, 0 drifted, 0 failed
   └── variant: dev
       └── ✓ eu-west-1 @ rev 12 [space=billing-team]
 
   checkout
+    impact: 4 targets, 1 behind, 1 drifted, 1 failed
   ├── variant: dev
   │   └── ✓ dev-1 @ rev 9 [space=checkout-team-dev]
   └── variant: prod
@@ -15,6 +17,7 @@ Impact: 3 apps, 6 targets, 1 behind, 1 drifted, 1 failed
       └── ⚠ prod-us @ rev 40 ← behind! [space=checkout-team]
 
   ops
+    impact: 1 targets, 0 behind, 0 drifted, 0 failed
   └── variant: prod
       └── ✓ ops-team @ rev 5 [space=ops-team]
 


### PR DESCRIPTION
## Scope
- Improves multi-cluster impact clarity in `map fleet` output.
- Adds per-application impact context line before variant/target details.

## Contract
- For each app section in ASCII output, adds:
  - `impact: <targets>, <behind>, <drifted>, <failed>`
- Global impact header and hierarchy remain.
- JSON output unchanged.

## Proof-First Evidence
- Red first:
  - `go test ./test/ascii -run 'TestMapFleet_Basic' -count=1`
- Green loop:
  - run #1/#2/#3 same command
- Broader checks:
  - `go test ./test/ascii -count=1`
  - `go test ./cmd/cub-scout -count=1`

Evidence logs: `/tmp/cub-scout-regression/m3/m3-t7/`
