### PR TITLE
mcp: add connected-mode ConfigHub routing tools

### DIFF
--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -1686,11 +1686,16 @@ Read-only MCP gateway that exposes cub-scout observation tools over stdio.
 ./cub-scout mcp serve
 ```
 
-**Served tools (current slice):**
+**Served tools (standalone):**
 - `map` → `map list --json`
 - `trace` → `trace --format json`
 - `scan` → `scan --json`
 - `explain` → `explain --format json`
+
+**Additional tools (connected mode):**
+- `confighub_changesets` → `cub changeset list --json`
+- `confighub_units` → `cub unit list --json`
+- `confighub_unit_get` → `cub unit get --json`
 
 **Safety contract:**
 - read-only behavior only

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ cub-scout graph export | jq '.nodes | length'
 cub-scout graph export --format svg --output graph.svg
 cub-scout scan --json > findings.json
 cub-scout mcp serve
+# (connected mode also exposes confighub_changesets/confighub_units/confighub_unit_get)
 ```
 
 Need contract docs for automation?

--- a/cmd/cub-scout/mcp.go
+++ b/cmd/cub-scout/mcp.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/confighub/cub-scout/pkg/hub"
 	"github.com/spf13/cobra"
 )
 
@@ -37,13 +38,19 @@ var mcpServeCmd = &cobra.Command{
 	Short: "Serve MCP over stdio",
 	Long: `Serve a read-only Model Context Protocol (MCP) gateway over stdio.
 
-Supported tools in this slice:
+Supported tools in standalone mode:
   - map
   - trace
   - scan
   - explain
 
-All tool responses are sourced from existing cub-scout CLI JSON output.`,
+Additional tools in connected mode (when authenticated to ConfigHub):
+  - confighub_changesets
+  - confighub_units
+  - confighub_unit_get
+
+Standalone tools are sourced from existing cub-scout CLI JSON output.
+Connected tools are sourced from read-only cub CLI queries.`,
 	RunE: runMCPServe,
 }
 
@@ -63,6 +70,7 @@ type mcpToolDescriptor struct {
 type mcpTool struct {
 	Descriptor mcpToolDescriptor
 	BuildArgs  func(arguments map[string]interface{}) ([]string, error)
+	Runner     mcpToolRunner
 }
 
 type mcpGateway struct {
@@ -92,7 +100,7 @@ type mcpError struct {
 }
 
 func runMCPServe(cmd *cobra.Command, args []string) error {
-	gateway := newMCPGateway(runMCPToolCommand)
+	gateway := newMCPGatewayWithMode(runMCPToolCommand, runMCPConnectedToolCommand, detectMCPConnectedMode())
 	return serveMCP(cmd.Context(), os.Stdin, os.Stdout, gateway)
 }
 
@@ -134,8 +142,15 @@ func serveMCP(ctx context.Context, in io.Reader, out io.Writer, gateway *mcpGate
 }
 
 func newMCPGateway(runner mcpToolRunner) *mcpGateway {
+	return newMCPGatewayWithMode(runner, nil, false)
+}
+
+func newMCPGatewayWithMode(runner mcpToolRunner, connectedRunner mcpToolRunner, connected bool) *mcpGateway {
 	if runner == nil {
 		runner = runMCPToolCommand
+	}
+	if connectedRunner == nil {
+		connectedRunner = runMCPConnectedToolCommand
 	}
 
 	tools := map[string]mcpTool{
@@ -252,6 +267,110 @@ func newMCPGateway(runner mcpToolRunner) *mcpGateway {
 			},
 		},
 	}
+	if connected {
+		tools["confighub_changesets"] = mcpTool{
+			Descriptor: mcpToolDescriptor{
+				Name:        "confighub_changesets",
+				Description: "Connected-mode ChangeSet history from ConfigHub (cub changeset list --json).",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"space": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional ConfigHub space slug or ID.",
+						},
+						"where": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional filter expression passed to --where.",
+						},
+					},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				args := []string{"changeset", "list", "--json"}
+				if space := argString(arguments, "space"); space != "" {
+					args = append(args, "--space", space)
+				}
+				if where := argString(arguments, "where"); where != "" {
+					args = append(args, "--where", where)
+				}
+				return args, nil
+			},
+			Runner: connectedRunner,
+		}
+		tools["confighub_units"] = mcpTool{
+			Descriptor: mcpToolDescriptor{
+				Name:        "confighub_units",
+				Description: "Connected-mode fleet/unit context from ConfigHub (cub unit list --json).",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"space": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional ConfigHub space slug or ID.",
+						},
+						"where": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional filter expression passed to --where.",
+						},
+						"contains": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional full-text contains query passed to --contains.",
+						},
+					},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				args := []string{"unit", "list", "--json"}
+				if space := argString(arguments, "space"); space != "" {
+					args = append(args, "--space", space)
+				}
+				if where := argString(arguments, "where"); where != "" {
+					args = append(args, "--where", where)
+				}
+				if contains := argString(arguments, "contains"); contains != "" {
+					args = append(args, "--contains", contains)
+				}
+				return args, nil
+			},
+			Runner: connectedRunner,
+		}
+		tools["confighub_unit_get"] = mcpTool{
+			Descriptor: mcpToolDescriptor{
+				Name:        "confighub_unit_get",
+				Description: "Connected-mode unit details from ConfigHub (cub unit get --json).",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"unit": map[string]interface{}{
+							"type":        "string",
+							"description": "Required unit slug or ID.",
+						},
+						"space": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional ConfigHub space slug or ID.",
+						},
+					},
+					"required":             []string{"unit"},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				unit := argString(arguments, "unit")
+				if unit == "" {
+					return nil, fmt.Errorf("missing required argument: unit")
+				}
+				args := []string{"unit", "get", "--json", unit}
+				if space := argString(arguments, "space"); space != "" {
+					args = append(args, "--space", space)
+				}
+				return args, nil
+			},
+			Runner: connectedRunner,
+		}
+	}
 
 	names := make([]string, 0, len(tools))
 	for name := range tools {
@@ -348,7 +467,12 @@ func (g *mcpGateway) callTool(ctx context.Context, paramsRaw json.RawMessage) ma
 		return mcpToolError(err.Error())
 	}
 
-	output, err := g.runTool(ctx, args)
+	runner := g.runTool
+	if tool.Runner != nil {
+		runner = tool.Runner
+	}
+
+	output, err := runner(ctx, args)
 	if err != nil {
 		return mcpToolError(err.Error())
 	}
@@ -415,6 +539,32 @@ func runMCPToolCommand(ctx context.Context, args []string) (string, error) {
 	}
 
 	return strings.TrimSpace(stdout.String()), nil
+}
+
+func runMCPConnectedToolCommand(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, "cub", args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("connected tool command failed (cub %s): %s", strings.Join(args, " "), msg)
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func detectMCPConnectedMode() bool {
+	if hub.CurrentMode() != hub.Connected {
+		return false
+	}
+	_, err := exec.LookPath("cub")
+	return err == nil
 }
 
 func readMCPFrame(r *bufio.Reader) ([]byte, error) {

--- a/cmd/cub-scout/mcp_test.go
+++ b/cmd/cub-scout/mcp_test.go
@@ -25,6 +25,29 @@ func TestNewMCPGateway_ToolsIncludeStandaloneSet(t *testing.T) {
 	}
 }
 
+func TestNewMCPGatewayWithMode_ConnectedAddsConfigHubTools(t *testing.T) {
+	gateway := newMCPGatewayWithMode(nil, nil, true)
+	tools := gateway.toolsForList()
+
+	var names []string
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+
+	want := []string{
+		"confighub_changesets",
+		"confighub_unit_get",
+		"confighub_units",
+		"explain",
+		"map",
+		"scan",
+		"trace",
+	}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("tool names = %v, want %v", names, want)
+	}
+}
+
 func TestMCPGatewayHandleRequest_ToolsList(t *testing.T) {
 	gateway := newMCPGateway(nil)
 	req := mcpRequest{
@@ -141,6 +164,49 @@ func TestMCPGatewayHandleRequest_ToolsCallValidationError(t *testing.T) {
 	}
 	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "resource") {
 		t.Fatalf("unexpected error text: %+v", result.Content)
+	}
+}
+
+func TestMCPGatewayHandleRequest_ToolsCallConnectedChangesets(t *testing.T) {
+	var gotStandaloneArgs []string
+	var gotConnectedArgs []string
+
+	gateway := newMCPGatewayWithMode(
+		func(ctx context.Context, args []string) (string, error) {
+			gotStandaloneArgs = append([]string(nil), args...)
+			return `{"standalone":true}`, nil
+		},
+		func(ctx context.Context, args []string) (string, error) {
+			gotConnectedArgs = append([]string(nil), args...)
+			return `{"connected":true}`, nil
+		},
+		true,
+	)
+
+	req := mcpRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`11`),
+		Method:  "tools/call",
+		Params: json.RawMessage(`{
+			"name":"confighub_changesets",
+			"arguments":{"space":"platform","where":"Slug LIKE 'release-%'"}
+		}`),
+	}
+
+	resp := gateway.handleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected rpc error: %+v", resp.Error)
+	}
+
+	if len(gotStandaloneArgs) != 0 {
+		t.Fatalf("standalone runner should not be used, got args %v", gotStandaloneArgs)
+	}
+	wantConnected := []string{"changeset", "list", "--json", "--space", "platform", "--where", "Slug LIKE 'release-%'"}
+	if !reflect.DeepEqual(gotConnectedArgs, wantConnected) {
+		t.Fatalf("connected args = %v, want %v", gotConnectedArgs, wantConnected)
 	}
 }
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -876,7 +876,7 @@ Read-only MCP gateway for AI agent tooling.
 
 ### mcp serve
 
-Serve MCP over stdio and expose observation tools (`map`, `trace`, `scan`, `explain`).
+Serve MCP over stdio and expose read-only tools.
 
 ```bash
 cub-scout mcp serve
@@ -884,7 +884,8 @@ cub-scout mcp serve
 
 #### Notes
 
-- Uses existing CLI JSON surfaces internally (`map list --json`, `trace --format json`, etc.).
+- Standalone tools: `map`, `trace`, `scan`, `explain` (via existing cub-scout JSON surfaces).
+- Connected tools (when authenticated to ConfigHub): `confighub_changesets`, `confighub_units`, `confighub_unit_get`.
 - Standalone and read-only: no cluster mutations and no ConfigHub write path.
 - Protocol transport is stdio with `Content-Length` framed JSON-RPC messages.
 

--- a/examples/mcp-gateway/README.md
+++ b/examples/mcp-gateway/README.md
@@ -6,11 +6,16 @@ Run cub-scout as a read-only MCP server over stdio:
 ./cub-scout mcp serve
 ```
 
-This exposes these tools in the current slice:
+This exposes these standalone tools:
 - `map`
 - `trace`
 - `scan`
 - `explain`
+
+When connected to ConfigHub (`cub auth login`), it additionally exposes:
+- `confighub_changesets`
+- `confighub_units`
+- `confighub_unit_get`
 
 ## Tool Behavior
 
@@ -20,6 +25,9 @@ The gateway reuses existing CLI JSON command outputs:
 - `trace` -> `trace --format json`
 - `scan` -> `scan --json`
 - `explain` -> `explain --format json`
+- `confighub_changesets` -> `cub changeset list --json`
+- `confighub_units` -> `cub unit list --json`
+- `confighub_unit_get` -> `cub unit get --json`
 
 That keeps MCP responses aligned with the normal CLI contract.
 


### PR DESCRIPTION
## Summary
- add connected-mode MCP routing in `mcp serve` with read-only ConfigHub tools
- keep existing standalone tools unchanged (`map`, `trace`, `scan`, `explain`)
- when connected (`hub.CurrentMode()==Connected` and `cub` is available), expose:
  - `confighub_changesets` -> `cub changeset list --json`
  - `confighub_units` -> `cub unit list --json`
  - `confighub_unit_get` -> `cub unit get --json`
- route connected tools through a dedicated `cub` runner while preserving read-only constraints
- add gateway-mode constructor to test tool registration and routing deterministically
- update MCP docs/examples across command reference + CLI guide + README

## Why
This closes the remaining connected-mode MCP follow-up after PR #285 by adding concrete ConfigHub-backed read-only routing for history/fleet context without introducing mutation paths.

## Proof
- `go test ./cmd/cub-scout -run 'TestNewMCPGateway_|TestMCPGatewayHandleRequest_|TestMCPFrameRoundTrip' -count=1`
- `for i in 1 2 3; do go test ./cmd/cub-scout -run 'TestNewMCPGateway_|TestMCPGatewayHandleRequest_|TestMCPFrameRoundTrip' -count=1 || exit 1; done`
- `go test ./cmd/cub-scout -count=1`

Closes #214
