### PR TITLE
ai: add reproducible integration examples for Claude/Cursor/Copilot

### DIFF
--- a/cmd/cub-scout/history.go
+++ b/cmd/cub-scout/history.go
@@ -89,10 +89,6 @@ func runHistory(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := requireHistoryConnectedFn(); err != nil {
-		return err
-	}
-
 	query := historyQuery{
 		Resource:  strings.TrimSpace(args[0]),
 		Namespace: strings.TrimSpace(historyNamespace),
@@ -101,7 +97,7 @@ func runHistory(cmd *cobra.Command, args []string) error {
 		Now:       historyNowFn().UTC(),
 	}
 
-	entries, err := fetchHistoryEntriesFn(cmd.Context(), query)
+	entries, err := resolveHistoryEntries(cmd.Context(), query)
 	if err != nil {
 		return err
 	}
@@ -125,6 +121,26 @@ func runHistory(cmd *cobra.Command, args []string) error {
 		fmt.Print(renderHistoryASCII(result))
 		return nil
 	}
+}
+
+func resolveHistoryEntries(ctx context.Context, q historyQuery) ([]historyEntry, error) {
+	if fixture := strings.TrimSpace(os.Getenv("CUB_SCOUT_TEST_HISTORY_JSON")); fixture != "" {
+		raw, err := os.ReadFile(fixture)
+		if err != nil {
+			return nil, fmt.Errorf("read history fixture %q: %w", fixture, err)
+		}
+		entries, err := buildHistoryEntriesFromChangeSets(string(raw), q.Now.Add(-q.Window))
+		if err != nil {
+			return nil, fmt.Errorf("parse history fixture %q: %w", fixture, err)
+		}
+		return entries, nil
+	}
+
+	if err := requireHistoryConnectedFn(); err != nil {
+		return nil, err
+	}
+
+	return fetchHistoryEntriesFn(ctx, q)
 }
 
 func requireHistoryConnected() error {

--- a/cmd/cub-scout/history_test.go
+++ b/cmd/cub-scout/history_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -189,5 +191,90 @@ func withHistoryFlagsForTest() func() {
 		historyFormat = prevFormat
 		historyNamespace = prevNamespace
 		historySince = prevSince
+	}
+}
+
+func TestRunHistory_UsesFixtureJSONWithoutConnection(t *testing.T) {
+	restoreFlags := withHistoryFlagsForTest()
+	defer restoreFlags()
+
+	prevRequire := requireHistoryConnectedFn
+	requireHistoryConnectedFn = func() error { return errHistoryDisconnected }
+	defer func() { requireHistoryConnectedFn = prevRequire }()
+
+	prevFetch := fetchHistoryEntriesFn
+	fetchHistoryEntriesFn = func(ctx context.Context, q historyQuery) ([]historyEntry, error) {
+		t.Fatalf("fetchHistoryEntriesFn should not be called in fixture mode")
+		return nil, nil
+	}
+	defer func() { fetchHistoryEntriesFn = prevFetch }()
+
+	prevNow := historyNowFn
+	historyNowFn = func() time.Time { return time.Date(2026, 3, 6, 12, 0, 0, 0, time.UTC) }
+	defer func() { historyNowFn = prevNow }()
+
+	fixturePath := filepath.Join(t.TempDir(), "changesets.json")
+	fixtureJSON := `[
+	  {
+	    "Slug": "CS-9901",
+	    "CreatedAt": "2026-03-05T09:20:00Z",
+	    "Description": "image: v2.3.1 -> v2.3.2",
+	    "CreatedBy": {"Slug":"release-bot"}
+	  }
+	]`
+	if err := os.WriteFile(fixturePath, []byte(fixtureJSON), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Setenv("CUB_SCOUT_TEST_HISTORY_JSON", fixturePath)
+
+	historyFormat = "json"
+	historySince = "7d"
+	historyNamespace = "prod"
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	out := captureStdout(t, func() {
+		if err := runHistory(cmd, []string{"deploy/checkout"}); err != nil {
+			t.Fatalf("runHistory() error = %v", err)
+		}
+	})
+
+	var payload historyResult
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("json decode output: %v\n%s", err, out)
+	}
+	if len(payload.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(payload.Entries))
+	}
+	if payload.Entries[0].ChangeSet != "CS-9901" {
+		t.Fatalf("changeset = %q, want CS-9901", payload.Entries[0].ChangeSet)
+	}
+}
+
+func TestRunHistory_FixtureReadError(t *testing.T) {
+	restoreFlags := withHistoryFlagsForTest()
+	defer restoreFlags()
+
+	prevRequire := requireHistoryConnectedFn
+	requireHistoryConnectedFn = func() error { return nil }
+	defer func() { requireHistoryConnectedFn = prevRequire }()
+
+	prevFetch := fetchHistoryEntriesFn
+	fetchHistoryEntriesFn = func(ctx context.Context, q historyQuery) ([]historyEntry, error) {
+		return []historyEntry{}, nil
+	}
+	defer func() { fetchHistoryEntriesFn = prevFetch }()
+
+	t.Setenv("CUB_SCOUT_TEST_HISTORY_JSON", filepath.Join(t.TempDir(), "missing.json"))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runHistory(cmd, []string{"deploy/checkout"})
+	if err == nil {
+		t.Fatal("expected error for missing fixture file")
+	}
+	if !strings.Contains(err.Error(), "read history fixture") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,7 @@ The `argo-import-confighub-demo` and `flux-import-confighub-demo` run against re
 | Example | Pattern | Shows |
 |---------|---------|-------|
 | [mcp-gateway/](mcp-gateway/) | **MCP stdio server** | Serve read-only `map`/`trace`/`scan`/`explain` tools to AI clients |
+| [ai-integration/](ai-integration/) | **Per-tool AI integrations** | Reproducible Claude/Cursor/Copilot MCP + CLI examples (offline fixtures) |
 
 **Using AI tools?** Start with [Giving Your AI Eyes](ai-agent-quest/) — watch your AI reason about cluster state and hit the wall that ConfigHub removes.
 

--- a/examples/ai-integration/README.md
+++ b/examples/ai-integration/README.md
@@ -1,0 +1,55 @@
+# AI Tool Integration Examples
+
+Reproducible AI integration examples for `cub-scout` with no live cluster required.
+
+This package documents CLI and MCP usage for:
+- Claude Code
+- Cursor
+- GitHub Copilot
+
+## What You Get
+
+- Per-tool MCP config examples (`claude-code/mcp.json`, `cursor/mcp.json`, `copilot/mcp.json`)
+- Fixture-backed scenarios that run offline
+- A blog-ready Claude Code walkthrough
+
+## Offline Scenario Set
+
+The fixture runner demonstrates these scenarios:
+
+1. Debug why a deployment is failing (`trace`)
+2. What changed in prod since yesterday (`history`)
+3. Is this manifest safe to deploy (`scan --file`)
+4. Show unmanaged resources (`map orphans`)
+
+## Run the Fixture Session
+
+From repo root:
+
+```bash
+./examples/ai-integration/run-fixture-session.sh
+```
+
+This writes sample outputs to:
+
+```text
+examples/ai-integration/sample-output/
+```
+
+Use a custom output directory:
+
+```bash
+./examples/ai-integration/run-fixture-session.sh --output-dir /tmp/cub-scout-ai-demo
+```
+
+## Tool Guides
+
+- [Claude Code](claude-code/README.md)
+- [Cursor](cursor/README.md)
+- [GitHub Copilot](copilot/README.md)
+
+## Notes
+
+- Fixture mode is explicit and opt-in via `CUB_SCOUT_TEST_*` env vars.
+- Normal command behavior is unchanged when test env vars are not set.
+- `history` stays connected-mode by default; fixture mode is for demos/tests only.

--- a/examples/ai-integration/claude-code/README.md
+++ b/examples/ai-integration/claude-code/README.md
@@ -1,0 +1,29 @@
+# Claude Code Integration
+
+## 1. Configure MCP
+
+Use [`mcp.json`](mcp.json) as your Claude Code MCP server definition.
+
+Key command:
+
+```json
+"command": "./cub-scout",
+"args": ["mcp", "serve"]
+```
+
+## 2. Run Offline Fixture Walkthrough
+
+```bash
+./examples/ai-integration/run-fixture-session.sh
+```
+
+## 3. Prompt Template
+
+```text
+Use cub-scout to diagnose deployment/checkout from the latest fixture outputs.
+Show trace evidence, then summarize likely operator actions.
+```
+
+## Blog-Ready Walkthrough
+
+See [WALKTHROUGH.md](WALKTHROUGH.md).

--- a/examples/ai-integration/claude-code/WALKTHROUGH.md
+++ b/examples/ai-integration/claude-code/WALKTHROUGH.md
@@ -1,0 +1,30 @@
+# Claude Code Walkthrough: Debug Kubernetes with cub-scout
+
+## Goal
+
+Show a complete, reproducible AI-assisted debugging flow without a live cluster.
+
+## Setup
+
+```bash
+go build ./cmd/cub-scout
+./examples/ai-integration/run-fixture-session.sh
+```
+
+## Session Flow
+
+1. Ask Claude: "Debug why deployment/checkout is failing."
+2. Claude reviews `sample-output/01-debug-deployment.txt`.
+3. Claude identifies source signal: `OutOfSync` and stale reconcile timestamp.
+4. Ask Claude: "What changed since yesterday?"
+5. Claude uses `sample-output/02-change-history.txt` to summarize the two latest ChangeSets.
+6. Ask Claude: "Is this safe to deploy?"
+7. Claude inspects `sample-output/03-scan-safety.json` and highlights finding `CCVE-2025-0244`.
+8. Ask Claude: "Show unmanaged resources."
+9. Claude reviews `sample-output/04-unmanaged-resources.txt` and flags native resources for ownership cleanup.
+
+## Why This Is Useful
+
+- CLI mode and MCP mode both use the same `cub-scout` command contract.
+- Every step is deterministic and replayable from local fixtures.
+- You can move from demo mode to live-cluster mode by removing fixture env vars.

--- a/examples/ai-integration/claude-code/mcp.json
+++ b/examples/ai-integration/claude-code/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cub-scout": {
+      "command": "./cub-scout",
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "cwd": "/path/to/cub-scout"
+    }
+  }
+}

