### PR TITLE
tui: add graph export action from maps panel

### DIFF
--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -1908,6 +1908,7 @@ Connected │ Cluster: prod-east │ Context: eks-prod-east │ Worker: ● brid
 | `Q` | Saved Queries | Filter with saved queries |
 | `T` | Trace | Trace ownership chain |
 | `S` | Scan | Scan for risk issues |
+| `e` / `E` | Export Graph | In `M` (Maps) view, export graph as HTML / SVG |
 | `I` | Import | Import wizard |
 
 #### Command Palette (`:`)

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ cub-scout map
 **TUI navigation:**
 - Press `s` for status dashboard
 - Press `w` for workloads by owner
+- Press `M`, then `e`/`E` to export graph (HTML/SVG)
 - Press `4` for deep-dive tree views
 - Press `T` to trace selected resource
 - Press `?` for all shortcuts

--- a/cmd/cub-scout/localcluster.go
+++ b/cmd/cub-scout/localcluster.go
@@ -315,6 +315,9 @@ type localKeyMap struct {
 	Hub     key.Binding
 	Tab     key.Binding
 	Enter   key.Binding
+	// Maps panel export actions
+	ExportHTML key.Binding
+	ExportSVG  key.Binding
 	// View shortcuts
 	Dashboard key.Binding
 	Workloads key.Binding
@@ -367,6 +370,8 @@ func defaultLocalKeyMap() localKeyMap {
 		Hub:           key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "ConfigHub")),
 		Tab:           key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next view")),
 		Enter:         key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+		ExportHTML:    key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export html")),
+		ExportSVG:     key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "export svg")),
 		Dashboard:     key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "status")),
 		Workloads:     key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "workloads")),
 		Pipelines:     key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pipelines")),
