### PR TITLE
ai: add run-to-issue evidence capture script and docs

### DIFF
--- a/docs/ai/cub-scout-skill.md
+++ b/docs/ai/cub-scout-skill.md
@@ -101,12 +101,13 @@ When user approves filing a request, capture:
 Then file issue:
 
 ```bash
-./scripts/create-ai-capability-issue.sh \
-  "Capability gap: <short title>" \
-  "<user goal>" \
-  "<commands attempted>" \
-  "<observed gap>" \
-  "<expected behavior>"
+./scripts/run-to-issue-evidence.sh \
+  --title "Capability gap: <short title>" \
+  --goal "<user goal>" \
+  --expected "<expected behavior>" \
+  --impact "<demo/user impact>" \
+  --transcript <failed-session-transcript.txt> \
+  --open
 ```
 
-Or use GitHub template: `AI capability gap`.
+Fallback (manual fields): `./scripts/create-ai-capability-issue.sh ...`

--- a/docs/howto/claude-capability-assistant.md
+++ b/docs/howto/claude-capability-assistant.md
@@ -66,18 +66,29 @@ If the user approves filing a request:
    - actual output
    - expected behavior
    - demo impact
-2. File issue via helper script:
+2. Generate issue-ready draft from transcript:
 
 ```bash
-./scripts/create-ai-capability-issue.sh \
-  "Capability gap: <short title>" \
-  "<user goal>" \
-  "<commands attempted>" \
-  "<observed gap>" \
-  "<expected behavior>"
+./scripts/run-to-issue-evidence.sh \
+  --title "Capability gap: <short title>" \
+  --goal "<user goal>" \
+  --expected "<expected behavior>" \
+  --impact "<demo/user impact>" \
+  --transcript <failed-session-transcript.txt> \
+  --output /tmp/cub-scout-issue-draft.md
 ```
 
-Or use GitHub template: `AI capability gap`.
+3. Optional direct open:
+
+```bash
+./scripts/run-to-issue-evidence.sh \
+  --title "Capability gap: <short title>" \
+  --goal "<user goal>" \
+  --expected "<expected behavior>" \
+  --impact "<demo/user impact>" \
+  --transcript <failed-session-transcript.txt> \
+  --open
+```
 
 ## 5) Response Format for Claude
 

--- a/docs/howto/using-cub-scout-from-ai-tool.md
+++ b/docs/howto/using-cub-scout-from-ai-tool.md
@@ -168,7 +168,31 @@ Capture:
 - expected behavior
 - demo/user impact
 
-File with helper script:
+Generate an issue-ready draft from a failed session transcript:
+
+```bash
+./scripts/run-to-issue-evidence.sh \
+  --title "Capability gap: <short title>" \
+  --goal "<user goal>" \
+  --expected "<expected behavior>" \
+  --impact "<demo/user impact>" \
+  --transcript <failed-session-transcript.txt> \
+  --output /tmp/cub-scout-issue-draft.md
+```
+
+Open directly on GitHub:
+
+```bash
+./scripts/run-to-issue-evidence.sh \
+  --title "Capability gap: <short title>" \
+  --goal "<user goal>" \
+  --expected "<expected behavior>" \
+  --impact "<demo/user impact>" \
+  --transcript <failed-session-transcript.txt> \
+  --open
+```
+
+Fallback (manual fields):
 
 ```bash
 ./scripts/create-ai-capability-issue.sh \
@@ -178,8 +202,6 @@ File with helper script:
   "<observed gap>" \
   "<expected behavior>"
 ```
-
-Or use GitHub issue template: `AI capability gap`.
 
 ## Related Guides
 

--- a/examples/ai-integration/README.md
+++ b/examples/ai-integration/README.md
@@ -48,6 +48,32 @@ Use a custom output directory:
 - [Cursor](cursor/README.md)
 - [GitHub Copilot](copilot/README.md)
 
