### PR TITLE
ci: validate proof coverage values for unit success

### DIFF
--- a/scripts/ci/emit-proof-artifact.sh
+++ b/scripts/ci/emit-proof-artifact.sh
@@ -20,9 +20,28 @@ full_result="${PROOF_FULL:-skipped}"
 coverage_total="${PROOF_COVERAGE_TOTAL:-unknown}"
 coverage_min="${PROOF_COVERAGE_MIN:-unknown}"
 
+is_numeric_percent() {
+  [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+
 if [[ "${unit_result}" == "success" ]]; then
   if [[ "${coverage_total}" == "unknown" || "${coverage_min}" == "unknown" ]]; then
     echo "coverage fields are required when unit tier succeeds" >&2
+    exit 1
+  fi
+
+  if ! is_numeric_percent "${coverage_total}" || ! is_numeric_percent "${coverage_min}"; then
+    echo "coverage fields must be numeric percentages when unit tier succeeds" >&2
+    exit 1
+  fi
+
+  if ! awk -v total="${coverage_total}" -v min="${coverage_min}" 'BEGIN {exit !(total+0 >= 0 && total+0 <= 100 && min+0 >= 0 && min+0 <= 100)}'; then
+    echo "coverage fields must be between 0 and 100 when unit tier succeeds" >&2
+    exit 1
+  fi
+
+  if ! awk -v total="${coverage_total}" -v min="${coverage_min}" 'BEGIN {exit !(total+0 >= min+0)}'; then
+    echo "coverage total must be greater than or equal to coverage minimum" >&2
     exit 1
   fi
 fi

--- a/scripts/ci/emit_proof_artifact_test.go
+++ b/scripts/ci/emit_proof_artifact_test.go
@@ -123,3 +123,60 @@ func TestEmitProofArtifact_FailsWhenUnitSuccessMissingCoverage(t *testing.T) {
 		t.Fatalf("expected explicit coverage requirement error, got: %s", string(output))
 	}
 }
+
+func TestEmitProofArtifact_FailsWhenUnitSuccessCoverageNotNumeric(t *testing.T) {
+	outDir := t.TempDir()
+	cmd := exec.Command("bash", "./emit-proof-artifact.sh", outDir)
+	cmd.Env = append(os.Environ(),
+		"PROOF_TIMESTAMP=2026-01-01T00:00:00Z",
+		"GITHUB_RUN_ID=112",
+		"PROOF_UNIT=success",
+		"PROOF_COVERAGE_TOTAL=twenty-seven",
+		"PROOF_COVERAGE_MIN=25.0",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure when coverage values are non-numeric; output=%s", string(output))
+	}
+	if !strings.Contains(string(output), "coverage fields must be numeric percentages when unit tier succeeds") {
+		t.Fatalf("expected numeric coverage error, got: %s", string(output))
+	}
+}
+
+func TestEmitProofArtifact_FailsWhenUnitSuccessCoverageOutOfRange(t *testing.T) {
+	outDir := t.TempDir()
+	cmd := exec.Command("bash", "./emit-proof-artifact.sh", outDir)
+	cmd.Env = append(os.Environ(),
+		"PROOF_TIMESTAMP=2026-01-01T00:00:00Z",
+		"GITHUB_RUN_ID=113",
+		"PROOF_UNIT=success",
+		"PROOF_COVERAGE_TOTAL=101.0",
+		"PROOF_COVERAGE_MIN=25.0",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure for out-of-range coverage values; output=%s", string(output))
+	}
+	if !strings.Contains(string(output), "coverage fields must be between 0 and 100 when unit tier succeeds") {
+		t.Fatalf("expected range validation error, got: %s", string(output))
+	}
+}
+
+func TestEmitProofArtifact_FailsWhenUnitSuccessCoverageTotalBelowMinimum(t *testing.T) {
+	outDir := t.TempDir()
+	cmd := exec.Command("bash", "./emit-proof-artifact.sh", outDir)
+	cmd.Env = append(os.Environ(),
+		"PROOF_TIMESTAMP=2026-01-01T00:00:00Z",
+		"GITHUB_RUN_ID=114",
+		"PROOF_UNIT=success",
+		"PROOF_COVERAGE_TOTAL=24.9",
+		"PROOF_COVERAGE_MIN=25.0",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure when coverage total is below minimum; output=%s", string(output))
+	}
+	if !strings.Contains(string(output), "coverage total must be greater than or equal to coverage minimum") {
+		t.Fatalf("expected total/min validation error, got: %s", string(output))
+	}
+}


### PR DESCRIPTION
## Scope
- Enforce stronger coverage semantics in CI proof artifact generation for successful unit-tier runs.

## Success Criteria
- Proof artifact emission fails if `PROOF_UNIT=success` and coverage values are non-numeric.
- Proof artifact emission fails if coverage values are outside `[0,100]`.
- Proof artifact emission fails if `coverage_total < coverage_min`.
- Existing behavior for non-success unit-tier runs remains unchanged.

## Graceful Degradation
- For skipped/failed unit-tier runs, coverage fields may remain `unknown` as before.

## Tests Added
- `TestEmitProofArtifact_FailsWhenUnitSuccessCoverageNotNumeric`
- `TestEmitProofArtifact_FailsWhenUnitSuccessCoverageOutOfRange`
- `TestEmitProofArtifact_FailsWhenUnitSuccessCoverageTotalBelowMinimum`

## Examples Updated
- None (CI-only contract hardening, no user-facing command output change).

## Commands Run
- `go test ./scripts/ci -run 'TestEmitProofArtifact_FailsWhenUnitSuccessCoverage(NotNumeric|OutOfRange|TotalBelowMinimum)' -count=1` (red first, then green x3)
- `go test ./scripts/ci -count=1`
- `go test ./cmd/cub-scout -count=1`
