### PR TITLE
docs/testing: codify CI coverage gate contract

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 - [ ] Workstream C: Hierarchy consistency across map/tree/unit surfaces
 - [ ] Workstream D: Fleet view delivery sequence (by-cluster → compare → matrix → revisions → rollout/deps/incident/security)
 - [ ] Workstream E: Claim→demo→status proof matrix
-- [ ] Workstream F: Testing gate contract (coverage matrix, CI-enforced gate, per-run proof artifact)
+- [x] Workstream F: Testing gate contract (coverage matrix, CI-enforced gate, per-run proof artifact) — graduated to #244, #245, #256, #258, #259, #260
 
 ### Pattern Contract (`reference/patterns-contract.md`)
 
@@ -74,7 +74,7 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 - [x] Production-scale E2E testing (500+ resources, mixed ownership, deep hierarchies) — resolved by #155, #156
 - [x] TUI performance profiling at scale (500+ resources) — resolved by #157
 - [x] Testing best practices cookbook (`docs/testing/BEST-PRACTICES.md`) — build tag standards, fixture conventions, golden patterns, cluster lifecycle, example-driven testing (#176)
-- [ ] CI-enforced coverage metrics
+- [x] CI-enforced coverage metrics — graduated to #245, #256, #260
 
 ### 1.x Connected Upsell (`roadmap-1x-connected-upsell.md`) — Complete
 

--- a/docs/testing/BEST-PRACTICES.md
+++ b/docs/testing/BEST-PRACTICES.md
@@ -20,6 +20,7 @@ Before writing code, check this table. Every change type has a minimum test expe
 | **CLI output format change** | ASCII golden in `test/ascii/<cmd>/` | Contract test if struct is exported |
 | **Connected mode feature** | Integration test with `skipIfNotConnected(t)` gate | Dry-run test (no ConfigHub writes) |
 | **Schema change to locked struct** | Contract test in `test/contract/` | Golden hash comparison |
+| **CI test-gate policy or thresholds** | `go test ./scripts/ci -count=1` + update `docs/testing/README.md` contract text | Add drift check in `coverage_policy_test.go` |
 
 **Minimum bar (from CLAUDE.md):**
 - Tests exist and pass

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -28,6 +28,31 @@ make test-import-delegation
 
 ---
 
+## CI Coverage Gate and Proof Artifact Contract
+
+CI unit tests enforce a coverage floor with `scripts/ci/check-coverage.sh`.
+
+- `COVERAGE_MIN_PERCENT` is currently `25.0` in `.github/workflows/ci.yaml`.
+- The unit tier must publish `coverage_total` and `coverage_min`.
+- Proof publishing writes both:
+  - `proof-matrix.json`
+  - `proof-summary.md`
+
+When `PROOF_UNIT=success`, `scripts/ci/emit-proof-artifact.sh` requires:
+
+- `coverage_total` and `coverage_min` to be present (not `unknown`)
+- numeric percentage values in `[0, 100]`
+- `coverage_total >= coverage_min`
+
+Local reproducibility:
+
+```bash
+go test ./scripts/ci -count=1
+go test ./scripts/ci -run 'TestCoveragePolicy_|TestEmitProofArtifact_' -count=1
+```
+
+---
+
 ## The Five Test Groups
 
 When using AI to write code, 100% test coverage is non-negotiable.

--- a/scripts/ci/coverage_policy_test.go
+++ b/scripts/ci/coverage_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -46,5 +47,53 @@ func TestCoveragePolicy_ProofArtifactCoverageWiring(t *testing.T) {
 	}
 	if !regexp.MustCompile(`PROOF_COVERAGE_MIN:\s*\$\{\{\s*needs\.unit\.outputs\.coverage_min\s*\}\}`).MatchString(content) {
 		t.Fatalf("proof-artifact coverage min env wiring missing")
+	}
+}
+
+func TestCoveragePolicy_TestingReadmeDocumentsCoverageGate(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", ".github", "workflows", "ci.yaml")
+	workflow, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	m := regexp.MustCompile(`COVERAGE_MIN_PERCENT:\s*"([^"]+)"`).FindStringSubmatch(string(workflow))
+	if len(m) < 2 {
+		t.Fatalf("COVERAGE_MIN_PERCENT not found in workflow")
+	}
+	requiredThreshold := m[1]
+
+	readmePath := filepath.Join("..", "..", "docs", "testing", "README.md")
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read docs/testing/README.md: %v", err)
+	}
+	content := string(readme)
+
+	if !strings.Contains(content, "COVERAGE_MIN_PERCENT") {
+		t.Fatalf("docs/testing/README.md must document COVERAGE_MIN_PERCENT")
+	}
+	if !strings.Contains(content, requiredThreshold) {
+		t.Fatalf("docs/testing/README.md missing current threshold value %s", requiredThreshold)
+	}
+}
+
+func TestCoveragePolicy_TestingReadmeDocumentsProofArtifactCoverageFields(t *testing.T) {
+	readmePath := filepath.Join("..", "..", "docs", "testing", "README.md")
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read docs/testing/README.md: %v", err)
+	}
+	content := string(readme)
+
+	requiredMarkers := []string{
+		"proof-matrix.json",
+		"proof-summary.md",
+		"coverage_total",
+		"coverage_min",
+	}
+	for _, marker := range requiredMarkers {
+		if !strings.Contains(content, marker) {
+			t.Fatalf("docs/testing/README.md missing proof artifact marker %q", marker)
+		}
 	}
 }


### PR DESCRIPTION
## Scope
- Add drift-guard tests ensuring testing docs remain aligned with CI coverage gate/proof-artifact policy.
- Update testing docs with explicit CI contract details.
- Mark roadmap testing-gate and coverage-metrics checklist items complete.

## Success Criteria
- `scripts/ci` policy tests fail if `docs/testing/README.md` omits current gate threshold contract text.
- `scripts/ci` policy tests fail if proof artifact coverage markers disappear from docs.
- Testing docs explicitly document `COVERAGE_MIN_PERCENT`, `proof-matrix.json`, `proof-summary.md`, `coverage_total`, and `coverage_min`.

## Graceful Degradation
- No runtime behavior changes; this is CI/docs contract hardening only.

## Tests Added
- `TestCoveragePolicy_TestingReadmeDocumentsCoverageGate`
- `TestCoveragePolicy_TestingReadmeDocumentsProofArtifactCoverageFields`

## Examples Updated
- None (documentation + CI policy only).

## Commands Run
- `go test ./scripts/ci -run 'TestCoveragePolicy_TestingReadmeDocuments(CoverageGate|ProofArtifactCoverageFields)' -count=1` (red first, then green x3)
- `go test ./scripts/ci -count=1`
- `go test ./cmd/cub-scout -count=1`
