### PR TITLE
trace: add kubectl fallback when argocd context is stale

### DIFF
--- a/cmd/cub-scout/trace.go
+++ b/cmd/cub-scout/trace.go
@@ -723,6 +723,10 @@ func outputTraceHuman(result *agent.TraceResult, artifacts map[string]mapsvc.Tra
 		os.Exit(1)
 		return nil // unreachable but required for compiler
 	}
+	if result.Error != "" {
+		// Degraded mode: still render available chain, but make missing context explicit.
+		fmt.Printf("  %s[warning] %s%s\n\n", colorYellow, result.Error, colorReset)
+	}
 
 	// Print chain
 	for i, link := range result.Chain {
@@ -954,6 +958,9 @@ func outputTraceMarkdown(result *agent.TraceResult, artifacts map[string]mapsvc.
 		fmt.Println("```")
 		os.Exit(1)
 		return nil
+	}
+	if result.Error != "" {
+		fmt.Printf("  [warning] %s\n\n", result.Error)
 	}
 
 	// Print chain without colors

--- a/cmd/cub-scout/trace_fallback_warning_test.go
+++ b/cmd/cub-scout/trace_fallback_warning_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestOutputTraceHuman_ShowsDegradedWarningWhenChainExists(t *testing.T) {
+	result := &agent.TraceResult{
+		Object: agent.ResourceRef{
+			Kind:      "Application",
+			Name:      "checkout",
+			Namespace: "argocd",
+		},
+		Tool:         "argocd",
+		FullyManaged: true,
+		Error:        "ArgoCD CLI unavailable - showing kubectl-based Application trace only.",
+		Chain: []agent.ChainLink{
+			{Kind: "Source", Name: "acme/checkout", Ready: true},
+			{Kind: "Application", Name: "checkout", Namespace: "argocd", Ready: true},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := outputTraceHuman(result, nil); err != nil {
+			t.Fatalf("outputTraceHuman() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "ArgoCD CLI unavailable") {
+		t.Fatalf("expected degraded warning in human output, got:\n%s", out)
+	}
+}
+
+func TestOutputTraceMarkdown_ShowsDegradedWarningWhenChainExists(t *testing.T) {
+	result := &agent.TraceResult{
+		Object: agent.ResourceRef{
+			Kind:      "Application",
+			Name:      "checkout",
+			Namespace: "argocd",
+		},
+		Tool:         "argocd",
+		FullyManaged: true,
+		Error:        "ArgoCD CLI unavailable - showing kubectl-based Application trace only.",
+		Chain: []agent.ChainLink{
+			{Kind: "Source", Name: "acme/checkout", Ready: true},
+			{Kind: "Application", Name: "checkout", Namespace: "argocd", Ready: true},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := outputTraceMarkdown(result, nil); err != nil {
+			t.Fatalf("outputTraceMarkdown() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "[warning] ArgoCD CLI unavailable") {
+		t.Fatalf("expected degraded warning in markdown output, got:\n%s", out)
+	}
+}
+

--- a/pkg/agent/argo_trace.go
+++ b/pkg/agent/argo_trace.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 )
@@ -17,19 +18,37 @@ import (
 type ArgoTracer struct {
 	// argocdPath is the path to the argocd CLI (default: "argocd")
 	argocdPath string
+	// kubectlPath is the path to kubectl (default: "kubectl")
+	kubectlPath string
 }
 
 // NewArgoTracer creates a new Argo CD tracer
 func NewArgoTracer() *ArgoTracer {
 	return &ArgoTracer{
-		argocdPath: "argocd",
+		argocdPath:  "argocd",
+		kubectlPath: "kubectl",
 	}
 }
 
 // NewArgoTracerWithPath creates an Argo tracer with a custom CLI path
 func NewArgoTracerWithPath(path string) *ArgoTracer {
 	return &ArgoTracer{
-		argocdPath: path,
+		argocdPath:  path,
+		kubectlPath: "kubectl",
+	}
+}
+
+// NewArgoTracerWithPaths creates an Argo tracer with custom CLI paths.
+func NewArgoTracerWithPaths(argocdPath, kubectlPath string) *ArgoTracer {
+	if strings.TrimSpace(argocdPath) == "" {
+		argocdPath = "argocd"
+	}
+	if strings.TrimSpace(kubectlPath) == "" {
+		kubectlPath = "kubectl"
+	}
+	return &ArgoTracer{
+		argocdPath:  argocdPath,
+		kubectlPath: kubectlPath,
 	}
 }
 
@@ -95,7 +114,13 @@ func (a *ArgoTracer) traceApplication(ctx context.Context, appName, namespace st
 
 		// Detect stale/invalid context and print actionable remediation path.
 		if help, ok := FormatArgoContextError(combinedOutput); ok {
-			return nil, fmt.Errorf("%s", help)
+			// Graceful degradation: fallback to kubectl-based Application CR trace.
+			fallbackResult, fallbackErr := a.traceApplicationViaKubectl(ctx, appName, namespace)
+			if fallbackErr == nil {
+				fallbackResult.Error = "ArgoCD CLI unavailable - showing kubectl-based Application trace only. Run 'argocd login <server>' for full CLI-backed trace context."
+				return fallbackResult, nil
+			}
+			return nil, fmt.Errorf("%s\n\nkubectl fallback failed: %v", help, fallbackErr)
 		}
 
 		return nil, fmt.Errorf("argocd app get failed: %w: %s", err, combinedOutput)
@@ -103,6 +128,67 @@ func (a *ArgoTracer) traceApplication(ctx context.Context, appName, namespace st
 
 	// Parse the JSON output
 	return a.parseAppOutput(stdout.Bytes(), appName, namespace)
+}
+
+// traceApplicationViaKubectl degrades to Application CR inspection when the
+// argocd CLI context is stale/unavailable.
+func (a *ArgoTracer) traceApplicationViaKubectl(ctx context.Context, appName, namespace string) (*TraceResult, error) {
+	args := []string{"get", "applications.argoproj.io", "--all-namespaces", "-o", "json"}
+	cmd := exec.CommandContext(ctx, a.kubectlPath, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("kubectl get applications failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	var appList struct {
+		Items []argoApp `json:"items"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &appList); err != nil {
+		return nil, fmt.Errorf("parse kubectl applications output: %w", err)
+	}
+
+	matches := make([]argoApp, 0, len(appList.Items))
+	for _, app := range appList.Items {
+		if strings.TrimSpace(app.Metadata.Name) != appName {
+			continue
+		}
+		if namespace != "" && strings.TrimSpace(app.Metadata.Namespace) != namespace {
+			continue
+		}
+		matches = append(matches, app)
+	}
+	if len(matches) == 0 {
+		if namespace != "" {
+			return nil, fmt.Errorf("application %q not found via kubectl in namespace %q", appName, namespace)
+		}
+		return nil, fmt.Errorf("application %q not found via kubectl", appName)
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Metadata.Namespace == matches[j].Metadata.Namespace {
+			return matches[i].Metadata.Name < matches[j].Metadata.Name
+		}
+		return matches[i].Metadata.Namespace < matches[j].Metadata.Namespace
+	})
+
+	selected := matches[0]
+	if namespace == "" {
+		for _, candidate := range matches {
+			if strings.TrimSpace(candidate.Metadata.Namespace) == "argocd" {
+				selected = candidate
+				break
+			}
+		}
+	}
+
+	selectedData, err := json.Marshal(selected)
+	if err != nil {
+		return nil, fmt.Errorf("marshal kubectl-selected application: %w", err)
+	}
+
+	return a.parseAppOutput(selectedData, selected.Metadata.Name, selected.Metadata.Namespace)
 }
 
 // argoOwnerRef mirrors metav1.OwnerReference for JSON parsing.

--- a/pkg/agent/argo_trace_test.go
+++ b/pkg/agent/argo_trace_test.go
@@ -4,6 +4,9 @@
 package agent
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -892,4 +895,131 @@ func TestFormatArgoContextError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestArgoTraceApplication_FallsBackToKubectlWhenArgoCLIContextIsStale(t *testing.T) {
+	tempDir := t.TempDir()
+	argocdPath := writeExecScript(t, tempDir, "argocd", `#!/usr/bin/env bash
+echo "rpc error: code = Unavailable desc = connection error: dial tcp 10.0.0.1:443: i/o timeout" >&2
+exit 1
+`)
+	kubectlPath := writeExecScript(t, tempDir, "kubectl", `#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "checkout", "namespace": "argocd"},
+      "spec": {
+        "source": {"repoURL": "https://github.com/acme/checkout.git", "path": "envs/prod", "targetRevision": "main"},
+        "destination": {"server": "https://kubernetes.default.svc", "namespace": "prod"}
+      },
+      "status": {
+        "sync": {"status": "Synced", "revision": "abc123"},
+        "health": {"status": "Healthy"},
+        "resources": []
+      }
+    }
+  ]
+}
+JSON
+`)
+
+	tracer := NewArgoTracerWithPaths(argocdPath, kubectlPath)
+	result, err := tracer.TraceApplication(context.Background(), "checkout")
+	if err != nil {
+		t.Fatalf("TraceApplication() fallback error = %v", err)
+	}
+	if result == nil {
+		t.Fatalf("TraceApplication() result is nil")
+	}
+	if !strings.Contains(result.Error, "ArgoCD CLI unavailable") {
+		t.Fatalf("expected degraded-mode warning in result.Error, got: %q", result.Error)
+	}
+	if result.Object.Namespace != "argocd" {
+		t.Fatalf("result.Object.Namespace = %q, want argocd", result.Object.Namespace)
+	}
+	if len(result.Chain) < 2 {
+		t.Fatalf("expected source + application chain from kubectl fallback, got len=%d", len(result.Chain))
+	}
+	if result.Chain[1].Kind != "Application" {
+		t.Fatalf("expected second link kind Application, got %q", result.Chain[1].Kind)
+	}
+}
+
+func TestArgoTraceApplication_FallbackHonorsNamespaceFilter(t *testing.T) {
+	tempDir := t.TempDir()
+	argocdPath := writeExecScript(t, tempDir, "argocd", `#!/usr/bin/env bash
+echo "FATA[0000] Argo CD server address unspecified" >&2
+exit 1
+`)
+	kubectlPath := writeExecScript(t, tempDir, "kubectl", `#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "checkout", "namespace": "argocd"},
+      "spec": {
+        "source": {"repoURL": "https://github.com/acme/checkout.git", "targetRevision": "main"},
+        "destination": {"server": "https://kubernetes.default.svc", "namespace": "prod"}
+      },
+      "status": {"sync": {"status": "Synced", "revision": "a1"}, "health": {"status": "Healthy"}, "resources": []}
+    },
+    {
+      "metadata": {"name": "checkout", "namespace": "team-b"},
+      "spec": {
+        "source": {"repoURL": "https://github.com/acme/checkout-alt.git", "targetRevision": "main"},
+        "destination": {"server": "https://kubernetes.default.svc", "namespace": "team-b"}
+      },
+      "status": {"sync": {"status": "OutOfSync", "revision": "b2"}, "health": {"status": "Degraded"}, "resources": []}
+    }
+  ]
+}
+JSON
+`)
+
+	tracer := NewArgoTracerWithPaths(argocdPath, kubectlPath)
+	result, err := tracer.traceApplication(context.Background(), "checkout", "team-b")
+	if err != nil {
+		t.Fatalf("traceApplication() fallback error = %v", err)
+	}
+	if result.Object.Namespace != "team-b" {
+		t.Fatalf("result.Object.Namespace = %q, want team-b", result.Object.Namespace)
+	}
+	if result.Chain[0].URL != "https://github.com/acme/checkout-alt.git" {
+		t.Fatalf("selected fallback application repoURL = %q, want team-b app", result.Chain[0].URL)
+	}
+}
+
+func TestArgoTraceApplication_ContextError_WhenKubectlFallbackFails(t *testing.T) {
+	tempDir := t.TempDir()
+	argocdPath := writeExecScript(t, tempDir, "argocd", `#!/usr/bin/env bash
+echo "rpc error: code = Unavailable desc = connection error: dial tcp 10.0.0.1:443: i/o timeout" >&2
+exit 1
+`)
+	kubectlPath := writeExecScript(t, tempDir, "kubectl", `#!/usr/bin/env bash
+echo "error: forbidden" >&2
+exit 1
+`)
+
+	tracer := NewArgoTracerWithPaths(argocdPath, kubectlPath)
+	_, err := tracer.TraceApplication(context.Background(), "checkout")
+	if err == nil {
+		t.Fatalf("expected error when both argocd and kubectl fallback fail")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "argocd context appears stale or invalid") {
+		t.Fatalf("expected stale-context remediation, got: %s", got)
+	}
+	if !strings.Contains(got, "kubectl fallback failed") {
+		t.Fatalf("expected kubectl fallback failure detail, got: %s", got)
+	}
+}
+
+func writeExecScript(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write script %s: %v", name, err)
+	}
+	return path
 }


### PR DESCRIPTION
## Scope
- Implement graceful Argo trace fallback to kubectl when ArgoCD CLI context is stale/unavailable.
- Add explicit degraded-mode messaging in trace output.

## Success Criteria
- `trace` can return Application trace data in kubectl fallback mode when Argo CLI fails due stale context/auth/session issues.
- Human/markdown output explicitly warns users that fallback mode is active.
- If fallback also fails, returned error includes both Argo troubleshooting guidance and kubectl fallback failure context.

## Graceful Degradation
- Uses kubectl Application CR data when Argo API/CLI context is unavailable.
- Keeps existing full behavior unchanged when Argo CLI works.

## Tests Added
- `TestArgoTraceApplication_FallsBackToKubectlWhenArgoCLIContextIsStale`
- `TestArgoTraceApplication_FallbackHonorsNamespaceFilter`
- `TestArgoTraceApplication_ContextError_WhenKubectlFallbackFails`
- `TestOutputTraceHuman_ShowsDegradedWarningWhenChainExists`
- `TestOutputTraceMarkdown_ShowsDegradedWarningWhenChainExists`

## Commands Run
- `go test ./cmd/cub-scout -run 'TestOutputTrace(Human|Markdown)_ShowsDegradedWarningWhenChainExists' -count=1` (red first, then green x3)
- `go test ./pkg/agent -run 'TestArgoTraceApplication_(FallsBackToKubectlWhenArgoCLIContextIsStale|FallbackHonorsNamespaceFilter|ContextError_WhenKubectlFallbackFails)' -count=1` (green x3)
- `go test ./pkg/agent -count=1`
- `go test ./cmd/cub-scout -count=1`
