### PR TITLE
cmd: add explain command MVP

### DIFF
--- a/cmd/cub-scout/explain.go
+++ b/cmd/cub-scout/explain.go
@@ -1,0 +1,283 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	explainNamespace string
+	explainFormat    string
+)
+
+var explainCmd = &cobra.Command{
+	Use:   "explain <kind/name> or <kind> <name>",
+	Short: "Explain resource ownership and lineage in plain English",
+	Long: `Explain provides a plain-English ownership and lineage summary for a resource.
+
+Examples:
+  cub-scout explain deploy/my-app -n prod
+  cub-scout explain Deployment my-app -n prod --format json
+  cub-scout explain deployment/my-app -n prod --format md
+`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runExplain,
+}
+
+func init() {
+	rootCmd.AddCommand(explainCmd)
+	explainCmd.Flags().StringVarP(&explainNamespace, "namespace", "n", "", "Namespace of the resource")
+	explainCmd.Flags().StringVar(&explainFormat, "format", "text", "Output format: text, json, md")
+}
+
+// ExplainSummary is the canonical model for explain output.
+type ExplainSummary struct {
+	Resource    string `json:"resource"`
+	Namespace   string `json:"namespace"`
+	Owner       string `json:"owner"`
+	Source      string `json:"source"`
+	DeployedVia string `json:"deployedVia"`
+	Health      string `json:"health"`
+	Risks       string `json:"risks"`
+	Drift       string `json:"drift"`
+}
+
+func runExplain(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(explainFormat))
+	if format == "ascii" {
+		format = "text"
+	}
+	if format != "text" && format != "json" && format != "md" {
+		return fmt.Errorf("invalid --format %q (valid: text, json, md)", explainFormat)
+	}
+
+	kind, name, err := parseExplainArgs(args)
+	if err != nil {
+		return err
+	}
+
+	ns := strings.TrimSpace(explainNamespace)
+	if ns == "" {
+		ns = "default"
+	}
+
+	traceResult, err := traceForExplain(cmd.Context(), kind, name, ns)
+	if err != nil {
+		return err
+	}
+
+	summary := buildExplainSummary(traceResult)
+	if summary.Resource == "" {
+		summary.Resource = fmt.Sprintf("%s/%s", kind, name)
+	}
+	if summary.Namespace == "" {
+		summary.Namespace = ns
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(summary)
+	case "md":
+		fmt.Print(renderExplainMarkdown(summary))
+		return nil
+	default:
+		fmt.Print(renderExplainText(summary))
+		return nil
+	}
+}
+
+func parseExplainArgs(args []string) (kind, name string, err error) {
+	if len(args) == 1 {
+		parts := strings.SplitN(args[0], "/", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("invalid resource format: use kind/name (e.g., deployment/nginx)")
+		}
+		return normalizeKind(parts[0]), parts[1], nil
+	}
+	return normalizeKind(args[0]), args[1], nil
+}
+
+func traceForExplain(ctx context.Context, kind, name, namespace string) (*agent.TraceResult, error) {
+	ownership, err := detectResourceOwnership(ctx, kind, name, namespace)
+	if err != nil {
+		ownership = &agent.Ownership{Type: agent.OwnerUnknown}
+	}
+
+	var tracer agent.Tracer
+	switch ownership.Type {
+	case agent.OwnerArgo:
+		tracer = agent.NewArgoTracer()
+	case agent.OwnerHelm:
+		cfg, cfgErr := buildConfig()
+		if cfgErr != nil {
+			return nil, cfgErr
+		}
+		clientset, clientErr := kubernetes.NewForConfig(cfg)
+		if clientErr != nil {
+			return nil, clientErr
+		}
+		tracer = agent.NewHelmTracer(clientset)
+	default:
+		tracer = agent.NewFluxTracer()
+	}
+
+	if tracer == nil || !tracer.Available() {
+		return nil, fmt.Errorf("required CLI for explain not available for owner type %q", ownership.Type)
+	}
+
+	result, err := tracer.Trace(ctx, kind, name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("no trace result available")
+	}
+	if result.Object.Kind == "" {
+		result.Object.Kind = kind
+		result.Object.Name = name
+		result.Object.Namespace = namespace
+	}
+	return result, nil
+}
+
+func buildExplainSummary(result *agent.TraceResult) ExplainSummary {
+	summary := ExplainSummary{
+		Resource:    fmt.Sprintf("%s/%s", result.Object.Kind, result.Object.Name),
+		Namespace:   result.Object.Namespace,
+		Owner:       explainOwner(result.Tool),
+		Source:      "unknown",
+		DeployedVia: "unknown",
+		Health:      "Unknown",
+		Risks:       "Not assessed",
+		Drift:       "Unknown",
+	}
+
+	if len(result.Chain) > 0 {
+		summary.DeployedVia = explainDeploymentChain(result.Chain)
+		summary.Source = explainSource(result.Chain)
+		leaf := result.Chain[len(result.Chain)-1]
+		if strings.TrimSpace(leaf.Status) != "" {
+			summary.Health = leaf.Status
+		} else if leaf.Ready {
+			summary.Health = "Healthy"
+		} else {
+			summary.Health = "Unhealthy"
+		}
+	}
+
+	if result.ConfigHub != nil {
+		if result.ConfigHub.DriftDetected {
+			summary.Drift = "Detected by ConfigHub"
+		} else {
+			summary.Drift = "None detected"
+		}
+	}
+
+	if result.Error != "" {
+		summary.Owner = "Unknown"
+		if summary.Health == "Unknown" {
+			summary.Health = "Unavailable"
+		}
+		if summary.DeployedVia == "unknown" {
+			summary.DeployedVia = "partial trace only"
+		}
+	}
+
+	return summary
+}
+
+func explainOwner(tool string) string {
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case "flux":
+		return "Flux"
+	case "argocd", "argo":
+		return "ArgoCD"
+	case "helm":
+		return "Helm"
+	default:
+		return "Unknown"
+	}
+}
+
+func explainSource(chain []agent.ChainLink) string {
+	url := ""
+	path := ""
+	rev := ""
+
+	for _, link := range chain {
+		if url == "" && strings.TrimSpace(link.URL) != "" {
+			url = strings.TrimSpace(link.URL)
+		}
+		if path == "" && strings.TrimSpace(link.Path) != "" {
+			path = strings.TrimSpace(link.Path)
+		}
+		if rev == "" && strings.TrimSpace(link.Revision) != "" {
+			rev = strings.TrimSpace(link.Revision)
+		}
+	}
+
+	if url == "" {
+		url = "unknown"
+	}
+
+	details := make([]string, 0, 2)
+	if path != "" {
+		details = append(details, fmt.Sprintf("path: %s", path))
+	}
+	if rev != "" {
+		details = append(details, fmt.Sprintf("revision: %s", rev))
+	}
+	if len(details) == 0 {
+		return url
+	}
+	return fmt.Sprintf("%s (%s)", url, strings.Join(details, ", "))
+}
+
+func explainDeploymentChain(chain []agent.ChainLink) string {
+	parts := make([]string, 0, len(chain))
+	for _, link := range chain {
+		parts = append(parts, fmt.Sprintf("%s/%s", link.Kind, link.Name))
+	}
+	if len(parts) == 0 {
+		return "unknown"
+	}
+	return strings.Join(parts, " -> ")
+}
+
+func renderExplainText(summary ExplainSummary) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s in namespace %s:\n", summary.Resource, summary.Namespace)
+	fmt.Fprintf(&b, "  Owner: %s\n", summary.Owner)
+	fmt.Fprintf(&b, "  Source: %s\n", summary.Source)
+	fmt.Fprintf(&b, "  Deployed via: %s\n", summary.DeployedVia)
+	fmt.Fprintf(&b, "  Health: %s\n", summary.Health)
+	fmt.Fprintf(&b, "  Risks: %s\n", summary.Risks)
+	fmt.Fprintf(&b, "  Drift: %s\n", summary.Drift)
+	return b.String()
+}
+
+func renderExplainMarkdown(summary ExplainSummary) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Explain\n\n")
+	fmt.Fprintf(&b, "- **Resource:** `%s`\n", summary.Resource)
+	fmt.Fprintf(&b, "- **Namespace:** `%s`\n", summary.Namespace)
+	fmt.Fprintf(&b, "- **Owner:** %s\n", summary.Owner)
+	fmt.Fprintf(&b, "- **Source:** %s\n", summary.Source)
+	fmt.Fprintf(&b, "- **Deployed via:** %s\n", summary.DeployedVia)
+	fmt.Fprintf(&b, "- **Health:** %s\n", summary.Health)
+	fmt.Fprintf(&b, "- **Risks:** %s\n", summary.Risks)
+	fmt.Fprintf(&b, "- **Drift:** %s\n", summary.Drift)
+	return b.String()
+}

