### PR TITLE
docs: close out v1.3.1 housekeeping tracking

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -510,11 +510,13 @@ Follow-up delivered:
 
 ### v1.3.1 — Housekeeping
 
-**Status:** In Progress
+**Status:** Released (2026-03-06)
 **Theme:** *Release hygiene*
 
+Delivered:
+
 * #204 — argo-import-confighub-demo determinism (pin versions + stronger readiness)
-* #206 — roadmap summary cleanup (remove closed #149-#151 from open backlog line)
+* #206 — roadmap summary cleanup (remove closed #149-#151 from open backlog tracking language)
 
 ---
 


### PR DESCRIPTION
## Summary
- update `docs/roadmap.md` `v1.3.1 — Housekeeping` from in-progress to released (`2026-03-06`)
- convert #204/#206 bullets into delivered items under that section
- align roadmap state with current issue reality now that housekeeping items are complete

## Verification
Captured in `/tmp/cub-scout-regression/m3/m3-t5-roadmap-summary-cleanup/`:
- `red-baseline.log`
- `green-verify.log`
- `proof-matrix.md`

Specifically:
- `rg -n "Open backlog" docs/roadmap.md` yields no stale summary sentence.
- section around `v1.3.1` now reflects delivered housekeeping instead of open tracking.

Closes #206
