### PR TITLE
Fix import link-back and connected fallback for existing units

### DIFF
--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -36,6 +36,9 @@ var (
 	importFromBundle string
 )
 
+var listUnitSlugsForSpace = fetchUnitSlugsForSpace
+var labelWorkloadForImport = labelWorkload
+
 type cubTargetRef struct {
 	Slug         string
 	ProviderType string
@@ -1252,7 +1255,10 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 	// Index workloads
 	workloadIndex := make(map[string]WorkloadInfo)
 	for _, w := range workloads {
-		key := fmt.Sprintf("%s/%s", w.Namespace, w.Name)
+		key := canonicalWorkloadRef(fmt.Sprintf("%s/%s", w.Namespace, w.Name))
+		if key == "" {
+			continue
+		}
 		workloadIndex[key] = w
 	}
 
@@ -1296,7 +1302,8 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 		}
 
 		// Get first workload's manifest
-		w, ok := workloadIndex[unit.Workloads[0]]
+		workloadRef := canonicalWorkloadRef(unit.Workloads[0])
+		w, ok := workloadIndex[workloadRef]
 		if !ok {
 			fmt.Println("✗ (workload not found)")
 			if logger != nil {
@@ -1335,6 +1342,11 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 			logger.Log("  OK: created with labels %v", labels)
 		}
 		created++
+
+		labelFailures := linkUnitWorkloadsToCluster(unit, workloadIndex, labelWorkloadForImport, logger)
+		if labelFailures > 0 {
+			fmt.Printf("  ! warning: %d workload link(s) failed for unit %s\n", labelFailures, unit.Slug)
+		}
 	}
 
 	fmt.Println()
@@ -1660,9 +1672,37 @@ func outputEmptyJSON() error {
 	return enc.Encode(result)
 }
 
