### PR TITLE
Fix #250: surface pod-level failures in gitops status

### DIFF
--- a/cmd/cub-scout/gitops.go
+++ b/cmd/cub-scout/gitops.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -125,12 +126,21 @@ type DeployerStatus struct {
 	SourceRef string `json:"sourceRef,omitempty"`
 
 	// Argo-specific fields
-	SyncStatus   string `json:"syncStatus,omitempty"`
-	HealthStatus string `json:"healthStatus,omitempty"`
+	SyncStatus    string         `json:"syncStatus,omitempty"`
+	HealthStatus  string         `json:"healthStatus,omitempty"`
+	PodReady      int            `json:"podReady,omitempty"`
+	PodTotal      int            `json:"podTotal,omitempty"`
+	RuntimeIssues []RuntimeIssue `json:"runtimeIssues,omitempty"`
 
 	// Revision information
 	LastAppliedRevision   string `json:"lastAppliedRevision,omitempty"`
 	LastAttemptedRevision string `json:"lastAttemptedRevision,omitempty"`
+}
+
+// RuntimeIssue summarizes pod runtime failures for an Argo Application.
+type RuntimeIssue struct {
+	Reason string `json:"reason"`
+	Count  int    `json:"count"`
 }
 
 // IsHealthy returns true if the deployer is healthy
@@ -307,6 +317,7 @@ func buildGitOpsSummary(ctx context.Context, client dynamic.Interface, info *age
 				status.SyncStatus = details.SyncStatus
 				status.HealthStatus = details.HealthStatus
 				status.LastAttemptedRevision = details.LastAttemptedRevision
+				enrichArgoApplicationRuntimeStatus(ctx, client, &status, resource)
 			}
 		}
 
@@ -350,6 +361,161 @@ func fetchDeployerResource(ctx context.Context, client dynamic.Interface, ref ag
 	return resource
 }
 
