### PR TITLE
ci: include coverage metrics in proof artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
+    outputs:
+      coverage_total: ${{ steps.coverage_metric.outputs.coverage_total }}
+      coverage_min: ${{ steps.coverage_metric.outputs.coverage_min }}
     steps:
       - uses: actions/checkout@v4
 
@@ -62,6 +65,17 @@ jobs:
         run: ./scripts/ci/check-coverage.sh coverage.out
         env:
           COVERAGE_MIN_PERCENT: "25.0"
+
+      - name: Capture coverage metric
+        id: coverage_metric
+        run: |
+          total="$(awk '/^total:/{gsub("%","",$3); print $3}' coverage-summary.txt)"
+          if [[ -z "${total}" ]]; then
+            echo "failed to extract total coverage from coverage-summary.txt" >&2
+            exit 1
+          fi
+          echo "coverage_total=${total}" >> "$GITHUB_OUTPUT"
+          echo "coverage_min=25.0" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
@@ -346,6 +360,8 @@ jobs:
           PROOF_DEMOS: ${{ needs.demos.result }}
           PROOF_CONNECTED: ${{ needs.connected.result }}
           PROOF_FULL: ${{ needs.full.result }}
+          PROOF_COVERAGE_TOTAL: ${{ needs.unit.outputs.coverage_total }}
+          PROOF_COVERAGE_MIN: ${{ needs.unit.outputs.coverage_min }}
 
       - name: Upload proof artifact
         uses: actions/upload-artifact@v4

--- a/scripts/ci/coverage_policy_test.go
+++ b/scripts/ci/coverage_policy_test.go
@@ -24,3 +24,27 @@ func TestCoveragePolicy_CIThresholdIs25Percent(t *testing.T) {
 	}
 }
 
+func TestCoveragePolicy_ProofArtifactCoverageWiring(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", ".github", "workflows", "ci.yaml")
+	b, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	content := string(b)
+
+	if !regexp.MustCompile(`(?m)^\s*outputs:\s*$`).MatchString(content) {
+		t.Fatalf("unit job outputs block missing")
+	}
+	if !regexp.MustCompile(`coverage_total:\s*\$\{\{\s*steps\.coverage_metric\.outputs\.coverage_total\s*\}\}`).MatchString(content) {
+		t.Fatalf("unit coverage_total output mapping missing")
+	}
+	if !regexp.MustCompile(`coverage_min:\s*\$\{\{\s*steps\.coverage_metric\.outputs\.coverage_min\s*\}\}`).MatchString(content) {
+		t.Fatalf("unit coverage_min output mapping missing")
+	}
+	if !regexp.MustCompile(`PROOF_COVERAGE_TOTAL:\s*\$\{\{\s*needs\.unit\.outputs\.coverage_total\s*\}\}`).MatchString(content) {
+		t.Fatalf("proof-artifact coverage total env wiring missing")
+	}
+	if !regexp.MustCompile(`PROOF_COVERAGE_MIN:\s*\$\{\{\s*needs\.unit\.outputs\.coverage_min\s*\}\}`).MatchString(content) {
+		t.Fatalf("proof-artifact coverage min env wiring missing")
+	}
+}

--- a/scripts/ci/emit-proof-artifact.sh
+++ b/scripts/ci/emit-proof-artifact.sh
@@ -17,6 +17,8 @@ gitops_result="${PROOF_GITOPS:-skipped}"
 demos_result="${PROOF_DEMOS:-skipped}"
 connected_result="${PROOF_CONNECTED:-skipped}"
 full_result="${PROOF_FULL:-skipped}"
+coverage_total="${PROOF_COVERAGE_TOTAL:-unknown}"
+coverage_min="${PROOF_COVERAGE_MIN:-unknown}"
 
 json_path="${out_dir}/proof-matrix.json"
 md_path="${out_dir}/proof-summary.md"
@@ -29,6 +31,8 @@ cat >"${json_path}" <<EOF
   "event": "${event_name}",
   "ref": "${ref_name}",
   "sha": "${sha}",
+  "coverage_total": "${coverage_total}",
+  "coverage_min": "${coverage_min}",
   "tiers": {
     "unit": "${unit_result}",
     "integration": "${integration_result}",
@@ -49,6 +53,7 @@ cat >"${md_path}" <<EOF
 - Event: ${event_name}
 - Ref: ${ref_name}
 - SHA: ${sha}
+- Coverage total: ${coverage_total}% (required >= ${coverage_min}%)
 
 | Tier | Result |
 |---|---|

--- a/scripts/ci/emit_proof_artifact_test.go
+++ b/scripts/ci/emit_proof_artifact_test.go
@@ -25,6 +25,8 @@ func TestEmitProofArtifact_WritesExpectedFiles(t *testing.T) {
 		"PROOF_DEMOS=skipped",
 		"PROOF_CONNECTED=skipped",
 		"PROOF_FULL=skipped",
+		"PROOF_COVERAGE_TOTAL=27.7",
+		"PROOF_COVERAGE_MIN=25.0",
 	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -59,6 +61,12 @@ func TestEmitProofArtifact_WritesExpectedFiles(t *testing.T) {
 	if got := doc["generated_at"]; got != "2026-01-01T00:00:00Z" {
 		t.Fatalf("generated_at mismatch: got=%v want=2026-01-01T00:00:00Z", got)
 	}
+	if got := doc["coverage_total"]; got != "27.7" {
+		t.Fatalf("coverage_total mismatch: got=%v want=27.7", got)
+	}
+	if got := doc["coverage_min"]; got != "25.0" {
+		t.Fatalf("coverage_min mismatch: got=%v want=25.0", got)
+	}
 
 	md := string(mdBytes)
 	if !strings.Contains(md, "| unit | success |") {
@@ -66,6 +74,9 @@ func TestEmitProofArtifact_WritesExpectedFiles(t *testing.T) {
 	}
 	if !strings.Contains(md, "| gitops | success |") {
 		t.Fatalf("markdown missing gitops row: %s", md)
+	}
+	if !strings.Contains(md, "Coverage total: 27.7% (required >= 25.0%)") {
+		t.Fatalf("markdown missing coverage summary: %s", md)
 	}
 }
 
@@ -94,4 +105,3 @@ func TestEmitProofArtifact_DefaultsToSkipped(t *testing.T) {
 		t.Fatalf("expected default skipped integration row: %s", md)
 	}
 }
-


### PR DESCRIPTION
## Scope
- Adds numeric coverage context to proof artifacts:
  - `coverage_total`
  - `coverage_min`
- Wires CI unit job outputs into proof-artifact env.

## Contract
- `proof-matrix.json` now includes coverage fields.
- `proof-summary.md` now includes coverage summary line.
- Missing coverage values degrade to `unknown`.

## Proof-First Evidence
- Red first:
  - `go test ./scripts/ci -run 'TestEmitProofArtifact_WritesExpectedFiles|TestCoveragePolicy_ProofArtifactCoverageWiring' -count=1`
- Green loop:
  - run #1/#2/#3 same command
- Broader checks:
  - `go test ./scripts/ci -count=1`
  - `go test ./cmd/cub-scout -count=1`

Evidence logs: `/tmp/cub-scout-regression/m4/m4-t4/`