--- a/examples/ai-integration/copilot/README.md
+++ b/examples/ai-integration/copilot/README.md
@@ -1,0 +1,21 @@
+# GitHub Copilot Integration
+
+## MCP Config
+
+Use [`mcp.json`](mcp.json) as the cub-scout MCP server definition for Copilot-enabled tooling.
+
+## Reproducible Demo
+
+```bash
+./examples/ai-integration/run-fixture-session.sh
+```
+
+Suggested prompt:
+
+```text
+Using cub-scout fixture outputs, answer:
+1) what is broken,
+2) what changed in the last 24h,
+3) what is unmanaged,
+4) what should be fixed first.
+```

--- a/examples/ai-integration/copilot/mcp.json
+++ b/examples/ai-integration/copilot/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cub-scout": {
+      "command": "./cub-scout",
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "cwd": "/path/to/cub-scout"
+    }
+  }
+}

--- a/examples/ai-integration/cursor/README.md
+++ b/examples/ai-integration/cursor/README.md
@@ -1,0 +1,18 @@
+# Cursor Integration
+
+## MCP Config
+
+Use [`mcp.json`](mcp.json) as the Cursor MCP entry for cub-scout.
+
+## Reproducible Demo
+
+```bash
+./examples/ai-integration/run-fixture-session.sh
+```
+
+Then ask Cursor:
+
+```text
+Analyze the four output files in examples/ai-integration/sample-output and
+produce an incident-ready summary with evidence references.
+```

