### PR TITLE
history: add connected CLI timeline command

### DIFF
--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -24,6 +24,7 @@ The table below reflects the current `cub-scout --help` output.
 | `gitops` | GitOps status and diagnostics |
 | `graph` | Resource graph operations |
 | `health` | Check issues (alias for `map issues`) |
+| `history` | Show connected change history from ConfigHub ChangeSets |
 | `import` | Import workloads into ConfigHub |
 | `import-argocd` | Import an ArgoCD Application into ConfigHub |
 | `import-cluster-aggregator` | Aggregate imports from multiple clusters (GUI) |
@@ -319,6 +320,29 @@ Context:    docker-desktop
 ```
 Connected │ Cluster: prod-east │ Context: eks-prod-east │ Worker: ● bridge-prod
 ```
+
+---
+
+## `history` — Connected Change Timeline
+
+**What it does:** Shows connected-mode resource history from ConfigHub ChangeSets.
+
+```bash
+./cub-scout history deploy/my-app -n prod
+./cub-scout history deploy/my-app -n prod --since 24h --format json
+./cub-scout history deploy/my-app --since 2w --format md
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `-n, --namespace` | Optional namespace scope |
+| `--since` | Lookback window (`24h`, `7d`, `2w`) |
+| `--format` | Output format: `ascii`, `json`, `md` |
+
+**Graceful behavior:**
+- Not connected: `history requires ConfigHub connection. Run: cub auth login`
+- No matching history: clear message that the resource may not be imported yet
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ Scanned: 47 resources │ Patterns: 46 active (4,500+ reference)
 | `cub-scout scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD |
 | `cub-scout map hooks` | List lifecycle hooks (Helm/ArgoCD) |
 | `cub-scout gitops status` | GitOps pipeline health and failure diagnosis |
+| `cub-scout history deploy/x -n y --since 7d` | Connected ChangeSet timeline for one resource |
 | `cub-scout snapshot --relations` | Export state with dependency graph (GSF format) |
 | `cub-scout bundle summarize` | Generate summary for Jira, PRs, or Slack |
 
@@ -760,6 +761,7 @@ cub-scout is an open-source cluster explorer designed to work with existing Kube
 | `snapshot` — Export state (GSF) | ✓ | ✓ |
 | `import` — Send to ConfigHub | — | ✓ |
 | `fleet` — Multi-cluster queries | — | ✓ |
+| `history` — ChangeSet timeline | — | ✓ |
 | DRY↔WET↔LIVE compare | — | ✓ |
 | Revision history | — | ✓ |
 | Team collaboration | — | ✓ |

