### PR TITLE
import: clarify non-interactive connect behavior for demos

### DIFF
--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -158,8 +158,11 @@ Examples:
   # Preview what would be created
   cub-scout import --dry-run
 
-  # Skip confirmation
+  # Skip confirmation (legacy: no auto-connect)
   cub-scout import -y
+
+  # Skip confirmation + connect worker/targets now
+  cub-scout import -y --connect
 
   # JSON output (for GUI integration)
   cub-scout import --json
@@ -341,15 +344,9 @@ func runImport(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Connection behavior:
-	// - Interactive confirmation defaults to connect now
-	// - Non-interactive (-y) preserves legacy behavior unless --connect is set
-	shouldConnect := importConnect
-	if !importYes && !importNoConnect && !importConnect {
-		shouldConnect = true
-	}
-	if importNoConnect {
-		shouldConnect = false
+	shouldConnect, showConnectHint := resolveImportConnectionMode(importYes, importConnect, importNoConnect)
+	if showConnectHint {
+		fmt.Println("\nTip: add --connect to start worker/targets now and avoid detached units.")
 	}
 
 	// Step 5: Apply
@@ -426,9 +423,17 @@ func runImportFromBundle(bundlePath string) error {
 		}
 	}
 
-	// Connection behavior:
-	// - Interactive confirmation defaults to connect now
-	// - Non-interactive (-y) preserves legacy behavior unless --connect is set
+	shouldConnect, showConnectHint := resolveImportConnectionMode(importYes, importConnect, importNoConnect)
+	if showConnectHint {
+		fmt.Println("\nTip: add --connect to start worker/targets now and avoid detached units.")
+	}
+
+	return applyImportWithLogger(proposal, workloads, nil, shouldConnect)
+}
+
+// resolveImportConnectionMode determines whether import should auto-connect workers/targets
+// and whether a non-interactive hint should be shown.
+func resolveImportConnectionMode(importYes, importConnect, importNoConnect bool) (bool, bool) {
 	shouldConnect := importConnect
 	if !importYes && !importNoConnect && !importConnect {
 		shouldConnect = true
@@ -437,7 +442,8 @@ func runImportFromBundle(bundlePath string) error {
 		shouldConnect = false
 	}
 
-	return applyImportWithLogger(proposal, workloads, nil, shouldConnect)
+	showConnectHint := importYes && !importConnect && !importNoConnect
+	return shouldConnect, showConnectHint
 }
 
 func buildImportFromBundlePreview(bundlePath string) (*FullProposal, []WorkloadInfo, []string, error) {

--- a/cmd/cub-scout/import_connect_mode_test.go
+++ b/cmd/cub-scout/import_connect_mode_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import "testing"
+
+func TestResolveImportConnectionMode(t *testing.T) {
+	tests := []struct {
+		name              string
+		importYes         bool
+		importConnect     bool
+		importNoConnect   bool
+		wantShouldConnect bool
+		wantShowHint      bool
+	}{
+		{
+			name:              "interactive defaults to connect",
+			importYes:         false,
+			importConnect:     false,
+			importNoConnect:   false,
+			wantShouldConnect: true,
+			wantShowHint:      false,
+		},
+		{
+			name:              "interactive explicit no-connect",
+			importYes:         false,
+			importConnect:     false,
+			importNoConnect:   true,
+			wantShouldConnect: false,
+			wantShowHint:      false,
+		},
+		{
+			name:              "non-interactive keeps legacy no-connect and shows hint",
+			importYes:         true,
+			importConnect:     false,
+			importNoConnect:   false,
+			wantShouldConnect: false,
+			wantShowHint:      true,
+		},
+		{
+			name:              "non-interactive with explicit connect",
+			importYes:         true,
+			importConnect:     true,
+			importNoConnect:   false,
+			wantShouldConnect: true,
+			wantShowHint:      false,
+		},
+		{
+			name:              "non-interactive explicit no-connect",
+			importYes:         true,
+			importConnect:     false,
+			importNoConnect:   true,
+			wantShouldConnect: false,
+			wantShowHint:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotShouldConnect, gotShowHint := resolveImportConnectionMode(tt.importYes, tt.importConnect, tt.importNoConnect)
+			if gotShouldConnect != tt.wantShouldConnect {
+				t.Fatalf("shouldConnect = %v, want %v", gotShouldConnect, tt.wantShouldConnect)
+			}
+			if gotShowHint != tt.wantShowHint {
+				t.Fatalf("showHint = %v, want %v", gotShowHint, tt.wantShowHint)
+			}
+		})
+	}
+}

--- a/examples/ai-agent-quest/README.md
+++ b/examples/ai-agent-quest/README.md
@@ -420,8 +420,8 @@ still works.
 # Preview what ConfigHub would structure (still read-only)
 ./cub-scout import --dry-run
 
-# Import (requires confirmation)
-./cub-scout import -y
+# Import + connect workers/targets
+./cub-scout import -y --connect
 ```
 
 ### Step 3 — Ask the same questions again

--- a/examples/demos/tui-import-demo.sh
+++ b/examples/demos/tui-import-demo.sh
@@ -157,8 +157,8 @@ echo ""
 echo -e "  ${CYAN}cub-scout import -n myapp --dry-run${NC}"
 echo -e "  ${DIM}-> Preview import for one namespace${NC}"
 echo ""
-echo -e "  ${CYAN}cub-scout import -y${NC}"
-echo -e "  ${DIM}-> Import without confirmation${NC}"
+echo -e "  ${CYAN}cub-scout import -y --connect${NC}"
+echo -e "  ${DIM}-> Import without confirmation and connect worker/targets${NC}"
 echo ""
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/examples/new-user-puzzle-quest/README.md
+++ b/examples/new-user-puzzle-quest/README.md
@@ -423,13 +423,14 @@ a ConfigHub account. The demo cluster persists (you used `--keep`).
 ### Import (only if authenticated)
 
 ```bash
-# Import with auto-confirm (scriptable, no interactive prompt)
-./cub-scout import -y
+# Import with auto-confirm + immediate worker/target connection
+./cub-scout import -y --connect
 ```
 
 This is equivalent to running `./cub-scout import` and typing `y` at the
 `Import N deployments into App 'X'? [y/N]` prompt. The `-y` flag makes it
-scriptable for both human and AI execution.
+scriptable for both human and AI execution, and `--connect` starts worker/target
+wiring so units do not stay detached.
 
 ### What to capture
 


### PR DESCRIPTION
## Summary
- add deterministic resolver `resolveImportConnectionMode` for import connect/no-connect behavior
- add unit coverage for connection-mode semantics, including non-interactive `-y` hint behavior
- print an explicit tip for non-interactive imports without flags: use `--connect` to avoid detached units
- update quest/demo docs/scripts to use `cub-scout import -y --connect` for connected-mode paths

## Why
Issue #253 reports repeated demo environments with detached/unapplied units and no active worker/targets. A practical root cause is that docs currently guide users to `import -y` without `--connect`, which intentionally keeps legacy no-connect behavior.

This PR keeps legacy behavior stable, but removes the ambiguity by:
- making mode resolution test-backed and explicit
- showing a runtime hint in the exact risky path
- updating demo/quest instructions to the connected-safe command

## Proof
- red/green matrix: `/tmp/cub-scout-regression/m3/m3-t1-import-connect-hint/proof-matrix.md`
- targeted test (2x):
  - `go test ./cmd/cub-scout -run TestResolveImportConnectionMode -count=1`
- broader package verify:
  - `go test ./cmd/cub-scout -count=1`
- full-suite baseline:
  - `go test ./... -count=1` (without binary shows expected harness precondition)
  - `go build -o cub-scout ./cmd/cub-scout`
  - `go test ./... -count=1` (with binary; only pre-existing `test/golden/scan-file` path normalization mismatch remains)

## Scope
- This is a focused demo/UX hardening slice for #253, not the full connected-demo data seeding solution.
