### PR TITLE
feat: expand distribution channels and windows release targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
@@ -33,6 +34,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
@@ -48,6 +50,10 @@ archives:
       - kubectl-cub-scout
     formats:
       - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md

--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ cub-scout import --dry-run -n ns # Preview ConfigHub import (connected)
 kubectl cub-scout map status     # Same command surface via kubectl plugin
 ```
 
+## Install Channels
+
+```bash
+# Homebrew
+brew install confighub/tap/cub-scout
+
+# Go install
+go install github.com/confighub/cub-scout/cmd/cub-scout@latest
+
+# Binary download
+curl -sL https://github.com/confighub/cub-scout/releases/latest
+
+# Container
+docker run ghcr.io/confighub/cub-scout:latest version
+
+# kubectl krew (after manifest publication in krew-index)
+kubectl krew install cub-scout
+```
+
 **What you get in 60 seconds:**
 - See which resources are managed by Flux, ArgoCD, Helm, or kubectl
 - Trace any Deployment back to its Git source

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -9,6 +9,7 @@ Every tagged release automatically produces:
 1. **GitHub Release** with binaries
    - linux/amd64, linux/arm64
    - darwin/amd64, darwin/arm64
+   - windows/amd64, windows/arm64
    - Includes both `cub-scout` and `kubectl-cub_scout`
    - checksums.txt
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -27,6 +27,23 @@ sudo mv cub-scout /usr/local/bin/
 curl -LO https://github.com/confighub/cub-scout/releases/latest/download/cub-scout-darwin-arm64.tar.gz
 tar xzf cub-scout-darwin-arm64.tar.gz
 sudo mv cub-scout /usr/local/bin/
+
+# Windows (PowerShell, amd64)
+curl.exe -LO https://github.com/confighub/cub-scout/releases/latest/download/cub-scout-windows-amd64.zip
+tar -xf cub-scout-windows-amd64.zip
+.\cub-scout.exe version
+```
+
+### Go Install
+
+```bash
+go install github.com/confighub/cub-scout/cmd/cub-scout@latest
+```
+
+### Container
+
+```bash
+docker run ghcr.io/confighub/cub-scout:latest version
 ```
 
 ### Build from Source
@@ -36,6 +53,14 @@ git clone https://github.com/confighub/cub-scout.git
 cd cub-scout
 go build -o cub-scout ./cmd/cub-scout
 sudo mv cub-scout /usr/local/bin/
+```
+
+### kubectl krew
+
+After `cub-scout` is published in krew-index:
+
+```bash
+kubectl krew install cub-scout
 ```
 
 ## Prerequisites

--- a/test/unit/release_distribution_contract_test.go
+++ b/test/unit/release_distribution_contract_test.go
@@ -1,0 +1,133 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type goreleaserConfig struct {
+	Builds []struct {
+		ID     string   `yaml:"id"`
+		Goos   []string `yaml:"goos"`
+		Goarch []string `yaml:"goarch"`
+	} `yaml:"builds"`
+	Archives []struct {
+		ID              string `yaml:"id"`
+		Formats         []string
+		FormatOverrides []struct {
+			Goos    string   `yaml:"goos"`
+			Format  string   `yaml:"format"`
+			Formats []string `yaml:"formats"`
+		} `yaml:"format_overrides"`
+	} `yaml:"archives"`
+	Brews []struct {
+		Name string `yaml:"name"`
+	} `yaml:"brews"`
+	Dockers []struct {
+		ImageTemplates []string `yaml:"image_templates"`
+	} `yaml:"dockers"`
+}
+
+func TestGoReleaser_DistributionTargets(t *testing.T) {
+	cfgPath := filepath.Join("..", "..", ".goreleaser.yaml")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read goreleaser config: %v", err)
+	}
+
+	var cfg goreleaserConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse goreleaser config: %v", err)
+	}
+
+	requiredBuilds := map[string]bool{
+		"cub-scout":         false,
+		"kubectl-cub-scout": false,
+	}
+	for _, b := range cfg.Builds {
+		if _, ok := requiredBuilds[b.ID]; !ok {
+			continue
+		}
+		requiredBuilds[b.ID] = true
+		for _, requiredOS := range []string{"linux", "darwin", "windows"} {
+			if !slices.Contains(b.Goos, requiredOS) {
+				t.Fatalf("build %q missing goos %q", b.ID, requiredOS)
+			}
+		}
+		for _, requiredArch := range []string{"amd64", "arm64"} {
+			if !slices.Contains(b.Goarch, requiredArch) {
+				t.Fatalf("build %q missing goarch %q", b.ID, requiredArch)
+			}
+		}
+	}
+	for id, found := range requiredBuilds {
+		if !found {
+			t.Fatalf("missing required build id %q", id)
+		}
+	}
+
+	if len(cfg.Archives) == 0 {
+		t.Fatal("goreleaser archives config missing")
+	}
+
+	hasWindowsZip := false
+	for _, arc := range cfg.Archives {
+		for _, override := range arc.FormatOverrides {
+			formats := override.Formats
+			if override.Format != "" {
+				formats = append(formats, override.Format)
+			}
+			if override.Goos == "windows" && slices.Contains(formats, "zip") {
+				hasWindowsZip = true
+			}
+		}
+	}
+	if !hasWindowsZip {
+		t.Fatal("expected windows archive zip format override")
+	}
+
+	if len(cfg.Brews) == 0 {
+		t.Fatal("expected at least one Homebrew config in goreleaser")
+	}
+	if len(cfg.Dockers) == 0 {
+		t.Fatal("expected at least one Docker image config in goreleaser")
+	}
+}
+
+func TestInstallDocs_IncludeDistributionChannels(t *testing.T) {
+	readmePath := filepath.Join("..", "..", "README.md")
+	installPath := filepath.Join("..", "..", "docs", "getting-started", "install.md")
+
+	readmeBytes, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	installBytes, err := os.ReadFile(installPath)
+	if err != nil {
+		t.Fatalf("read install doc: %v", err)
+	}
+
+	readme := string(readmeBytes)
+	installDoc := string(installBytes)
+
+	requiredSnippets := []string{
+		"brew install confighub/tap/cub-scout",
+		"go install github.com/confighub/cub-scout/cmd/cub-scout@latest",
+		"github.com/confighub/cub-scout/releases",
+		"docker run ghcr.io/confighub/cub-scout",
+		"kubectl krew install cub-scout",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(readme, snippet) {
+			t.Fatalf("README missing distribution channel snippet %q", snippet)
+		}
+		if !strings.Contains(installDoc, snippet) {
+			t.Fatalf("install doc missing distribution channel snippet %q", snippet)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expand GoReleaser builds to include Windows (`amd64`, `arm64`) for both `cub-scout` and `kubectl-cub_scout`
- add Windows archive zip override in `.goreleaser.yaml`
- document all install/distribution channels in README + install guide:
  - Homebrew
  - `go install`
  - GitHub Releases binary download
  - container image run
  - krew install path
- add unit contract test to prevent regressions in release target matrix and distribution docs

## Testing
- `go test ./test/unit -run 'TestGoReleaser_DistributionTargets|TestInstallDocs_IncludeDistributionChannels' -count=1 -v`
- `go test ./cmd/cub-scout -count=1`
- `go test ./test/unit -count=1`

Closes #222
