### PR TITLE
scan: detect runtime pod failures in --state (#249)

### DIFF
--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -1259,7 +1259,7 @@ Summary: 1 critical, 2 warning, 0 info
 | Option | Description |
 |--------|-------------|
 | `-n, --namespace` | Namespace to scan |
-| `--state` | State scan only (stuck reconciliations) |
+| `--state` | State scan only (stuck reconciliations + pod runtime failures) |
 | `--kyverno` | Kyverno scan only (PolicyReports) |
 | `--timing-bombs` | Expiring certs, quota limits |
 | `--dangling` | Orphan HPAs, Services, Ingress, NetworkPolicy |

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Scanned: 47 resources │ Patterns: 46 active (4,500+ reference)
 | Command | What It Detects |
 |---------|------------------|
 | `cub-scout scan` | Full scan (state + Kyverno findings) |
-| `cub-scout scan --state` | Stuck HelmRelease/Kustomization/Application reconciliations |
+| `cub-scout scan --state` | Stuck reconciliations plus pod runtime failures (ImagePullBackOff, CrashLoopBackOff, Pending, Evicted) |
 | `cub-scout scan --kyverno` | Kyverno PolicyReport violations |
 | `cub-scout scan --lifecycle-hazards` | Helm hooks that conflict with ArgoCD lifecycle behavior |
 | `cub-scout scan --timing-bombs` | Expiring certs and quota/resource timing risks |

--- a/cmd/cub-scout/scan.go
+++ b/cmd/cub-scout/scan.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -326,6 +327,29 @@ func outputCombinedHuman(kyvernoResult *agent.ScanResult, stateResult *agent.Sta
 
 	hasOutput := false
 
+	// Output runtime failures first (direct pod-level breakages).
+	if stateResult != nil && len(stateResult.RuntimeFindings) > 0 {
+		hasOutput = true
+		fmt.Printf("%s%sRUNTIME FAILURES%s\n", colorBold, colorCyan, colorReset)
+		fmt.Printf("%sScanned at: %s%s\n\n", colorDim, stateResult.ScannedAt.Format("2006-01-02 15:04:05"), colorReset)
+
+		for _, group := range groupRuntimeFailures(stateResult.RuntimeFindings) {
+			podLabel := "pods"
+			if len(group.Pods) == 1 {
+				podLabel = "pod"
+			}
+			fmt.Printf("%s✗ %s (%d %s)%s\n", colorRed, group.FailureType, len(group.Pods), podLabel, colorReset)
+			fmt.Printf("  %sAffected:%s %s\n", colorDim, colorReset, strings.Join(group.Pods, ", "))
+			if group.Image != "" {
+				fmt.Printf("  %sImage:%s %s\n", colorDim, colorReset, group.Image)
+			}
+			if group.Message != "" {
+				fmt.Printf("  %sReason:%s %s\n", colorDim, colorReset, group.Message)
+			}
+			fmt.Printf("  %sSuggestion:%s %s\n\n", colorDim, colorReset, group.Suggestion)
+		}
+	}
+
 	// Output state findings first (stuck resources are more urgent)
 	if stateResult != nil && len(stateResult.Findings) > 0 {
 		hasOutput = true
@@ -382,6 +406,10 @@ func outputCombinedHuman(kyvernoResult *agent.ScanResult, stateResult *agent.Sta
 			colorRed, stateResult.Summary.HelmReleaseStuck, colorReset,
 			colorYellow, stateResult.Summary.KustomizationStuck, colorReset,
 			colorCyan, stateResult.Summary.ApplicationStuck, colorReset)
+	} else if stateResult != nil && len(stateResult.RuntimeFindings) > 0 {
+		// Explicitly distinguish runtime failures from GitOps state issues.
+		fmt.Printf("STATE ISSUES\n")
+		fmt.Printf("%s%s✓ No state issues found%s\n\n", colorBold, colorGreen, colorReset)
 	}
 
 	// Output Kyverno findings
@@ -661,6 +689,70 @@ func outputCombinedHuman(kyvernoResult *agent.ScanResult, stateResult *agent.Sta
 	fmt.Printf("%s🔗 Track violations in ConfigHub: cub-scout scan --confighub%s\n\n", colorDim, colorReset)
 
 	return nil
+}
+
+type runtimeFailureGroup struct {
+	FailureType string
+	Pods        []string
+	Image       string
+	Message     string
+	Suggestion  string
+}
+
+func groupRuntimeFailures(findings []agent.RuntimeFailureFinding) []runtimeFailureGroup {
+	byType := map[string]*runtimeFailureGroup{}
+
+	for _, finding := range findings {
+		group, ok := byType[finding.FailureType]
+		if !ok {
+			group = &runtimeFailureGroup{
+				FailureType: finding.FailureType,
+				Suggestion:  finding.Remediation,
+			}
+			byType[finding.FailureType] = group
+		}
+
+		group.Pods = append(group.Pods, fmt.Sprintf("%s/%s", finding.Namespace, finding.Name))
+		if group.Image == "" && finding.Image != "" {
+			group.Image = finding.Image
+		}
+		if group.Message == "" {
+			group.Message = strings.TrimSpace(finding.Message)
+			if group.Message == "" {
+				group.Message = strings.TrimSpace(finding.Reason)
+			}
+		}
+		if group.Suggestion == "" && finding.Remediation != "" {
+			group.Suggestion = finding.Remediation
+		}
+	}
+
+	ordered := make([]runtimeFailureGroup, 0, len(byType))
+	for _, group := range byType {
+		sort.Strings(group.Pods)
+		ordered = append(ordered, *group)
+	}
+
+	sort.Slice(ordered, func(i, j int) bool {
+		return runtimeFailureOrder(ordered[i].FailureType) < runtimeFailureOrder(ordered[j].FailureType)
+	})
+
+	return ordered
+}
+
+func runtimeFailureOrder(failureType string) int {
+	order := map[string]int{
+		"ImagePullBackOff":     0,
+		"ErrImagePull":         1,
+		"CrashLoopBackOff":     2,
+		"CreateContainerError": 3,
+		"Pending":              4,
+		"Evicted":              5,
+	}
+	if idx, ok := order[failureType]; ok {
+		return idx
+	}
+	return 99
 }
 
 // outputStuckFinding outputs a single stuck finding with remediation

--- a/docs/howto/scan-for-risks.md
+++ b/docs/howto/scan-for-risks.md
@@ -15,7 +15,7 @@ go build ./cmd/cub-scout
 Common variants:
 
 ```bash
-# State-only checks
+# State-only checks (stuck reconciliations + runtime pod failures)
 ./cub-scout scan --state
 
 # Kyverno-only checks
@@ -30,6 +30,7 @@ Common variants:
 The scanner evaluates live cluster state against a maintained risk-pattern catalog. Typical findings include:
 
 - stuck GitOps reconciliation
+- pod runtime failures (ImagePullBackOff, ErrImagePull, CrashLoopBackOff, Pending, Evicted)
 - invalid or missing dependencies
 - drift and ownership gaps
 - fragile lifecycle sequencing patterns

--- a/internal/scan/normalized.go
+++ b/internal/scan/normalized.go
@@ -87,6 +87,22 @@ func Normalize(combined *CombinedResult) *NormalizedResult {
 				Command:     f.Command,
 			})
 		}
+
+		// Runtime findings (pod-level failures from scan --state)
+		for _, f := range combined.State.RuntimeFindings {
+			findings = append(findings, NormalizedFinding{
+				ID:          f.CCVEID,
+				Title:       fmt.Sprintf("Pod/%s %s", f.Name, f.FailureType),
+				Category:    f.Category,
+				Track:       "runtime",
+				Severity:    f.Severity,
+				Resource:    fmt.Sprintf("%s/%s", f.Kind, f.Name),
+				Namespace:   f.Namespace,
+				Message:     f.Message,
+				Remediation: f.Remediation,
+				Command:     f.Command,
+			})
+		}
 	}
 
 	// Timing bomb findings

--- a/internal/scan/normalized_test.go
+++ b/internal/scan/normalized_test.go
@@ -75,6 +75,46 @@ func TestNormalize_StateFindings(t *testing.T) {
 	}
 }
 
+func TestNormalize_RuntimeFindings(t *testing.T) {
+	combined := &CombinedResult{
+		State: &agent.StateScanResult{
+			RuntimeFindings: []agent.RuntimeFailureFinding{
+				{
+					CCVEID:      "CCVE-2025-0690",
+					Category:    "RUNTIME",
+					Severity:    "critical",
+					Kind:        "Pod",
+					Name:        "api-1",
+					Namespace:   "prod",
+					FailureType: "ImagePullBackOff",
+					Message:     "pull access denied",
+					Remediation: "Check imagePullSecrets",
+					Command:     "kubectl describe pod api-1 -n prod",
+				},
+			},
+		},
+	}
+
+	got := Normalize(combined)
+	if got.Summary.Total != 1 {
+		t.Fatalf("Total = %d, want 1", got.Summary.Total)
+	}
+
+	f := got.Findings[0]
+	if f.Track != "runtime" {
+		t.Errorf("Track = %q, want runtime", f.Track)
+	}
+	if f.Resource != "Pod/api-1" {
+		t.Errorf("Resource = %q, want Pod/api-1", f.Resource)
+	}
+	if f.Namespace != "prod" {
+		t.Errorf("Namespace = %q, want prod", f.Namespace)
+	}
+	if f.Command != "kubectl describe pod api-1 -n prod" {
+		t.Errorf("Command = %q, want kubectl describe pod api-1 -n prod", f.Command)
+	}
+}
+
 func TestNormalize_KyvernoFindings(t *testing.T) {
 	combined := &CombinedResult{
 		Kyverno: &agent.ScanResult{

--- a/pkg/agent/state_scanner.go
+++ b/pkg/agent/state_scanner.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -45,12 +46,31 @@ type StuckFinding struct {
 	Command     string `json:"command,omitempty"`
 }
 
+// RuntimeFailureFinding represents a runtime pod failure detected by scan --state.
+type RuntimeFailureFinding struct {
+	CCVEID      string `json:"ccveId"`
+	Category    string `json:"category"`
+	Severity    string `json:"severity"`
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	FailureType string `json:"failureType"`
+	Container   string `json:"container,omitempty"`
+	Image       string `json:"image,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Duration    string `json:"duration,omitempty"`
+	Remediation string `json:"remediation"`
+	Command     string `json:"command,omitempty"`
+}
+
 // StateScanResult contains findings from state scanning
 type StateScanResult struct {
-	ScannedAt time.Time        `json:"scannedAt"`
-	Findings  []StuckFinding   `json:"findings"`
-	Summary   StateScanSummary `json:"summary"`
-	Warnings  []string         `json:"warnings,omitempty"`
+	ScannedAt       time.Time               `json:"scannedAt"`
+	Findings        []StuckFinding          `json:"findings"`
+	RuntimeFindings []RuntimeFailureFinding `json:"runtimeFindings,omitempty"`
+	Summary         StateScanSummary        `json:"summary"`
+	Warnings        []string                `json:"warnings,omitempty"`
 }
 
 // StateScanSummary counts findings by type
@@ -59,6 +79,7 @@ type StateScanSummary struct {
 	KustomizationStuck int `json:"kustomizationStuck"`
 	ApplicationStuck   int `json:"applicationStuck"`
 	SilentFailures     int `json:"silentFailures"`
+	RuntimeFailures    int `json:"runtimeFailures"`
 	Total              int `json:"total"`
 }
 
@@ -100,8 +121,9 @@ func (s *StateScanner) Scan(ctx context.Context) (*StateScanResult, error) {
 // ScanWithThreshold performs a state scan with a custom threshold
 func (s *StateScanner) ScanWithThreshold(ctx context.Context, threshold time.Duration) (*StateScanResult, error) {
 	result := &StateScanResult{
-		ScannedAt: time.Now(),
-		Findings:  []StuckFinding{},
+		ScannedAt:       time.Now(),
+		Findings:        []StuckFinding{},
+		RuntimeFindings: []RuntimeFailureFinding{},
 	}
 	var warnings []string
 
@@ -119,6 +141,11 @@ func (s *StateScanner) ScanWithThreshold(ctx context.Context, threshold time.Dur
 	argoFindings := s.scanApplications(ctx, threshold, &warnings)
 	result.Findings = append(result.Findings, argoFindings...)
 	result.Summary.ApplicationStuck = len(argoFindings)
+
+	// Scan pod runtime failures (ImagePullBackOff, CrashLoopBackOff, etc.)
+	runtimeFindings := s.scanRuntimeFailures(ctx, "", threshold, &warnings)
+	result.RuntimeFindings = append(result.RuntimeFindings, runtimeFindings...)
+	result.Summary.RuntimeFailures = len(runtimeFindings)
 
 	// Scan for silent failures (Ready=True but misconfigured)
 	silentFindings := s.scanSilentFailures(ctx, &warnings)
@@ -138,8 +165,9 @@ func (s *StateScanner) ScanNamespace(ctx context.Context, namespace string) (*St
 // ScanNamespaceWithThreshold scans a specific namespace with custom threshold
 func (s *StateScanner) ScanNamespaceWithThreshold(ctx context.Context, namespace string, threshold time.Duration) (*StateScanResult, error) {
 	result := &StateScanResult{
-		ScannedAt: time.Now(),
-		Findings:  []StuckFinding{},
+		ScannedAt:       time.Now(),
+		Findings:        []StuckFinding{},
+		RuntimeFindings: []RuntimeFailureFinding{},
 	}
 	var warnings []string
 
@@ -157,6 +185,11 @@ func (s *StateScanner) ScanNamespaceWithThreshold(ctx context.Context, namespace
 	argoFindings := s.scanApplicationsNamespace(ctx, namespace, threshold, &warnings)
 	result.Findings = append(result.Findings, argoFindings...)
 	result.Summary.ApplicationStuck = len(argoFindings)
+
+	// Scan pod runtime failures in namespace
+	runtimeFindings := s.scanRuntimeFailures(ctx, namespace, threshold, &warnings)
+	result.RuntimeFindings = append(result.RuntimeFindings, runtimeFindings...)
+	result.Summary.RuntimeFailures = len(runtimeFindings)
 
 	// Scan for silent failures in namespace
 	silentFindings := s.scanSilentFailuresNamespace(ctx, namespace, &warnings)
@@ -648,6 +681,238 @@ func (s *StateScanner) checkApplications(items []unstructured.Unstructured, thre
 	}
 
 	return findings
+}
+
+// scanRuntimeFailures scans Pods for runtime failures that are not captured by
+// GitOps reconciler state (for example ImagePullBackOff / CrashLoopBackOff).
+func (s *StateScanner) scanRuntimeFailures(ctx context.Context, namespace string, threshold time.Duration, warnings *[]string) []RuntimeFailureFinding {
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
+
+	var (
+		list *unstructured.UnstructuredList
+		err  error
+	)
+	if namespace != "" {
+		list, err = s.client.Resource(gvr).Namespace(namespace).List(ctx, v1.ListOptions{})
+	} else {
+		list, err = s.client.Resource(gvr).List(ctx, v1.ListOptions{})
+	}
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			*warnings = append(*warnings, formatScanWarning(gvr, namespace, err))
+		}
+		return nil
+	}
+
+	findings := make([]RuntimeFailureFinding, 0, len(list.Items))
+	for i := range list.Items {
+		finding, ok := s.detectRuntimeFailureForPod(list.Items[i], threshold)
+		if !ok {
+			continue
+		}
+		findings = append(findings, finding)
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].FailureType == findings[j].FailureType {
+			if findings[i].Namespace == findings[j].Namespace {
+				return findings[i].Name < findings[j].Name
+			}
+			return findings[i].Namespace < findings[j].Namespace
+		}
+		return findings[i].FailureType < findings[j].FailureType
+	})
+
+	return findings
+}
+
+func (s *StateScanner) detectRuntimeFailureForPod(pod unstructured.Unstructured, threshold time.Duration) (RuntimeFailureFinding, bool) {
+	failureType, container, image, reason, message, hasWaitingFailure := podWaitingFailure(&pod)
+	age, ageKnown := podAge(&pod)
+	if !hasWaitingFailure {
+		phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
+		statusReason, _, _ := unstructured.NestedString(pod.Object, "status", "reason")
+		statusMessage, _, _ := unstructured.NestedString(pod.Object, "status", "message")
+
+		if strings.EqualFold(phase, "Failed") && strings.EqualFold(statusReason, "Evicted") {
+			return buildRuntimeFailureFinding(&pod, "Evicted", "", "", statusReason, statusMessage, age), true
+		}
+
+		if strings.EqualFold(phase, "Pending") && ageKnown && age > threshold {
+			if strings.TrimSpace(statusReason) == "" {
+				statusReason = "PendingTooLong"
+			}
+			if strings.TrimSpace(statusMessage) == "" {
+				statusMessage = "Pod has been pending beyond threshold"
+			}
+			return buildRuntimeFailureFinding(&pod, "Pending", "", "", statusReason, statusMessage, age), true
+		}
+
+		return RuntimeFailureFinding{}, false
+	}
+
+	return buildRuntimeFailureFinding(&pod, failureType, container, image, reason, message, age), true
+}
+
+func podWaitingFailure(pod *unstructured.Unstructured) (failureType, container, image, reason, message string, ok bool) {
+	checkStatuses := func(statuses []interface{}) (string, string, string, string, string, bool) {
+		for _, raw := range statuses {
+			status, castOK := raw.(map[string]interface{})
+			if !castOK {
+				continue
+			}
+
+			state, _ := status["state"].(map[string]interface{})
+			waiting, _ := state["waiting"].(map[string]interface{})
+			if waiting == nil {
+				continue
+			}
+
+			waitingReason := strings.TrimSpace(fmt.Sprintf("%v", waiting["reason"]))
+			if waitingReason == "" {
+				continue
+			}
+
+			switch waitingReason {
+			case "ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff":
+				return waitingReason,
+					strings.TrimSpace(fmt.Sprintf("%v", status["name"])),
+					strings.TrimSpace(fmt.Sprintf("%v", status["image"])),
+					waitingReason,
+					strings.TrimSpace(fmt.Sprintf("%v", waiting["message"])),
+					true
+			case "CreateContainerError", "CreateContainerConfigError":
+				return "CreateContainerError",
+					strings.TrimSpace(fmt.Sprintf("%v", status["name"])),
+					strings.TrimSpace(fmt.Sprintf("%v", status["image"])),
+					waitingReason,
+					strings.TrimSpace(fmt.Sprintf("%v", waiting["message"])),
+					true
+			}
+		}
+		return "", "", "", "", "", false
+	}
+
+	initStatuses, _, _ := unstructured.NestedSlice(pod.Object, "status", "initContainerStatuses")
+	if ft, c, img, r, msg, found := checkStatuses(initStatuses); found {
+		return ft, c, img, r, msg, true
+	}
+
+	containerStatuses, _, _ := unstructured.NestedSlice(pod.Object, "status", "containerStatuses")
+	if ft, c, img, r, msg, found := checkStatuses(containerStatuses); found {
+		return ft, c, img, r, msg, true
+	}
+
+	return "", "", "", "", "", false
+}
+
+func podAge(pod *unstructured.Unstructured) (time.Duration, bool) {
+	createdAt := pod.GetCreationTimestamp().Time
+	if createdAt.IsZero() {
+		rawCreatedAt, found, _ := unstructured.NestedString(pod.Object, "metadata", "creationTimestamp")
+		if found && strings.TrimSpace(rawCreatedAt) != "" {
+			if parsed, err := time.Parse(time.RFC3339, rawCreatedAt); err == nil {
+				createdAt = parsed
+			}
+		}
+	}
+	if createdAt.IsZero() {
+		return 0, false
+	}
+	age := time.Since(createdAt)
+	if age < 0 {
+		return 0, true
+	}
+	return age, true
+}
+
+func buildRuntimeFailureFinding(
+	pod *unstructured.Unstructured,
+	failureType, container, image, reason, message string,
+	age time.Duration,
+) RuntimeFailureFinding {
+	namespace := pod.GetNamespace()
+	name := pod.GetName()
+
+	remediation := runtimeFailureRemediation(failureType)
+	finding := RuntimeFailureFinding{
+		CCVEID:      runtimeFailureCCVEID(failureType),
+		Category:    "RUNTIME",
+		Severity:    runtimeFailureSeverity(failureType),
+		Kind:        "Pod",
+		Name:        name,
+		Namespace:   namespace,
+		FailureType: failureType,
+		Container:   container,
+		Image:       image,
+		Reason:      strings.TrimSpace(reason),
+		Message:     truncateMessage(strings.TrimSpace(message), 160),
+		Remediation: remediation,
+	}
+
+	if age > 0 {
+		finding.Duration = formatDuration(age)
+	}
+
+	switch failureType {
+	case "CrashLoopBackOff":
+		finding.Command = fmt.Sprintf("kubectl logs %s -n %s --previous", name, namespace)
+	default:
+		finding.Command = fmt.Sprintf("kubectl describe pod %s -n %s", name, namespace)
+	}
+
+	return finding
+}
+
+func runtimeFailureSeverity(failureType string) string {
+	switch failureType {
+	case "ImagePullBackOff", "ErrImagePull", "Evicted":
+		return "critical"
+	case "CrashLoopBackOff", "CreateContainerError", "Pending":
+		return "warning"
+	default:
+		return "info"
+	}
+}
+
+func runtimeFailureCCVEID(failureType string) string {
+	switch failureType {
+	case "ImagePullBackOff":
+		return "CCVE-2025-0690"
+	case "ErrImagePull":
+		return "CCVE-2025-0691"
+	case "CrashLoopBackOff":
+		return "CCVE-2025-0692"
+	case "CreateContainerError":
+		return "CCVE-2025-0693"
+	case "Pending":
+		return "CCVE-2025-0694"
+	case "Evicted":
+		return "CCVE-2025-0695"
+	default:
+		return "CCVE-2025-0699"
+	}
+}
+
+func runtimeFailureRemediation(failureType string) string {
+	switch failureType {
+	case "ImagePullBackOff", "ErrImagePull":
+		return "Check imagePullSecrets or verify image exists in registry"
+	case "CrashLoopBackOff":
+		return "Inspect pod logs and recent config changes"
+	case "CreateContainerError":
+		return "Check referenced ConfigMaps/Secrets and container command"
+	case "Pending":
+		return "Check scheduler events, resource requests, and node capacity"
+	case "Evicted":
+		return "Check node pressure and pod resource limits"
+	default:
+		return "Inspect pod events and controller status"
+	}
 }
 
 // determineSeverity determines severity based on duration

--- a/pkg/agent/state_scanner_test.go
+++ b/pkg/agent/state_scanner_test.go
@@ -1029,6 +1029,201 @@ func TestScanContractSummaryConsistency(t *testing.T) {
 	assert.Equal(t, 1, result.Summary.KustomizationStuck, "Expected 1 stuck Kustomization")
 }
 
+func TestScanRuntimeFailures_DetectsCommonPodFailureTypes(t *testing.T) {
+	oldCreatedAt := time.Now().Add(-30 * time.Minute).Format(time.RFC3339)
+
+	imagePullBackoffPod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "api-7d9b8c-1",
+			"namespace":         "myapp-dev",
+			"creationTimestamp": oldCreatedAt,
+		},
+		"status": map[string]interface{}{
+			"phase": "Pending",
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name":  "api",
+					"image": "acme/api:v1.2.0",
+					"state": map[string]interface{}{
+						"waiting": map[string]interface{}{
+							"reason":  "ImagePullBackOff",
+							"message": "pull access denied, repository does not exist",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	crashLoopPod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "worker-6dbf6f-1",
+			"namespace":         "myapp-dev",
+			"creationTimestamp": oldCreatedAt,
+		},
+		"status": map[string]interface{}{
+			"phase": "Running",
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name":  "worker",
+					"image": "acme/worker:v2.0.1",
+					"state": map[string]interface{}{
+						"waiting": map[string]interface{}{
+							"reason":  "CrashLoopBackOff",
+							"message": "back-off 5m0s restarting failed container",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	pendingTooLongPod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "scheduler-blocked-1",
+			"namespace":         "myapp-dev",
+			"creationTimestamp": oldCreatedAt,
+		},
+		"status": map[string]interface{}{
+			"phase":   "Pending",
+			"reason":  "Unschedulable",
+			"message": "0/3 nodes are available: insufficient cpu",
+		},
+	}}
+
+	evictedPod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "cache-evicted-1",
+			"namespace":         "myapp-prod",
+			"creationTimestamp": oldCreatedAt,
+		},
+		"status": map[string]interface{}{
+			"phase":   "Failed",
+			"reason":  "Evicted",
+			"message": "The node had condition: [MemoryPressure]",
+		},
+	}}
+
+	healthyPod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "healthy-1",
+			"namespace":         "myapp-dev",
+			"creationTimestamp": oldCreatedAt,
+		},
+		"status": map[string]interface{}{
+			"phase": "Running",
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name":  "app",
+					"image": "acme/app:v1.0.0",
+					"state": map[string]interface{}{
+						"running": map[string]interface{}{
+							"startedAt": oldCreatedAt,
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	client := newFakeDynamicClientForScan(imagePullBackoffPod, crashLoopPod, pendingTooLongPod, evictedPod, healthyPod)
+	scanner := NewStateScannerWithClient(client)
+
+	result, err := scanner.ScanWithThreshold(context.Background(), 5*time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Contract: runtime findings are tracked separately and grouped by failure type.
+	assert.Len(t, result.RuntimeFindings, 4, "expected 4 runtime failure findings")
+	assert.Equal(t, 4, result.Summary.RuntimeFailures, "runtime summary count should match runtime findings length")
+	assert.Equal(t, len(result.Findings), result.Summary.Total, "stuck summary total contract should remain unchanged")
+
+	gotTypes := map[string]int{}
+	for _, f := range result.RuntimeFindings {
+		gotTypes[f.FailureType]++
+	}
+	assert.Equal(t, 1, gotTypes["ImagePullBackOff"], "expected one ImagePullBackOff finding")
+	assert.Equal(t, 1, gotTypes["CrashLoopBackOff"], "expected one CrashLoopBackOff finding")
+	assert.Equal(t, 1, gotTypes["Pending"], "expected one long-pending finding")
+	assert.Equal(t, 1, gotTypes["Evicted"], "expected one evicted finding")
+}
+
+func TestScanRuntimeFailures_RespectsNamespaceFilter(t *testing.T) {
+	oldCreatedAt := time.Now().Add(-20 * time.Minute).Format(time.RFC3339)
+
+	teamAPod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "api-team-a",
+			"namespace":         "team-a",
+			"creationTimestamp": oldCreatedAt,
+		},
+		"status": map[string]interface{}{
+			"phase": "Pending",
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name":  "api",
+					"image": "acme/team-a:v1.0.0",
+					"state": map[string]interface{}{
+						"waiting": map[string]interface{}{
+							"reason":  "ErrImagePull",
+							"message": "pull access denied",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	teamBPod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "api-team-b",
+			"namespace":         "team-b",
+			"creationTimestamp": oldCreatedAt,
+		},
+		"status": map[string]interface{}{
+			"phase": "Pending",
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name":  "api",
+					"image": "acme/team-b:v1.0.0",
+					"state": map[string]interface{}{
+						"waiting": map[string]interface{}{
+							"reason":  "ErrImagePull",
+							"message": "pull access denied",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	client := newFakeDynamicClientForScan(teamAPod, teamBPod)
+	scanner := NewStateScannerWithClient(client)
+
+	result, err := scanner.ScanNamespaceWithThreshold(context.Background(), "team-a", 5*time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.RuntimeFindings, 1, "expected only team-a runtime finding")
+	assert.Equal(t, "team-a", result.RuntimeFindings[0].Namespace)
+	assert.Equal(t, "ErrImagePull", result.RuntimeFindings[0].FailureType)
+	assert.Equal(t, 1, result.Summary.RuntimeFailures)
+}
+
 // TestScanDanglingResourcesEmpty tests scanning with no resources
 func TestScanDanglingResourcesEmpty(t *testing.T) {
 	t.Run("Empty cluster returns no findings", func(t *testing.T) {

--- a/test/ascii/scan/runtime.txt
+++ b/test/ascii/scan/runtime.txt
@@ -1,0 +1,21 @@
+
+RUNTIME FAILURES
+Scanned at: 2026-03-05 12:00:00
+
+✗ ImagePullBackOff (2 pods)
+  Affected: myapp-dev/api-7d9b8c-1, myapp-prod/api-7d9b8c-2
+  Image: acme/api:v1.2.0
+  Reason: pull access denied, repository does not exist
+  Suggestion: Check imagePullSecrets or verify image exists in registry
+
+✗ CrashLoopBackOff (1 pod)
+  Affected: myapp-dev/worker-6dbf6f-1
+  Image: acme/worker:v2.0.1
+  Reason: back-off 5m0s restarting failed container
+  Suggestion: Inspect pod logs and recent config changes
+
+STATE ISSUES
+✓ No state issues found
+
+🔗 Track violations in ConfigHub: cub-scout scan --confighub
+

--- a/test/ascii/scan/testdata/runtime.json
+++ b/test/ascii/scan/testdata/runtime.json
@@ -1,0 +1,60 @@
+{
+  "state": {
+    "scannedAt": "2026-03-05T12:00:00Z",
+    "runtimeFindings": [
+      {
+        "ccveId": "CCVE-2025-0690",
+        "category": "RUNTIME",
+        "severity": "critical",
+        "kind": "Pod",
+        "name": "api-7d9b8c-1",
+        "namespace": "myapp-dev",
+        "failureType": "ImagePullBackOff",
+        "container": "api",
+        "image": "acme/api:v1.2.0",
+        "reason": "ImagePullBackOff",
+        "message": "pull access denied, repository does not exist",
+        "duration": "22m",
+        "remediation": "Check imagePullSecrets or verify image exists in registry"
+      },
+      {
+        "ccveId": "CCVE-2025-0690",
+        "category": "RUNTIME",
+        "severity": "critical",
+        "kind": "Pod",
+        "name": "api-7d9b8c-2",
+        "namespace": "myapp-prod",
+        "failureType": "ImagePullBackOff",
+        "container": "api",
+        "image": "acme/api:v1.2.0",
+        "reason": "ImagePullBackOff",
+        "message": "pull access denied, repository does not exist",
+        "duration": "19m",
+        "remediation": "Check imagePullSecrets or verify image exists in registry"
+      },
+      {
+        "ccveId": "CCVE-2025-0692",
+        "category": "RUNTIME",
+        "severity": "warning",
+        "kind": "Pod",
+        "name": "worker-6dbf6f-1",
+        "namespace": "myapp-dev",
+        "failureType": "CrashLoopBackOff",
+        "container": "worker",
+        "image": "acme/worker:v2.0.1",
+        "reason": "CrashLoopBackOff",
+        "message": "back-off 5m0s restarting failed container",
+        "duration": "41m",
+        "remediation": "Inspect pod logs and recent config changes"
+      }
+    ],
+    "summary": {
+      "helmReleaseStuck": 0,
+      "kustomizationStuck": 0,
+      "applicationStuck": 0,
+      "silentFailures": 0,
+      "runtimeFailures": 3,
+      "total": 0
+    }
+  }
+}

--- a/test/ascii/scan_test.go
+++ b/test/ascii/scan_test.go
@@ -46,3 +46,18 @@ func TestScan_Clean(t *testing.T) {
 	goldenPath := filepath.Join(repoRoot, "test", "ascii", "scan", "clean.txt")
 	golden.AssertGolden(t, out, goldenPath)
 }
+
+func TestScan_RuntimeFailures(t *testing.T) {
+	repoRoot := runner.RepoRoot(t)
+	fixtureAbs := filepath.Join(repoRoot, "test", "ascii", "scan", "testdata", "runtime.json")
+
+	out := runner.RunWithEnv(t, repoRoot,
+		map[string]string{
+			"CUB_SCOUT_TEST_SCAN_JSON": fixtureAbs,
+		},
+		"scan", "--state",
+	)
+
+	goldenPath := filepath.Join(repoRoot, "test", "ascii", "scan", "runtime.txt")
+	golden.AssertGolden(t, out, goldenPath)
+}


### PR DESCRIPTION
## Scope
- Closes #249 by adding runtime pod failure detection to `scan --state`.
- Detects and reports: `ImagePullBackOff`, `ErrImagePull`, `CrashLoopBackOff`, `CreateContainerError` (including `CreateContainerConfigError`), long `Pending`, and `Evicted`.
- Adds explicit runtime section in CLI output and keeps state-reconciliation findings separate.
- Extends normalized output with `runtime` track entries.

## Success Criteria
- `scan --state` surfaces common runtime pod failures.
- Failures are grouped by failure type with affected pods and actionable suggestion text.
- Output distinguishes runtime failures from stuck reconciliation/state findings.

## Graceful Degradation
- Runtime scanning is best-effort and warning-based when pod listing fails (same warning pattern as other scan tracks).
- Pending pods are only flagged when age exceeds the configured threshold.
- If no runtime failures exist, behavior remains unchanged.

## Tests Added/Updated
- `pkg/agent/state_scanner_test.go`
  - `TestScanRuntimeFailures_DetectsCommonPodFailureTypes`
  - `TestScanRuntimeFailures_RespectsNamespaceFilter`
- `internal/scan/normalized_test.go`
  - `TestNormalize_RuntimeFindings`
- `test/ascii/scan_test.go`
  - `TestScan_RuntimeFailures`
- Added fixture/golden:
  - `test/ascii/scan/testdata/runtime.json`
  - `test/ascii/scan/runtime.txt`

## Commands Run
- `go test ./pkg/agent -run 'TestScanRuntimeFailures' -count=1` (red baseline + 3 stable reruns)
- `go test ./internal/scan -run 'TestNormalize_RuntimeFindings' -count=1`
- `go test ./test/ascii -run 'TestScan_RuntimeFailures' -count=1`
- `go test ./scripts/ci -run 'TestReadme_ScanVariantsAndAdvancedScannerLinkDocumented' -count=1`
- `go build ./cmd/cub-scout`
- `go test ./...` *(fails on existing unrelated golden placeholder mismatch in `test/golden/scan-file`)*

## Proof Artifact
- `/tmp/cub-scout-regression/m2/m2-t2-scan-runtime-failures/proof-matrix.md`
