### PR TITLE
examples: add guarded synthetic history seed workflow

### DIFF
--- a/examples/ai-agent-quest/README.md
+++ b/examples/ai-agent-quest/README.md
@@ -440,6 +440,14 @@ cub changeset list --space myapp-team
 cub unit list --space myapp-team
 ```
 
+If your demo space has no history yet, you can seed synthetic demo ChangeSets explicitly:
+
+```bash
+./examples/scripts/seed-connected-demo-history.sh --space myapp-team --allow-synthetic --apply
+```
+
+Synthetic records are tagged (`demo=true`, `synthetic=true`) and are for demo storytelling only.
+
 And reports:
 
 - "Three changes in the last 7 days."

--- a/examples/argo-import-confighub-demo/README.md
+++ b/examples/argo-import-confighub-demo/README.md
@@ -31,6 +31,12 @@ After a `--live` run, verify the demo has active workers/targets and connected w
 ../scripts/verify-connected-demo.sh --space argo-import-demo --renderer argocdrenderer
 ```
 
+Optional (demo storytelling only): seed tagged synthetic ChangeSet history.
+
+```bash
+../scripts/seed-connected-demo-history.sh --space argo-import-demo --allow-synthetic --apply
+```
+
 ## Prerequisites
 
 | Tool | Required for | Install |

--- a/examples/flux-import-confighub-demo/README.md
+++ b/examples/flux-import-confighub-demo/README.md
@@ -31,6 +31,12 @@ After a `--live` run, verify the demo has active workers/targets and connected w
 ../scripts/verify-connected-demo.sh --space flux-import-demo --renderer fluxrenderer
 ```
 
+Optional (demo storytelling only): seed tagged synthetic ChangeSet history.
+
+```bash
+../scripts/seed-connected-demo-history.sh --space flux-import-demo --allow-synthetic --apply
+```
+
 ## Prerequisites
 
 | Tool | Required for | Install |

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -14,6 +14,26 @@ Fail-fast checks for `--live` demo runs (workers, targets, connected workloads):
 ./verify-connected-demo.sh --space flux-import-demo --renderer fluxrenderer
 ```
 
+## Synthetic History Seed (Demo Only)
+
+Create tagged synthetic ChangeSets for storytelling demos.
+
+```bash
+# Dry run (default)
+./seed-connected-demo-history.sh --space argo-import-demo --allow-synthetic
+
+# Apply (explicit)
+./seed-connected-demo-history.sh --space argo-import-demo --allow-synthetic --apply
+```
+
+Safety contract:
+- Requires `--allow-synthetic`.
+- Synthetic records are tagged with:
+  - `demo=true`
+  - `synthetic=true`
+  - `source=cub-scout-demo-seed`
+- Never run against production spaces.
+
 ## k9s Plugin
 
 Add map/scan commands to k9s:

--- a/examples/scripts/seed-connected-demo-history.sh
+++ b/examples/scripts/seed-connected-demo-history.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# seed-connected-demo-history.sh - Demo-only synthetic ChangeSet seeding.
+#
+# IMPORTANT:
+# - Synthetic demo data only. Never run in production spaces.
+# - Requires explicit --allow-synthetic.
+# - Defaults to dry-run; pass --apply to execute.
+
+set -euo pipefail
+
+SPACE=""
+ALLOW_SYNTHETIC=false
+APPLY=false
+ALLOW_CI=false
+PREFIX="demo"
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") --space <slug> --allow-synthetic [--apply] [--allow-ci] [--prefix <value>]
+
+Options:
+  --space <slug>         Target ConfigHub space (required)
+  --allow-synthetic      Required safety gate acknowledging synthetic demo data
+  --apply                Execute changeset creation (default: dry-run only)
+  --allow-ci             Allow --apply when CI environment variable is set
+  --prefix <value>       Prefix for seeded ChangeSet slugs (default: demo)
+  -h, --help             Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --space)
+            [[ $# -ge 2 ]] || { echo "missing value for --space" >&2; usage; exit 2; }
+            SPACE="$2"
+            shift 2
+            ;;
+        --space=*)
+            SPACE="${1#*=}"
+            shift
+            ;;
+        --allow-synthetic)
+            ALLOW_SYNTHETIC=true
+            shift
+            ;;
+        --apply)
+            APPLY=true
+            shift
+            ;;
+        --allow-ci)
+            ALLOW_CI=true
+            shift
+            ;;
+        --prefix)
+            [[ $# -ge 2 ]] || { echo "missing value for --prefix" >&2; usage; exit 2; }
+            PREFIX="$2"
+            shift 2
+            ;;
+        --prefix=*)
+            PREFIX="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$SPACE" ]]; then
+    echo "--space is required" >&2
+    usage
+    exit 2
+fi
+
+if [[ "$ALLOW_SYNTHETIC" != "true" ]]; then
+    echo "Refusing to seed synthetic data without --allow-synthetic" >&2
+    exit 1
+fi
+
+if [[ "$APPLY" == "true" && -n "${CI:-}" && "$ALLOW_CI" != "true" ]]; then
+    echo "Refusing --apply in CI without --allow-ci" >&2
+    exit 1
+fi
+
+if [[ "$APPLY" == "true" ]] && ! command -v cub >/dev/null 2>&1; then
+    echo "cub CLI not found in PATH" >&2
+    exit 1
+fi
+
+# slug|description
+seed_items=(
+    "${PREFIX}-ci-rollout-api-v1-4-3|ci-bot rolled api from v1.4.2 to v1.4.3"
+    "${PREFIX}-scale-worker-debug|sarah scaled worker replicas from 3 to 1 for incident triage"
+    "${PREFIX}-db-pool-tuning|platform tuned database pool config for checkout latency"
+)
+
+run_create() {
+    local slug="$1"
+    local description="$2"
+
+    local cmd=(
+        cub changeset create
+        --space "$SPACE"
+        "$slug"
+        --description "$description"
+        --label demo=true
+        --label synthetic=true
+        --label source=cub-scout-demo-seed
+        --label scenario=connected-history
+        --allow-exists
+        --quiet
+    )
+
+    if [[ "$APPLY" == "true" ]]; then
+        "${cmd[@]}"
+        echo "Created: $slug"
+    else
+        printf 'DRY RUN: '
+        printf '%q ' "${cmd[@]}"
+        printf '\n'
+    fi
+}
+
+echo "Seeding connected demo history"
+echo "space=$SPACE mode=$([[ "$APPLY" == "true" ]] && echo apply || echo dry-run) synthetic=true"
+
+for item in "${seed_items[@]}"; do
+    slug="${item%%|*}"
+    description="${item#*|}"
+    run_create "$slug" "$description"
+done
+
+if [[ "$APPLY" != "true" ]]; then
+    echo "No changes applied. Re-run with --apply to create synthetic ChangeSets."
+    echo "Synthetic markers: demo=true, synthetic=true, source=cub-scout-demo-seed"
+fi