@@ -426,6 +431,12 @@ type scanResultMsg struct {
 	err        error
 	findings   []scanFinding  // Parsed findings for category display
 	categories map[string]int // Category counts
+}
+
+type graphExportMsg struct {
+	format     string
+	outputPath string
+	err        error
 }
 
 type localCmdCompleteMsg struct {
@@ -1109,6 +1120,14 @@ func (m LocalClusterModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.scanCategories = msg.categories
 		return m, nil
 
+	case graphExportMsg:
+		if msg.err != nil {
+			m.statusMsg = fmt.Sprintf("Graph export failed (%s): %v", msg.format, msg.err)
+		} else {
+			m.statusMsg = fmt.Sprintf("Graph export (%s) saved to %s", msg.format, msg.outputPath)
+		}
+		return m, nil
+
 	case localCmdCompleteMsg:
 		m.cmdRunning = false
 		if msg.err != nil {
@@ -1410,6 +1429,14 @@ func (m LocalClusterModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Toggle focus between dashboard and panel
 				m.panelFocused = !m.panelFocused
 				return m, nil
+
+			case key.Matches(msg, m.keymap.ExportHTML) && m.panelView == viewMaps:
+				m.statusMsg = "Exporting graph (html)..."
+				return m, m.runGraphExport("html")
+
+			case key.Matches(msg, m.keymap.ExportSVG) && m.panelView == viewMaps:
+				m.statusMsg = "Exporting graph (svg)..."
+				return m, m.runGraphExport("svg")
 
 			case m.panelFocused:
 				// Panel scrolling when focused
@@ -2447,6 +2474,7 @@ func (m LocalClusterModel) renderHelp() string {
 	b.WriteString("  " + lcNameStyle.Render("Q") + "  Saved queries (filter resources)\n")
 	b.WriteString("  " + lcNameStyle.Render("T") + "  Trace ownership chain\n")
 	b.WriteString("  " + lcNameStyle.Render("S") + "  Scan for risk issues\n")
+	b.WriteString("  " + lcNameStyle.Render("e/E") + "  Export graph from MAPS panel (HTML/SVG)\n")
 	b.WriteString("  " + lcNameStyle.Render("I") + "  Import wizard (bring workloads to ConfigHub)\n")
 	b.WriteString("\n")
 
@@ -2684,6 +2712,20 @@ func (m LocalClusterModel) getSuggestions() []Suggestion {
 			}
 		}
 
+	case viewMaps:
+		suggestions = append(suggestions, Suggestion{
+			Command:     "./cub-scout graph export --format html --output graph.html",
+			Description: "Export interactive ownership topology",
+		})
+		suggestions = append(suggestions, Suggestion{
+			Command:     "./cub-scout graph export --format svg --output graph.svg",
+			Description: "Export embeddable static diagram",
+		})
+		suggestions = append(suggestions, Suggestion{
+			Command:     "./cub-scout graph export --format dot --output graph.dot",
+			Description: "Export Graphviz source for docs tooling",
+		})
+
 	default:
 		// Dashboard: overview commands (cub-scout first)
 		suggestions = append(suggestions, Suggestion{
@@ -2865,8 +2907,16 @@ func (m LocalClusterModel) renderSplitView() string {
 	if nsIndicator != "" {
 		b.WriteString(nsIndicator + " " + lcDimStyle.Render("|") + " ")
 	}
-	b.WriteString(lcDimStyle.Render("[]/[]ns [w]ork [p]ipe [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]"))
+	footer := "[]/[]ns [w]ork [p]ipe [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]"
+	if m.panelView == viewMaps {
+		footer = "[]/[]ns [e]xport html [E]xport svg | Tab:focus Esc:close [H]ub [?] [q]"
+	}
+	b.WriteString(lcDimStyle.Render(footer))
 	b.WriteString("\n")
+	if m.statusMsg != "" {
+		b.WriteString(lcDimStyle.Render(m.statusMsg))
+		b.WriteString("\n")
+	}
 
 	return b.String()
 }
@@ -3995,6 +4045,7 @@ func (m LocalClusterModel) getPanelMaps() string {
 
 	// MAP 1: GitOps Resource Trees
 	b.WriteString(lcSectionStyle.Render("MAP 1: GITOPS TREES") + "\n")
+	b.WriteString(lcDimStyle.Render("Press e to export HTML or E to export SVG") + "\n\n")
 
 	if len(m.gitops) == 0 {
 		b.WriteString(lcDimStyle.Render("No GitOps deployers") + "\n")
@@ -5305,6 +5356,78 @@ func (m LocalClusterModel) runScan() tea.Cmd {
 			err:        err,
 			findings:   findings,
 			categories: categories,
+		}
+	}
+}
+
+var runGraphExportCommand = runGraphExportViaCLI
+
+func graphExportOutputPath(format string) string {
+	filename := fmt.Sprintf("cub-scout-graph-%s.%s", time.Now().Format("20060102-150405"), format)
+	return filepath.Join(".", filename)
+}
+
+func runGraphExportViaCLI(format, outputPath string) error {
+	args := []string{"graph", "export", "--format", format, "--output", outputPath}
+
+	var primaryErr error
+	bin := strings.TrimSpace(os.Args[0])
+	if bin != "" {
+		cmd := exec.Command(bin, args...)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		if details := strings.TrimSpace(string(out)); details != "" {
+			primaryErr = fmt.Errorf("%w: %s", err, details)
+		} else {
+			primaryErr = err
+		}
+	}
+
+	cmd := exec.Command("cub-scout", args...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if details := strings.TrimSpace(string(out)); details != "" {
+		if primaryErr != nil {
+			return fmt.Errorf("%v; fallback cub-scout failed: %w: %s", primaryErr, err, details)
+		}
+		return fmt.Errorf("%w: %s", err, details)
+	}
+	if primaryErr != nil {
+		return fmt.Errorf("%v; fallback cub-scout failed: %w", primaryErr, err)
+	}
+	return err
+}
+
+func (m LocalClusterModel) runGraphExport(format string) tea.Cmd {
+	return func() tea.Msg {
+		normalized := strings.ToLower(strings.TrimSpace(format))
+		if normalized == "" {
+			normalized = "html"
+		}
+		switch normalized {
+		case "html", "svg", "dot", "json":
+		default:
+			return graphExportMsg{
+				format: normalized,
+				err:    fmt.Errorf("unsupported graph export format %q", normalized),
+			}
+		}
+
+		outputPath := graphExportOutputPath(normalized)
+		if err := runGraphExportCommand(normalized, outputPath); err != nil {
+			return graphExportMsg{
+				format:     normalized,
+				outputPath: outputPath,
+				err:        err,
+			}
+		}
+		return graphExportMsg{
+			format:     normalized,
+			outputPath: outputPath,
 		}
 	}
 }

--- a/cmd/cub-scout/localcluster_test.go
+++ b/cmd/cub-scout/localcluster_test.go
@@ -6,8 +6,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -339,6 +341,98 @@ func TestLocalClusterMaps(t *testing.T) {
 	fm := finalModel.(LocalClusterModel)
 	if !fm.panelMode || fm.panelView != viewMaps {
 		t.Errorf("expected maps view, got panelMode=%v view=%v", fm.panelMode, fm.panelView)
+	}
+}
+
+// TestLocalClusterMapsExportShortcut tests 'e' key in maps panel starts graph export.
+func TestLocalClusterMapsExportShortcut(t *testing.T) {
+	m := testLocalModel()
+	m.panelMode = true
+	m.panelView = viewMaps
+	m.updatePanelContent()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	fm := updated.(LocalClusterModel)
+
+	if cmd == nil {
+		t.Fatal("expected export command when pressing 'e' in maps view")
+	}
+	if !strings.Contains(strings.ToLower(fm.statusMsg), "exporting graph") {
+		t.Fatalf("expected exporting status message, got %q", fm.statusMsg)
+	}
+}
+
+// TestLocalClusterSplitViewShowsMapsExportHint tests split footer includes export hint for maps panel.
+func TestLocalClusterSplitViewShowsMapsExportHint(t *testing.T) {
+	m := testLocalModel()
+	m.panelMode = true
+	m.panelView = viewMaps
+	m.updatePanelContent()
+
+	view := m.renderSplitView()
+	if !strings.Contains(view, "e") || !strings.Contains(strings.ToLower(view), "export") {
+		t.Fatalf("expected maps split view footer to mention export shortcut, got:\n%s", view)
+	}
+}
+
+// TestLocalClusterMapsExportCompletionStatus tests successful completion status message.
+func TestLocalClusterMapsExportCompletionStatus(t *testing.T) {
+	m := testLocalModel()
+	m.panelMode = true
+	m.panelView = viewMaps
+	m.updatePanelContent()
+
+	original := runGraphExportCommand
+	runGraphExportCommand = func(format, outputPath string) error {
+		return nil
+	}
+	defer func() {
+		runGraphExportCommand = original
+	}()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd == nil {
+		t.Fatal("expected export command")
+	}
+
+	msg := cmd()
+	updated2, _ := updated.(LocalClusterModel).Update(msg)
+	fm := updated2.(LocalClusterModel)
+
+	if !strings.Contains(strings.ToLower(fm.statusMsg), "saved") {
+		t.Fatalf("expected successful save status, got %q", fm.statusMsg)
+	}
+	if !strings.Contains(strings.ToLower(fm.statusMsg), "html") {
+		t.Fatalf("expected html format in status, got %q", fm.statusMsg)
+	}
+}
+
+// TestLocalClusterMapsExportFailureStatus tests failed completion status message.
+func TestLocalClusterMapsExportFailureStatus(t *testing.T) {
+	m := testLocalModel()
+	m.panelMode = true
+	m.panelView = viewMaps
+	m.updatePanelContent()
+
+	original := runGraphExportCommand
+	runGraphExportCommand = func(format, outputPath string) error {
+		return fmt.Errorf("boom")
+	}
+	defer func() {
+		runGraphExportCommand = original
+	}()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd == nil {
+		t.Fatal("expected export command")
+	}
+
+	msg := cmd()
+	updated2, _ := updated.(LocalClusterModel).Update(msg)
+	fm := updated2.(LocalClusterModel)
+
+	if !strings.Contains(strings.ToLower(fm.statusMsg), "failed") {
+		t.Fatalf("expected failure status, got %q", fm.statusMsg)
 	}
 }
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -76,10 +76,13 @@ cub-scout map [flags]
 | Key | Action |
 |-----|--------|
 | `1-5` | Switch tabs |
+| `M` | Open Three Maps view |
 | `H` | Hub view (ConfigHub hierarchy) |
 | `j/k` | Navigate up/down |
 | `Enter` | Select/expand |
-| `t` | Trace selected resource |
+| `T` | Trace selected resource |
+| `e` | Export graph as HTML (Maps view) |
+| `E` | Export graph as SVG (Maps view) |
 | `?` | Help |
 | `q` | Quit |
 

--- a/examples/graph-export/README.md
+++ b/examples/graph-export/README.md
@@ -21,6 +21,7 @@ Use `graph export` to generate shareable topology artifacts from the same
 
 ## Notes
 
+- TUI parity: in `./cub-scout map`, press `M` for Maps, then `e` (HTML) or `E` (SVG).
 - `--max-nodes` applies to visual formats (`dot`, `svg`, `html`) to keep large
   clusters shareable.
 - `--format json` remains the contract format for automation and schema checks.

--- a/test/ascii/tui/help_120x40.txt
+++ b/test/ascii/tui/help_120x40.txt
@@ -39,6 +39,7 @@ ACTIONS
   Q  Saved queries (filter resources)
   T  Trace ownership chain
   S  Scan for risk issues
+  e/E  Export graph from MAPS panel (HTML/SVG)
   I  Import wizard (bring workloads to ConfigHub)
 
 COMMAND PALETTE

--- a/test/ascii/tui/help_80x24.txt
+++ b/test/ascii/tui/help_80x24.txt
@@ -39,6 +39,7 @@ ACTIONS
   Q  Saved queries (filter resources)
   T  Trace ownership chain
   S  Scan for risk issues
+  e/E  Export graph from MAPS panel (HTML/SVG)
   I  Import wizard (bring workloads to ConfigHub)
 
 COMMAND PALETTE

--- a/test/ascii/tui/map.txt
+++ b/test/ascii/tui/map.txt
@@ -1,4 +1,6 @@
 MAP 1: GITOPS TREES
+Press e to export HTML or E to export SVG
+
 ✓ Kustomization infra → 12
 ✓ Kustomization apps → 8
 ✓ HelmRelease nginx → 5


### PR DESCRIPTION
## Summary
- add TUI graph export actions from Local Cluster `Maps` panel for parity with `graph export`
- wire `e` (HTML) and `E` (SVG) shortcuts in split-panel mode (works with or without panel focus)
- run export asynchronously, then show success/failure status with output path
- add maps-context command suggestions for `graph export` invocations
- update docs/examples for discoverability and refresh TUI snapshot goldens

## User-facing behavior
- `cub-scout map` -> press `M` for Maps, then:
  - `e` exports `html`
  - `E` exports `svg`
- output files are written to current directory:
  - `cub-scout-graph-YYYYMMDD-HHMMSS.html|svg`

## Proof
- `go test ./cmd/cub-scout -run 'TestLocalClusterMapsExportShortcut|TestLocalClusterSplitViewShowsMapsExportHint|TestLocalClusterMapsExportCompletionStatus|TestLocalClusterMapsExportFailureStatus' -count=1`
- `go test ./cmd/cub-scout -run 'TestTUISnapshot_Map|TestTUISnapshot_Help_80x24|TestTUISnapshot_Help_120x40' -count=1`
- `for i in 1 2 3; do go test ./cmd/cub-scout -run 'TestLocalClusterMapsExportShortcut|TestLocalClusterSplitViewShowsMapsExportHint|TestLocalClusterMapsExportCompletionStatus|TestLocalClusterMapsExportFailureStatus|TestTUISnapshot_Map|TestTUISnapshot_Help_80x24|TestTUISnapshot_Help_120x40' -count=1 || exit 1; done`
- `go test ./cmd/cub-scout -count=1`

Closes #220
