### PR TITLE
Add MCP stdio gateway (read-only map/trace/scan/explain tools)

### DIFF
--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -1673,6 +1673,32 @@ Resource graph operations for exploring cluster relationships.
 
 ---
 
+## `mcp` — Model Context Protocol Gateway (v1.4)
+
+Read-only MCP gateway that exposes cub-scout observation tools over stdio.
+
+**What it does:** Hosts MCP tools backed by existing CLI JSON outputs.
+
+**When to use it:** When integrating cub-scout with AI clients that speak MCP.
+
+```bash
+# Start MCP stdio server
+./cub-scout mcp serve
+```
+
+**Served tools (current slice):**
+- `map` → `map list --json`
+- `trace` → `trace --format json`
+- `scan` → `scan --json`
+- `explain` → `explain --format json`
+
+**Safety contract:**
+- read-only behavior only
+- no kubernetes mutation path
+- no ConfigHub write path
+
+---
+
 ## `patterns` — Pattern Detection (v0.7)
 
 Pattern detection engine for analyzing resource graphs.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ cub-scout map list --json | jq '.[] | select(.owner=="Native")'
 cub-scout graph export | jq '.nodes | length'
 cub-scout graph export --format svg --output graph.svg
 cub-scout scan --json > findings.json
+cub-scout mcp serve
 ```
 
 Need contract docs for automation?

--- a/cmd/cub-scout/mcp.go
+++ b/cmd/cub-scout/mcp.go
@@ -1,0 +1,472 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "MCP gateway (read-only observation tools)",
+	Long: `MCP gateway for exposing cub-scout observation tools to AI agents.
+
+Standalone mode:
+  Serves read-only observation tools using local cluster access.
+
+Connected mode:
+  Future versions can route richer context from ConfigHub while preserving
+  read-only behavior in cub-scout itself.`,
+}
+
+var mcpServeCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Serve MCP over stdio",
+	Long: `Serve a read-only Model Context Protocol (MCP) gateway over stdio.
+
+Supported tools in this slice:
+  - map
+  - trace
+  - scan
+  - explain
+
+All tool responses are sourced from existing cub-scout CLI JSON output.`,
+	RunE: runMCPServe,
+}
+
+func init() {
+	rootCmd.AddCommand(mcpCmd)
+	mcpCmd.AddCommand(mcpServeCmd)
+}
+
+type mcpToolRunner func(ctx context.Context, args []string) (string, error)
+
+type mcpToolDescriptor struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+type mcpTool struct {
+	Descriptor mcpToolDescriptor
+	BuildArgs  func(arguments map[string]interface{}) ([]string, error)
+}
+
+type mcpGateway struct {
+	tools    map[string]mcpTool
+	toolList []mcpToolDescriptor
+	runTool  mcpToolRunner
+}
+
+type mcpRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type mcpResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *mcpError       `json:"error,omitempty"`
+}
+
+type mcpError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+func runMCPServe(cmd *cobra.Command, args []string) error {
+	gateway := newMCPGateway(runMCPToolCommand)
+	return serveMCP(cmd.Context(), os.Stdin, os.Stdout, gateway)
+}
+
+func serveMCP(ctx context.Context, in io.Reader, out io.Writer, gateway *mcpGateway) error {
+	reader := bufio.NewReader(in)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		frame, err := readMCPFrame(reader)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("read mcp frame: %w", err)
+		}
+
+		var req mcpRequest
+		if err := json.Unmarshal(frame, &req); err != nil {
+			continue
+		}
+
+		resp := gateway.handleRequest(ctx, req)
+		if resp == nil {
+			continue
+		}
+
+		payload, err := json.Marshal(resp)
+		if err != nil {
+			return fmt.Errorf("marshal mcp response: %w", err)
+		}
+		if err := writeMCPFrame(out, payload); err != nil {
+			return fmt.Errorf("write mcp frame: %w", err)
+		}
+	}
+}
+
+func newMCPGateway(runner mcpToolRunner) *mcpGateway {
+	if runner == nil {
+		runner = runMCPToolCommand
+	}
+
+	tools := map[string]mcpTool{
+		"map": {
+			Descriptor: mcpToolDescriptor{
+				Name:        "map",
+				Description: "List resources with ownership classification (map list --json).",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"namespace": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional namespace filter.",
+						},
+					},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				args := []string{"map", "list", "--json"}
+				if ns := argString(arguments, "namespace"); ns != "" {
+					args = append(args, "-n", ns)
+				}
+				return args, nil
+			},
+		},
+		"scan": {
+			Descriptor: mcpToolDescriptor{
+				Name:        "scan",
+				Description: "Run configuration and runtime scan findings (scan --json).",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"namespace": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional namespace filter.",
+						},
+					},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				args := []string{"scan", "--json"}
+				if ns := argString(arguments, "namespace"); ns != "" {
+					args = append(args, "-n", ns)
+				}
+				return args, nil
+			},
+		},
+		"trace": {
+			Descriptor: mcpToolDescriptor{
+				Name:        "trace",
+				Description: "Trace ownership chain for one resource (trace --format json).",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"resource": map[string]interface{}{
+							"type":        "string",
+							"description": "Resource selector as kind/name (for example deployment/api).",
+						},
+						"namespace": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional namespace override.",
+						},
+					},
+					"required":             []string{"resource"},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				resource := argString(arguments, "resource")
+				if resource == "" {
+					return nil, fmt.Errorf("missing required argument: resource")
+				}
+				args := []string{"trace", resource}
+				if ns := argString(arguments, "namespace"); ns != "" {
+					args = append(args, "-n", ns)
+				}
+				args = append(args, "--format", "json")
+				return args, nil
+			},
+		},
+		"explain": {
+			Descriptor: mcpToolDescriptor{
+				Name:        "explain",
+				Description: "Plain-English ownership and lineage summary (explain --format json).",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"resource": map[string]interface{}{
+							"type":        "string",
+							"description": "Resource selector as kind/name (for example deployment/api).",
+						},
+						"namespace": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional namespace override.",
+						},
+					},
+					"required":             []string{"resource"},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				resource := argString(arguments, "resource")
+				if resource == "" {
+					return nil, fmt.Errorf("missing required argument: resource")
+				}
+				args := []string{"explain", resource}
+				if ns := argString(arguments, "namespace"); ns != "" {
+					args = append(args, "-n", ns)
+				}
+				args = append(args, "--format", "json")
+				return args, nil
+			},
+		},
+	}
+
+	names := make([]string, 0, len(tools))
+	for name := range tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	list := make([]mcpToolDescriptor, 0, len(names))
+	for _, name := range names {
+		list = append(list, tools[name].Descriptor)
+	}
+
+	return &mcpGateway{
+		tools:    tools,
+		toolList: list,
+		runTool:  runner,
+	}
+}
+
+func (g *mcpGateway) toolsForList() []mcpToolDescriptor {
+	out := make([]mcpToolDescriptor, len(g.toolList))
+	copy(out, g.toolList)
+	return out
+}
+
+func (g *mcpGateway) handleRequest(ctx context.Context, req mcpRequest) *mcpResponse {
+	if req.Method == "" {
+		return g.errorResponse(req.ID, -32600, "invalid request: missing method")
+	}
+
+	switch req.Method {
+	case "notifications/initialized":
+		return nil
+	case "initialize":
+		return &mcpResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: map[string]interface{}{
+				"protocolVersion": "2025-03-26",
+				"capabilities": map[string]interface{}{
+					"tools": map[string]interface{}{},
+				},
+				"serverInfo": map[string]interface{}{
+					"name":    "cub-scout-mcp",
+					"version": BuildTag,
+				},
+			},
+		}
+	case "ping":
+		return &mcpResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  map[string]interface{}{},
+		}
+	case "tools/list":
+		return &mcpResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: map[string]interface{}{
+				"tools": g.toolsForList(),
+			},
+		}
+	case "tools/call":
+		result := g.callTool(ctx, req.Params)
+		return &mcpResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  result,
+		}
+	default:
+		return g.errorResponse(req.ID, -32601, "method not found")
+	}
+}
+
+func (g *mcpGateway) callTool(ctx context.Context, paramsRaw json.RawMessage) map[string]interface{} {
+	var params struct {
+		Name      string                 `json:"name"`
+		Arguments map[string]interface{} `json:"arguments"`
+	}
+	if err := json.Unmarshal(paramsRaw, &params); err != nil {
+		return mcpToolError(fmt.Sprintf("invalid tools/call params: %v", err))
+	}
+
+	tool, ok := g.tools[params.Name]
+	if !ok {
+		return mcpToolError(fmt.Sprintf("unknown tool %q", params.Name))
+	}
+	if params.Arguments == nil {
+		params.Arguments = map[string]interface{}{}
+	}
+
+	args, err := tool.BuildArgs(params.Arguments)
+	if err != nil {
+		return mcpToolError(err.Error())
+	}
+
+	output, err := g.runTool(ctx, args)
+	if err != nil {
+		return mcpToolError(err.Error())
+	}
+
+	return map[string]interface{}{
+		"isError": false,
+		"content": []map[string]string{
+			{
+				"type": "text",
+				"text": output,
+			},
+		},
+	}
+}
+
+func mcpToolError(msg string) map[string]interface{} {
+	return map[string]interface{}{
+		"isError": true,
+		"content": []map[string]string{
+			{
+				"type": "text",
+				"text": msg,
+			},
+		},
+	}
+}
+
+func (g *mcpGateway) errorResponse(id json.RawMessage, code int, message string) *mcpResponse {
+	return &mcpResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &mcpError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+func argString(arguments map[string]interface{}, key string) string {
+	raw, ok := arguments[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func runMCPToolCommand(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, os.Args[0], args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("tool command failed (%s): %s", strings.Join(args, " "), msg)
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func readMCPFrame(r *bufio.Reader) ([]byte, error) {
+	contentLength := -1
+
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			if err == io.EOF && line == "" {
+				return nil, io.EOF
+			}
+			return nil, err
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(strings.ToLower(parts[0]))
+		value := strings.TrimSpace(parts[1])
+		if key == "content-length" {
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid content-length %q", value)
+			}
+			contentLength = n
+		}
+	}
+
+	if contentLength < 0 {
+		return nil, fmt.Errorf("missing content-length header")
+	}
+	if contentLength == 0 {
+		return []byte{}, nil
+	}
+
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func writeMCPFrame(w io.Writer, payload []byte) error {
+	if _, err := fmt.Fprintf(w, "Content-Length: %d\r\n\r\n", len(payload)); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
+}

--- a/cmd/cub-scout/mcp_test.go
+++ b/cmd/cub-scout/mcp_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewMCPGateway_ToolsIncludeStandaloneSet(t *testing.T) {
+	gateway := newMCPGateway(nil)
+	tools := gateway.toolsForList()
+
+	var names []string
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+
+	want := []string{"explain", "map", "scan", "trace"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("tool names = %v, want %v", names, want)
+	}
+}
+
+func TestMCPGatewayHandleRequest_ToolsList(t *testing.T) {
+	gateway := newMCPGateway(nil)
+	req := mcpRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/list",
+	}
+
+	resp := gateway.handleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error response: %+v", resp.Error)
+	}
+
+	var result struct {
+		Tools []mcpToolDescriptor `json:"tools"`
+	}
+	if err := marshalInto(resp.Result, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if len(result.Tools) != 4 {
+		t.Fatalf("tool count = %d, want 4", len(result.Tools))
+	}
+}
+
+func TestMCPGatewayHandleRequest_ToolsCallTrace(t *testing.T) {
+	var gotArgs []string
+	gateway := newMCPGateway(func(ctx context.Context, args []string) (string, error) {
+		gotArgs = append([]string(nil), args...)
+		return `{"ok":true}`, nil
+	})
+
+	req := mcpRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`7`),
+		Method:  "tools/call",
+		Params: json.RawMessage(`{
+			"name":"trace",
+			"arguments":{"resource":"deployment/api","namespace":"payments"}
+		}`),
+	}
+
+	resp := gateway.handleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error response: %+v", resp.Error)
+	}
+
+	wantArgs := []string{"trace", "deployment/api", "-n", "payments", "--format", "json"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("tool args = %v, want %v", gotArgs, wantArgs)
+	}
+
+	var result struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := marshalInto(resp.Result, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("result.isError = true, want false")
+	}
+	if len(result.Content) != 1 || result.Content[0].Type != "text" {
+		t.Fatalf("content = %+v, want single text item", result.Content)
+	}
+	if result.Content[0].Text != `{"ok":true}` {
+		t.Fatalf("content text = %q, want %q", result.Content[0].Text, `{"ok":true}`)
+	}
+}
+
+func TestMCPGatewayHandleRequest_ToolsCallValidationError(t *testing.T) {
+	gateway := newMCPGateway(func(ctx context.Context, args []string) (string, error) {
+		t.Fatal("runner should not be called for validation error")
+		return "", nil
+	})
+
+	req := mcpRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`9`),
+		Method:  "tools/call",
+		Params: json.RawMessage(`{
+			"name":"trace",
+			"arguments":{"namespace":"payments"}
+		}`),
+	}
+
+	resp := gateway.handleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected rpc error: %+v", resp.Error)
+	}
+
+	var result struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := marshalInto(resp.Result, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("result.isError = false, want true")
+	}
+	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "resource") {
+		t.Fatalf("unexpected error text: %+v", result.Content)
+	}
+}
+
+func TestMCPFrameRoundTrip(t *testing.T) {
+	payload := []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	var stream bytes.Buffer
+	if err := writeMCPFrame(&stream, payload); err != nil {
+		t.Fatalf("writeMCPFrame() error = %v", err)
+	}
+
+	got, err := readMCPFrame(bufio.NewReader(&stream))
+	if err != nil {
+		t.Fatalf("readMCPFrame() error = %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("payload mismatch\ngot=%s\nwant=%s", string(got), string(payload))
+	}
+}
+
+func marshalInto(v interface{}, target interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, target)
+}

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -64,6 +64,7 @@ Human-friendly JSON contract index: [json-contracts.md](json-contracts.md)
 | `cub-scout completion` | Generate shell completion script | v0.19 |
 | `cub-scout connect` | Configure kube context from server URL or kubeconfig import | v1.0 |
 | `cub-scout status` | Show connection status and cluster info | v1.0 |
+| `cub-scout mcp serve` | Serve read-only MCP observation tools over stdio | v1.4 |
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -36,6 +36,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `status` | Show connection status and cluster info | v1.0 |
 | `connect` | Quickly configure kube context from server URL or kubeconfig | v1.0 |
 | `setup` | Set up shell completions | v0.19 |
+| `mcp serve` | Serve read-only MCP tools over stdio | v1.4 |
 | `graph export` | Export resource graph as JSON/DOT/SVG/HTML | v0.6 |
 | `graph explain` | Explain a resource's graph relationships | v0.6 |
 | `patterns list` | List registered patterns | v0.7 |
@@ -862,6 +863,33 @@ cub-scout setup --shell zsh
 
 # Preview without installing
 cub-scout setup --dry-run
+```
+
+---
+
+## mcp
+
+Read-only MCP gateway for AI agent tooling.
+
+### mcp serve
+
+Serve MCP over stdio and expose observation tools (`map`, `trace`, `scan`, `explain`).
+
+```bash
+cub-scout mcp serve
+```
+
+#### Notes
+
+- Uses existing CLI JSON surfaces internally (`map list --json`, `trace --format json`, etc.).
+- Standalone and read-only: no cluster mutations and no ConfigHub write path.
+- Protocol transport is stdio with `Content-Length` framed JSON-RPC messages.
+
+#### Example
+
+```bash
+# Run as MCP server process (stdio)
+cub-scout mcp serve
 ```
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -71,6 +71,12 @@ The `argo-import-confighub-demo` and `flux-import-confighub-demo` run against re
 |---------|---------|-------|
 | [graph-export/](graph-export/) | **Topology sharing** | Export graph data as JSON/DOT/SVG/HTML for docs, Slack, and presentations |
 
