### PR TITLE
ci: raise coverage threshold to 25 percent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Enforce coverage gate
         run: ./scripts/ci/check-coverage.sh coverage.out
         env:
-          COVERAGE_MIN_PERCENT: "15.0"
+          COVERAGE_MIN_PERCENT: "25.0"
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/scripts/ci/coverage_policy_test.go
+++ b/scripts/ci/coverage_policy_test.go
@@ -1,0 +1,26 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestCoveragePolicy_CIThresholdIs25Percent(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", ".github", "workflows", "ci.yaml")
+	b, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	content := string(b)
+	re := regexp.MustCompile(`COVERAGE_MIN_PERCENT:\s*"([^"]+)"`)
+	m := re.FindStringSubmatch(content)
+	if len(m) < 2 {
+		t.Fatalf("COVERAGE_MIN_PERCENT not found in workflow")
+	}
+	if m[1] != "25.0" {
+		t.Fatalf("expected COVERAGE_MIN_PERCENT=25.0, got %s", m[1])
+	}
+}
+


### PR DESCRIPTION
## Scope
- Tightens CI unit coverage gate from `15.0` to `25.0`.
- Adds deterministic policy test asserting workflow threshold value.

## Evidence
- Recent CI unit run showed:
  - `Coverage gate passed: observed=27.7% required>=15.0%`
  - Run `22712568110`, job `65854007299`.
- New threshold keeps margin while tightening policy.

## Contract
- Unit job now fails when total coverage falls below `25.0`.
- Coverage gate script behavior remains unchanged.

## Proof-First Evidence
- Red first:
  - `go test ./scripts/ci -run 'TestCoveragePolicy_' -count=1`
- Green loop:
  - run #1/#2/#3 same command
- Broader checks:
  - `go test ./scripts/ci -count=1`
  - `go test ./cmd/cub-scout -count=1`

Evidence logs: `/tmp/cub-scout-regression/m4/m4-t3/`