--- a/examples/ai-integration/cursor/mcp.json
+++ b/examples/ai-integration/cursor/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cub-scout": {
+      "command": "./cub-scout",
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "cwd": "/path/to/cub-scout"
+    }
+  }
+}

--- a/examples/ai-integration/run-fixture-session.sh
+++ b/examples/ai-integration/run-fixture-session.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TESTDATA_DIR="$SCRIPT_DIR/testdata"
+OUTPUT_DIR="$SCRIPT_DIR/sample-output"
+BINARY="${CUB_SCOUT_BINARY:-$REPO_ROOT/cub-scout}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: run-fixture-session.sh [--output-dir <path>]"
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "Building cub-scout binary at $BINARY"
+    (
+        cd "$REPO_ROOT"
+        go build -o "$BINARY" ./cmd/cub-scout
+    )
+fi
+
+echo "Running fixture-backed AI integration session"
+echo "Output directory: $OUTPUT_DIR"
+
+TRACE_OUT="$OUTPUT_DIR/01-debug-deployment.txt"
+HISTORY_OUT="$OUTPUT_DIR/02-change-history.txt"
+SCAN_OUT="$OUTPUT_DIR/03-scan-safety.json"
+ORPHANS_OUT="$OUTPUT_DIR/04-unmanaged-resources.txt"
+
+CUB_SCOUT_TEST_TRACE_JSON="$TESTDATA_DIR/trace_argo_source_signals.json" \
+"$BINARY" trace deployment/checkout -n checkout > "$TRACE_OUT"
+
+echo "Wrote $TRACE_OUT"
+
+CUB_SCOUT_TEST_HISTORY_JSON="$TESTDATA_DIR/history_changesets.json" \
+"$BINARY" history deployment/checkout -n checkout --since 24h > "$HISTORY_OUT"
+
+echo "Wrote $HISTORY_OUT"
+
+set +e
+"$BINARY" scan --file "$TESTDATA_DIR/misconfigured-deployment.yaml" --json > "$SCAN_OUT"
+scan_rc=$?
+set -e
+if [[ "$scan_rc" -ne 1 ]]; then
+    echo "Expected scan --file exit code 1 (findings), got $scan_rc" >&2
+    exit 1
+fi
+echo "Wrote $SCAN_OUT (expected exit code 1 due to findings)"
+
+CUB_SCOUT_TEST_MAP_ENTRIES_JSON="$TESTDATA_DIR/map_orphans.json" \
+"$BINARY" map orphans > "$ORPHANS_OUT"
+
+echo "Wrote $ORPHANS_OUT"
+
+# Quick assertions so demo failures are obvious.
+grep -q "OutOfSync" "$TRACE_OUT"
+grep -q "Change History" "$HISTORY_OUT"
+grep -q "CCVE-2025-0244" "$SCAN_OUT"
+grep -q "debug-nginx" "$ORPHANS_OUT"
+
+echo "Fixture session completed successfully"

