### PR TITLE
feat: add kubectl plugin packaging and krew manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 /cub-scout
+/kubectl-cub_scout
 *.exe
 *.dll
 *.so

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,9 +25,27 @@ builds:
       - -s -w
       - -X main.BuildTag={{.Version}}
       - -X main.BuildDate={{.Date}}
+  - id: kubectl-cub-scout
+    main: ./cmd/cub-scout
+    binary: kubectl-cub_scout
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.BuildTag={{.Version}}
+      - -X main.BuildDate={{.Date}}
 
 archives:
   - id: default
+    ids:
+      - cub-scout
+      - kubectl-cub-scout
     formats:
       - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -64,8 +82,10 @@ brews:
     license: "MIT"
     install: |
       bin.install "cub-scout"
+      bin.install "kubectl-cub_scout"
     test: |
       system "#{bin}/cub-scout", "version"
+      system "#{bin}/kubectl-cub_scout", "version"
 
 dockers:
   - image_templates:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cub-scout Makefile
 # Canonical verification commands for development and CI
 
-.PHONY: build test test-race fmt lint clean regression-argo test-import-delegation
+.PHONY: build build-kubectl-plugin test test-race fmt lint clean regression-argo test-import-delegation
 
 # Default target
 all: build test
@@ -9,6 +9,11 @@ all: build test
 # Build the binary
 build:
 	go build ./cmd/cub-scout
+
+# Build kubectl plugin-compatible binary alias (kubectl-cub_scout)
+build-kubectl-plugin: build
+	cp cub-scout kubectl-cub_scout
+	chmod +x kubectl-cub_scout
 
 # Run all tests
 test:
@@ -29,6 +34,7 @@ fmt-check:
 # Clean build artifacts
 clean:
 	rm -f cub-scout
+	rm -f kubectl-cub_scout
 	go clean ./...
 
 # Run lint (requires golangci-lint)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ cub-scout tree ownership         # See resources grouped by GitOps owner
 cub-scout trace deploy/app -n ns # Trace any resource to its Git source
 cub-scout scan                   # Find misconfigurations (46 patterns)
 cub-scout import --dry-run -n ns # Preview ConfigHub import (connected)
+kubectl cub-scout map status     # Same command surface via kubectl plugin
 ```
 
 **What you get in 60 seconds:**
@@ -143,10 +144,28 @@ cub-scout map
 ## Quickstart (2 minutes)
 
 1. **Install:** `brew install confighub/tap/cub-scout`
-2. **Prerequisites:** kubectl access to a cluster (`kubectl get pods` works)
-3. **First command:** `cub-scout map` — launches interactive TUI
-4. **Press `?`** for keyboard shortcuts
-5. **Try:** `cub-scout trace deploy/<name> -n <namespace>` on any deployment
+2. **Optional kubectl plugin alias:** `cp "$(command -v cub-scout)" /usr/local/bin/kubectl-cub_scout`
+3. **Verify plugin mode:** `kubectl cub-scout version`
+4. **Prerequisites:** kubectl access to a cluster (`kubectl get pods` works)
+5. **First command:** `cub-scout map` — launches interactive TUI
+6. **Press `?`** for keyboard shortcuts
+7. **Try:** `cub-scout trace deploy/<name> -n <namespace>` on any deployment
+
+## kubectl Plugin Mode
+
+kubectl discovers plugins by executable name. For `kubectl cub-scout`, it looks
+for `kubectl-cub_scout` on `PATH`.
+
+```bash
+# Build both binaries locally
+make build-kubectl-plugin
+
+# Run through kubectl (same command surface)
+kubectl cub-scout map list --json
+kubectl cub-scout map
+```
+
+If you installed via Homebrew, both `cub-scout` and `kubectl-cub_scout` are installed automatically.
 
 ---
 

--- a/dist/krew/cub-scout.yaml
+++ b/dist/krew/cub-scout.yaml
@@ -1,0 +1,41 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: cub-scout
+spec:
+  version: v0.0.0
+  homepage: https://github.com/confighub/cub-scout
+  shortDescription: Explore and map GitOps in your clusters
+  description: |
+    cub-scout is an offline-first, deterministic, read-only cluster explorer
+    for Kubernetes and GitOps. Run it as a kubectl plugin via
+    `kubectl cub-scout ...`.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/confighub/cub-scout/releases/download/v0.0.0/cub-scout_v0.0.0_linux_amd64.tar.gz
+      sha256: REPLACE_WITH_LINUX_AMD64_SHA256
+      bin: kubectl-cub_scout
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/confighub/cub-scout/releases/download/v0.0.0/cub-scout_v0.0.0_linux_arm64.tar.gz
+      sha256: REPLACE_WITH_LINUX_ARM64_SHA256
+      bin: kubectl-cub_scout
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/confighub/cub-scout/releases/download/v0.0.0/cub-scout_v0.0.0_darwin_amd64.tar.gz
+      sha256: REPLACE_WITH_DARWIN_AMD64_SHA256
+      bin: kubectl-cub_scout
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/confighub/cub-scout/releases/download/v0.0.0/cub-scout_v0.0.0_darwin_arm64.tar.gz
+      sha256: REPLACE_WITH_DARWIN_ARM64_SHA256
+      bin: kubectl-cub_scout

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -9,6 +9,7 @@ Every tagged release automatically produces:
 1. **GitHub Release** with binaries
    - linux/amd64, linux/arm64
    - darwin/amd64, darwin/arm64
+   - Includes both `cub-scout` and `kubectl-cub_scout`
    - checksums.txt
 
 2. **Homebrew Formula**
@@ -18,6 +19,10 @@ Every tagged release automatically produces:
 3. **Docker Images**
    - `ghcr.io/confighub/cub-scout:<version>`
    - `ghcr.io/confighub/cub-scout:latest`
+
+4. **Krew Manifest Template**
+   - Source template: `dist/krew/cub-scout.yaml`
+   - Update `spec.version`, `uri`, and `sha256` values per release before submitting to krew-index
 
 ## How to Release
 
@@ -89,6 +94,7 @@ with the new SHA256 checksums automatically.
 - [ ] Release notes describe changes clearly
 - [ ] After release: verify GitHub artifacts exist
 - [ ] After release: verify `brew info confighub/tap/cub-scout` shows new version
+- [ ] Prepare krew manifest from `dist/krew/cub-scout.yaml` with release checksums
 
 ## Troubleshooting
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -8,6 +8,7 @@ brew install confighub/tap/cub-scout
 
 # Verify installation
 cub-scout version
+kubectl cub-scout version
 ```
 
 ## Alternative Methods