+func linkUnitWorkloadsToCluster(unit UnitProposal, workloadIndex map[string]WorkloadInfo, labelFn func(kind, namespace, name, unitSlug string) error, logger *ImportLogger) int {
+	if len(unit.Workloads) == 0 {
+		return 0
+	}
+
+	labelFailures := 0
+	for _, ref := range unit.Workloads {
+		workloadRef := canonicalWorkloadRef(ref)
+		workload, ok := workloadIndex[workloadRef]
+		if !ok {
+			labelFailures++
+			if logger != nil {
+				logger.Log("  WARN: label skip, workload ref not found: %s", ref)
+			}
+			continue
+		}
+		if err := labelFn(workload.Kind, workload.Namespace, workload.Name, unit.Slug); err != nil {
+			labelFailures++
+			if logger != nil {
+				logger.Log("  WARN: label workload failed %s/%s (%s): %v", workload.Namespace, workload.Name, unit.Slug, err)
+			}
+		}
+	}
+	return labelFailures
+}
+
 func outputProposalJSON(proposal *FullProposal, workloads []WorkloadInfo, namespaces []string) error {
-	wJSON := make([]WorkloadJSON, 0, len(workloads))
-	for _, w := range workloads {
+	resolvedWorkloads := resolveConnectedWorkloadsFromProposal(proposal, workloads)
+
+	wJSON := make([]WorkloadJSON, 0, len(resolvedWorkloads))
+	for _, w := range resolvedWorkloads {
 		wJSON = append(wJSON, WorkloadJSON{
 			Kind:              w.Kind,
 			Namespace:         w.Namespace,
@@ -1688,6 +1728,165 @@ func outputProposalJSON(proposal *FullProposal, workloads []WorkloadInfo, namesp
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(result)
+}
+
+func resolveConnectedWorkloadsFromProposal(proposal *FullProposal, workloads []WorkloadInfo) []WorkloadInfo {
+	if proposal == nil || strings.TrimSpace(proposal.AppSpace) == "" || len(proposal.Units) == 0 || len(workloads) == 0 {
+		return workloads
+	}
+
+	needsFallback := false
+	for _, w := range workloads {
+		if strings.TrimSpace(w.UnitSlug) == "" {
+			needsFallback = true
+			break
+		}
+	}
+	if !needsFallback {
+		return workloads
+	}
+
+	existingUnitSlugs, err := listUnitSlugsForSpace(proposal.AppSpace)
+	if err != nil || len(existingUnitSlugs) == 0 {
+		return workloads
+	}
+
+	workloadToUnit := make(map[string]string)
+	for _, unit := range proposal.Units {
+		if !existingUnitSlugs[unit.Slug] {
+			continue
+		}
+		for _, ref := range unit.Workloads {
+			key := canonicalWorkloadRef(ref)
+			if key == "" {
+				continue
+			}
+			if _, exists := workloadToUnit[key]; !exists {
+				workloadToUnit[key] = unit.Slug
+			}
+		}
+	}
+	if len(workloadToUnit) == 0 {
+		return workloads
+	}
+
+	updated := make([]WorkloadInfo, len(workloads))
+	copy(updated, workloads)
+	for i := range updated {
+		if strings.TrimSpace(updated[i].UnitSlug) != "" {
+			continue
+		}
+		key := canonicalWorkloadRef(fmt.Sprintf("%s/%s", updated[i].Namespace, updated[i].Name))
+		if key == "" {
+			continue
+		}
+		if slug := workloadToUnit[key]; slug != "" {
+			updated[i].UnitSlug = slug
+		}
+	}
+
+	return updated
+}
+
+func fetchUnitSlugsForSpace(space string) (map[string]bool, error) {
+	space = strings.TrimSpace(space)
+	if space == "" {
+		return map[string]bool{}, nil
+	}
+
+	cmd := exec.Command("cub", "unit", "list", "--space", space, "--json", "--quiet")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseUnitSlugsFromListJSON(output)
+}
+
+func parseUnitSlugsFromListJSON(raw []byte) (map[string]bool, error) {
+	var decoded interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, err
+	}
+
+	entries := extractUnitListEntries(decoded)
+	slugs := make(map[string]bool)
+	for _, entry := range entries {
+		if slug := extractUnitSlug(entry); slug != "" {
+			slugs[slug] = true
+		}
+	}
+	return slugs, nil
+}
+
+func extractUnitListEntries(decoded interface{}) []interface{} {
+	switch typed := decoded.(type) {
+	case []interface{}:
+		return typed
+	case map[string]interface{}:
+		for _, key := range []string{"units", "Units", "items", "Items", "data", "Data"} {
+			if items, ok := typed[key].([]interface{}); ok {
+				return items
+			}
+		}
+		return []interface{}{typed}
+	default:
+		return nil
+	}
+}
+
+func extractUnitSlug(entry interface{}) string {
+	m, ok := entry.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	if unit, ok := m["Unit"].(map[string]interface{}); ok {
+		if slug := readUnitSlug(unit); slug != "" {
+			return slug
+		}
+	}
+	if unit, ok := m["unit"].(map[string]interface{}); ok {
+		if slug := readUnitSlug(unit); slug != "" {
+			return slug
+		}
+	}
+
+	return readUnitSlug(m)
+}
+
+func readUnitSlug(m map[string]interface{}) string {
+	for _, key := range []string{"Slug", "slug"} {
+		if value, ok := m[key].(string); ok {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func canonicalWorkloadRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+
+	parts := strings.Split(ref, "/")
+	switch len(parts) {
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return ""
+		}
+		return parts[0] + "/" + parts[1]
+	case 3:
+		if parts[1] == "" || parts[2] == "" {
+			return ""
+		}
+		return parts[1] + "/" + parts[2]
+	default:
+		return ""
+	}
 }
 
 func buildImportEvidenceJSON() importEvidenceJSON {

--- a/cmd/cub-scout/import_bundle_test.go
+++ b/cmd/cub-scout/import_bundle_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -335,6 +336,172 @@ func TestOutputProposalJSON_ClusterEvidenceSource(t *testing.T) {
 	}
 	if result.Evidence.Source != "cluster" {
 		t.Fatalf("evidence.source = %q, want cluster", result.Evidence.Source)
+	}
+}
+
+func TestOutputProposalJSON_ConnectedFallbackFromExistingUnits(t *testing.T) {
+	restore := setImportFlagState(importFlagState{
+		fromBundle: "",
+		noLog:      true,
+	})
+	defer restore()
+
+	prevLookup := listUnitSlugsForSpace
+	listUnitSlugsForSpace = func(space string) (map[string]bool, error) {
+		if space != "orders-team" {
+			t.Fatalf("space lookup = %q, want orders-team", space)
+		}
+		return map[string]bool{
+			"orders-api": true,
+		}, nil
+	}
+	defer func() {
+		listUnitSlugsForSpace = prevLookup
+	}()
+
+	proposal := &FullProposal{
+		AppSpace: "orders-team",
+		Units: []UnitProposal{
+			{
+				Slug:      "orders-api",
+				Workloads: []string{"Deployment/orders/orders-api"},
+			},
+		},
+	}
+	workloads := []WorkloadInfo{
+		{
+			Kind:      "Deployment",
+			Namespace: "orders",
+			Name:      "orders-api",
+			Owner:     "Native",
+		},
+	}
+
+	output := captureStdout(t, func() {
+		if err := outputProposalJSON(proposal, workloads, []string{"orders"}); err != nil {
+			t.Fatalf("outputProposalJSON() error = %v", err)
+		}
+	})
+
+	var result struct {
+		Workloads []WorkloadJSON `json:"workloads"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, output)
+	}
+	if len(result.Workloads) != 1 {
+		t.Fatalf("len(workloads) = %d, want 1", len(result.Workloads))
+	}
+	if !result.Workloads[0].Connected {
+		t.Fatal("workloads[0].connected = false, want true")
+	}
+	if result.Workloads[0].UnitSlug != "orders-api" {
+		t.Fatalf("workloads[0].unitSlug = %q, want orders-api", result.Workloads[0].UnitSlug)
+	}
+}
+
+func TestCanonicalWorkloadRef(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "namespace/name", in: "payments/api", want: "payments/api"},
+		{name: "kind/namespace/name", in: "Deployment/payments/api", want: "payments/api"},
+		{name: "empty", in: "", want: ""},
+		{name: "invalid", in: "payments", want: ""},
+		{name: "invalid-empty-segment", in: "Deployment//api", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := canonicalWorkloadRef(tt.in)
+			if got != tt.want {
+				t.Fatalf("canonicalWorkloadRef(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseUnitSlugsFromListJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "array with Unit wrapper",
+			raw: `[
+				{"Unit":{"Slug":"api-dev"}},
+				{"Unit":{"Slug":"worker-dev"}}
+			]`,
+			want: []string{"api-dev", "worker-dev"},
+		},
+		{
+			name: "top-level units key",
+			raw: `{
+				"units": [
+					{"unit":{"slug":"api-prod"}},
+					{"slug":"worker-prod"}
+				]
+			}`,
+			want: []string{"api-prod", "worker-prod"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUnitSlugsFromListJSON([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("parseUnitSlugsFromListJSON() error = %v", err)
+			}
+			for _, slug := range tt.want {
+				if !got[slug] {
+					t.Fatalf("expected slug %q in %v", slug, got)
+				}
+			}
+		})
+	}
+}
+
+func TestLinkUnitWorkloadsToCluster(t *testing.T) {
+	unit := UnitProposal{
+		Slug:      "orders-api",
+		Workloads: []string{"orders/api", "Deployment/orders/worker", "bad-ref"},
+	}
+	workloadIndex := map[string]WorkloadInfo{
+		"orders/api": {
+			Kind:      "Deployment",
+			Namespace: "orders",
+			Name:      "api",
+		},
+		"orders/worker": {
+			Kind:      "Deployment",
+			Namespace: "orders",
+			Name:      "worker",
+		},
+	}
+
+	var calls []string
+	failures := linkUnitWorkloadsToCluster(unit, workloadIndex, func(kind, namespace, name, unitSlug string) error {
+		calls = append(calls, fmt.Sprintf("%s/%s/%s->%s", kind, namespace, name, unitSlug))
+		if name == "worker" {
+			return fmt.Errorf("simulated label failure")
+		}
+		return nil
+	}, nil)
+
+	if failures != 2 {
+		t.Fatalf("link failures = %d, want 2", failures)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("label call count = %d, want 2", len(calls))
+	}
+	if calls[0] != "Deployment/orders/api->orders-api" {
+		t.Fatalf("first label call = %q, want Deployment/orders/api->orders-api", calls[0])
+	}
+	if calls[1] != "Deployment/orders/worker->orders-api" {
+		t.Fatalf("second label call = %q, want Deployment/orders/worker->orders-api", calls[1])
 	}
 }
 

--- a/docs/howto/import-to-confighub.md
+++ b/docs/howto/import-to-confighub.md
@@ -151,9 +151,11 @@ Rollback is safe: import creates ConfigHub state only — it does not modify wor
 ## Notes
 
 - `cub-scout import --json` is for proposal automation and GUI workflows (`evidence.source` shows `cluster` vs `bundle`).
+- `workloads[].connected` in `--json` is computed from live cluster labels and a same-space unit lookup, so reruns can stay connected even before labels are re-read.
 - `cub-scout import --wizard` runs the interactive TUI wizard.
 - `cub-scout import --from-bundle <path>` uses bundle facts instead of live cluster discovery.
 - `cub-scout import` now performs connected delegation for Argo/Flux when available, then imports leftovers.
+- Snapshot-imported workloads are linked back with `confighub.com/UnitSlug=<unit-slug>` labels.
 - This path prioritizes predictable migration over fast migration.
 
 ## Repeatable Delegation Check

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -712,6 +712,7 @@ cub-scout import --from-bundle ./debug-bundle --dry-run --json
 `import --json` output includes an `evidence` block:
 - `evidence.source`: `cluster` or `bundle`
 - `evidence.bundlePath`: set when source is `bundle`
+- `workloads[].connected`: true when the workload is already linked by `confighub.com/UnitSlug` or when a proposed unit slug already exists in the target App Space.
 
 ---
 

--- a/examples/new-user-puzzle-quest/README.md
+++ b/examples/new-user-puzzle-quest/README.md
@@ -362,7 +362,7 @@ jq '.workloads[] | {name, namespace, owner, connected}' /tmp/cub-import-proposal
   across dev/staging/prod — that tracks").
 - At least one label mapping to question or note.
 - Confirm `(dry-run mode - no changes made)` appears in the ASCII output.
-- All workloads should show `"connected": false` — nothing is imported yet.
+- On a fresh cluster, workloads should usually show `"connected": false`; if this space was already imported, connected workloads may already appear as `true`.
 
 ### Success condition
 

--- a/examples/scripts/verify-connected-demo.sh
+++ b/examples/scripts/verify-connected-demo.sh
@@ -6,6 +6,7 @@
 #   2) At least one Kubernetes target in the given space
 #   3) At least one renderer target (argocdrenderer/fluxrenderer, or generic renderer)
 #   4) Connected workload count from `cub-scout import --dry-run --json`
+#      (labels + existing unit link-back in the target App Space)
 #
 # Usage:
 #   examples/scripts/verify-connected-demo.sh --space argo-import-demo --renderer argocdrenderer


### PR DESCRIPTION
## Summary
- label imported workloads with `confighub.com/UnitSlug=<unit-slug>` after unit creation
- add `--json` connected fallback that marks workloads connected when proposed unit slugs already exist in the target App Space
- normalize workload refs (`namespace/name` and `Kind/namespace/name`) for deterministic matching
- sync docs/examples for updated connected semantics

## Proof
- `go test ./cmd/cub-scout -run 'TestOutputProposalJSON_ConnectedFallbackFromExistingUnits|TestCanonicalWorkloadRef|TestParseUnitSlugsFromListJSON|TestLinkUnitWorkloadsToCluster|TestRunImport_FromBundleJSONContract' -count=1` (3 consecutive runs)
- `go test ./cmd/cub-scout -count=1`