+## Failed Run -> Issue Draft
+
+When an AI-assisted session fails or is partial, capture an issue-ready draft:
+
+```bash
+./scripts/run-to-issue-evidence.sh \
+  --title "Capability gap: deterministic post-import patch flow" \
+  --goal "Import workloads and produce deterministic patch follow-up" \
+  --expected "A supported command sequence for post-import patch planning" \
+  --impact "Blocks AI-assisted remediation handoff" \
+  --transcript examples/ai-integration/testdata/failed-session.transcript.txt \
+  --output /tmp/cub-scout-issue-draft.md
+```
+
+To open directly on GitHub (requires `gh`):
+
+```bash
+./scripts/run-to-issue-evidence.sh \
+  --title "Capability gap: deterministic post-import patch flow" \
+  --goal "Import workloads and produce deterministic patch follow-up" \
+  --expected "A supported command sequence for post-import patch planning" \
+  --impact "Blocks AI-assisted remediation handoff" \
+  --transcript examples/ai-integration/testdata/failed-session.transcript.txt \
+  --open
+```
+
 ## Notes
 
 - Fixture mode is explicit and opt-in via `CUB_SCOUT_TEST_*` env vars.

--- a/examples/ai-integration/testdata/failed-session.transcript.txt
+++ b/examples/ai-integration/testdata/failed-session.transcript.txt
@@ -1,0 +1,7 @@
+$ ./cub-scout import --dry-run -n payments
+Connected mode: true
+Scanning namespace payments...
+2026-03-06T19:22:01Z ERROR expected follow-up command "patch-plan" not found
+Observed: import preview completed, but no deterministic patch/upgrade continuation path
+Token seen in stderr: github_pat_demo_redacted_example
+/tmp/cub-scout-ai-session-019/output.log

