### PR TITLE
feat: add guided quickstart wizard command

### DIFF
--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -30,6 +30,7 @@ The table below reflects the current `cub-scout --help` output.
 | `map` | Interactive map of resources and ownership |
 | `parse-repo` | Parse a GitOps repository structure |
 | `patterns` | Pattern detection engine |
+| `quickstart` | Guided first-run tour across doctor, explain, ownership, and scan |
 | `remedy` | Execute remediation for risk issue findings |
 | `scan` | Scan for risk issues and stuck states |
 | `setup` | Set up shell completions and configuration |
@@ -61,6 +62,30 @@ The table below reflects the current `cub-scout --help` output.
 | `--kubeconfig` | Destination kubeconfig path |
 | `--skip-verify` | Skip API connectivity check |
 | `--map` | Launch `cub-scout map` immediately |
+
+---
+
+## `quickstart` — Guided First-Run Tour
+
+**What it does:** Runs a short wizard over your current cluster context and surfaces immediate value in one flow: doctor summary, explain, ownership snapshot, top finding, and next steps.
+
+```bash
+./cub-scout quickstart
+./cub-scout quickstart --yes
+./cub-scout quickstart --namespace production --top-finding 1
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `-y, --yes` | Non-interactive mode (no pause prompts) |
+| `-n, --namespace` | Scope doctor + finding collection to one namespace |
+| `--top-finding` | 1-based finding index to highlight after severity sort |
+
+**Graceful degradation behavior:**
+- No cluster connectivity: wizard prints fallback guidance for example bundle mode.
+- Empty cluster: doctor/ownership steps still run and explain no representative workload.
+- No connected context: connected-mode preview step is skipped.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Please send feedback by [opening an issue](https://github.com/confighub/cub-scou
 
 ```bash
 brew install confighub/tap/cub-scout
+cub-scout quickstart             # Guided first-run tour of your current cluster
 cub-scout map                    # Interactive TUI — explore your cluster
 cub-scout map list --json | jq   # JSON output — pipe to your tools
 cub-scout tree ownership         # See resources grouped by GitOps owner
@@ -166,9 +167,10 @@ cub-scout map
 2. **Optional kubectl plugin alias:** `cp "$(command -v cub-scout)" /usr/local/bin/kubectl-cub_scout`
 3. **Verify plugin mode:** `kubectl cub-scout version`
 4. **Prerequisites:** kubectl access to a cluster (`kubectl get pods` works)
-5. **First command:** `cub-scout map` — launches interactive TUI
-6. **Press `?`** for keyboard shortcuts
-7. **Try:** `cub-scout trace deploy/<name> -n <namespace>` on any deployment
+5. **Run guided tour:** `cub-scout quickstart`
+6. **Then launch map:** `cub-scout map`
+7. **Press `?`** for keyboard shortcuts
+8. **Try:** `cub-scout trace deploy/<name> -n <namespace>` on any deployment
 
 ## kubectl Plugin Mode
 

