### PR TITLE
docs: sync roadmap trace workstream status

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,9 +25,9 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 
 ### Rendered Manifest + Argo (`roadmap-rendered-manifest-and-argo.md`)
 
-- [ ] Workstream A: Distinguish "ConfigHub via OCI" ownership in trace outputs (relates to [ConfigHub rendered manifests](https://docs.confighub.com/guide/rendered-manifests/))
+- [x] Workstream A: Distinguish "ConfigHub via OCI" ownership in trace outputs (relates to [ConfigHub rendered manifests](https://docs.confighub.com/guide/rendered-manifests/)) — validated by `TestArgoTracerConfigHubOCIDetection` + trace ASCII/JSON proofs
 - [x] Workstream A: Show explicit `source → render → OCI → deployer → workload` chain — scoped in #149
-- [ ] Workstream A: Source staleness/sync signals where evidence is available
+- [x] Workstream A: Source staleness/sync signals where evidence is available — validated by `TestArgoTrace` + trace ASCII/JSON proofs
 - [x] Workstream B: Source inventory view — resolved #148
 - [x] Workstream C: Schema extension for `rendered_from` / `original_source` — scoped in #150
 - [x] Workstream D: Bridge patterns (Git→Flux, Git→Argo, Git→ConfigHub→OCI, Live→ConfigHub→OCI) — scoped in #151

--- a/scripts/ci/roadmap_status_test.go
+++ b/scripts/ci/roadmap_status_test.go
@@ -28,3 +28,21 @@ func TestRoadmapStatus_FleetAndCoverageWorkstreamsMarkedComplete(t *testing.T) {
 	}
 }
 
+func TestRoadmapStatus_TraceOCIAndSourceSignalsMarkedComplete(t *testing.T) {
+	roadmapPath := filepath.Join("..", "..", "docs", "roadmap.md")
+	b, err := os.ReadFile(roadmapPath)
+	if err != nil {
+		t.Fatalf("read roadmap: %v", err)
+	}
+	content := string(b)
+
+	requiredCheckedItems := []string{
+		"- [x] Workstream A: Distinguish \"ConfigHub via OCI\" ownership in trace outputs",
+		"- [x] Workstream A: Source staleness/sync signals where evidence is available",
+	}
+	for _, item := range requiredCheckedItems {
+		if !strings.Contains(content, item) {
+			t.Fatalf("roadmap missing completed trace marker: %s", item)
+		}
+	}
+}


### PR DESCRIPTION
## Scope
- Sync roadmap status for M1 trace OCI/source-signal workstreams based on current passing proof suite.
- Add CI drift test to keep those roadmap markers consistent.

## Success Criteria
- CI test fails if either M1 trace checklist item regresses to unchecked.
- `docs/roadmap.md` reflects the current M1 trace state with proof references.

## Graceful Degradation
- No runtime behavior changes; this is roadmap/CI consistency hardening.

## Tests Added
- `TestRoadmapStatus_TraceOCIAndSourceSignalsMarkedComplete`

## Examples Updated
- None.

## Commands Run
- Baseline M1 proof commands (`pkg/agent` + `test/ascii` trace suites)
- `go test ./scripts/ci -run 'TestRoadmapStatus_TraceOCIAndSourceSignalsMarkedComplete' -count=1` (red first, then green x3)
- `go test ./scripts/ci -count=1`
- `go test ./cmd/cub-scout -count=1`
- `go test ./test/ascii -run 'TestTrace_Argo|TestTraceArgo_JSON' -count=1`