--- a/scripts/run-to-issue-evidence.sh
+++ b/scripts/run-to-issue-evidence.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./scripts/run-to-issue-evidence.sh \
+    --title "<issue-title>" \
+    --goal "<user-goal>" \
+    --expected "<expected-behavior>" \
+    --impact "<demo-or-user-impact>" \
+    --transcript <path> \
+    [--observed "<observed-behavior>"] \
+    [--attempted "<commands-attempted>"] \
+    [--output <issue-body.md>] \
+    [--repo <owner/repo>] \
+    [--open]
+
+Examples:
+  ./scripts/run-to-issue-evidence.sh \
+    --title "Capability gap: import follow-up" \
+    --goal "Import and then generate patch plan" \
+    --expected "Offer deterministic patch-plan command" \
+    --impact "Blocks AI-assisted remediation flow" \
+    --transcript examples/ai-integration/testdata/failed-session.transcript.txt
+
+  ./scripts/run-to-issue-evidence.sh \
+    --title "Capability gap: import follow-up" \
+    --goal "Import and then generate patch plan" \
+    --expected "Offer deterministic patch-plan command" \
+    --impact "Blocks AI-assisted remediation flow" \
+    --transcript examples/ai-integration/testdata/failed-session.transcript.txt \
+    --open
+USAGE
+}
+
+sanitize_stream() {
+  sed -E \
+    -e "s|${HOME}|<HOME>|g" \
+    -e 's|/private/tmp/[^[:space:]]+|<TEMP_PATH>|g' \
+    -e 's|/tmp/[^[:space:]]+|<TEMP_PATH>|g' \
+    -e 's|/var/folders/[^[:space:]]+|<TEMP_PATH>|g' \
+    -e 's|github_pat_[A-Za-z0-9_]+|<REDACTED_TOKEN>|g' \
+    -e 's|ghp_[A-Za-z0-9]+|<REDACTED_TOKEN>|g' \
+    -e 's|Bearer[[:space:]]+[A-Za-z0-9._-]+|Bearer <REDACTED_TOKEN>|g' \
+    -e 's|[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z|<TIMESTAMP>|g'
+}
+
+sanitize_text() {
+  printf '%s\n' "$1" | sanitize_stream
+}
+
+safe_cmd_output() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "unavailable"
+    return
+  fi
+  "$@" 2>/dev/null || echo "unknown"
+}
+
+if [[ "${1:-}" == "--help" || "$#" -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+title=""
+goal=""
+expected=""
+impact=""
+transcript=""
+observed_override=""
+attempted_override=""
+output=""
+repo="confighub/cub-scout"
+open_issue="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      title="${2:-}"
+      shift 2
+      ;;
+    --goal)
+      goal="${2:-}"
+      shift 2
+      ;;
+    --expected)
+      expected="${2:-}"
+      shift 2
+      ;;
+    --impact)
+      impact="${2:-}"
+      shift 2
+      ;;
+    --transcript)
+      transcript="${2:-}"
+      shift 2
+      ;;
+    --observed)
+      observed_override="${2:-}"
+      shift 2
+      ;;
+    --attempted)
+      attempted_override="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --open)
+      open_issue="true"
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$title" || -z "$goal" || -z "$expected" || -z "$impact" || -z "$transcript" ]]; then
+  echo "Missing required flags." >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$transcript" ]]; then
+  echo "Transcript not found: $transcript" >&2
+  exit 1
+fi
+
+if [[ -z "$output" ]]; then
+  output="$(mktemp "${TMPDIR:-/tmp}/run-to-issue-XXXXXX.md")"
+fi
+mkdir -p "$(dirname "$output")"
+
+max_commands=20
+max_observed=20
+max_evidence=80
+
+if [[ -n "$attempted_override" ]]; then
+  attempted="$attempted_override"
+else
+  attempted="$(grep -E '^\$ ' "$transcript" | sed 's/^\$ //' | head -n "$max_commands" || true)"
+fi
+if [[ -z "${attempted// }" ]]; then
+  attempted="(no shell commands detected in transcript)"
+fi
+
+if [[ -n "$observed_override" ]]; then
+  observed="$observed_override"
+else
+  observed="$(grep -Ei 'error|fail|panic|denied|not found|unsupported|timed out|timeout' "$transcript" | head -n "$max_observed" || true)"
+fi
+if [[ -z "${observed// }" ]]; then
+  observed="$(tail -n "$max_observed" "$transcript")"
+fi
+
+evidence_excerpt="$(tail -n "$max_evidence" "$transcript")"
+
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+git_commit="unknown"
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git_commit="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+fi
+kubectl_context="$(safe_cmd_output kubectl kubectl config current-context)"
+cub_scout_version="unknown"
+if [[ -x "./cub-scout" ]]; then
+  cub_scout_version="$(./cub-scout version 2>/dev/null || echo unknown)"
+elif command -v cub-scout >/dev/null 2>&1; then
+  cub_scout_version="$(cub-scout version 2>/dev/null || echo unknown)"
+fi
+
+attempted_clean="$(sanitize_text "$attempted")"
+observed_clean="$(sanitize_text "$observed")"
+expected_clean="$(sanitize_text "$expected")"
+goal_clean="$(sanitize_text "$goal")"
+impact_clean="$(sanitize_text "$impact")"
+transcript_clean="$(sanitize_text "$transcript")"
+generated_clean="$(sanitize_text "$generated_at")"
+git_commit_clean="$(sanitize_text "$git_commit")"
+kubectl_context_clean="$(sanitize_text "$kubectl_context")"
+cub_scout_version_clean="$(sanitize_text "$cub_scout_version")"
+os_clean="$(sanitize_text "$(uname -s)")"
+evidence_clean="$(sanitize_text "$evidence_excerpt")"
+
+cat > "$output" <<ISSUE
+## User Goal
+$goal_clean
+
+## Commands Attempted
+\`\`\`bash
+$attempted_clean
+\`\`\`
+
+## Observed Behavior
+$observed_clean
+
+## Expected Behavior
+$expected_clean
+
+## Demo/User Impact
+$impact_clean
+
+## Evidence
+- Transcript: $transcript_clean
+- Generated at (UTC): $generated_clean
+- Git commit: $git_commit_clean
+- kubectl context: $kubectl_context_clean
+- cub-scout version: $cub_scout_version_clean
+- Host OS: $os_clean
+
+\`\`\`text
+$evidence_clean
+\`\`\`
+ISSUE
+
+printf 'Issue draft written: %s\n' "$output"
+
+if [[ "$open_issue" == "true" ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Cannot open issue: gh CLI not found. Draft is available at $output" >&2
+    exit 1
+  fi
+  gh issue create -R "$repo" --title "$title" --template ai-capability-gap.yml --body-file "$output"
+fi

--- a/test/unit/ai_integration_examples_contract_test.go
+++ b/test/unit/ai_integration_examples_contract_test.go
@@ -12,6 +12,7 @@ func TestAIIntegrationExamplesContract(t *testing.T) {
 		filepath.Join("..", "..", "examples", "ai-integration", "README.md"),
 		filepath.Join("..", "..", "examples", "ai-integration", "run-fixture-session.sh"),
 		filepath.Join("..", "..", "examples", "ai-integration", "testdata", "history_changesets.json"),
+		filepath.Join("..", "..", "examples", "ai-integration", "testdata", "failed-session.transcript.txt"),
 		filepath.Join("..", "..", "examples", "ai-integration", "claude-code", "README.md"),
 		filepath.Join("..", "..", "examples", "ai-integration", "claude-code", "mcp.json"),
 		filepath.Join("..", "..", "examples", "ai-integration", "cursor", "README.md"),

--- a/test/unit/run_to_issue_evidence_script_test.go
+++ b/test/unit/run_to_issue_evidence_script_test.go
@@ -1,0 +1,184 @@
+package unit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunToIssueEvidenceScript_GeneratesSanitizedDraft(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	scriptRel := filepath.Join("scripts", "run-to-issue-evidence.sh")
+	if _, err := os.Stat(filepath.Join(repoRoot, scriptRel)); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	transcriptPath := filepath.Join(tmpDir, "failed-session.txt")
+	outPath := filepath.Join(tmpDir, "issue-draft.md")
+	transcript := strings.Join([]string{
+		"$ ./cub-scout import --dry-run -n payments",
+		"2026-03-06T20:00:00Z ERROR auth failed token github_pat_12345abcdef",
+		"path=/tmp/session-123/output.log",
+		"expected follow-up command unavailable",
+	}, "\n")
+	if err := os.WriteFile(transcriptPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	cmd := exec.Command("bash", scriptRel,
+		"--title", "Capability gap: test",
+		"--goal", "Capture issue-ready evidence",
+		"--expected", "Generate reproducible issue draft",
+		"--impact", "Blocks AI-assisted triage",
+		"--transcript", transcriptPath,
+		"--output", outPath,
+	)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, string(out))
+	}
+
+	draft, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read draft: %v", err)
+	}
+	body := string(draft)
+	if !strings.Contains(body, "## User Goal") {
+		t.Fatalf("draft missing User Goal section:\n%s", body)
+	}
+	if !strings.Contains(body, "## Commands Attempted") {
+		t.Fatalf("draft missing Commands Attempted section:\n%s", body)
+	}
+	if !strings.Contains(body, "./cub-scout import --dry-run -n payments") {
+		t.Fatalf("draft missing extracted command:\n%s", body)
+	}
+	if strings.Contains(body, "github_pat_12345abcdef") {
+		t.Fatalf("draft leaked token:\n%s", body)
+	}
+	if !strings.Contains(body, "<REDACTED_TOKEN>") {
+		t.Fatalf("draft missing token redaction marker:\n%s", body)
+	}
+	if strings.Contains(body, "/tmp/session-123/output.log") {
+		t.Fatalf("draft leaked temp path:\n%s", body)
+	}
+	if !strings.Contains(body, "<TEMP_PATH>") {
+		t.Fatalf("draft missing temp-path redaction marker:\n%s", body)
+	}
+}
+
+func TestRunToIssueEvidenceScript_OpenCallsGh(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	scriptRel := filepath.Join("scripts", "run-to-issue-evidence.sh")
+	if _, err := os.Stat(filepath.Join(repoRoot, scriptRel)); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	transcriptPath := filepath.Join(tmpDir, "failed-session.txt")
+	outPath := filepath.Join(tmpDir, "issue-draft.md")
+	argsLog := filepath.Join(tmpDir, "gh-args.log")
+	bodyCopy := filepath.Join(tmpDir, "gh-body.md")
+
+	if err := os.WriteFile(transcriptPath, []byte("$ ./cub-scout map list\nerror: demo failure\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	mockBinDir := t.TempDir()
+	writeExecutableRunToIssue(t, filepath.Join(mockBinDir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$MOCK_GH_ARGS"
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--body-file" ]]; then
+    cp "$2" "$MOCK_GH_BODY"
+    break
+  fi
+  shift
+done
+echo "https://github.com/confighub/cub-scout/issues/999"
+`)
+
+	cmd := exec.Command("bash", scriptRel,
+		"--title", "Capability gap: open",
+		"--goal", "Capture and open",
+		"--expected", "Issue created",
+		"--impact", "Demo blocked",
+		"--transcript", transcriptPath,
+		"--output", outPath,
+		"--open",
+		"--repo", "confighub/cub-scout",
+	)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"MOCK_GH_ARGS="+argsLog,
+		"MOCK_GH_BODY="+bodyCopy,
+		"PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, string(out))
+	}
+
+	argsRaw, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read gh args log: %v", err)
+	}
+	args := string(argsRaw)
+	if !strings.Contains(args, "issue create") {
+		t.Fatalf("gh args missing issue create:\n%s", args)
+	}
+	if !strings.Contains(args, "--template ai-capability-gap.yml") {
+		t.Fatalf("gh args missing template:\n%s", args)
+	}
+	if !strings.Contains(args, "-R confighub/cub-scout") {
+		t.Fatalf("gh args missing repo:\n%s", args)
+	}
+
+	bodyRaw, err := os.ReadFile(bodyCopy)
+	if err != nil {
+		t.Fatalf("read gh body copy: %v", err)
+	}
+	body := string(bodyRaw)
+	if !strings.Contains(body, "## Evidence") {
+		t.Fatalf("body missing evidence section:\n%s", body)
+	}
+	if !strings.Contains(string(out), "https://github.com/confighub/cub-scout/issues/999") {
+		t.Fatalf("stdout missing mocked issue url:\n%s", string(out))
+	}
+}
+
+func TestRunToIssueEvidenceScript_RequiresFlags(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	scriptRel := filepath.Join("scripts", "run-to-issue-evidence.sh")
+	if _, err := os.Stat(filepath.Join(repoRoot, scriptRel)); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	cmd := exec.Command("bash", scriptRel, "--title", "x")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected script to fail on missing required flags:\n%s", string(out))
+	}
+	if !strings.Contains(string(out), "Usage:") {
+		t.Fatalf("expected usage output, got:\n%s", string(out))
+	}
+}
+
+func writeExecutableRunToIssue(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		mode = 0o644
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #217 with a deterministic run-to-issue capture flow for failed AI sessions.

### What changed

- Added `scripts/run-to-issue-evidence.sh`:
  - captures transcript-derived `commands attempted` and `observed behavior`
  - records environment/context (`git commit`, `kubectl context`, `cub-scout version`, host OS)
  - sanitizes sensitive/unstable content (tokens, temp paths, RFC3339 timestamps)
  - emits issue-template-compatible Markdown draft
  - supports `--open` to call `gh issue create` directly
- Added example failed-session transcript fixture:
  - `examples/ai-integration/testdata/failed-session.transcript.txt`
- Updated docs and AI skill references to use run-to-issue flow first:
  - `docs/howto/using-cub-scout-from-ai-tool.md`
  - `docs/howto/claude-capability-assistant.md`
  - `docs/ai/cub-scout-skill.md`
  - `examples/ai-integration/README.md`
- Added unit coverage:
  - `TestRunToIssueEvidenceScript_GeneratesSanitizedDraft`
  - `TestRunToIssueEvidenceScript_OpenCallsGh`
  - `TestRunToIssueEvidenceScript_RequiresFlags`
  - Updated `TestAIIntegrationExamplesContract` to require failed-session fixture

## Proof-first evidence

Proof logs:
- `/tmp/cub-scout-regression/v1.5/issue-217/proof-matrix.md`
- `/tmp/cub-scout-regression/v1.5/issue-217/proof-results.md`

Scoped proof loop (3 consecutive passes):
- `go test ./test/unit -run 'TestRunToIssueEvidenceScript_' -count=1`
- `go test ./test/unit -run 'TestAIIntegrationExamplesContract' -count=1`

Baseline:
- `go build ./cmd/cub-scout`
- `go test ./test/unit -count=1`

## Contract notes

- Draft generation is bounded and deterministic:
  - commands attempted: max 20 lines
  - observed behavior: max 20 lines
  - evidence excerpt: max 80 lines
- If `--open` is used without `gh`, script fails clearly after draft write.
- If `kubectl`/`git`/`cub-scout` context is unavailable, fields degrade to `unknown`/`unavailable`.

Closes #217.
