### PR TITLE
docs(readme): add scan variants and advanced scanner link

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,28 @@ Summary: 1 CRITICAL │ 2 WARNING │ 1 INFO
 Scanned: 47 resources │ Patterns: 46 active (4,500+ reference)
 ```
 
+### Scan Variants
+
+| Command | What It Detects |
+|---------|------------------|
+| `cub-scout scan` | Full scan (state + Kyverno findings) |
+| `cub-scout scan --state` | Stuck HelmRelease/Kustomization/Application reconciliations |
+| `cub-scout scan --kyverno` | Kyverno PolicyReport violations |
+| `cub-scout scan --lifecycle-hazards` | Helm hooks that conflict with ArgoCD lifecycle behavior |
+| `cub-scout scan --timing-bombs` | Expiring certs and quota/resource timing risks |
+| `cub-scout scan --dangling` | Orphan HPA/Service/Ingress/NetworkPolicy resources |
+| `cub-scout scan --file manifest.yaml` | Static YAML analysis (no cluster required) |
+| `cub-scout scan --json` | JSON output for CI/CD pipelines |
+| `cub-scout scan --normalized-json` | Normalized JSON (`scan.normalized.v1`) for downstream tooling |
+
+**Want deeper scanning?** See [confighub-scan](https://github.com/confighubai/confighub-scan) for:
+
+- 285 scanner rules (vs 46 patterns in `cub-scout scan`)
+- 3,513 risk patterns in the catalog
+- Custom CEL + Rego policy integration
+- Kyverno and Trivy integration options
+- ConfigHub GUI integration
+
 ---
 
 ## Quick Commands

--- a/scripts/ci/readme_scan_docs_test.go
+++ b/scripts/ci/readme_scan_docs_test.go
@@ -1,0 +1,38 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadme_ScanVariantsAndAdvancedScannerLinkDocumented(t *testing.T) {
+	readmePath := filepath.Join("..", "..", "README.md")
+	b, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	content := string(b)
+
+	requiredMarkers := []string{
+		"### Scan Variants",
+		"`cub-scout scan --state`",
+		"`cub-scout scan --kyverno`",
+		"`cub-scout scan --lifecycle-hazards`",
+		"`cub-scout scan --timing-bombs`",
+		"`cub-scout scan --dangling`",
+		"`cub-scout scan --file manifest.yaml`",
+		"`cub-scout scan --json`",
+		"`cub-scout scan --normalized-json`",
+		"[confighub-scan](https://github.com/confighubai/confighub-scan)",
+		"46 patterns",
+		"3,513 risk patterns",
+	}
+	for _, marker := range requiredMarkers {
+		if !strings.Contains(content, marker) {
+			t.Fatalf("README missing required scan docs marker: %s", marker)
+		}
+	}
+}
+


### PR DESCRIPTION
## Scope
- Resolve issue #257 by documenting scan variants and advanced scanner guidance in README.
- Add CI guardrails to keep this docs contract from regressing.

## Success Criteria
- README has a dedicated Scan Variants table covering the requested command modes.
- README links to `confighub-scan` and includes pattern-scale comparison markers.
- CI test fails if these markers are removed.

## Graceful Degradation
- No runtime behavior changes.

## Tests Added
- `TestReadme_ScanVariantsAndAdvancedScannerLinkDocumented`

## Examples Updated
- README scan usage section only.

## Commands Run
- `go test ./scripts/ci -run 'TestReadme_ScanVariantsAndAdvancedScannerLinkDocumented' -count=1` (red first, then green x3)
- `go test ./scripts/ci -count=1`
- `go test ./cmd/cub-scout -count=1`