+func enrichArgoApplicationRuntimeStatus(ctx context.Context, client dynamic.Interface, status *DeployerStatus, app *unstructured.Unstructured) {
+	if client == nil || status == nil || app == nil {
+		return
+	}
+
+	appName := strings.TrimSpace(status.Name)
+	if appName == "" {
+		appName = strings.TrimSpace(app.GetName())
+	}
+	if appName == "" {
+		return
+	}
+
+	destinationNamespace, _, _ := unstructured.NestedString(app.Object, "spec", "destination", "namespace")
+	destinationNamespace = strings.TrimSpace(destinationNamespace)
+	if destinationNamespace == "" {
+		return
+	}
+
+	podsGVR := kindToGVR("Pod")
+	if podsGVR.Resource == "" {
+		return
+	}
+
+	podList, err := client.Resource(podsGVR).Namespace(destinationNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+
+	issueCounts := map[string]int{}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if strings.TrimSpace(pod.GetLabels()["argocd.argoproj.io/instance"]) != appName {
+			continue
+		}
+
+		status.PodTotal++
+		if isPodReadyForGitOpsStatus(pod) {
+			status.PodReady++
+			continue
+		}
+
+		if reason := extractPodRuntimeIssueReason(pod); reason != "" {
+			issueCounts[reason]++
+		}
+	}
+
+	if len(issueCounts) == 0 {
+		return
+	}
+
+	issues := make([]RuntimeIssue, 0, len(issueCounts))
+	for reason, count := range issueCounts {
+		issues = append(issues, RuntimeIssue{
+			Reason: reason,
+			Count:  count,
+		})
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		if runtimeIssueOrder(issues[i].Reason) == runtimeIssueOrder(issues[j].Reason) {
+			return issues[i].Reason < issues[j].Reason
+		}
+		return runtimeIssueOrder(issues[i].Reason) < runtimeIssueOrder(issues[j].Reason)
+	})
+
+	status.RuntimeIssues = issues
+}
+
+func isPodReadyForGitOpsStatus(pod *unstructured.Unstructured) bool {
+	phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
+	if !strings.EqualFold(strings.TrimSpace(phase), "Running") {
+		return false
+	}
+
+	containerStatuses, found, _ := unstructured.NestedSlice(pod.Object, "status", "containerStatuses")
+	if !found || len(containerStatuses) == 0 {
+		return false
+	}
+
+	for _, raw := range containerStatuses {
+		status, ok := raw.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		ready, ok := status["ready"].(bool)
+		if !ok || !ready {
+			return false
+		}
+	}
+	return true
+}
+
+func extractPodRuntimeIssueReason(pod *unstructured.Unstructured) string {
+	checkStatuses := func(statuses []interface{}) string {
+		for _, raw := range statuses {
+			status, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			state, _ := status["state"].(map[string]interface{})
+			waiting, _ := state["waiting"].(map[string]interface{})
+			if waiting == nil {
+				continue
+			}
+
+			reason := strings.TrimSpace(fmt.Sprintf("%v", waiting["reason"]))
+			switch reason {
+			case "ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff":
+				return reason
+			case "CreateContainerError", "CreateContainerConfigError":
+				return "CreateContainerError"
+			}
+		}
+		return ""
+	}
+
+	initStatuses, _, _ := unstructured.NestedSlice(pod.Object, "status", "initContainerStatuses")
+	if reason := checkStatuses(initStatuses); reason != "" {
+		return reason
+	}
+
+	containerStatuses, _, _ := unstructured.NestedSlice(pod.Object, "status", "containerStatuses")
+	if reason := checkStatuses(containerStatuses); reason != "" {
+		return reason
+	}
+
+	phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
+	statusReason, _, _ := unstructured.NestedString(pod.Object, "status", "reason")
+
+	if strings.EqualFold(strings.TrimSpace(phase), "Failed") && strings.EqualFold(strings.TrimSpace(statusReason), "Evicted") {
+		return "Evicted"
+	}
+
+	if strings.EqualFold(strings.TrimSpace(phase), "Pending") {
+		return "Pending"
+	}
+
+	return ""
+}
+
+func runtimeIssueOrder(reason string) int {
+	order := map[string]int{
+		"ImagePullBackOff":     0,
+		"ErrImagePull":         1,
+		"CrashLoopBackOff":     2,
+		"CreateContainerError": 3,
+		"Pending":              4,
+		"Evicted":              5,
+	}
+	if idx, ok := order[reason]; ok {
+		return idx
+	}
+	return 99
+}
 
 // outputGitOpsStatusJSON outputs the summary as JSON
 func outputGitOpsStatusJSON(summary GitOpsSummary) error {
@@ -582,7 +748,24 @@ func outputDeployerStatus(dep DeployerStatus) {
 			if dep.HealthStatus != "Healthy" {
 				healthColor = colorRed
 			}
-			fmt.Printf("      %sHealth:%s %s%s%s\n", colorDim, colorReset, healthColor, dep.HealthStatus, colorReset)
+			healthLabel := dep.HealthStatus + " (ArgoCD)"
+			fmt.Printf("      %sHealth:%s %s%s%s\n", colorDim, colorReset, healthColor, healthLabel, colorReset)
+		}
+
+		if dep.PodTotal > 0 {
+			fmt.Printf("      Pods: %d/%d running\n", dep.PodReady, dep.PodTotal)
+		}
+
+		if strings.EqualFold(dep.HealthStatus, "Healthy") && dep.PodTotal > 0 && dep.PodReady < dep.PodTotal {
+			fmt.Printf("      %s⚠ Warning:%s %d/%d pods running - ArgoCD health may be misleading\n",
+				colorYellow, colorReset, dep.PodReady, dep.PodTotal)
+		}
+
+		if len(dep.RuntimeIssues) > 0 {
+			fmt.Printf("      %sRuntime issues:%s\n", colorDim, colorReset)
+			for _, issue := range dep.RuntimeIssues {
+				fmt.Printf("        %s: %d pod(s)\n", issue.Reason, issue.Count)
+			}
 		}
 	}
 

