### PR TITLE
examples: add connected-demo readiness verifier

### DIFF
--- a/examples/argo-import-confighub-demo/README.md
+++ b/examples/argo-import-confighub-demo/README.md
@@ -23,6 +23,14 @@ ArgoCD's scope.
 ./demo.sh --live --confighub-url=http://localhost:9090
 ```
 
+## Connected Readiness Check
+
+After a `--live` run, verify the demo has active workers/targets and connected workloads:
+
+```bash
+../scripts/verify-connected-demo.sh --space argo-import-demo --renderer argocdrenderer
+```
+
 ## Prerequisites
 
 | Tool | Required for | Install |

--- a/examples/flux-import-confighub-demo/README.md
+++ b/examples/flux-import-confighub-demo/README.md
@@ -23,6 +23,14 @@ outside Flux's scope.
 ./demo.sh --live --confighub-url=http://localhost:9090
 ```
 
+## Connected Readiness Check
+
+After a `--live` run, verify the demo has active workers/targets and connected workloads:
+
+```bash
+../scripts/verify-connected-demo.sh --space flux-import-demo --renderer fluxrenderer
+```
+
 ## Prerequisites
 
 | Tool | Required for | Install |

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -2,6 +2,18 @@
 
 **Status: Working** — Copy-paste scripts for integrating cub-scout into your workflow.
 
+## Connected Demo Readiness
+
+Fail-fast checks for `--live` demo runs (workers, targets, connected workloads):
+
+```bash
+# Argo demo space
+./verify-connected-demo.sh --space argo-import-demo --renderer argocdrenderer
+
+# Flux demo space
+./verify-connected-demo.sh --space flux-import-demo --renderer fluxrenderer
+```
+
 ## k9s Plugin
 
 Add map/scan commands to k9s:

--- a/examples/scripts/verify-connected-demo.sh
+++ b/examples/scripts/verify-connected-demo.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# verify-connected-demo.sh - Fail-fast readiness check for connected demo environments.
+#
+# Checks:
+#   1) At least one ready/connected worker in the given space
+#   2) At least one Kubernetes target in the given space
+#   3) At least one renderer target (argocdrenderer/fluxrenderer, or generic renderer)
+#   4) Connected workload count from `cub-scout import --dry-run --json`
+#
+# Usage:
+#   examples/scripts/verify-connected-demo.sh --space argo-import-demo --renderer argocdrenderer
+#   examples/scripts/verify-connected-demo.sh --space flux-import-demo --renderer fluxrenderer
+
+set -euo pipefail
+
+SPACE=""
+RENDERER_TOKEN=""
+MIN_CONNECTED=1
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") --space <slug> [--renderer <token>] [--min-connected <n>]
+
+Options:
+  --space <slug>         ConfigHub space slug to validate (required)
+  --renderer <token>     Renderer token to require (e.g., argocdrenderer, fluxrenderer)
+                         If omitted, any target containing "renderer" satisfies the check.
+  --min-connected <n>    Minimum connected workloads required from cub-scout dry-run (default: 1)
+  -h, --help             Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --space)
+            [[ $# -ge 2 ]] || { echo "missing value for --space" >&2; usage; exit 2; }
+            SPACE="$2"
+            shift 2
+            ;;
+        --space=*)
+            SPACE="${1#*=}"
+            shift
+            ;;
+        --renderer)
+            [[ $# -ge 2 ]] || { echo "missing value for --renderer" >&2; usage; exit 2; }
+            RENDERER_TOKEN="$2"
+            shift 2
+            ;;
+        --renderer=*)
+            RENDERER_TOKEN="${1#*=}"
+            shift
+            ;;
+        --min-connected)
+            [[ $# -ge 2 ]] || { echo "missing value for --min-connected" >&2; usage; exit 2; }
+            MIN_CONNECTED="$2"
+            shift 2
+            ;;
+        --min-connected=*)
+            MIN_CONNECTED="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$SPACE" ]]; then
+    echo "--space is required" >&2
+    usage
+    exit 2
+fi
+
+if ! [[ "$MIN_CONNECTED" =~ ^[0-9]+$ ]]; then
+    echo "--min-connected must be a non-negative integer" >&2
+    exit 2
+fi
+
+if ! command -v cub >/dev/null 2>&1; then
+    echo "FAIL connected demo readiness"
+    echo "- cub CLI not found in PATH"
+    exit 1
+fi
+
+if [[ -n "${CUB_SCOUT_BIN:-}" ]]; then
+    CUB_SCOUT="$CUB_SCOUT_BIN"
+elif [[ -x "./cub-scout" ]]; then
+    CUB_SCOUT="./cub-scout"
+elif command -v cub-scout >/dev/null 2>&1; then
+    CUB_SCOUT="$(command -v cub-scout)"
+else
+    echo "FAIL connected demo readiness"
+    echo "- cub-scout binary not found (set CUB_SCOUT_BIN or build ./cub-scout)"
+    exit 1
+fi
+
+workers_json=""
+if ! workers_json=$(cub worker list --space "$SPACE" --json 2>/dev/null); then
+    echo "FAIL connected demo readiness"
+    echo "- failed to list workers for space '$SPACE'"
+    exit 1
+fi
+
+targets_json=""
+if ! targets_json=$(cub target list --space "$SPACE" --json 2>/dev/null); then
+    echo "FAIL connected demo readiness"
+    echo "- failed to list targets for space '$SPACE'"
+    exit 1
+fi
+
+import_json=""
+if ! import_json=$("$CUB_SCOUT" import --dry-run --json 2>/dev/null); then
+    echo "FAIL connected demo readiness"
+    echo "- failed to run '$CUB_SCOUT import --dry-run --json'"
+    exit 1
+fi
+
+ready_workers=$(python3 - "$workers_json" <<'PY'
+import json, sys
+raw = (sys.argv[1] if len(sys.argv) > 1 else "").strip()
+if not raw:
+    print(-1)
+    raise SystemExit(0)
+try:
+    data = json.loads(raw)
+except Exception:
+    print(-1)
+    raise SystemExit(0)
+if isinstance(data, dict):
+    data = [data]
+if not isinstance(data, list):
+    print(-1)
+    raise SystemExit(0)
+count = 0
+for item in data:
+    if not isinstance(item, dict):
+        continue
+    nested = item.get("BridgeWorker")
+    condition = ""
+    if isinstance(nested, dict):
+        condition = nested.get("Condition") or nested.get("condition") or ""
+    if not condition:
+        condition = item.get("Condition") or item.get("condition") or item.get("Status") or item.get("status") or ""
+    if str(condition).strip().lower() in {"ready", "connected"}:
+        count += 1
+print(count)
+PY
+)
+
+if [[ "$ready_workers" -lt 0 ]]; then
+    echo "FAIL connected demo readiness"
+    echo "- could not parse worker list JSON"
+    exit 1
+fi
+
+read -r kubernetes_targets renderer_targets < <(python3 - "$targets_json" "$RENDERER_TOKEN" <<'PY'
+import json, sys
+raw = (sys.argv[1] if len(sys.argv) > 1 else "").strip()
+renderer = (sys.argv[2] if len(sys.argv) > 2 else "").strip().lower()
+if not raw:
+    print("-1 -1")
+    raise SystemExit(0)
+try:
+    data = json.loads(raw)
+except Exception:
+    print("-1 -1")
+    raise SystemExit(0)
+if isinstance(data, dict):
+    data = [data]
+if not isinstance(data, list):
+    print("-1 -1")
+    raise SystemExit(0)
+k8s = 0
+renderer_count = 0
+for item in data:
+    if not isinstance(item, dict):
+        continue
+    target = item.get("Target") if isinstance(item.get("Target"), dict) else {}
+    slug = str(target.get("Slug") or item.get("Slug") or item.get("slug") or "")
+    provider = str(target.get("ProviderType") or item.get("ProviderType") or item.get("providerType") or "")
+    toolchain = str(target.get("ToolchainType") or item.get("ToolchainType") or item.get("toolchainType") or "")
+    hay = f"{slug} {provider} {toolchain}".lower()
+    if "kubernetes" in hay or "k8s" in hay:
+        k8s += 1
+    if renderer:
+        if renderer in hay:
+            renderer_count += 1
+    else:
+        if "renderer" in hay:
+            renderer_count += 1
+print(f"{k8s} {renderer_count}")
+PY
+)
+
+if [[ "$kubernetes_targets" -lt 0 || "$renderer_targets" -lt 0 ]]; then
+    echo "FAIL connected demo readiness"
+    echo "- could not parse target list JSON"
+    exit 1
+fi
+
+connected_workloads=$(python3 - "$import_json" <<'PY'
+import json, sys
+raw = (sys.argv[1] if len(sys.argv) > 1 else "").strip()
+if not raw:
+    print(-1)
+    raise SystemExit(0)
+try:
+    data = json.loads(raw)
+except Exception:
+    print(-1)
+    raise SystemExit(0)
+if not isinstance(data, dict):
+    print(-1)
+    raise SystemExit(0)
+workloads = data.get("workloads")
+if not isinstance(workloads, list):
+    print(-1)
+    raise SystemExit(0)
+count = 0
+for w in workloads:
+    if not isinstance(w, dict):
+        continue
+    value = w.get("connected")
+    if value is True:
+        count += 1
+        continue
+    if isinstance(value, str) and value.strip().lower() in {"true", "1", "yes"}:
+        count += 1
+print(count)
+PY
+)
+
+if [[ "$connected_workloads" -lt 0 ]]; then
+    echo "FAIL connected demo readiness"
+    echo "- could not parse cub-scout import dry-run JSON"
+    exit 1
+fi
+
+failures=()
+if [[ "$ready_workers" -lt 1 ]]; then
+    failures+=("no ready workers found in space '$SPACE'")
+fi
+if [[ "$kubernetes_targets" -lt 1 ]]; then
+    failures+=("no Kubernetes target found in space '$SPACE'")
+fi
+if [[ "$renderer_targets" -lt 1 ]]; then
+    if [[ -n "$RENDERER_TOKEN" ]]; then
+        failures+=("no renderer target matching '$RENDERER_TOKEN' found in space '$SPACE'")
+    else
+        failures+=("no renderer target found in space '$SPACE'")
+    fi
+fi
+if [[ "$connected_workloads" -lt "$MIN_CONNECTED" ]]; then
+    failures+=("connected workloads below threshold ($connected_workloads < $MIN_CONNECTED)")
+fi
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+    echo "FAIL connected demo readiness"
+    for msg in "${failures[@]}"; do
+        echo "- $msg"
+    done
+    echo "workers_ready=$ready_workers targets_kubernetes=$kubernetes_targets targets_renderer=$renderer_targets connected_workloads=$connected_workloads"
+    exit 1
+fi
+
+echo "PASS connected demo readiness"
+echo "workers_ready=$ready_workers targets_kubernetes=$kubernetes_targets targets_renderer=$renderer_targets connected_workloads=$connected_workloads"