--- a/examples/ai-integration/testdata/history_changesets.json
+++ b/examples/ai-integration/testdata/history_changesets.json
@@ -1,0 +1,24 @@
+[
+  {
+    "Slug": "CS-9012",
+    "CreatedAt": "2026-03-06T09:15:00Z",
+    "Description": "image: checkout:v2.4.0 -> checkout:v2.4.1",
+    "CreatedBy": {
+      "Slug": "release-bot"
+    }
+  },
+  {
+    "Slug": "CS-9007",
+    "CreatedAt": "2026-03-05T18:40:00Z",
+    "Description": "replicas: 2 -> 3",
+    "CreatedBy": {
+      "Email": "sre-oncall@example.com"
+    }
+  },
+  {
+    "Slug": "CS-8998",
+    "CreatedAt": "2026-03-03T08:05:00Z",
+    "Description": "old change outside 24h window",
+    "CreatedBy": "alex"
+  }
+]

--- a/examples/ai-integration/testdata/map_orphans.json
+++ b/examples/ai-integration/testdata/map_orphans.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "default/temp-test/apps/Deployment/debug-nginx",
+    "clusterName": "default",
+    "namespace": "temp-test",
+    "kind": "Deployment",
+    "name": "debug-nginx",
+    "apiVersion": "apps/v1",
+    "owner": "Native",
+    "status": "Ready"
+  },
+  {
+    "id": "default/kube-system/apps/Deployment/metrics-server",
+    "clusterName": "default",
+    "namespace": "kube-system",
+    "kind": "Deployment",
+    "name": "metrics-server",
+    "apiVersion": "apps/v1",
+    "owner": "Native",
+    "status": "Ready"
+  },
+  {
+    "id": "default/default//ConfigMap/debug-config",
+    "clusterName": "default",
+    "namespace": "default",
+    "kind": "ConfigMap",
+    "name": "debug-config",
+    "apiVersion": "v1",
+    "owner": "Native",
+    "status": "Ready"
+  }
+]