--- a/test/unit/demo_seed_history_script_test.go
+++ b/test/unit/demo_seed_history_script_test.go
@@ -1,0 +1,132 @@
+package unit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSeedConnectedDemoHistoryScript_RequiresAllowSynthetic(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "scripts", "seed-connected-demo-history.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	cmd := exec.Command("bash", scriptPath, "--space", "demo-space", "--apply")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure without --allow-synthetic, got success:\n%s", string(out))
+	}
+	if !strings.Contains(string(out), "--allow-synthetic") {
+		t.Fatalf("expected allow-synthetic guard message, got:\n%s", string(out))
+	}
+}
+
+func TestSeedConnectedDemoHistoryScript_DryRunDoesNotCallCub(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "scripts", "seed-connected-demo-history.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	mockBinDir := t.TempDir()
+	callsLog := filepath.Join(t.TempDir(), "calls.log")
+
+	writeExecutableSeed(t, filepath.Join(mockBinDir, "cub"), `#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$MOCK_CALLS_LOG"
+exit 0
+`)
+
+	cmd := exec.Command("bash", scriptPath, "--space", "demo-space", "--allow-synthetic")
+	cmd.Env = append(os.Environ(),
+		"MOCK_CALLS_LOG="+callsLog,
+		"PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, string(out))
+	}
+	if !strings.Contains(string(out), "DRY RUN") {
+		t.Fatalf("expected dry-run output, got:\n%s", string(out))
+	}
+	if _, err := os.Stat(callsLog); err == nil {
+		data, _ := os.ReadFile(callsLog)
+		if strings.TrimSpace(string(data)) != "" {
+			t.Fatalf("expected no cub calls in dry-run, got:\n%s", string(data))
+		}
+	}
+}
+
+func TestSeedConnectedDemoHistoryScript_ApplyUsesSyntheticLabels(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "scripts", "seed-connected-demo-history.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	mockBinDir := t.TempDir()
+	callsLog := filepath.Join(t.TempDir(), "calls.log")
+
+	writeExecutableSeed(t, filepath.Join(mockBinDir, "cub"), `#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$MOCK_CALLS_LOG"
+if [[ "$1" == "changeset" && "$2" == "create" ]]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+echo "unexpected cub invocation: $*" >&2
+exit 2
+`)
+
+	cmd := exec.Command("bash", scriptPath,
+		"--space", "demo-space",
+		"--allow-synthetic",
+		"--apply",
+		"--allow-ci",
+	)
+	cmd.Env = append(os.Environ(),
+		"MOCK_CALLS_LOG="+callsLog,
+		"PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, string(out))
+	}
+	if !strings.Contains(string(out), "Created") {
+		t.Fatalf("expected creation output, got:\n%s", string(out))
+	}
+
+	data, err := os.ReadFile(callsLog)
+	if err != nil {
+		t.Fatalf("read calls log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "--label demo=true") {
+		t.Fatalf("expected demo label in cub calls, got:\n%s", log)
+	}
+	if !strings.Contains(log, "--label synthetic=true") {
+		t.Fatalf("expected synthetic label in cub calls, got:\n%s", log)
+	}
+	if !strings.Contains(log, "--label source=cub-scout-demo-seed") {
+		t.Fatalf("expected source label in cub calls, got:\n%s", log)
+	}
+	if !strings.Contains(log, "--space demo-space") {
+		t.Fatalf("expected space argument in cub calls, got:\n%s", log)
+	}
+}
+
+func writeExecutableSeed(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		mode = 0o644
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `examples/scripts/seed-connected-demo-history.sh` to seed demo-only synthetic ChangeSet history
- enforce safety gates so synthetic data is explicit and isolated (`--allow-synthetic`, dry-run default, CI apply guard)
- add unit coverage for script guardrails and labels
- document optional synthetic seeding in demo READMEs and scripts README

## Why
Demo flows can be technically connected but still look detached when history is empty. This provides an explicit, opt-in way to seed demo storytelling history without polluting normal testing or production-like usage.

## Proof / Tests
- red: `go test ./test/unit -run TestSeedConnectedDemoHistoryScript -count=1` (script missing)
- green: `go test ./test/unit -run TestSeedConnectedDemoHistoryScript -count=1` (pass, repeated)
- verify: `go test ./test/unit -count=1`
- verify: `go test ./cmd/cub-scout -count=1`
- full-suite note: with local `./cub-scout` binary, only pre-existing `test/golden/scan-file` mismatch (`<FILE>` vs `/private<TEMP_PATH>`) remains

Regression artifacts: `/tmp/cub-scout-regression/m3/m3-t3-connected-history-seed/`

Closes #253