--- a/test/unit/demo_readiness_script_test.go
+++ b/test/unit/demo_readiness_script_test.go
@@ -1,0 +1,150 @@
+package unit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestVerifyConnectedDemoScript_Success(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "scripts", "verify-connected-demo.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	mockBinDir := t.TempDir()
+	workerJSON := filepath.Join(t.TempDir(), "workers.json")
+	targetJSON := filepath.Join(t.TempDir(), "targets.json")
+	importJSON := filepath.Join(t.TempDir(), "import.json")
+
+	mustWrite(t, workerJSON, `[{"Condition":"Ready","Name":"demo-worker","Cluster":"kind-demo"}]`)
+	mustWrite(t, targetJSON, `[
+	  {"Target":{"Slug":"demo-kubernetes","ProviderType":"Kubernetes","ToolchainType":"Kubernetes"}},
+	  {"Target":{"Slug":"demo-argocdrenderer","ProviderType":"Renderer","ToolchainType":"argocdrenderer"}}
+	]`)
+	mustWrite(t, importJSON, `{"workloads":[{"name":"api","connected":true},{"name":"worker","connected":true}]}`)
+
+	writeExecutable(t, filepath.Join(mockBinDir, "cub"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "worker" && "$2" == "list" ]]; then
+  cat "$MOCK_WORKER_JSON"
+  exit 0
+fi
+if [[ "$1" == "target" && "$2" == "list" ]]; then
+  cat "$MOCK_TARGET_JSON"
+  exit 0
+fi
+echo "unexpected cub args: $*" >&2
+exit 2
+`)
+
+	writeExecutable(t, filepath.Join(mockBinDir, "cub-scout"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "import" && "$2" == "--dry-run" && "$3" == "--json" ]]; then
+  cat "$MOCK_IMPORT_JSON"
+  exit 0
+fi
+echo "unexpected cub-scout args: $*" >&2
+exit 2
+`)
+
+	cmd := exec.Command("bash", scriptPath, "--space", "demo-space", "--renderer", "argocdrenderer")
+	cmd.Env = append(os.Environ(),
+		"MOCK_WORKER_JSON="+workerJSON,
+		"MOCK_TARGET_JSON="+targetJSON,
+		"MOCK_IMPORT_JSON="+importJSON,
+		"CUB_SCOUT_BIN="+filepath.Join(mockBinDir, "cub-scout"),
+		"PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, string(out))
+	}
+	if !strings.Contains(string(out), "PASS") {
+		t.Fatalf("expected PASS output, got:\n%s", string(out))
+	}
+	if !strings.Contains(string(out), "connected_workloads=2") {
+		t.Fatalf("expected connected workload count in output, got:\n%s", string(out))
+	}
+}
+
+func TestVerifyConnectedDemoScript_FailsWhenNoConnectedWorkloads(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "scripts", "verify-connected-demo.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	mockBinDir := t.TempDir()
+	workerJSON := filepath.Join(t.TempDir(), "workers.json")
+	targetJSON := filepath.Join(t.TempDir(), "targets.json")
+	importJSON := filepath.Join(t.TempDir(), "import.json")
+
+	mustWrite(t, workerJSON, `[{"Condition":"Ready","Name":"demo-worker","Cluster":"kind-demo"}]`)
+	mustWrite(t, targetJSON, `[
+	  {"Target":{"Slug":"demo-kubernetes","ProviderType":"Kubernetes","ToolchainType":"Kubernetes"}},
+	  {"Target":{"Slug":"demo-argocdrenderer","ProviderType":"Renderer","ToolchainType":"argocdrenderer"}}
+	]`)
+	mustWrite(t, importJSON, `{"workloads":[{"name":"api","connected":false}]}`)
+
+	writeExecutable(t, filepath.Join(mockBinDir, "cub"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "worker" && "$2" == "list" ]]; then
+  cat "$MOCK_WORKER_JSON"
+  exit 0
+fi
+if [[ "$1" == "target" && "$2" == "list" ]]; then
+  cat "$MOCK_TARGET_JSON"
+  exit 0
+fi
+echo "unexpected cub args: $*" >&2
+exit 2
+`)
+
+	writeExecutable(t, filepath.Join(mockBinDir, "cub-scout"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "import" && "$2" == "--dry-run" && "$3" == "--json" ]]; then
+  cat "$MOCK_IMPORT_JSON"
+  exit 0
+fi
+echo "unexpected cub-scout args: $*" >&2
+exit 2
+`)
+
+	cmd := exec.Command("bash", scriptPath, "--space", "demo-space", "--renderer", "argocdrenderer")
+	cmd.Env = append(os.Environ(),
+		"MOCK_WORKER_JSON="+workerJSON,
+		"MOCK_TARGET_JSON="+targetJSON,
+		"MOCK_IMPORT_JSON="+importJSON,
+		"CUB_SCOUT_BIN="+filepath.Join(mockBinDir, "cub-scout"),
+		"PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure when no connected workloads, got success:\n%s", string(out))
+	}
+	if !strings.Contains(string(out), "connected workloads below threshold") {
+		t.Fatalf("expected connected-workload failure message, got:\n%s", string(out))
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	mustWrite(t, path, content)
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		mode = 0o644
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `examples/scripts/verify-connected-demo.sh` to fail-fast validate connected demo environments
- check four concrete readiness signals:
  - ready/connected worker present in the demo space
  - Kubernetes target present
  - renderer target present (specific token or generic renderer)
  - connected workload count from `cub-scout import --dry-run --json`
- add deterministic unit tests for script success path and connected-workload failure path
- document readiness command in Argo/Flux demo READMEs and `examples/scripts/README.md`

## Why
Issue #253 reports repeated demo sessions ending in detached/unapplied states. This script gives an executable gate to validate demo readiness before presenting connected-mode value.

## Proof
- red/green matrix: `/tmp/cub-scout-regression/m3/m3-t2-demo-readiness-check/proof-matrix.md`
- targeted tests (2x):
  - `go test ./test/unit -run TestVerifyConnectedDemoScript -count=1`
- broader verification:
  - `go test ./test/unit -count=1`
  - `go test ./cmd/cub-scout -count=1`
- full-suite baseline:
  - `go test ./... -count=1` (without binary shows expected harness precondition)
  - `go build -o cub-scout ./cmd/cub-scout`
  - `go test ./... -count=1` (with binary; only pre-existing `test/golden/scan-file` path normalization mismatch remains)

## Scope
- This is a #253 readiness/verification slice.
- It does not yet seed synthetic changeset history or manage persistent worker lifecycle policy.
