### PR TITLE
docs: mark core navigation snapshot coverage complete

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 
 - [x] Workstream A: Navigation-first messaging and "aha in seconds" walkthrough — graduated to #224
 - [x] Workstream B: Scale-real demo assets — resolved #158
-- [ ] Workstream B: Expected-output snapshots for core navigation flows
+- [x] Workstream B: Expected-output snapshots for core navigation flows — validated by `test/ascii` map status/list + tree golden proofs
 - [ ] Workstream C: WET-LIVE panel clarity and causality messaging
 - [ ] Workstream C: Break-glass decision ergonomics and audit visibility
 - [ ] Workstream C: Hierarchy consistency across map/tree/unit surfaces

--- a/scripts/ci/roadmap_status_test.go
+++ b/scripts/ci/roadmap_status_test.go
@@ -46,3 +46,17 @@ func TestRoadmapStatus_TraceOCIAndSourceSignalsMarkedComplete(t *testing.T) {
 		}
 	}
 }
+
+func TestRoadmapStatus_CoreNavigationSnapshotsMarkedComplete(t *testing.T) {
+	roadmapPath := filepath.Join("..", "..", "docs", "roadmap.md")
+	b, err := os.ReadFile(roadmapPath)
+	if err != nil {
+		t.Fatalf("read roadmap: %v", err)
+	}
+	content := string(b)
+
+	requiredCheckedItem := "- [x] Workstream B: Expected-output snapshots for core navigation flows"
+	if !strings.Contains(content, requiredCheckedItem) {
+		t.Fatalf("roadmap missing completed navigation snapshot marker: %s", requiredCheckedItem)
+	}
+}


### PR DESCRIPTION
## Scope
- Mark Connected Views Workstream B navigation snapshot item complete in roadmap.
- Add CI drift test to prevent status regression.

## Success Criteria
- Roadmap marker for core navigation snapshots is checked.
- CI fails if that marker is later removed/unchecked.

## Graceful Degradation
- No runtime behavior changes.

## Tests Added
- `TestRoadmapStatus_CoreNavigationSnapshotsMarkedComplete`

## Examples Updated
- None.

## Commands Run
- `go test ./test/ascii -run 'TestMapStatus_(Healthy|Problems)|TestMapList_(Basic|OwnerNative|FormatJSON|FormatMarkdown)|TestTreeRuntime_Basic' -count=1`
- `go test ./scripts/ci -run 'TestRoadmapStatus_CoreNavigationSnapshotsMarkedComplete' -count=1` (red first, then green x3)
- `go test ./scripts/ci -count=1`
- `go test ./cmd/cub-scout -count=1`
- baseline proof rerun
