### PR TITLE
test: add explain golden coverage and close #219

### DIFF
--- a/cmd/cub-scout/explain_golden_test.go
+++ b/cmd/cub-scout/explain_golden_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestExplainText_GoldenByOwner(t *testing.T) {
+	cases := []struct {
+		name   string
+		result *agent.TraceResult
+		golden string
+	}{
+		{
+			name: "flux",
+			result: &agent.TraceResult{
+				Tool: "flux",
+				Object: agent.ResourceRef{Kind: "Deployment", Name: "payments-api", Namespace: "prod"},
+				Chain: []agent.ChainLink{
+					{Kind: "GitRepository", Name: "platform-config", Namespace: "flux-system", URL: "https://github.com/acme/platform-config.git", Revision: "main@sha1:abc1234", Ready: true, Status: "Ready"},
+					{Kind: "Kustomization", Name: "payments", Namespace: "flux-system", Path: "./apps/payments", Revision: "main@sha1:abc1234", Ready: true, Status: "Ready"},
+					{Kind: "Deployment", Name: "payments-api", Namespace: "prod", Ready: true, Status: "Healthy"},
+				},
+			},
+			golden: "flux_text.golden.txt",
+		},
+		{
+			name: "argocd",
+			result: &agent.TraceResult{
+				Tool: "argocd",
+				Object: agent.ResourceRef{Kind: "Deployment", Name: "frontend", Namespace: "prod"},
+				Chain: []agent.ChainLink{
+					{Kind: "Application", Name: "frontend-app", Namespace: "argocd", URL: "https://github.com/acme/apps.git", Revision: "main@sha1:def4567", Ready: true, Status: "Synced/Healthy"},
+					{Kind: "Deployment", Name: "frontend", Namespace: "prod", Ready: true, Status: "Healthy"},
+				},
+			},
+			golden: "argocd_text.golden.txt",
+		},
+		{
+			name: "helm",
+			result: &agent.TraceResult{
+				Tool: "helm",
+				Object: agent.ResourceRef{Kind: "StatefulSet", Name: "redis", Namespace: "prod"},
+				Chain: []agent.ChainLink{
+					{Kind: "HelmRelease", Name: "redis", Namespace: "prod", Revision: "chart@1.2.3", Ready: true, Status: "Ready"},
+					{Kind: "StatefulSet", Name: "redis", Namespace: "prod", Ready: true, Status: "Healthy"},
+				},
+			},
+			golden: "helm_text.golden.txt",
+		},
+		{
+			name: "unknown",
+			result: &agent.TraceResult{
+				Object: agent.ResourceRef{Kind: "Deployment", Name: "legacy-api", Namespace: "default"},
+				Error:  "resource not managed by any detected GitOps tool",
+			},
+			golden: "unknown_text.golden.txt",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			summary := buildExplainSummary(tc.result)
+			actual := renderExplainText(summary)
+			assertExplainGolden(t, tc.golden, actual)
+		})
+	}
+}
+
+func TestExplainMarkdown_Golden(t *testing.T) {
+	result := &agent.TraceResult{
+		Tool: "flux",
+		Object: agent.ResourceRef{Kind: "Deployment", Name: "payments-api", Namespace: "prod"},
+		Chain: []agent.ChainLink{
+			{Kind: "GitRepository", Name: "platform-config", Namespace: "flux-system", URL: "https://github.com/acme/platform-config.git", Revision: "main@sha1:abc1234", Ready: true, Status: "Ready"},
+			{Kind: "Kustomization", Name: "payments", Namespace: "flux-system", Path: "./apps/payments", Revision: "main@sha1:abc1234", Ready: true, Status: "Ready"},
+			{Kind: "Deployment", Name: "payments-api", Namespace: "prod", Ready: true, Status: "Healthy"},
+		},
+	}
+
+	summary := buildExplainSummary(result)
+	actual := renderExplainMarkdown(summary)
+	assertExplainGolden(t, "flux_md.golden.md", actual)
+}
+
+func TestExplainJSON_Golden(t *testing.T) {
+	result := &agent.TraceResult{
+		Tool: "flux",
+		Object: agent.ResourceRef{Kind: "Deployment", Name: "payments-api", Namespace: "prod"},
+		Chain: []agent.ChainLink{
+			{Kind: "GitRepository", Name: "platform-config", Namespace: "flux-system", URL: "https://github.com/acme/platform-config.git", Revision: "main@sha1:abc1234", Ready: true, Status: "Ready"},
+			{Kind: "Kustomization", Name: "payments", Namespace: "flux-system", Path: "./apps/payments", Revision: "main@sha1:abc1234", Ready: true, Status: "Ready"},
+			{Kind: "Deployment", Name: "payments-api", Namespace: "prod", Ready: true, Status: "Healthy"},
+		},
+	}
+
+	summary := buildExplainSummary(result)
+	b, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	actual := string(b) + "\n"
+	assertExplainGolden(t, "flux_json.golden.json", actual)
+}
+
+func assertExplainGolden(t *testing.T, goldenFile string, actual string) {
+	t.Helper()
+	goldenPath := filepath.Join("testdata", "explain", goldenFile)
+	expected, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", goldenPath, err)
+	}
+	if actual != string(expected) {
+		t.Fatalf("golden mismatch for %s\n--- expected ---\n%s\n--- actual ---\n%s", goldenFile, string(expected), actual)
+	}
+}