+### AI Gateway Example
+
+| Example | Pattern | Shows |
+|---------|---------|-------|
+| [mcp-gateway/](mcp-gateway/) | **MCP stdio server** | Serve read-only `map`/`trace`/`scan`/`explain` tools to AI clients |
+
 **Using AI tools?** Start with [Giving Your AI Eyes](ai-agent-quest/) — watch your AI reason about cluster state and hit the wall that ConfigHub removes.
 
 **Learning hands-on?** Try the [Puzzle Quest](new-user-puzzle-quest/) — a guided walkthrough from zero to full cluster discovery and ConfigHub import.

--- a/examples/mcp-gateway/README.md
+++ b/examples/mcp-gateway/README.md
@@ -1,0 +1,30 @@
+# MCP Gateway Example
+
+Run cub-scout as a read-only MCP server over stdio:
+
+```bash
+./cub-scout mcp serve
+```
+
+This exposes these tools in the current slice:
+- `map`
+- `trace`
+- `scan`
+- `explain`
+
+## Tool Behavior
+
+The gateway reuses existing CLI JSON command outputs:
+
+- `map` -> `map list --json`
+- `trace` -> `trace --format json`
+- `scan` -> `scan --json`
+- `explain` -> `explain --format json`
+
+That keeps MCP responses aligned with the normal CLI contract.
+
+## Safety
+
+- Read-only: no Kubernetes mutation path.
+- Read-only: no ConfigHub write path.
+- Works in standalone mode without ConfigHub.


### PR DESCRIPTION
## Summary
- add `cub-scout mcp serve` to run a read-only MCP gateway over stdio
- implement framed JSON-RPC transport (`Content-Length`) and core MCP methods:
  - `initialize`
  - `ping`
  - `tools/list`
  - `tools/call`
- expose standalone observation tools in this slice:
  - `map` (backs `map list --json`)
  - `trace` (backs `trace --format json`)
  - `scan` (backs `scan --json`)
  - `explain` (backs `explain --format json`)
- route tool calls through subprocess execution of the existing CLI to preserve current JSON contracts
- add command/docs/examples coverage for MCP usage

## Proof
- `go test ./cmd/cub-scout -run 'TestNewMCPGateway_|TestMCPGatewayHandleRequest_|TestMCPFrameRoundTrip' -count=1` (3 consecutive reruns)
- `go test ./cmd/cub-scout -count=1`
- local stdio handshake proof:
  - send framed `initialize` + `tools/list` requests
  - verify `serverInfo.name == cub-scout-mcp` and tool count `== 4`

## Scope Notes
- This PR is the standalone/read-only gateway slice for #214.
- Connected-mode routing to ConfigHub MCP capabilities remains future work.
