### PR TITLE
examples: harden argo import demo determinism

### DIFF
--- a/examples/argo-import-confighub-demo/README.md
+++ b/examples/argo-import-confighub-demo/README.md
@@ -116,6 +116,8 @@ Creates the kind cluster, installs real ArgoCD (~2-4 min for all 6
 deployments), and applies both fixture sets. The guestbook Applications have
 `syncPolicy.automated`, so ArgoCD fetches the source repos and creates real
 Deployments in the `guestbook` namespace.
+This demo pins both the ArgoCD release and guestbook source revision for
+deterministic behavior across reruns.
 
 **What happens:** You'll see ArgoCD install progress, namespace creation,
 fixture application, and guestbook sync status. If ArgoCD takes longer than
@@ -129,7 +131,7 @@ You should see output like:
 >> Creating kind cluster...
 >> Cluster ready: kind-argo-import-demo
 
->> Installing ArgoCD (this takes 2-4 minutes)...
+>> Installing ArgoCD v3.3.2 (this takes 2-4 minutes)...
 >> Waiting for ArgoCD deployments...
 >> ArgoCD installed and ready
 

--- a/examples/argo-import-confighub-demo/demo.sh
+++ b/examples/argo-import-confighub-demo/demo.sh
@@ -22,6 +22,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARNIE_FIXTURES="$SCRIPT_DIR/../import-from-live/fixtures"
 GUESTBOOK_FIXTURES="$SCRIPT_DIR/fixtures"
 CLUSTER_NAME="argo-import-demo"
+ARGOCD_VERSION="v3.3.2"
+ARGOCD_INSTALL_URL="https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml"
 KEEP=false
 LIVE=false
 CONFIGHUB_URL_OVERRIDE=""
@@ -50,6 +52,16 @@ step()    { echo -e "${GREEN}>>${NC} $1"; }
 note()    { echo -e "${DIM}   $1${NC}"; }
 warn()    { echo -e "${YELLOW}!!${NC} $1"; }
 fail()    { echo -e "${RED}!!${NC} $1"; }