--- a/cmd/cub-scout/explain_test.go
+++ b/cmd/cub-scout/explain_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestBuildExplainSummary_FromTraceResult(t *testing.T) {
+	now := time.Date(2026, 3, 6, 12, 0, 0, 0, time.UTC)
+	result := &agent.TraceResult{
+		Tool: "flux",
+		Object: agent.ResourceRef{
+			Kind:      "Deployment",
+			Name:      "payments-api",
+			Namespace: "prod",
+		},
+		Chain: []agent.ChainLink{
+			{
+				Kind:      "GitRepository",
+				Name:      "platform-config",
+				Namespace: "flux-system",
+				URL:       "https://github.com/acme/platform-config.git",
+				Revision:  "main@sha1:abc1234",
+				Ready:     true,
+				Status:    "Ready",
+			},
+			{
+				Kind:      "Kustomization",
+				Name:      "payments",
+				Namespace: "flux-system",
+				Path:      "./apps/payments",
+				Revision:  "main@sha1:abc1234",
+				Ready:     true,
+				Status:    "Ready",
+			},
+			{
+				Kind:      "Deployment",
+				Name:      "payments-api",
+				Namespace: "prod",
+				Ready:     true,
+				Status:    "Healthy",
+			},
+		},
+		TracedAt: now,
+	}
+
+	summary := buildExplainSummary(result)
+
+	if summary.Owner != "Flux" {
+		t.Fatalf("owner = %q, want Flux", summary.Owner)
+	}
+	if !strings.Contains(summary.Source, "https://github.com/acme/platform-config.git") {
+		t.Fatalf("source missing git URL: %q", summary.Source)
+	}
+	if !strings.Contains(summary.Source, "./apps/payments") {
+		t.Fatalf("source missing kustomize path: %q", summary.Source)
+	}
+	if !strings.Contains(summary.DeployedVia, "GitRepository/platform-config") || !strings.Contains(summary.DeployedVia, "Kustomization/payments") {
+		t.Fatalf("deployed-via chain incomplete: %q", summary.DeployedVia)
+	}
+	if !strings.Contains(summary.Health, "Healthy") {
+		t.Fatalf("health = %q, want Healthy", summary.Health)
+	}
+}
+
+func TestRenderExplainText_ContainsPlainEnglishSections(t *testing.T) {
+	summary := ExplainSummary{
+		Resource:    "Deployment/payments-api",
+		Namespace:   "prod",
+		Owner:       "ArgoCD",
+		Source:      "git@github.com:acme/platform.git (path: apps/payments, revision: main@abc1234)",
+		DeployedVia: "Application/payments -> HelmRelease/payments -> Deployment/payments-api",
+		Health:      "Healthy",
+		Risks:       "1 WARNING",
+		Drift:       "None detected",
+	}
+
+	out := renderExplainText(summary)
+
+	required := []string{
+		"Deployment/payments-api in namespace prod:",
+		"Owner: ArgoCD",
+		"Source: git@github.com:acme/platform.git",
+		"Deployed via: Application/payments -> HelmRelease/payments -> Deployment/payments-api",
+		"Health: Healthy",
+		"Risks: 1 WARNING",
+		"Drift: None detected",
+	}
+	for _, s := range required {
+		if !strings.Contains(out, s) {
+			t.Fatalf("expected %q in explain text:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderExplainMarkdown_ContainsHeadingsAndFields(t *testing.T) {
+	summary := ExplainSummary{
+		Resource:    "Deployment/payments-api",
+		Namespace:   "prod",
+		Owner:       "Flux",
+		Source:      "https://github.com/acme/platform-config.git (path: ./apps/payments, revision: main@abc1234)",
+		DeployedVia: "GitRepository/platform-config -> Kustomization/payments -> Deployment/payments-api",
+		Health:      "Healthy",
+		Risks:       "0 findings",
+		Drift:       "None detected",
+	}
+
+	out := renderExplainMarkdown(summary)
+
+	required := []string{
+		"## Explain",
+		"- **Resource:** `Deployment/payments-api`",
+		"- **Namespace:** `prod`",
+		"- **Owner:** Flux",
+		"- **Source:** https://github.com/acme/platform-config.git",
+	}
+	for _, s := range required {
+		if !strings.Contains(out, s) {
+			t.Fatalf("expected %q in explain markdown:\n%s", s, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
First incremental slice for #219 (`cub-scout explain`):
- add new `explain` command with resource args (`kind/name` or `kind name`)
- add `--format text|json|md` outputs from one canonical `ExplainSummary` model
- build plain-English ownership/source/lineage/health summary from trace result
- add tests for summary construction + text/markdown renderers

## Proof / Tests
Regression artifacts: `/tmp/cub-scout-regression/m4/m4-t2-explain-mvp/`
- red: `go test ./cmd/cub-scout -run TestBuildExplainSummary -count=1`
- green: `go test ./cmd/cub-scout -run 'TestBuildExplainSummary|TestRenderExplain' -count=1`
- verify: `go test ./cmd/cub-scout -count=1`
- verify: `go test ./test/unit -count=1`

## Notes
This is an MVP slice and does not claim full #219 DoD yet (no bundle-mode path, no TUI parity yet).

Part of #219