@@ -63,11 +64,26 @@ For tracing GitOps ownership chains, install these if you use them:
 # Check cub-scout version
 cub-scout version
 
+# Check kubectl plugin mode
+kubectl cub-scout version
+
 # Quick cluster scan
 cub-scout map list
 
 # Interactive TUI
 cub-scout map
+```
+
+## kubectl Plugin Mode
+
+kubectl discovers plugins by executable name. For `kubectl cub-scout`, it looks
+for `kubectl-cub_scout` in `PATH`.
+
+Homebrew installs both binaries automatically. For source builds:
+
+```bash
+make build-kubectl-plugin
+sudo cp kubectl-cub_scout /usr/local/bin/
 ```
 
 ## Next Steps

--- a/test/integration/kubectl_plugin_test.go
+++ b/test/integration/kubectl_plugin_test.go
@@ -1,0 +1,177 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestKubectlPlugin_BuildTargetProducesExecutablePlugin(t *testing.T) {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		t.Skip("kubectl not installed")
+	}
+
+	repoRoot := mustFindRepoRoot(t)
+	pluginPath := filepath.Join(repoRoot, "kubectl-cub_scout")
+	_ = os.Remove(pluginPath)
+	t.Cleanup(func() {
+		_ = os.Remove(pluginPath)
+	})
+
+	if makeOut, err := runInRepo(repoRoot, "make", "build-kubectl-plugin"); err != nil {
+		t.Fatalf("make build-kubectl-plugin failed: %v\n%s", err, makeOut)
+	}
+
+	if _, err := os.Stat(pluginPath); err != nil {
+		t.Fatalf("plugin binary missing at %s: %v", pluginPath, err)
+	}
+
+	kubectlOut, err := runWithPath(repoRoot, "kubectl", "cub-scout", "version")
+	if err != nil {
+		t.Fatalf("kubectl cub-scout version failed: %v\n%s", err, kubectlOut)
+	}
+	if !strings.Contains(kubectlOut, "cub-scout version") {
+		t.Fatalf("unexpected plugin version output:\n%s", kubectlOut)
+	}
+}
+
+func TestKubectlPlugin_MapListJSONParity(t *testing.T) {
+	skipIfNoCluster(t)
+	repoRoot := mustFindRepoRoot(t)
+
+	if makeOut, err := runInRepo(repoRoot, "make", "build-kubectl-plugin"); err != nil {
+		t.Fatalf("make build-kubectl-plugin failed: %v\n%s", err, makeOut)
+	}
+
+	directOut, err := runCmd(getCubAgentPath(), "map", "list", "--json")
+	if err != nil {
+		t.Fatalf("cub-scout map list --json failed: %v\n%s", err, directOut)
+	}
+
+	pluginOut, err := runWithPath(repoRoot, "kubectl", "cub-scout", "map", "list", "--json")
+	if err != nil {
+		t.Fatalf("kubectl cub-scout map list --json failed: %v\n%s", err, pluginOut)
+	}
+
+	directKeys, err := extractMapListIdentityKeys(directOut)
+	if err != nil {
+		t.Fatalf("parse direct map list json: %v\n%s", err, directOut)
+	}
+	pluginKeys, err := extractMapListIdentityKeys(pluginOut)
+	if err != nil {
+		t.Fatalf("parse plugin map list json: %v\n%s", err, pluginOut)
+	}
+
+	if len(directKeys) != len(pluginKeys) {
+		t.Fatalf("map list entry count mismatch: direct=%d plugin=%d", len(directKeys), len(pluginKeys))
+	}
+
+	for i := range directKeys {
+		if directKeys[i] != pluginKeys[i] {
+			t.Fatalf("map list identity mismatch at index %d: direct=%q plugin=%q", i, directKeys[i], pluginKeys[i])
+		}
+	}
+}
+
+func TestKubectlPlugin_KrewManifestContract(t *testing.T) {
+	repoRoot := mustFindRepoRoot(t)
+	manifestPath := filepath.Join(repoRoot, "dist", "krew", "cub-scout.yaml")
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read krew manifest: %v", err)
+	}
+
+	var manifest struct {
+		APIVersion string `yaml:"apiVersion"`
+		Kind       string `yaml:"kind"`
+		Metadata   struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Spec struct {
+			Platforms []struct {
+				Bin string `yaml:"bin"`
+				URI string `yaml:"uri"`
+			} `yaml:"platforms"`
+		} `yaml:"spec"`
+	}
+
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse krew manifest: %v", err)
+	}
+
+	if manifest.APIVersion != "krew.googlecontainertools.github.com/v1alpha2" {
+		t.Fatalf("apiVersion = %q, want krew.googlecontainertools.github.com/v1alpha2", manifest.APIVersion)
+	}
+	if manifest.Kind != "Plugin" {
+		t.Fatalf("kind = %q, want Plugin", manifest.Kind)
+	}
+	if manifest.Metadata.Name != "cub-scout" {
+		t.Fatalf("metadata.name = %q, want cub-scout", manifest.Metadata.Name)
+	}
+	if len(manifest.Spec.Platforms) == 0 {
+		t.Fatal("manifest has no platforms")
+	}
+
+	for i, p := range manifest.Spec.Platforms {
+		if p.Bin != "kubectl-cub_scout" {
+			t.Fatalf("platform[%d].bin = %q, want kubectl-cub_scout", i, p.Bin)
+		}
+		if strings.TrimSpace(p.URI) == "" {
+			t.Fatalf("platform[%d].uri is empty", i)
+		}
+	}
+}
+
+func extractMapListIdentityKeys(raw string) ([]string, error) {
+	var entries []struct {
+		Namespace string `json:"namespace"`
+		Kind      string `json:"kind"`
+		Name      string `json:"name"`
+		Owner     string `json:"owner"`
+	}
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(entries))
+	for _, e := range entries {
+		keys = append(keys, fmt.Sprintf("%s/%s/%s/%s", e.Namespace, e.Kind, e.Name, e.Owner))
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func runInRepo(repoRoot, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func runWithPath(pathPrefix, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Env = append(os.Environ(), "PATH="+pathPrefix+":"+os.Getenv("PATH"), "NO_COLOR=1")
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func runCmd(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}


### PR DESCRIPTION
## Summary
- add `make build-kubectl-plugin` to emit `kubectl-cub_scout` for kubectl plugin discovery
- package/install plugin binary in releases and Homebrew via `.goreleaser.yaml`
- add krew manifest template at `dist/krew/cub-scout.yaml`
- add integration tests for plugin build/runtime contract and krew manifest contract
- document kubectl plugin install/use in README + install/release docs

## Testing
- `go test -tags=integration ./test/integration/... -run TestKubectlPlugin -count=1 -v`
- `go test ./cmd/cub-scout -count=1`
- `go test ./test/unit -count=1`

## Notes
- `TestKubectlPlugin_MapListJSONParity` is cluster-gated and skips in local no-cluster environments; it runs in CI integration jobs.
- local `go test ./...` still hits existing `test/golden/scan-file` path canonicalization mismatch unrelated to this change.

Closes #221