--- a/examples/ai-integration/testdata/misconfigured-deployment.yaml
+++ b/examples/ai-integration/testdata/misconfigured-deployment.yaml
@@ -1,0 +1,45 @@
+# Misconfigured deployment with intentional issues for testing.
+# Used for testing scan --file with expected exit code 1.
+#
+# Known issues in this file:
+# 1. CCVE-2025-0244: Probe timeout (15s) exceeds period (10s) - warning
+# 2. CCVE-2025-0248: Missing resource limits - warning
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: misconfigured-app
+  namespace: default
+  labels:
+    app: misconfigured
+  # Included finalizer marker used in scanner fixture scenarios
+  finalizers:
+    - orphan.example.com/cleanup
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: misconfigured
+  template:
+    metadata:
+      labels:
+        app: misconfigured
+    spec:
+      containers:
+        - name: app
+          image: nginx:latest
+          ports:
+            - containerPort: 8080
+          # Probe timeout > period - triggers CCVE-2025-0244 (warning)
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 5
+            timeoutSeconds: 10

--- a/examples/ai-integration/testdata/trace_argo_source_signals.json
+++ b/examples/ai-integration/testdata/trace_argo_source_signals.json
@@ -1,0 +1,38 @@
+{
+  "object": {
+    "kind": "Deployment",
+    "name": "checkout",
+    "namespace": "checkout"
+  },
+  "chain": [
+    {
+      "kind": "Source",
+      "name": "acme/checkout",
+      "namespace": "argocd",
+      "ready": false,
+      "status": "OutOfSync (reconciledAt: 2026-03-01T12:34:56Z)",
+      "revision": "main",
+      "url": "https://github.com/acme/checkout",
+      "path": "./apps/checkout",
+      "message": "application sync status is OutOfSync; reconciledAt=2026-03-01T12:34:56Z"
+    },
+    {
+      "kind": "Application",
+      "name": "checkout-app",
+      "namespace": "argocd",
+      "ready": false,
+      "status": "OutOfSync / Healthy",
+      "revision": "abc123"
+    },
+    {
+      "kind": "Deployment",
+      "name": "checkout",
+      "namespace": "checkout",
+      "ready": true,
+      "status": "1/1 ready"
+    }
+  ],
+  "fullyManaged": false,
+  "tool": "ArgoCD",
+  "tracedAt": "2026-03-01T12:35:00Z"
+}

--- a/test/unit/ai_integration_examples_contract_test.go
+++ b/test/unit/ai_integration_examples_contract_test.go
@@ -1,0 +1,37 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAIIntegrationExamplesContract(t *testing.T) {
+	required := []string{
+		filepath.Join("..", "..", "examples", "ai-integration", "README.md"),
+		filepath.Join("..", "..", "examples", "ai-integration", "run-fixture-session.sh"),
+		filepath.Join("..", "..", "examples", "ai-integration", "testdata", "history_changesets.json"),
+		filepath.Join("..", "..", "examples", "ai-integration", "claude-code", "README.md"),
+		filepath.Join("..", "..", "examples", "ai-integration", "claude-code", "mcp.json"),
+		filepath.Join("..", "..", "examples", "ai-integration", "cursor", "README.md"),
+		filepath.Join("..", "..", "examples", "ai-integration", "cursor", "mcp.json"),
+		filepath.Join("..", "..", "examples", "ai-integration", "copilot", "README.md"),
+		filepath.Join("..", "..", "examples", "ai-integration", "copilot", "mcp.json"),
+	}
+
+	for _, p := range required {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("missing required ai-integration artifact %s: %v", p, err)
+		}
+	}
+
+	examplesIndexPath := filepath.Join("..", "..", "examples", "README.md")
+	examplesIndex, err := os.ReadFile(examplesIndexPath)
+	if err != nil {
+		t.Fatalf("read examples index: %v", err)
+	}
+	if !strings.Contains(string(examplesIndex), "ai-integration/") {
+		t.Fatalf("examples index missing ai-integration link in %s", examplesIndexPath)
+	}
+}