--- a/cmd/cub-scout/history.go
+++ b/cmd/cub-scout/history.go
@@ -1,0 +1,437 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/hub"
+	"github.com/spf13/cobra"
+)
+
+var (
+	historyNamespace string
+	historyFormat    string
+	historySince     string
+)
+
+var historyCmd = &cobra.Command{
+	Use:   "history <resource>",
+	Short: "Show connected change history from ConfigHub ChangeSets",
+	Long: `Show change history for a resource using ConfigHub ChangeSets.
+
+Examples:
+  cub-scout history deploy/my-app -n prod
+  cub-scout history deploy/my-app -n prod --since 24h --format json
+  cub-scout history deploy/my-app --format md
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: runHistory,
+}
+
+func init() {
+	rootCmd.AddCommand(historyCmd)
+	historyCmd.Flags().StringVarP(&historyNamespace, "namespace", "n", "", "Namespace scope (optional)")
+	historyCmd.Flags().StringVar(&historyFormat, "format", "ascii", "Output format: ascii, json, md")
+	historyCmd.Flags().StringVar(&historySince, "since", "7d", "Lookback window (examples: 24h, 7d, 2w)")
+}
+
+var errHistoryDisconnected = errors.New("history requires ConfigHub connection. Run: cub auth login")
+
+type historyQuery struct {
+	Resource  string
+	Namespace string
+	Since     string
+	Window    time.Duration
+	Now       time.Time
+}
+
+type historyEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Actor     string    `json:"actor"`
+	Change    string    `json:"change"`
+	ChangeSet string    `json:"changeset,omitempty"`
+}
+
+type historyResult struct {
+	Resource  string         `json:"resource"`
+	Namespace string         `json:"namespace,omitempty"`
+	Since     string         `json:"since"`
+	Entries   []historyEntry `json:"entries"`
+}
+
+var (
+	requireHistoryConnectedFn = requireHistoryConnected
+	fetchHistoryEntriesFn     = fetchHistoryEntries
+	historyNowFn              = time.Now
+	runHistoryCubCommand      = runHistoryCubCommandImpl
+)
+
+func runHistory(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(historyFormat))
+	if format != "ascii" && format != "json" && format != "md" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json, md)", historyFormat)
+	}
+
+	window, err := parseHistorySince(historySince)
+	if err != nil {
+		return err
+	}
+
+	if err := requireHistoryConnectedFn(); err != nil {
+		return err
+	}
+
+	query := historyQuery{
+		Resource:  strings.TrimSpace(args[0]),
+		Namespace: strings.TrimSpace(historyNamespace),
+		Since:     strings.TrimSpace(historySince),
+		Window:    window,
+		Now:       historyNowFn().UTC(),
+	}
+
+	entries, err := fetchHistoryEntriesFn(cmd.Context(), query)
+	if err != nil {
+		return err
+	}
+
+	result := historyResult{
+		Resource:  query.Resource,
+		Namespace: query.Namespace,
+		Since:     query.Since,
+		Entries:   entries,
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	case "md":
+		fmt.Print(renderHistoryMarkdown(result))
+		return nil
+	default:
+		fmt.Print(renderHistoryASCII(result))
+		return nil
+	}
+}
+
+func requireHistoryConnected() error {
+	if err := hub.NewClient().RequireConnected(); err != nil {
+		return errHistoryDisconnected
+	}
+	if _, err := exec.LookPath("cub"); err != nil {
+		return fmt.Errorf("history requires cub CLI for connected queries: %w", err)
+	}
+	return nil
+}
+
+func parseHistorySince(raw string) (time.Duration, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return 7 * 24 * time.Hour, nil
+	}
+
+	if d, err := time.ParseDuration(value); err == nil {
+		if d <= 0 {
+			return 0, fmt.Errorf("--since must be > 0")
+		}
+		return d, nil
+	}
+
+	if strings.HasSuffix(value, "d") || strings.HasSuffix(value, "w") {
+		unit := value[len(value)-1]
+		numRaw := strings.TrimSpace(value[:len(value)-1])
+		n, err := strconv.Atoi(numRaw)
+		if err != nil || n <= 0 {
+			return 0, fmt.Errorf("invalid --since %q (examples: 24h, 7d, 2w)", raw)
+		}
+		switch unit {
+		case 'd':
+			return time.Duration(n) * 24 * time.Hour, nil
+		case 'w':
+			return time.Duration(n) * 7 * 24 * time.Hour, nil
+		}
+	}
+
+	return 0, fmt.Errorf("invalid --since %q (examples: 24h, 7d, 2w)", raw)
+}
+
+func fetchHistoryEntries(ctx context.Context, q historyQuery) ([]historyEntry, error) {
+	contains := q.Resource
+	if q.Namespace != "" {
+		contains = q.Namespace + " " + q.Resource
+	}
+
+	args := []string{"changeset", "list", "--json", "--contains", contains}
+	if space := detectHistorySpace(ctx); space != "" {
+		args = append(args, "--space", space)
+	}
+
+	raw, err := runHistoryCubCommand(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("fetch changeset history: %w", err)
+	}
+
+	cutoff := q.Now.Add(-q.Window)
+	entries, err := buildHistoryEntriesFromChangeSets(raw, cutoff)
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func detectHistorySpace(ctx context.Context) string {
+	cubCtx, _, err := getStatusCubContext()
+	if err != nil || cubCtx == nil {
+		return ""
+	}
+	return strings.TrimSpace(cubCtx.Settings.DefaultSpace)
+}
+
+func runHistoryCubCommandImpl(ctx context.Context, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, "cub", args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("cub %s failed: %s", strings.Join(args, " "), msg)
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func buildHistoryEntriesFromChangeSets(raw string, cutoff time.Time) ([]historyEntry, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return nil, nil
+	}
+
+	var payload interface{}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("parse changeset list json: %w", err)
+	}
+
+	items := historyExtractItems(payload)
+	entries := make([]historyEntry, 0, len(items))
+	for _, item := range items {
+		ts, ok := historyExtractTime(item, "CreatedAt", "createdAt", "Timestamp", "timestamp", "UpdatedAt", "updatedAt")
+		if !ok {
+			continue
+		}
+		ts = ts.UTC()
+		if ts.Before(cutoff) {
+			continue
+		}
+
+		changeSet := historyFirstString(item, "Slug", "slug", "Name", "name", "ID", "id")
+		change := historyFirstString(item, "Description", "description", "DisplayName", "displayName", "Summary", "summary", "Message", "message")
+		if change == "" {
+			change = changeSet
+		}
+		if change == "" {
+			change = "change recorded"
+		}
+
+		actor := historyActor(item)
+		if actor == "" {
+			actor = "unknown"
+		}
+
+		entries = append(entries, historyEntry{
+			Timestamp: ts,
+			Actor:     actor,
+			Change:    change,
+			ChangeSet: changeSet,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.After(entries[j].Timestamp)
+	})
+
+	return entries, nil
+}
+
+func historyExtractItems(payload interface{}) []map[string]interface{} {
+	switch typed := payload.(type) {
+	case []interface{}:
+		return historyArrayToObjects(typed)
+	case map[string]interface{}:
+		for _, key := range []string{"items", "data", "results", "changesets", "ChangeSets"} {
+			if arr, ok := typed[key].([]interface{}); ok {
+				return historyArrayToObjects(arr)
+			}
+		}
+		return []map[string]interface{}{typed}
+	default:
+		return nil
+	}
+}
+
+func historyArrayToObjects(arr []interface{}) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(arr))
+	for _, raw := range arr {
+		m, ok := raw.(map[string]interface{})
+		if ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func historyExtractTime(item map[string]interface{}, keys ...string) (time.Time, bool) {
+	for _, key := range keys {
+		raw, ok := item[key]
+		if !ok || raw == nil {
+			continue
+		}
+		switch v := raw.(type) {
+		case string:
+			s := strings.TrimSpace(v)
+			if s == "" {
+				continue
+			}
+			if t, err := time.Parse(time.RFC3339, s); err == nil {
+				return t, true
+			}
+			if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
+				return t, true
+			}
+		case float64:
+			if v > 0 {
+				return time.Unix(int64(v), 0), true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func historyFirstString(item map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		raw, ok := item[key]
+		if !ok || raw == nil {
+			continue
+		}
+		if s, ok := raw.(string); ok {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func historyActor(item map[string]interface{}) string {
+	for _, key := range []string{"CreatedBy", "createdBy", "Actor", "actor", "User", "user"} {
+		raw, ok := item[key]
+		if !ok || raw == nil {
+			continue
+		}
+		switch typed := raw.(type) {
+		case string:
+			s := strings.TrimSpace(typed)
+			if s != "" {
+				return s
+			}
+		case map[string]interface{}:
+			s := historyFirstString(typed, "Slug", "slug", "Email", "email", "Name", "name", "DisplayName", "displayName", "ID", "id")
+			if s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func renderHistoryASCII(result historyResult) string {
+	var b strings.Builder
+	target := result.Resource
+	if result.Namespace != "" {
+		target = fmt.Sprintf("%s (namespace: %s)", result.Resource, result.Namespace)
+	}
+
+	b.WriteString(fmt.Sprintf("Change History (last %s): %s\n", result.Since, target))
+	if len(result.Entries) == 0 {
+		b.WriteString("No history available — resource not yet imported to ConfigHub\n")
+		return b.String()
+	}
+
+	for _, entry := range result.Entries {
+		changeSet := entry.ChangeSet
+		if strings.TrimSpace(changeSet) == "" {
+			changeSet = "-"
+		}
+		actor := entry.Actor
+		if strings.TrimSpace(actor) == "" {
+			actor = "unknown"
+		}
+		b.WriteString(fmt.Sprintf("  %s  %s  by: %s  changeset: %s\n",
+			entry.Timestamp.Format("2006-01-02 15:04"),
+			entry.Change,
+			actor,
+			changeSet,
+		))
+	}
+
+	return b.String()
+}
+
+func renderHistoryMarkdown(result historyResult) string {
+	var b strings.Builder
+	b.WriteString("# Change History\n\n")
+	b.WriteString(fmt.Sprintf("- Resource: `%s`\n", result.Resource))
+	if result.Namespace != "" {
+		b.WriteString(fmt.Sprintf("- Namespace: `%s`\n", result.Namespace))
+	}
+	b.WriteString(fmt.Sprintf("- Since: `%s`\n\n", result.Since))
+
+	if len(result.Entries) == 0 {
+		b.WriteString("No history available — resource not yet imported to ConfigHub.\n")
+		return b.String()
+	}
+
+	b.WriteString("| Time (UTC) | Change | Actor | ChangeSet |\n")
+	b.WriteString("|---|---|---|---|\n")
+	for _, entry := range result.Entries {
+		changeSet := strings.TrimSpace(entry.ChangeSet)
+		if changeSet == "" {
+			changeSet = "-"
+		}
+		actor := strings.TrimSpace(entry.Actor)
+		if actor == "" {
+			actor = "unknown"
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+			entry.Timestamp.Format(time.RFC3339),
+			historyEscapeMarkdown(entry.Change),
+			historyEscapeMarkdown(actor),
+			historyEscapeMarkdown(changeSet),
+		))
+	}
+
+	return b.String()
+}
+
+func historyEscapeMarkdown(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return strings.TrimSpace(s)
+}

--- a/cmd/cub-scout/history_test.go
+++ b/cmd/cub-scout/history_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func TestHistoryCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "history" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("history command is not registered on rootCmd")
+	}
+}
+
+func TestParseHistorySince(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{raw: "24h", want: 24 * time.Hour},
+		{raw: "7d", want: 7 * 24 * time.Hour},
+		{raw: "2w", want: 14 * 24 * time.Hour},
+		{raw: "0", wantErr: true},
+		{raw: "garbage", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		got, err := parseHistorySince(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("parseHistorySince(%q) expected error", tt.raw)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseHistorySince(%q) error = %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Fatalf("parseHistorySince(%q) = %v, want %v", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestBuildHistoryEntriesFromChangeSets_FiltersAndSorts(t *testing.T) {
+	now := time.Date(2026, 3, 6, 12, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-7 * 24 * time.Hour)
+
+	raw := `[
+	  {
+	    "Slug": "CS-4821",
+	    "CreatedAt": "2026-03-03T14:22:00Z",
+	    "Description": "image: v1.4.2 -> v1.4.3",
+	    "CreatedBy": {"Slug":"ci-bot"}
+	  },
+	  {
+	    "Slug": "CS-4701",
+	    "CreatedAt": "2026-02-10T09:15:00Z",
+	    "Description": "old change",
+	    "CreatedBy": "alex"
+	  },
+	  {
+	    "Slug": "CS-4799",
+	    "CreatedAt": "2026-03-01T09:15:00Z",
+	    "Description": "replicas: 2 -> 3",
+	    "CreatedBy": {"Email":"sarah@example.com"}
+	  }
+	]`
+
+	got, err := buildHistoryEntriesFromChangeSets(raw, cutoff)
+	if err != nil {
+		t.Fatalf("buildHistoryEntriesFromChangeSets() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(got))
+	}
+	if got[0].ChangeSet != "CS-4821" || got[1].ChangeSet != "CS-4799" {
+		t.Fatalf("unexpected ordering or changesets: %+v", got)
+	}
+	if got[0].Actor != "ci-bot" {
+		t.Fatalf("entry[0] actor = %q, want ci-bot", got[0].Actor)
+	}
+	if got[1].Actor != "sarah@example.com" {
+		t.Fatalf("entry[1] actor = %q, want sarah@example.com", got[1].Actor)
+	}
+}
+
+func TestRenderHistoryASCII_Empty(t *testing.T) {
+	out := renderHistoryASCII(historyResult{
+		Resource:  "deploy/my-app",
+		Namespace: "prod",
+		Since:     "7d",
+		Entries:   nil,
+	})
+	if !strings.Contains(out, "No history available") {
+		t.Fatalf("expected empty-history message, got:\n%s", out)
+	}
+}
+
+func TestRunHistory_NotConnected(t *testing.T) {
+	restoreFlags := withHistoryFlagsForTest()
+	defer restoreFlags()
+
+	prevRequire := requireHistoryConnectedFn
+	requireHistoryConnectedFn = func() error {
+		return errHistoryDisconnected
+	}
+	defer func() { requireHistoryConnectedFn = prevRequire }()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runHistory(cmd, []string{"deploy/my-app"})
+	if err == nil {
+		t.Fatal("expected error when not connected")
+	}
+	if !strings.Contains(err.Error(), "history requires ConfigHub connection") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunHistory_JSONOutput(t *testing.T) {
+	restoreFlags := withHistoryFlagsForTest()
+	defer restoreFlags()
+
+	prevRequire := requireHistoryConnectedFn
+	requireHistoryConnectedFn = func() error { return nil }
+	defer func() { requireHistoryConnectedFn = prevRequire }()
+
+	prevFetch := fetchHistoryEntriesFn
+	fetchHistoryEntriesFn = func(ctx context.Context, q historyQuery) ([]historyEntry, error) {
+		return []historyEntry{
+			{
+				Timestamp: time.Date(2026, 3, 3, 14, 22, 0, 0, time.UTC),
+				Actor:     "ci-bot",
+				Change:    "image: v1.4.2 -> v1.4.3",
+				ChangeSet: "CS-4821",
+			},
+		}, nil
+	}
+	defer func() { fetchHistoryEntriesFn = prevFetch }()
+
+	historyFormat = "json"
+	historySince = "7d"
+	historyNamespace = "prod"
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	out := captureStdout(t, func() {
+		if err := runHistory(cmd, []string{"deploy/my-app"}); err != nil {
+			t.Fatalf("runHistory() error = %v", err)
+		}
+	})
+
+	var payload historyResult
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("json decode output: %v\n%s", err, out)
+	}
+	if payload.Resource != "deploy/my-app" {
+		t.Fatalf("resource = %q, want deploy/my-app", payload.Resource)
+	}
+	if payload.Namespace != "prod" {
+		t.Fatalf("namespace = %q, want prod", payload.Namespace)
+	}
+	if len(payload.Entries) != 1 || payload.Entries[0].ChangeSet != "CS-4821" {
+		t.Fatalf("unexpected entries: %+v", payload.Entries)
+	}
+}
+
+func withHistoryFlagsForTest() func() {
+	prevFormat := historyFormat
+	prevNamespace := historyNamespace
+	prevSince := historySince
+	historyFormat = "ascii"
+	historyNamespace = ""
+	historySince = "7d"
+	return func() {
+		historyFormat = prevFormat
+		historyNamespace = prevNamespace
+		historySince = prevSince
+	}
+}

--- a/cmd/cub-scout/smoke_test.go
+++ b/cmd/cub-scout/smoke_test.go
@@ -80,6 +80,12 @@ func TestSmoke_CLIHelp(t *testing.T) {
 			wantContains: []string{"status", "connection", "Usage:"},
 		},
 		{
+			name:         "history help",
+			args:         []string{"history", "--help"},
+			wantExitCode: 0,
+			wantContains: []string{"history", "ChangeSets", "Usage:"},
+		},
+		{
 			name:         "debug help",
 			args:         []string{"debug", "--help"},
 			wantExitCode: 0,
@@ -143,7 +149,7 @@ func TestSmoke_RootCommand(t *testing.T) {
 	}
 
 	// Verify key subcommands exist
-	expectedCmds := []string{"version", "completion", "map", "quickstart", "scan", "trace", "status"}
+	expectedCmds := []string{"version", "completion", "map", "quickstart", "scan", "trace", "status", "history"}
 	for _, name := range expectedCmds {
 		found := false
 		for _, cmd := range rootCmd.Commands() {

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -64,6 +64,7 @@ Human-friendly JSON contract index: [json-contracts.md](json-contracts.md)
 | `cub-scout completion` | Generate shell completion script | v0.19 |
 | `cub-scout connect` | Configure kube context from server URL or kubeconfig import | v1.0 |
 | `cub-scout status` | Show connection status and cluster info | v1.0 |
+| `cub-scout history` | Connected change timeline from ConfigHub ChangeSets | v1.4 |
 | `cub-scout mcp serve` | Serve read-only MCP observation tools over stdio | v1.4 |
 
 ---
@@ -867,6 +868,48 @@ Worker:     ● bridge-prod (connected)
     "name": "bridge-prod",
     "status": "connected"
   }
+}
+```
+
+---
+
+## cub-scout history (v1.4)
+
+Show connected resource history from ConfigHub ChangeSets.
+
+```bash
+cub-scout history <resource> [flags]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-n, --namespace` | string | empty | Optional namespace scope |
+| `--since` | string | `7d` | Lookback window (`24h`, `7d`, `2w`) |
+| `--format` | string | `ascii` | Output format: `ascii`, `json`, `md` |
+
+### Connected Behavior
+
+- Requires ConfigHub authentication (`cub auth login`).
+- Uses read-only ChangeSet queries from ConfigHub.
+- Returns clear empty-history messaging when no matching tracked changes exist.
+
+### Output (JSON)
+
+```json
+{
+  "resource": "deploy/my-app",
+  "namespace": "prod",
+  "since": "7d",
+  "entries": [
+    {
+      "timestamp": "2026-03-03T14:22:00Z",
+      "actor": "ci-bot",
+      "change": "image: v1.4.2 -> v1.4.3",
+      "changeset": "CS-4821"
+    }
+  ]
 }
 ```
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -34,6 +34,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `discover` | Scout-style workload discovery | v0.5 |
 | `health` | Scout-style health check | v0.5 |
 | `status` | Show connection status and cluster info | v1.0 |
+| `history` | Show connected change history from ConfigHub ChangeSets | v1.4 |
 | `connect` | Quickly configure kube context from server URL or kubeconfig | v1.0 |
 | `setup` | Set up shell completions | v0.19 |
 | `mcp serve` | Serve read-only MCP tools over stdio | v1.4 |
@@ -837,6 +838,43 @@ cub-scout status --json
 Displays ConfigHub connection mode (Offline/Online/Connected), current cluster
 name, kubectl context, and optional worker/space info when the `cub` CLI is
 available.
+
+---
+
+## history
+
+Show connected change history for one resource from ConfigHub ChangeSets.
+
+```bash
+cub-scout history <resource> [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-n, --namespace` | Optional namespace scope |
+| `--since` | Lookback window (examples: `24h`, `7d`, `2w`) |
+| `--format` | Output format: `ascii`, `json`, `md` |
+
+### Examples
+
+```bash
+# Default lookback (7d), ASCII output
+cub-scout history deploy/my-app -n prod
+
+# JSON for automation
+cub-scout history deploy/my-app -n prod --since 24h --format json
+
+# Markdown timeline for tickets/PRs
+cub-scout history deploy/my-app --since 2w --format md
+```
+
+### Connected Mode Notes
+
+- Requires ConfigHub authentication (`cub auth login`).
+- Uses read-only ChangeSet queries under the hood.
+- If no history is found, output clearly notes the resource may not be imported yet.
 
 ---
 


### PR DESCRIPTION
## Summary
This PR delivers the **CLI slice** for connected history/timeline support:

- add `cub-scout history <resource>` command
- add `--namespace`, `--since`, `--format ascii|json|md`
- enforce connected-mode gating with clear remediation message
- query read-only ConfigHub ChangeSets via `cub changeset list --json`
- parse and normalize history rows into a stable output model
- add empty-history messaging for not-yet-imported resources
- update command docs/contracts/CLI guide/README and smoke coverage

## Notes on scope
This is a scoped increment for issue #227.

Included here:
- CLI command and output contracts (`ascii/json/md`)

Deferred follow-up:
- TUI timeline panel integration

## Proof
- `go test ./cmd/cub-scout -run 'TestHistoryCommandRegistered|TestParseHistorySince|TestBuildHistoryEntriesFromChangeSets_FiltersAndSorts|TestRenderHistoryASCII_Empty|TestRunHistory_NotConnected|TestRunHistory_JSONOutput|TestSmoke_RootCommand|TestSmoke_CLIHelp' -count=1`
- `for i in 1 2 3; do go test ./cmd/cub-scout -run 'TestHistoryCommandRegistered|TestParseHistorySince|TestBuildHistoryEntriesFromChangeSets_FiltersAndSorts|TestRenderHistoryASCII_Empty|TestRunHistory_NotConnected|TestRunHistory_JSONOutput|TestSmoke_RootCommand|TestSmoke_CLIHelp' -count=1 || exit 1; done`
- `go test ./cmd/cub-scout -count=1`

Additional regression attempt:
- `go test ./... -count=1` ran broadly; non-slice failures were due golden suites expecting a prebuilt `./cub-scout` binary in the worktree.

Refs #227
