### PR TITLE
ci: require coverage fields when unit tier succeeds

### DIFF
--- a/scripts/ci/emit-proof-artifact.sh
+++ b/scripts/ci/emit-proof-artifact.sh
@@ -20,6 +20,13 @@ full_result="${PROOF_FULL:-skipped}"
 coverage_total="${PROOF_COVERAGE_TOTAL:-unknown}"
 coverage_min="${PROOF_COVERAGE_MIN:-unknown}"
 
+if [[ "${unit_result}" == "success" ]]; then
+  if [[ "${coverage_total}" == "unknown" || "${coverage_min}" == "unknown" ]]; then
+    echo "coverage fields are required when unit tier succeeds" >&2
+    exit 1
+  fi
+fi
+
 json_path="${out_dir}/proof-matrix.json"
 md_path="${out_dir}/proof-summary.md"
 

--- a/scripts/ci/emit_proof_artifact_test.go
+++ b/scripts/ci/emit_proof_artifact_test.go
@@ -105,3 +105,21 @@ func TestEmitProofArtifact_DefaultsToSkipped(t *testing.T) {
 		t.Fatalf("expected default skipped integration row: %s", md)
 	}
 }
+
+func TestEmitProofArtifact_FailsWhenUnitSuccessMissingCoverage(t *testing.T) {
+	outDir := t.TempDir()
+	cmd := exec.Command("bash", "./emit-proof-artifact.sh", outDir)
+	cmd.Env = append(os.Environ(),
+		"PROOF_TIMESTAMP=2026-01-01T00:00:00Z",
+		"GITHUB_RUN_ID=111",
+		"PROOF_UNIT=success",
+		// Intentionally omit PROOF_COVERAGE_TOTAL / PROOF_COVERAGE_MIN.
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure when unit success lacks coverage fields; output=%s", string(output))
+	}
+	if !strings.Contains(string(output), "coverage fields are required when unit tier succeeds") {
+		t.Fatalf("expected explicit coverage requirement error, got: %s", string(output))
+	}
+}


### PR DESCRIPTION
## Scope
- Adds proof-artifact guardrail: coverage fields are mandatory when unit tier is successful.

## Contract
- `emit-proof-artifact.sh` now fails if:
  - `PROOF_UNIT=success` and
  - `PROOF_COVERAGE_TOTAL` or `PROOF_COVERAGE_MIN` is missing/unknown.
- Non-success unit tiers retain graceful behavior.

## Proof-First Evidence
- Red first:
  - `go test ./scripts/ci -run 'TestEmitProofArtifact_FailsWhenUnitSuccessMissingCoverage' -count=1`
- Green loop:
  - run #1/#2/#3 same command
- Broader checks:
  - `go test ./scripts/ci -count=1`
  - `go test ./cmd/cub-scout -count=1`

Evidence logs: `/tmp/cub-scout-regression/m4/m4-t5/`