+
+guestbook_app_ready() {
+    local app="$1"
+    local sync_status health_status
+
+    sync_status="$(kubectl get application "$app" -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null || true)"
+    health_status="$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)"
+
+    [[ "$sync_status" == "Synced" && "$health_status" == "Healthy" ]]
+}
 
 cleanup() {
     if [[ -n "$PORT_FORWARD_PID" ]]; then
@@ -138,9 +150,9 @@ step "Cluster ready: kind-$CLUSTER_NAME"
 echo ""
 
 # --- Install real ArgoCD ---
-step "Installing ArgoCD (this takes 2-4 minutes)..."
+step "Installing ArgoCD ${ARGOCD_VERSION} (this takes 2-4 minutes)..."
 kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply --server-side -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl apply --server-side -n argocd -f "$ARGOCD_INSTALL_URL"
 
 step "Waiting for ArgoCD deployments..."
 ARGOCD_READY=true
@@ -195,12 +207,9 @@ echo ""
 step "Waiting for guestbook apps to sync (up to 120s)..."
 GUESTBOOK_SYNCED=false
 for i in $(seq 1 24); do
-    if kubectl get namespace guestbook >/dev/null 2>&1; then
-        DEPLOY_COUNT=$(kubectl get deployments -n guestbook --no-headers 2>/dev/null | wc -l | tr -d ' ')
-        if [[ "$DEPLOY_COUNT" -gt 0 ]]; then
-            GUESTBOOK_SYNCED=true
-            break
-        fi
+    if guestbook_app_ready helm-guestbook && guestbook_app_ready kustomize-guestbook; then
+        GUESTBOOK_SYNCED=true
+        break
     fi
     printf "."
     sleep 5

--- a/examples/argo-import-confighub-demo/fixtures/guestbook-apps.yaml
+++ b/examples/argo-import-confighub-demo/fixtures/guestbook-apps.yaml
@@ -7,6 +7,7 @@
 #
 # helm-guestbook:      Helm chart rendering
 # kustomize-guestbook: Kustomize overlay rendering
+# targetRevision values are pinned to a commit for deterministic demos.
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -20,7 +21,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/argoproj/argocd-example-apps.git
-    targetRevision: HEAD
+    targetRevision: 723b86e01bea11dcf72316cb172868fcbf05d69e
     path: helm-guestbook
   destination:
     server: https://kubernetes.default.svc
@@ -44,7 +45,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/argoproj/argocd-example-apps.git
-    targetRevision: HEAD
+    targetRevision: 723b86e01bea11dcf72316cb172868fcbf05d69e
     path: kustomize-guestbook
   destination:
     server: https://kubernetes.default.svc

--- a/test/unit/argo_import_demo_determinism_test.go
+++ b/test/unit/argo_import_demo_determinism_test.go
@@ -1,0 +1,75 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestArgoImportDemoScript_PinsArgoInstallVersion(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "argo-import-confighub-demo", "demo.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	script := string(content)
+
+	if strings.Contains(script, "argoproj/argo-cd/stable/manifests/install.yaml") {
+		t.Fatalf("demo still installs ArgoCD from floating stable manifest")
+	}
+
+	versionRe := regexp.MustCompile(`ARGOCD_VERSION="v\d+\.\d+\.\d+"`)
+	if !versionRe.MatchString(script) {
+		t.Fatalf("expected ARGOCD_VERSION to be pinned to a release tag")
+	}
+
+	if !strings.Contains(script, "argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml") {
+		t.Fatalf("expected pinned ArgoCD install URL to use ${ARGOCD_VERSION}")
+	}
+}
+
+func TestArgoImportGuestbookFixtures_PinTargetRevision(t *testing.T) {
+	fixturePath := filepath.Join("..", "..", "examples", "argo-import-confighub-demo", "fixtures", "guestbook-apps.yaml")
+	content, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	fixture := string(content)
+
+	if strings.Contains(fixture, "targetRevision: HEAD") {
+		t.Fatalf("guestbook fixture still uses floating targetRevision: HEAD")
+	}
+
+	shaRe := regexp.MustCompile(`targetRevision:\s*[a-f0-9]{40}`)
+	matches := shaRe.FindAllString(fixture, -1)
+	if len(matches) < 2 {
+		t.Fatalf("expected both guestbook apps to pin targetRevision to a commit SHA")
+	}
+}
+
+func TestArgoImportDemoScript_WaitsForSyncedHealthyGuestbookApps(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "argo-import-confighub-demo", "demo.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	script := string(content)
+
+	if strings.Contains(script, "DEPLOY_COUNT=") {
+		t.Fatalf("demo readiness still uses deployment-count gate")
+	}
+
+	required := []string{
+		"guestbook_app_ready()",
+		".status.sync.status",
+		".status.health.status",
+		"guestbook_app_ready helm-guestbook && guestbook_app_ready kustomize-guestbook",
+	}
+	for _, needle := range required {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected Synced+Healthy readiness check to include %q", needle)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- pin ArgoCD install in `examples/argo-import-confighub-demo/demo.sh` to `v3.3.2`
- pin guestbook fixture `targetRevision` to commit `723b86e01bea11dcf72316cb172868fcbf05d69e`
- replace deployment-count readiness gate with application status gate requiring both apps to be `Synced` + `Healthy`
- add deterministic unit tests for these contracts
- align README sample output with pinned ArgoCD version

## Why
The demo previously depended on floating upstream state (`stable` manifest + `HEAD`) and used a weak readiness check. That made demo behavior drift over time and occasionally disagree with README expectations.

## Proof / Tests
Red -> Green (recorded in `/tmp/cub-scout-regression/m3/m3-t4-argo-demo-determinism/`):
- red: `go test ./test/unit -run TestArgoImport -count=1`
- green: `go test ./test/unit -run TestArgoImport -count=1` (repeated)

Verification:
- `go test ./test/unit -count=1`
- `go test ./cmd/cub-scout -count=1`

Closes #204