--- a/cmd/cub-scout/main.go
+++ b/cmd/cub-scout/main.go
@@ -31,6 +31,7 @@ var rootCmd = &cobra.Command{
 Offline-first, deterministic, read-only cluster explorer for Kubernetes and GitOps.
 
 POPULAR COMMANDS
+  quickstart       Guided first-run tour across doctor/explain/ownership/scan
   map              Interactive TUI dashboard — explore cluster visually
   map list         List resources with ownership (scriptable, supports --json)
   tree             Hierarchical views: runtime, ownership, git, composition
@@ -64,6 +65,7 @@ Environment Variables:
 		fmt.Println("cub-scout - explore and map GitOps in your clusters")
 		fmt.Println()
 		fmt.Println("Quick start:")
+		fmt.Println("  cub-scout quickstart       Guided first-run tour")
 		fmt.Println("  cub-scout map              Interactive TUI (press ? for help)")
 		fmt.Println("  cub-scout tree ownership   See resources by GitOps owner")
 		fmt.Println("  cub-scout trace deploy/x   Trace a resource to Git")

--- a/cmd/cub-scout/quickstart.go
+++ b/cmd/cub-scout/quickstart.go
@@ -1,0 +1,415 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/confighub/cub-scout/internal/scan"
+	"github.com/spf13/cobra"
+)
+
+var (
+	quickstartYes        bool
+	quickstartNamespace  string
+	quickstartTopFinding int
+)
+
+var quickstartCmd = &cobra.Command{
+	Use:   "quickstart",
+	Short: "Run a guided first-run tour on your cluster",
+	Long: `quickstart walks through core cub-scout capabilities using your current cluster.
+
+Flow:
+  1) detect cluster access and context
+  2) show doctor summary
+  3) explain one representative workload
+  4) show ownership snapshot
+  5) highlight top finding
+  6) show connected-mode preview when relevant
+  7) print practical next steps
+`,
+	RunE: runQuickstart,
+}
+
+func init() {
+	rootCmd.AddCommand(quickstartCmd)
+	quickstartCmd.Flags().BoolVarP(&quickstartYes, "yes", "y", false, "Run non-interactively (skip prompts)")
+	quickstartCmd.Flags().StringVarP(&quickstartNamespace, "namespace", "n", "", "Namespace scope (default: all namespaces)")
+	quickstartCmd.Flags().IntVar(&quickstartTopFinding, "top-finding", 1, "Numbered top finding to highlight (1-based)")
+}
+
+type quickstartFixtureInput struct {
+	ClusterConnected bool                     `json:"clusterConnected"`
+	Context          string                   `json:"context"`
+	ConnectedPreview bool                     `json:"connectedPreview"`
+	Entries          []MapEntry               `json:"entries"`
+	Findings         []scan.NormalizedFinding `json:"findings"`
+}
+
+type quickstartState struct {
+	ClusterConnected bool
+	Context          string
+	ConnectedPreview bool
+	Summary          DoctorSummary
+	Entries          []MapEntry
+	Findings         []scan.NormalizedFinding
+	Representative   *MapEntry
+	Explain          *ExplainSummary
+}
+
+func runQuickstart(cmd *cobra.Command, args []string) error {
+	if quickstartTopFinding < 1 {
+		return fmt.Errorf("--top-finding must be >= 1")
+	}
+
+	state, err := loadQuickstartState(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	renderQuickstart(os.Stdout, state, shouldQuickstartPrompt())
+	return nil
+}
+
+func loadQuickstartState(ctx context.Context) (quickstartState, error) {
+	if fixturePath := os.Getenv("CUB_SCOUT_TEST_QUICKSTART_JSON"); strings.TrimSpace(fixturePath) != "" {
+		return loadQuickstartFromFixture(fixturePath)
+	}
+
+	connected, contextName := detectQuickstartCluster()
+	if !connected {
+		return quickstartState{ClusterConnected: false, Context: contextName}, nil
+	}
+
+	namespaceLabel := strings.TrimSpace(quickstartNamespace)
+	if namespaceLabel == "" {
+		namespaceLabel = "all"
+	}
+
+	entries, clusterName, err := collectDoctorEntries(ctx, quickstartNamespace)
+	if err != nil {
+		return quickstartState{}, err
+	}
+	findings, err := collectDoctorFindings(ctx, quickstartNamespace)
+	if err != nil {
+		findings = nil
+	}
+
+	summary := buildDoctorSummary(entries, findings, clusterName, namespaceLabel, 3)
+	state := quickstartState{
+		ClusterConnected: true,
+		Context:          contextName,
+		ConnectedPreview: detectQuickstartConnectedPreview(),
+		Summary:          summary,
+		Entries:          entries,
+		Findings:         findings,
+	}
+
+	if rep, ok := pickQuickstartRepresentative(entries); ok {
+		state.Representative = &rep
+		explain := quickstartExplainForEntry(ctx, rep)
+		state.Explain = &explain
+	}
+
+	return state, nil
+}
+
+func loadQuickstartFromFixture(path string) (quickstartState, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return quickstartState{}, fmt.Errorf("read quickstart fixture: %w", err)
+	}
+	var in quickstartFixtureInput
+	if err := json.Unmarshal(b, &in); err != nil {
+		return quickstartState{}, fmt.Errorf("parse quickstart fixture: %w", err)
+	}
+
+	contextName := strings.TrimSpace(in.Context)
+	if contextName == "" {
+		contextName = getCurrentContext()
+	}
+	if !in.ClusterConnected {
+		return quickstartState{ClusterConnected: false, Context: contextName}, nil
+	}
+
+	namespaceLabel := strings.TrimSpace(quickstartNamespace)
+	if namespaceLabel == "" {
+		namespaceLabel = "all"
+	}
+
+	summary := buildDoctorSummary(in.Entries, in.Findings, contextName, namespaceLabel, 3)
+	state := quickstartState{
+		ClusterConnected: true,
+		Context:          contextName,
+		ConnectedPreview: in.ConnectedPreview,
+		Summary:          summary,
+		Entries:          in.Entries,
+		Findings:         in.Findings,
+	}
+
+	if rep, ok := pickQuickstartRepresentative(in.Entries); ok {
+		state.Representative = &rep
+		explain := buildQuickstartExplainFromEntry(rep)
+		state.Explain = &explain
+	}
+
+	return state, nil
+}
+
+func detectQuickstartCluster() (bool, string) {
+	contextName := getCurrentContext()
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		return false, contextName
+	}
+	if err := exec.Command("kubectl", "cluster-info").Run(); err != nil {
+		return false, contextName
+	}
+	return true, contextName
+}
+
+func detectQuickstartConnectedPreview() bool {
+	if _, err := exec.LookPath("cub"); err != nil {
+		return false
+	}
+	return exec.Command("cub", "context", "get").Run() == nil
+}
+
+func pickQuickstartRepresentative(entries []MapEntry) (MapEntry, bool) {
+	if len(entries) == 0 {
+		return MapEntry{}, false
+	}
+
+	priority := map[string]int{
+		"Deployment":  1,
+		"StatefulSet": 2,
+		"DaemonSet":   3,
+		"Pod":         4,
+		"Service":     5,
+	}
+
+	bestIdx := -1
+	bestRank := 999
+	for i, e := range entries {
+		rank, ok := priority[e.Kind]
+		if !ok {
+			rank = 500
+		}
+		if rank < bestRank {
+			bestRank = rank
+			bestIdx = i
+		}
+	}
+	if bestIdx < 0 {
+		return MapEntry{}, false
+	}
+	return entries[bestIdx], true
+}
+
+func quickstartExplainForEntry(ctx context.Context, entry MapEntry) ExplainSummary {
+	if result, err := traceForExplain(ctx, entry.Kind, entry.Name, entry.Namespace); err == nil && result != nil {
+		summary := buildExplainSummary(result)
+		if summary.Resource == "" {
+			summary.Resource = fmt.Sprintf("%s/%s", entry.Kind, entry.Name)
+		}
+		if summary.Namespace == "" {
+			summary.Namespace = entry.Namespace
+		}
+		return summary
+	}
+	return buildQuickstartExplainFromEntry(entry)
+}
+
+func buildQuickstartExplainFromEntry(entry MapEntry) ExplainSummary {
+	owner := strings.TrimSpace(entry.Owner)
+	if owner == "" {
+		owner = "Unknown"
+	}
+	health := strings.TrimSpace(entry.Status)
+	if health == "" {
+		health = "Unknown"
+	}
+	return ExplainSummary{
+		Resource:    fmt.Sprintf("%s/%s", entry.Kind, entry.Name),
+		Namespace:   entry.Namespace,
+		Owner:       owner,
+		Source:      "unknown",
+		DeployedVia: fmt.Sprintf("%s/%s", entry.Kind, entry.Name),
+		Health:      health,
+		Risks:       "Not assessed",
+		Drift:       "Unknown",
+		Notes:       []string{"quickstart fallback: trace unavailable in this environment"},
+	}
+}
+
+func renderQuickstart(w io.Writer, state quickstartState, interactive bool) {
+	fmt.Fprintln(w, "Quickstart Wizard")
+	fmt.Fprintln(w, "================")
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "Step 1/7 - Cluster check\n")
+	if !state.ClusterConnected {
+		fmt.Fprintf(w, "No cluster connection detected (context: %s).\n", state.Context)
+		fmt.Fprintln(w, "Run quickstart again after kubectl is connected, or use example bundle mode:")
+		fmt.Fprintln(w, "  cub-scout map --bundle ./testdata/fixtures/bundle")
+		fmt.Fprintln(w, "  cub-scout doctor")
+		fmt.Fprintln(w)
+		return
+	}
+	fmt.Fprintf(w, "Connected to context: %s\n\n", state.Context)
+	quickstartPause(w, interactive)
+
+	fmt.Fprintln(w, "Step 2/7 - Doctor Summary")
+	fmt.Fprintf(w, "Doctor Summary: resources=%d healthy=%d warning=%d error=%d\n",
+		state.Summary.Resources.Total,
+		state.Summary.Health.Healthy,
+		state.Summary.Health.Warning,
+		state.Summary.Health.Error,
+	)
+	fmt.Fprintln(w)
+	quickstartPause(w, interactive)
+
+	fmt.Fprintln(w, "Step 3/7 - Explain representative workload")
+	if state.Explain != nil {
+		fmt.Fprintf(w, "Explain: %s\n", state.Explain.Resource)
+		fmt.Fprintf(w, "  Owner: %s\n", state.Explain.Owner)
+		fmt.Fprintf(w, "  Health: %s\n", state.Explain.Health)
+	} else {
+		fmt.Fprintln(w, "Explain: no representative workload found")
+	}
+	fmt.Fprintln(w)
+	quickstartPause(w, interactive)
+
+	fmt.Fprintln(w, "Step 4/7 - Ownership snapshot")
+	printQuickstartOwnershipSnapshot(w, state.Entries)
+	fmt.Fprintln(w)
+	quickstartPause(w, interactive)
+
+	fmt.Fprintln(w, "Step 5/7 - Top finding")
+	printQuickstartTopFinding(w, state.Findings)
+	fmt.Fprintln(w)
+	quickstartPause(w, interactive)
+
+	fmt.Fprintln(w, "Step 6/7 - Connected mode preview")
+	if state.ConnectedPreview {
+		fmt.Fprintln(w, "Connected mode preview available: import/fleet history features detected.")
+		fmt.Fprintln(w, "Try: cub-scout import --dry-run -n <namespace>")
+	} else {
+		fmt.Fprintln(w, "Connected mode preview unavailable (cub CLI context not detected).")
+	}
+	fmt.Fprintln(w)
+	quickstartPause(w, interactive)
+
+	fmt.Fprintln(w, "Step 7/7 - Next steps")
+	fmt.Fprintln(w, "Next steps:")
+	fmt.Fprintln(w, "  1) cub-scout doctor")
+	fmt.Fprintln(w, "  2) cub-scout explain <kind/name> -n <namespace>")
+	fmt.Fprintln(w, "  3) cub-scout map list --json")
+	fmt.Fprintln(w, "  4) cub-scout scan")
+	if state.ConnectedPreview {
+		fmt.Fprintln(w, "  5) cub-scout import --dry-run -n <namespace>")
+	}
+}
+
+func printQuickstartOwnershipSnapshot(w io.Writer, entries []MapEntry) {
+	counts := map[string]int{}
+	for _, e := range entries {
+		owner := strings.TrimSpace(e.Owner)
+		if owner == "" {
+			owner = "Unknown"
+		}
+		counts[owner]++
+	}
+	if len(counts) == 0 {
+		fmt.Fprintln(w, "Ownership snapshot: no resources discovered")
+		return
+	}
+
+	owners := make([]string, 0, len(counts))
+	for owner := range counts {
+		owners = append(owners, owner)
+	}
+	sort.Strings(owners)
+
+	fmt.Fprintln(w, "Ownership snapshot:")
+	for _, owner := range owners {
+		fmt.Fprintf(w, "  - %s: %d\n", owner, counts[owner])
+	}
+}
+
+func printQuickstartTopFinding(w io.Writer, findings []scan.NormalizedFinding) {
+	if len(findings) == 0 {
+		fmt.Fprintln(w, "Top finding: none (no findings returned)")
+		return
+	}
+
+	sorted := append([]scan.NormalizedFinding(nil), findings...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ri := quickstartSeverityRank(sorted[i].Severity)
+		rj := quickstartSeverityRank(sorted[j].Severity)
+		if ri != rj {
+			return ri < rj
+		}
+		if sorted[i].Namespace != sorted[j].Namespace {
+			return sorted[i].Namespace < sorted[j].Namespace
+		}
+		return sorted[i].Resource < sorted[j].Resource
+	})
+
+	idx := quickstartTopFinding - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	f := sorted[idx]
+	fmt.Fprintf(w, "Top finding: [%s] %s/%s - %s\n",
+		strings.ToUpper(f.Severity),
+		f.Namespace,
+		f.Resource,
+		f.Message,
+	)
+}
+
+func quickstartSeverityRank(sev string) int {
+	switch strings.ToLower(strings.TrimSpace(sev)) {
+	case "critical":
+		return 0
+	case "warning":
+		return 1
+	case "info":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func shouldQuickstartPrompt() bool {
+	if quickstartYes {
+		return false
+	}
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+func quickstartPause(w io.Writer, interactive bool) {
+	if !interactive {
+		return
+	}
+	fmt.Fprint(w, "Press Enter to continue... ")
+	_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+	fmt.Fprintln(w)
+}

--- a/cmd/cub-scout/quickstart_test.go
+++ b/cmd/cub-scout/quickstart_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/internal/scan"
+	"github.com/spf13/cobra"
+)
+
+func TestQuickstartCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "quickstart" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("quickstart command is not registered on rootCmd")
+	}
+}
+
+func TestPickQuickstartRepresentativePrefersWorkloadKinds(t *testing.T) {
+	entries := []MapEntry{
+		{Kind: "Service", Namespace: "prod", Name: "payments"},
+		{Kind: "Deployment", Namespace: "prod", Name: "payments-api"},
+		{Kind: "Pod", Namespace: "prod", Name: "payments-api-abc123"},
+	}
+
+	chosen, ok := pickQuickstartRepresentative(entries)
+	if !ok {
+		t.Fatal("expected representative workload to be selected")
+	}
+	if chosen.Kind != "Deployment" || chosen.Name != "payments-api" {
+		t.Fatalf("unexpected representative: %s/%s", chosen.Kind, chosen.Name)
+	}
+}
+
+func TestRunQuickstart_WithFixtureRendersGuidedFlow(t *testing.T) {
+	fixture := quickstartFixtureInput{
+		ClusterConnected: true,
+		Context:          "kind-test",
+		ConnectedPreview: true,
+		Entries: []MapEntry{
+			{Kind: "Deployment", Name: "payments-api", Namespace: "prod", Owner: "Flux", Status: "Ready"},
+			{Kind: "Service", Name: "payments", Namespace: "prod", Owner: "Flux", Status: "Ready"},
+		},
+		Findings: []scan.NormalizedFinding{
+			{Severity: "critical", Resource: "Deployment/payments-api", Namespace: "prod", Message: "missing limits"},
+		},
+	}
+
+	fixturePath := writeQuickstartFixture(t, fixture)
+	t.Setenv("CUB_SCOUT_TEST_QUICKSTART_JSON", fixturePath)
+
+	restore := withQuickstartFlagsForTest(true)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	out := captureStdout(t, func() {
+		if err := runQuickstart(cmd, nil); err != nil {
+			t.Fatalf("runQuickstart failed: %v", err)
+		}
+	})
+
+	required := []string{
+		"Quickstart Wizard",
+		"Step 1/7",
+		"Doctor Summary",
+		"Explain: Deployment/payments-api",
+		"Ownership snapshot",
+		"Top finding",
+		"Connected mode preview available",
+		"Next steps",
+	}
+	for _, s := range required {
+		if !strings.Contains(out, s) {
+			t.Fatalf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRunQuickstart_NoClusterFallback(t *testing.T) {
+	fixture := quickstartFixtureInput{ClusterConnected: false}
+	fixturePath := writeQuickstartFixture(t, fixture)
+	t.Setenv("CUB_SCOUT_TEST_QUICKSTART_JSON", fixturePath)
+
+	restore := withQuickstartFlagsForTest(true)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	out := captureStdout(t, func() {
+		if err := runQuickstart(cmd, nil); err != nil {
+			t.Fatalf("runQuickstart failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No cluster connection detected") {
+		t.Fatalf("expected no-cluster fallback message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "example bundle mode") {
+		t.Fatalf("expected example bundle guidance, got:\n%s", out)
+	}
+}
+
+func writeQuickstartFixture(t *testing.T, fixture quickstartFixtureInput) string {
+	t.Helper()
+	b, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "quickstart-fixture.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func withQuickstartFlagsForTest(yes bool) func() {
+	prevYes := quickstartYes
+	prevNamespace := quickstartNamespace
+	prevTop := quickstartTopFinding
+	quickstartYes = yes
+	quickstartNamespace = ""
+	quickstartTopFinding = 1
+
+	return func() {
+		quickstartYes = prevYes
+		quickstartNamespace = prevNamespace
+		quickstartTopFinding = prevTop
+	}
+}

--- a/cmd/cub-scout/smoke_test.go
+++ b/cmd/cub-scout/smoke_test.go
@@ -56,6 +56,12 @@ func TestSmoke_CLIHelp(t *testing.T) {
 			wantContains: []string{"scan", "Usage:"},
 		},
 		{
+			name:         "quickstart help",
+			args:         []string{"quickstart", "--help"},
+			wantExitCode: 0,
+			wantContains: []string{"quickstart", "Usage:"},
+		},
+		{
 			name:         "trace help",
 			args:         []string{"trace", "--help"},
 			wantExitCode: 0,
@@ -137,7 +143,7 @@ func TestSmoke_RootCommand(t *testing.T) {
 	}
 
 	// Verify key subcommands exist
-	expectedCmds := []string{"version", "completion", "map", "scan", "trace", "status"}
+	expectedCmds := []string{"version", "completion", "map", "quickstart", "scan", "trace", "status"}
 	for _, name := range expectedCmds {
 		found := false
 		for _, cmd := range rootCmd.Commands() {


### PR DESCRIPTION
## Summary
- add new `cub-scout quickstart` guided wizard command with a 7-step first-run flow
  1. cluster connectivity/context
  2. doctor summary
  3. explain representative workload
  4. ownership snapshot
  5. top finding highlight
  6. connected mode preview when available
  7. practical next-step commands
- add graceful no-cluster fallback path with example-bundle guidance
- add deterministic fixture input path (`CUB_SCOUT_TEST_QUICKSTART_JSON`) for command tests
- update root quick-start text, README, and CLI-GUIDE with quickstart documentation
- extend smoke tests/root command checks to include quickstart command

## Testing
- `go test ./cmd/cub-scout -run 'TestQuickstartCommandRegistered|TestPickQuickstartRepresentativePrefersWorkloadKinds|TestRunQuickstart_WithFixtureRendersGuidedFlow|TestRunQuickstart_NoClusterFallback|TestSmoke_RootCommand' -count=1 -v`
- `go test ./cmd/cub-scout -count=1`
- `go test ./test/unit -count=1`

Closes #223