--- a/test/unit/ai_integration_fixture_script_test.go
+++ b/test/unit/ai_integration_fixture_script_test.go
@@ -1,0 +1,56 @@
+package unit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAIIntegrationFixtureSessionScript(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	scriptRel := filepath.Join("examples", "ai-integration", "run-fixture-session.sh")
+	if _, err := os.Stat(filepath.Join(repoRoot, scriptRel)); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "cub-scout")
+	outputDir := filepath.Join(tmpDir, "output")
+
+	build := exec.Command("go", "build", "-o", binaryPath, "./cmd/cub-scout")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build cub-scout: %v\n%s", err, string(out))
+	}
+
+	run := exec.Command("bash", scriptRel, "--output-dir", outputDir)
+	run.Dir = repoRoot
+	run.Env = append(os.Environ(), "CUB_SCOUT_BINARY="+binaryPath)
+	out, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fixture script failed: %v\n%s", err, string(out))
+	}
+
+	requiredOutputs := []struct {
+		path    string
+		needle  string
+		section string
+	}{
+		{path: filepath.Join(outputDir, "01-debug-deployment.txt"), needle: "OutOfSync", section: "trace"},
+		{path: filepath.Join(outputDir, "02-change-history.txt"), needle: "Change History", section: "history"},
+		{path: filepath.Join(outputDir, "03-scan-safety.json"), needle: "CCVE-2025-0244", section: "scan"},
+		{path: filepath.Join(outputDir, "04-unmanaged-resources.txt"), needle: "debug-nginx", section: "orphans"},
+	}
+
+	for _, check := range requiredOutputs {
+		data, err := os.ReadFile(check.path)
+		if err != nil {
+			t.Fatalf("read %s output %s: %v", check.section, check.path, err)
+		}
+		if !strings.Contains(string(data), check.needle) {
+			t.Fatalf("%s output missing %q in %s", check.section, check.needle, check.path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #225 by adding a dedicated `examples/ai-integration/` package with per-tool MCP configs and an offline, fixture-backed demo flow.

### What changed

- Added `examples/ai-integration/` with:
  - `claude-code/`, `cursor/`, `copilot/` guides + `mcp.json` configs
  - `claude-code/WALKTHROUGH.md` (blog-ready walkthrough)
  - `run-fixture-session.sh` deterministic scenario runner
  - fixture data for `trace`, `history`, `scan --file`, and `map orphans`
- Added `CUB_SCOUT_TEST_HISTORY_JSON` fixture path in `history` command resolution for deterministic demo/test flows.
  - Normal connected behavior remains unchanged when fixture var is unset.
- Added unit coverage:
  - `TestAIIntegrationExamplesContract`
  - `TestAIIntegrationFixtureSessionScript`
  - `TestRunHistory_UsesFixtureJSONWithoutConnection`
  - `TestRunHistory_FixtureReadError`
- Updated `examples/README.md` to index `ai-integration/`.

## Proof-first workflow evidence

Proof matrix + logs:
- `/tmp/cub-scout-regression/v1.5/issue-225/proof-matrix.md`
- `/tmp/cub-scout-regression/v1.5/issue-225/proof-results.md`

Scoped proof loop (3 consecutive passes):
- `go test ./cmd/cub-scout -run 'TestRunHistory_UsesFixtureJSONWithoutConnection|TestRunHistory_FixtureReadError' -count=1`
- `go test ./test/unit -run 'TestAIIntegrationExamplesContract|TestAIIntegrationFixtureSessionScript' -count=1`

Baseline:
- `go build ./cmd/cub-scout`
- `go test ./cmd/cub-scout ./test/unit -count=1`

Note on full sweep:
- Local `go test ./... -count=1` surfaced an existing golden normalization mismatch in `test/golden/scan-file` (`/private<TEMP_PATH>` vs `<FILE>` placeholder). This is outside this slice and unchanged by this PR.

## Graceful degradation notes

- `history` remains connected-only by default.
- Fixture mode is explicit and opt-in via `CUB_SCOUT_TEST_HISTORY_JSON`.
- Missing/invalid fixture files return clear read/parse errors.

Closes #225.
