### PR TITLE
docs: sync roadmap fleet workstream status

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,8 +32,8 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 - [x] Workstream C: Schema extension for `rendered_from` / `original_source` — scoped in #150
 - [x] Workstream D: Bridge patterns (Git→Flux, Git→Argo, Git→ConfigHub→OCI, Live→ConfigHub→OCI) — scoped in #151
 - [x] Workstream E: Orphan detection for broken ApplicationSet generator links — graduated to #232
-- [ ] Workstream F: Fleet query ergonomics and provenance readability
-- [ ] Workstream F: Impact analysis ergonomics and multi-cluster context clarity
+- [x] Workstream F: Fleet query ergonomics and provenance readability — graduated to #242, #251
+- [x] Workstream F: Impact analysis ergonomics and multi-cluster context clarity — graduated to #243, #254
 - [ ] Workstream G: Platform-only surfaces (Functions, Actions, ChangeSets, saved queries, alert triggers, dependency graphing, time-travel UX, three-state drift resolution, bulk operations)
 
 ### Connected Views + Launch (`roadmap-connected-views-and-launch.md`)

--- a/scripts/ci/roadmap_status_test.go
+++ b/scripts/ci/roadmap_status_test.go
@@ -1,0 +1,30 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRoadmapStatus_FleetAndCoverageWorkstreamsMarkedComplete(t *testing.T) {
+	roadmapPath := filepath.Join("..", "..", "docs", "roadmap.md")
+	b, err := os.ReadFile(roadmapPath)
+	if err != nil {
+		t.Fatalf("read roadmap: %v", err)
+	}
+	content := string(b)
+
+	requiredCheckedItems := []string{
+		"- [x] Workstream F: Fleet query ergonomics and provenance readability",
+		"- [x] Workstream F: Impact analysis ergonomics and multi-cluster context clarity",
+		"- [x] Workstream F: Testing gate contract (coverage matrix, CI-enforced gate, per-run proof artifact)",
+		"- [x] CI-enforced coverage metrics",
+	}
+	for _, item := range requiredCheckedItems {
+		if !strings.Contains(content, item) {
+			t.Fatalf("roadmap missing completed item marker: %s", item)
+		}
+	}
+}
+


### PR DESCRIPTION
## Scope
- Add roadmap status drift protection in `scripts/ci`.
- Mark delivered fleet ergonomics + impact roadmap items complete.

## Success Criteria
- CI test fails if those roadmap checklist entries regress to unchecked.
- `docs/roadmap.md` marks fleet provenance readability and impact context clarity as delivered with PR references.

## Graceful Degradation
- No runtime/product behavior changes; this is roadmap/CI consistency hardening.

## Tests Added
- `TestRoadmapStatus_FleetAndCoverageWorkstreamsMarkedComplete`

## Examples Updated
- None.

## Commands Run
- `go test ./scripts/ci -run 'TestRoadmapStatus_FleetAndCoverageWorkstreamsMarkedComplete' -count=1` (red first, then green x3)
- `go test ./scripts/ci -count=1`
- `go test ./cmd/cub-scout -count=1`