--- a/cmd/cub-scout/testdata/explain/argocd_text.golden.txt
+++ b/cmd/cub-scout/testdata/explain/argocd_text.golden.txt
@@ -1,0 +1,7 @@
+Deployment/frontend in namespace prod:
+  Owner: ArgoCD
+  Source: https://github.com/acme/apps.git (revision: main@sha1:def4567)
+  Deployed via: Application/frontend-app -> Deployment/frontend
+  Health: Healthy
+  Risks: Not assessed
+  Drift: Unknown

--- a/cmd/cub-scout/testdata/explain/flux_json.golden.json
+++ b/cmd/cub-scout/testdata/explain/flux_json.golden.json
@@ -1,0 +1,10 @@
+{
+  "resource": "Deployment/payments-api",
+  "namespace": "prod",
+  "owner": "Flux",
+  "source": "https://github.com/acme/platform-config.git (path: ./apps/payments, revision: main@sha1:abc1234)",
+  "deployedVia": "GitRepository/platform-config -\u003e Kustomization/payments -\u003e Deployment/payments-api",
+  "health": "Healthy",
+  "risks": "Not assessed",
+  "drift": "Unknown"
+}

--- a/cmd/cub-scout/testdata/explain/flux_md.golden.md
+++ b/cmd/cub-scout/testdata/explain/flux_md.golden.md
@@ -1,0 +1,10 @@
+## Explain
+
+- **Resource:** `Deployment/payments-api`
+- **Namespace:** `prod`
+- **Owner:** Flux
+- **Source:** https://github.com/acme/platform-config.git (path: ./apps/payments, revision: main@sha1:abc1234)
+- **Deployed via:** GitRepository/platform-config -> Kustomization/payments -> Deployment/payments-api
+- **Health:** Healthy
+- **Risks:** Not assessed
+- **Drift:** Unknown

--- a/cmd/cub-scout/testdata/explain/flux_text.golden.txt
+++ b/cmd/cub-scout/testdata/explain/flux_text.golden.txt
@@ -1,0 +1,7 @@
+Deployment/payments-api in namespace prod:
+  Owner: Flux
+  Source: https://github.com/acme/platform-config.git (path: ./apps/payments, revision: main@sha1:abc1234)
+  Deployed via: GitRepository/platform-config -> Kustomization/payments -> Deployment/payments-api
+  Health: Healthy
+  Risks: Not assessed
+  Drift: Unknown

--- a/cmd/cub-scout/testdata/explain/helm_text.golden.txt
+++ b/cmd/cub-scout/testdata/explain/helm_text.golden.txt
@@ -1,0 +1,7 @@
+StatefulSet/redis in namespace prod:
+  Owner: Helm
+  Source: unknown (revision: chart@1.2.3)
+  Deployed via: HelmRelease/redis -> StatefulSet/redis
+  Health: Healthy
+  Risks: Not assessed
+  Drift: Unknown

--- a/cmd/cub-scout/testdata/explain/unknown_text.golden.txt
+++ b/cmd/cub-scout/testdata/explain/unknown_text.golden.txt
@@ -1,0 +1,9 @@
+Deployment/legacy-api in namespace default:
+  Owner: Unknown - no recognized ownership labels found
+  Source: unknown
+  Deployed via: partial trace only
+  Health: Unavailable
+  Risks: Not assessed
+  Drift: Unknown
+  Notes:
+    - partial trace: no GitOps owner chain was discovered


### PR DESCRIPTION
## Summary
Final #219 closure slice:
- add golden-style explain coverage for owner scenarios:
  - Flux text
  - ArgoCD text
  - Helm text
  - Unknown-owner fallback text
- add markdown golden coverage (Flux)
- add JSON golden coverage (Flux)
- store deterministic fixtures under `cmd/cub-scout/testdata/explain/`

## Why
The previous two explain slices delivered command behavior and graceful degradation. This slice adds the explicit golden coverage requested in #219’s testing criteria.

## Proof / Tests
Regression artifacts: `/tmp/cub-scout-regression/m4/m4-t4-explain-golden/`
- red: `go test ./cmd/cub-scout -run TestExplainText_GoldenByOwner -count=1`
- green: `go test ./cmd/cub-scout -run 'TestExplainText_GoldenByOwner|TestExplainMarkdown_Golden|TestExplainJSON_Golden' -count=1`
- verify: `go test ./cmd/cub-scout -count=1`
- verify: `go test ./test/unit -count=1`

Closes #219