--- a/cmd/cub-scout/gitops_runtime_test.go
+++ b/cmd/cub-scout/gitops_runtime_test.go
@@ -1,0 +1,160 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestEnrichArgoApplicationRuntimeStatus_AddsPodReadinessAndIssues(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      "myapp-prod",
+				"namespace": "argocd",
+			},
+			"spec": map[string]interface{}{
+				"destination": map[string]interface{}{
+					"namespace": "myapp-prod",
+				},
+			},
+		},
+	}
+
+	imagePullPod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "api-1",
+				"namespace": "myapp-prod",
+				"labels": map[string]interface{}{
+					"argocd.argoproj.io/instance": "myapp-prod",
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Pending",
+				"containerStatuses": []interface{}{
+					map[string]interface{}{
+						"name":  "api",
+						"ready": false,
+						"state": map[string]interface{}{
+							"waiting": map[string]interface{}{
+								"reason":  "ImagePullBackOff",
+								"message": "pull access denied",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runningPod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "worker-1",
+				"namespace": "myapp-prod",
+				"labels": map[string]interface{}{
+					"argocd.argoproj.io/instance": "myapp-prod",
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Running",
+				"containerStatuses": []interface{}{
+					map[string]interface{}{
+						"name":  "worker",
+						"ready": true,
+						"state": map[string]interface{}{
+							"running": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := newGitOpsRuntimeFakeClient(app, imagePullPod, runningPod)
+	status := &DeployerStatus{
+		Kind:         "Application",
+		Name:         "myapp-prod",
+		Namespace:    "argocd",
+		SyncStatus:   "Unknown",
+		HealthStatus: "Healthy",
+	}
+
+	enrichArgoApplicationRuntimeStatus(context.Background(), client, status, app)
+
+	if status.PodTotal != 2 {
+		t.Fatalf("expected PodTotal=2, got %d", status.PodTotal)
+	}
+	if status.PodReady != 1 {
+		t.Fatalf("expected PodReady=1, got %d", status.PodReady)
+	}
+	if len(status.RuntimeIssues) == 0 {
+		t.Fatalf("expected runtime issues to be populated")
+	}
+
+	issue := status.RuntimeIssues[0]
+	if issue.Reason != "ImagePullBackOff" {
+		t.Fatalf("expected runtime reason ImagePullBackOff, got %q", issue.Reason)
+	}
+	if issue.Count != 1 {
+		t.Fatalf("expected runtime issue count 1, got %d", issue.Count)
+	}
+}
+
+func TestOutputDeployerStatus_WarnsWhenArgoHealthyButPodsNotReady(t *testing.T) {
+	deployer := DeployerStatus{
+		Kind:         "Application",
+		Name:         "myapp-prod",
+		Namespace:    "argocd",
+		Ready:        false,
+		Stage:        "sync",
+		SyncStatus:   "Unknown",
+		HealthStatus: "Healthy",
+		PodReady:     0,
+		PodTotal:     6,
+		RuntimeIssues: []RuntimeIssue{
+			{Reason: "ImagePullBackOff", Count: 6},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		outputDeployerStatus(deployer)
+	})
+
+	if !strings.Contains(out, "Health:") || !strings.Contains(out, "Healthy (ArgoCD)") {
+		t.Fatalf("expected ArgoCD health label in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Pods: 0/6 running") {
+		t.Fatalf("expected pod readiness line in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ArgoCD health may be misleading") {
+		t.Fatalf("expected contradiction warning in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Runtime issues:") || !strings.Contains(out, "ImagePullBackOff: 6 pod(s)") {
+		t.Fatalf("expected runtime issue breakdown in output, got:\n%s", out)
+	}
+}
+
+func newGitOpsRuntimeFakeClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}: "ApplicationList",
+		{Group: "", Version: "v1", Resource: "pods"}:                          "PodList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+}

--- a/cmd/cub-scout/trace.go
+++ b/cmd/cub-scout/trace.go
@@ -792,6 +792,8 @@ func kindToGVR(kind string) schema.GroupVersionResource {
 		return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}
 	case "Service":
 		return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	case "Pod":
+		return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	case "ConfigMap":
 		return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 	case "Secret":

--- a/test/ascii/gitops-status/argo_healthy_pods_failing.txt
+++ b/test/ascii/gitops-status/argo_healthy_pods_failing.txt
@@ -1,0 +1,26 @@
+
+GITOPS STATUS
+════════════════════════════════════════════════════════════════════
+
+  Backend:   ARGOCD
+  Transport: GIT
+
+  ⚠ 1/1 deployers failing
+
+DEPLOYERS
+────────────────────────────────────────────────────────────────────
+  ✗ Application/myapp-prod
+      Namespace: argocd
+      Stage: sync
+      Sync: Unknown
+      Health: Healthy (ArgoCD)
+      Pods: 0/6 running
+      ⚠ Warning: 0/6 pods running - ArgoCD health may be misleading
+      Runtime issues:
+        ImagePullBackOff: 3 pod(s)
+        CrashLoopBackOff: 3 pod(s)
+
+
+NEXT STEPS:
+→ Trace failing resource:  cub-scout trace application/myapp-prod -n argocd
+→ Scan for issues:         cub-scout scan --state

--- a/test/ascii/gitops-status/testdata/argo_healthy_pods_failing.json
+++ b/test/ascii/gitops-status/testdata/argo_healthy_pods_failing.json
@@ -1,0 +1,30 @@
+{
+  "backend": "argocd",
+  "transport": "git",
+  "deployers": [
+    {
+      "kind": "Application",
+      "name": "myapp-prod",
+      "namespace": "argocd",
+      "ready": false,
+      "stage": "sync",
+      "syncStatus": "Unknown",
+      "healthStatus": "Healthy",
+      "podReady": 0,
+      "podTotal": 6,
+      "runtimeIssues": [
+        {
+          "reason": "ImagePullBackOff",
+          "count": 3
+        },
+        {
+          "reason": "CrashLoopBackOff",
+          "count": 3
+        }
+      ]
+    }
+  ],
+  "sources": [],
+  "healthyCount": 0,
+  "failedCount": 1
+}

--- a/test/ascii/gitops_status_test.go
+++ b/test/ascii/gitops_status_test.go
@@ -1,0 +1,27 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package ascii_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/confighub/cub-scout/test/ascii/golden"
+	"github.com/confighub/cub-scout/test/ascii/runner"
+)
+
+func TestGitOpsStatus_ArgoHealthyButPodsFailing(t *testing.T) {
+	repoRoot := runner.RepoRoot(t)
+	fixtureAbs := filepath.Join(repoRoot, "test", "ascii", "gitops-status", "testdata", "argo_healthy_pods_failing.json")
+
+	out := runner.RunWithEnv(t, repoRoot,
+		map[string]string{
+			"CUB_SCOUT_TEST_GITOPS_JSON": fixtureAbs,
+		},
+		"gitops", "status",
+	)
+
+	goldenPath := filepath.Join(repoRoot, "test", "ascii", "gitops-status", "argo_healthy_pods_failing.txt")
+	golden.AssertGolden(t, out, goldenPath)
+}


### PR DESCRIPTION
## Summary
- enrich Argo Application deployer status with pod readiness and runtime issue counts from destination namespace pods
- render pod readiness and runtime issue breakdown in `gitops status` output
- warn when Argo health reports `Healthy` but pods are not fully running
- add pod kind mapping to shared `kindToGVR` for runtime pod lookup
- add unit and ASCII golden tests for the healthy-argo / failing-pods contradiction scenario

## Proof
- red/green matrix: `/tmp/cub-scout-regression/m2/m2-t3-gitops-status-pod-failures/proof-matrix.md`
- targeted unit tests (2x):
  - `go test ./cmd/cub-scout -run 'TestEnrichArgoApplicationRuntimeStatus_AddsPodReadinessAndIssues|TestOutputDeployerStatus_WarnsWhenArgoHealthyButPodsNotReady' -count=1`
- targeted ASCII test (2x):
  - `go test ./test/ascii -run TestGitOpsStatus_ArgoHealthyButPodsFailing -count=1`
- broader package verify:
  - `go test ./cmd/cub-scout -count=1`
- full suite baseline check:
  - `go test ./... -count=1` (after `go build -o cub-scout ./cmd/cub-scout`) shows only pre-existing `test/golden/scan-file` golden path normalization mismatch (`<FILE>` vs `/private<TEMP_PATH>`)

## Risk
- Changes are scoped to Argo Application deployer rendering/enrichment and include deterministic tests for the new behavior.
