### PR TITLE
ai: add context-pack v2 command for deterministic AI evidence

### DIFF
--- a/cmd/cub-scout/context_pack.go
+++ b/cmd/cub-scout/context_pack.go
@@ -1,0 +1,316 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/internal/scan"
+	"github.com/spf13/cobra"
+)
+
+var (
+	contextPackNamespace string
+	contextPackFormat    string
+	contextPackTopRisks  int
+	contextPackTraceN    int
+	contextPackMaxBytes  int
+	contextPackNowFn     = time.Now
+)
+
+var contextPackCmd = &cobra.Command{
+	Use:   "context-pack",
+	Short: "Export deterministic AI context-pack JSON (v2)",
+	Long: `Export a compact, model-agnostic Kubernetes evidence bundle for AI handoffs.
+
+The pack includes ownership summary, top risks, trace seeds, and command evidence references.
+`,
+	RunE: runContextPack,
+}
+
+func init() {
+	rootCmd.AddCommand(contextPackCmd)
+	contextPackCmd.Flags().StringVarP(&contextPackNamespace, "namespace", "n", "", "Namespace scope (default: all namespaces)")
+	contextPackCmd.Flags().StringVar(&contextPackFormat, "format", "json", "Output format (json)")
+	contextPackCmd.Flags().IntVar(&contextPackTopRisks, "top-risks", 5, "Number of risk issues to include")
+	contextPackCmd.Flags().IntVar(&contextPackTraceN, "trace-seeds", 5, "Number of trace seed resources to include")
+	contextPackCmd.Flags().IntVar(&contextPackMaxBytes, "max-bytes", 16384, "Maximum JSON output size in bytes")
+}
+
+type contextPackV2 struct {
+	Version          string                   `json:"version"`
+	GeneratedAt      string                   `json:"generatedAt"`
+	Cluster          string                   `json:"cluster"`
+	Namespace        string                   `json:"namespace"`
+	Provenance       contextPackProvenance    `json:"provenance"`
+	OwnershipSummary DoctorOwnershipSummary   `json:"ownershipSummary"`
+	TopRisks         []DoctorIssue            `json:"topRisks"`
+	TraceSeeds       []contextPackTraceSeed   `json:"traceSeeds"`
+	CommandEvidence  []contextPackCommandHint `json:"commandEvidence"`
+	Truncated        bool                     `json:"truncated"`
+	SizeBytes        int                      `json:"sizeBytes"`
+}
+
+type contextPackProvenance struct {
+	Source        string `json:"source"`
+	Deterministic bool   `json:"deterministic"`
+	Confidence    string `json:"confidence"`
+}
+
+type contextPackTraceSeed struct {
+	Kind         string `json:"kind"`
+	Name         string `json:"name"`
+	Namespace    string `json:"namespace"`
+	Owner        string `json:"owner"`
+	Status       string `json:"status"`
+	Confidence   string `json:"confidence"`
+	TraceCommand string `json:"traceCommand"`
+}
+
+type contextPackCommandHint struct {
+	Command string `json:"command"`
+	Purpose string `json:"purpose"`
+}
+
+type contextPackInput struct {
+	Cluster   string                   `json:"cluster"`
+	Namespace string                   `json:"namespace"`
+	Entries   []MapEntry               `json:"entries"`
+	Findings  []scan.NormalizedFinding `json:"findings"`
+}
+
+func runContextPack(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(contextPackFormat))
+	if format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: json)", contextPackFormat)
+	}
+	if contextPackTopRisks < 0 {
+		return fmt.Errorf("--top-risks must be >= 0")
+	}
+	if contextPackTraceN < 0 {
+		return fmt.Errorf("--trace-seeds must be >= 0")
+	}
+	if contextPackMaxBytes <= 0 {
+		return fmt.Errorf("--max-bytes must be > 0")
+	}
+
+	input, source, err := loadContextPackInput(cmd.Context(), strings.TrimSpace(contextPackNamespace))
+	if err != nil {
+		return err
+	}
+
+	namespace := "all"
+	if strings.TrimSpace(contextPackNamespace) != "" {
+		namespace = strings.TrimSpace(contextPackNamespace)
+	} else if strings.TrimSpace(input.Namespace) != "" {
+		namespace = strings.TrimSpace(input.Namespace)
+	}
+
+	cluster := strings.TrimSpace(input.Cluster)
+	if cluster == "" {
+		cluster = getClusterName()
+	}
+
+	now := contextPackNowFn().UTC()
+	if raw := strings.TrimSpace(os.Getenv("CUB_SCOUT_TEST_TIME")); raw != "" {
+		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+			now = parsed.UTC()
+		}
+	}
+
+	summary := buildDoctorSummary(input.Entries, input.Findings, cluster, namespace, contextPackTopRisks)
+	pack := contextPackV2{
+		Version:          "v2",
+		GeneratedAt:      now.Format(time.RFC3339),
+		Cluster:          cluster,
+		Namespace:        namespace,
+		OwnershipSummary: summary.Ownership,
+		TopRisks:         summary.TopIssues,
+		TraceSeeds:       buildContextPackTraceSeeds(input.Entries, contextPackTraceN),
+		CommandEvidence:  buildContextPackCommandHints(namespace),
+		Provenance: contextPackProvenance{
+			Source:        source,
+			Deterministic: source == "fixture",
+			Confidence:    contextPackConfidence(source),
+		},
+	}
+
+	pack, payload, err := applyContextPackSizeLimit(pack, contextPackMaxBytes)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stdout.Write(payload); err != nil {
+		return err
+	}
+	if len(payload) == 0 || payload[len(payload)-1] != '\n' {
+		fmt.Println()
+	}
+	_ = pack
+	return nil
+}
+
+func loadContextPackInput(ctx context.Context, namespace string) (contextPackInput, string, error) {
+	if fixturePath := strings.TrimSpace(os.Getenv("CUB_SCOUT_TEST_CONTEXT_PACK_INPUT_JSON")); fixturePath != "" {
+		var in contextPackInput
+		b, err := os.ReadFile(fixturePath)
+		if err != nil {
+			return contextPackInput{}, "", fmt.Errorf("read context-pack fixture: %w", err)
+		}
+		if err := json.Unmarshal(b, &in); err != nil {
+			return contextPackInput{}, "", fmt.Errorf("parse context-pack fixture: %w", err)
+		}
+		return in, "fixture", nil
+	}
+
+	entries, cluster, err := collectDoctorEntries(ctx, namespace)
+	if err != nil {
+		return contextPackInput{}, "", withKubeRecoveryHint(err, "cub-scout context-pack")
+	}
+
+	findings, err := collectDoctorFindings(ctx, namespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Note: context-pack risk scan unavailable: %v\n", err)
+		findings = nil
+	}
+
+	return contextPackInput{
+		Cluster:   cluster,
+		Namespace: namespace,
+		Entries:   entries,
+		Findings:  findings,
+	}, "cluster", nil
+}
+
+func buildContextPackTraceSeeds(entries []MapEntry, limit int) []contextPackTraceSeed {
+	if limit <= 0 {
+		return nil
+	}
+	items := append([]MapEntry(nil), entries...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Namespace != items[j].Namespace {
+			return items[i].Namespace < items[j].Namespace
+		}
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].Name < items[j].Name
+	})
+
+	out := make([]contextPackTraceSeed, 0, limit)
+	for _, e := range items {
+		if strings.TrimSpace(e.Kind) == "" || strings.TrimSpace(e.Name) == "" {
+			continue
+		}
+		ns := strings.TrimSpace(e.Namespace)
+		nsFlag := ""
+		if ns != "" {
+			nsFlag = " -n " + ns
+		}
+		kind := strings.ToLower(strings.TrimSpace(e.Kind))
+		out = append(out, contextPackTraceSeed{
+			Kind:         e.Kind,
+			Name:         e.Name,
+			Namespace:    e.Namespace,
+			Owner:        e.Owner,
+			Status:       e.Status,
+			Confidence:   contextPackSeedConfidence(e.Owner),
+			TraceCommand: fmt.Sprintf("cub-scout trace %s/%s%s", kind, e.Name, nsFlag),
+		})
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+func buildContextPackCommandHints(namespace string) []contextPackCommandHint {
+	nsFlag := ""
+	if strings.TrimSpace(namespace) != "" && namespace != "all" {
+		nsFlag = " -n " + strings.TrimSpace(namespace)
+	}
+	return []contextPackCommandHint{
+		{
+			Command: fmt.Sprintf("cub-scout map list --json%s", nsFlag),
+			Purpose: "ownership and inventory baseline",
+		},
+		{
+			Command: fmt.Sprintf("cub-scout scan --json%s", nsFlag),
+			Purpose: "risk findings and severity summary",
+		},
+		{
+			Command: fmt.Sprintf("cub-scout doctor --format json%s", nsFlag),
+			Purpose: "compact health + ownership + risk summary",
+		},
+	}
+}
+
+func contextPackSeedConfidence(owner string) string {
+	switch strings.TrimSpace(owner) {
+	case "Flux", "ArgoCD", "Helm":
+		return "high"
+	case "Native":
+		return "low"
+	default:
+		return "medium"
+	}
+}
+
+func contextPackConfidence(source string) string {
+	switch source {
+	case "fixture":
+		return "high"
+	case "cluster":
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func applyContextPackSizeLimit(pack contextPackV2, maxBytes int) (contextPackV2, []byte, error) {
+	if maxBytes <= 0 {
+		return contextPackV2{}, nil, fmt.Errorf("maxBytes must be > 0")
+	}
+
+	marshal := func(p contextPackV2) ([]byte, error) {
+		return json.MarshalIndent(p, "", "  ")
+	}
+
+	payload, err := marshal(pack)
+	if err != nil {
+		return contextPackV2{}, nil, err
+	}
+
+	for len(payload) > maxBytes && (len(pack.TopRisks) > 0 || len(pack.TraceSeeds) > 0) {
+		if len(pack.TopRisks) >= len(pack.TraceSeeds) && len(pack.TopRisks) > 0 {
+			pack.TopRisks = pack.TopRisks[:len(pack.TopRisks)-1]
+		} else if len(pack.TraceSeeds) > 0 {
+			pack.TraceSeeds = pack.TraceSeeds[:len(pack.TraceSeeds)-1]
+		}
+		pack.Truncated = true
+		payload, err = marshal(pack)
+		if err != nil {
+			return contextPackV2{}, nil, err
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		pack.SizeBytes = len(payload)
+		payload, err = marshal(pack)
+		if err != nil {
+			return contextPackV2{}, nil, err
+		}
+	}
+
+	if len(payload) > maxBytes {
+		return contextPackV2{}, nil, fmt.Errorf("context-pack cannot fit within --max-bytes=%d", maxBytes)
+	}
+	return pack, payload, nil
+}

--- a/cmd/cub-scout/context_pack_test.go
+++ b/cmd/cub-scout/context_pack_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/internal/scan"
+	"github.com/spf13/cobra"
+)
+
+func TestContextPackCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "context-pack" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("context-pack command is not registered on rootCmd")
+	}
+}
+
+func TestBuildContextPackTraceSeeds_DeterministicOrder(t *testing.T) {
+	entries := []MapEntry{
+		{Kind: "Deployment", Name: "checkout", Namespace: "prod", Owner: "Flux", Status: "Ready"},
+		{Kind: "Deployment", Name: "api", Namespace: "prod", Owner: "Native", Status: "NotReady"},
+		{Kind: "Application", Name: "payments", Namespace: "argocd", Owner: "ArgoCD", Status: "OutOfSync"},
+	}
+
+	got := buildContextPackTraceSeeds(entries, 2)
+	if len(got) != 2 {
+		t.Fatalf("seed count = %d, want 2", len(got))
+	}
+	if got[0].Kind != "Application" || got[0].Name != "payments" {
+		t.Fatalf("unexpected first seed ordering: %+v", got[0])
+	}
+	if got[0].Confidence != "high" {
+		t.Fatalf("seed confidence = %q, want high", got[0].Confidence)
+	}
+	if !strings.Contains(got[1].TraceCommand, "cub-scout trace deployment/") {
+		t.Fatalf("unexpected trace command: %q", got[1].TraceCommand)
+	}
+}
+
+func TestApplyContextPackSizeLimit_Truncates(t *testing.T) {
+	pack := contextPackV2{
+		Version:     "v2",
+		GeneratedAt: "2026-03-06T20:00:00Z",
+		Cluster:     "kind-dev",
+		Namespace:   "all",
+		TopRisks: []DoctorIssue{
+			{Severity: "CRITICAL", Resource: "deploy/a", Namespace: "prod", Message: strings.Repeat("x", 80)},
+			{Severity: "WARNING", Resource: "deploy/b", Namespace: "prod", Message: strings.Repeat("y", 80)},
+		},
+		TraceSeeds: []contextPackTraceSeed{
+			{Kind: "Deployment", Name: "a", Namespace: "prod", TraceCommand: "cub-scout trace deployment/a -n prod"},
+			{Kind: "Deployment", Name: "b", Namespace: "prod", TraceCommand: "cub-scout trace deployment/b -n prod"},
+		},
+	}
+
+	got, payload, err := applyContextPackSizeLimit(pack, 650)
+	if err != nil {
+		t.Fatalf("applyContextPackSizeLimit error = %v", err)
+	}
+	if len(payload) > 650 {
+		t.Fatalf("payload size = %d, want <= 650", len(payload))
+	}
+	if !got.Truncated {
+		t.Fatalf("expected truncated=true when limiting payload")
+	}
+}
+
+func TestRunContextPack_FromFixtureJSON(t *testing.T) {
+	restore := withContextPackFlagsForTest()
+	defer restore()
+
+	fixture := contextPackInput{
+		Cluster: "kind-dev",
+		Entries: []MapEntry{
+			{Kind: "Deployment", Name: "checkout", Namespace: "prod", Owner: "Flux", Status: "Ready"},
+			{Kind: "Deployment", Name: "debug-shell", Namespace: "prod", Owner: "Native", Status: "NotReady"},
+		},
+		Findings: []scan.NormalizedFinding{
+			{Severity: "critical", Resource: "Deployment/checkout", Namespace: "prod", Message: "missing limits"},
+			{Severity: "warning", Resource: "Deployment/debug-shell", Namespace: "prod", Message: "no probes"},
+		},
+	}
+	fixturePath := filepath.Join(t.TempDir(), "context-pack-input.json")
+	raw, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, raw, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Setenv("CUB_SCOUT_TEST_CONTEXT_PACK_INPUT_JSON", fixturePath)
+	t.Setenv("CUB_SCOUT_TEST_TIME", "2026-03-06T20:30:00Z")
+
+	contextPackFormat = "json"
+	contextPackNamespace = ""
+	contextPackTopRisks = 2
+	contextPackTraceN = 2
+	contextPackMaxBytes = 4096
+	contextPackNowFn = func() time.Time { return time.Date(2026, 3, 6, 20, 30, 0, 0, time.UTC) }
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	out := captureStdout(t, func() {
+		if err := runContextPack(cmd, nil); err != nil {
+			t.Fatalf("runContextPack() error = %v", err)
+		}
+	})
+
+	var payload contextPackV2
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode context-pack json: %v\n%s", err, out)
+	}
+
+	if payload.Version != "v2" {
+		t.Fatalf("version = %q, want v2", payload.Version)
+	}
+	if payload.Cluster != "kind-dev" {
+		t.Fatalf("cluster = %q, want kind-dev", payload.Cluster)
+	}
+	if payload.OwnershipSummary.Flux != 1 || payload.OwnershipSummary.Native != 1 {
+		t.Fatalf("unexpected ownership summary: %+v", payload.OwnershipSummary)
+	}
+	if len(payload.TopRisks) != 2 {
+		t.Fatalf("topRisks len = %d, want 2", len(payload.TopRisks))
+	}
+	if len(payload.TraceSeeds) != 2 {
+		t.Fatalf("traceSeeds len = %d, want 2", len(payload.TraceSeeds))
+	}
+	if payload.SizeBytes <= 0 {
+		t.Fatalf("sizeBytes = %d, want > 0", payload.SizeBytes)
+	}
+}
+
+func withContextPackFlagsForTest() func() {
+	prevNamespace := contextPackNamespace
+	prevFormat := contextPackFormat
+	prevTopRisks := contextPackTopRisks
+	prevTraceN := contextPackTraceN
+	prevMaxBytes := contextPackMaxBytes
+	prevNowFn := contextPackNowFn
+
+	contextPackNamespace = ""
+	contextPackFormat = "json"
+	contextPackTopRisks = 5
+	contextPackTraceN = 5
+	contextPackMaxBytes = 16384
+	contextPackNowFn = time.Now
+
+	return func() {
+		contextPackNamespace = prevNamespace
+		contextPackFormat = prevFormat
+		contextPackTopRisks = prevTopRisks
+		contextPackTraceN = prevTraceN
+		contextPackMaxBytes = prevMaxBytes
+		contextPackNowFn = prevNowFn
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ New to cub-scout? Start here:
 | Using cub-scout from an AI tool | [howto/using-cub-scout-from-ai-tool.md](howto/using-cub-scout-from-ai-tool.md) |
 | Claude capability assistant | [howto/claude-capability-assistant.md](howto/claude-capability-assistant.md) |
 | AI ask-mode safety contract | [howto/ai-ask-mode-contract.md](howto/ai-ask-mode-contract.md) |
+| Context-pack v2 for AI handoffs | [howto/context-pack-v2.md](howto/context-pack-v2.md) |
 
 ---
 

--- a/docs/howto/context-pack-v2.md
+++ b/docs/howto/context-pack-v2.md
@@ -1,0 +1,43 @@
+# Context-Pack v2 for AI Handoffs
+
+Use `context-pack` when you need one deterministic JSON payload for AI-assisted investigation.
+
+## Command
+
+```bash
+./cub-scout context-pack --format json
+```
+
+## Common usage
+
+All namespaces, bounded payload:
+
+```bash
+./cub-scout context-pack --format json --max-bytes 16384 > /tmp/context-pack.json
+```
+
+Namespace-scoped, tighter risk/trace focus:
+
+```bash
+./cub-scout context-pack -n payments --top-risks 3 --trace-seeds 3 --max-bytes 8192 --format json
+```
+
+## Output model (v2)
+
+The pack includes:
+- ownership summary
+- top risks
+- trace seed commands
+- command evidence references
+- provenance + confidence markers
+- truncation/size metadata for bounded payloads
+
+## Deterministic fixture mode
+
+For tests and reproducible demos:
+
+```bash
+CUB_SCOUT_TEST_CONTEXT_PACK_INPUT_JSON=test/ascii/context-pack/testdata/basic_input.json \
+CUB_SCOUT_TEST_TIME=2026-03-06T20:30:00Z \
+./cub-scout context-pack --format json
+```

--- a/test/ascii/context-pack/basic.json.golden
+++ b/test/ascii/context-pack/basic.json.golden
@@ -1,0 +1,84 @@
+{
+  "version": "v2",
+  "generatedAt": "<TIMESTAMP>",
+  "cluster": "kind-dev",
+  "namespace": "prod",
+  "provenance": {
+    "source": "fixture",
+    "deterministic": true,
+    "confidence": "high"
+  },
+  "ownershipSummary": {
+    "flux": 1,
+    "argocd": 1,
+    "helm": 0,
+    "native": 1,
+    "other": 0,
+    "unmanaged": 1
+  },
+  "topRisks": [
+    {
+      "severity": "CRITICAL",
+      "resource": "Deployment/checkout",
+      "namespace": "prod",
+      "message": "missing resource limits"
+    },
+    {
+      "severity": "WARNING",
+      "resource": "Deployment/debug-shell",
+      "namespace": "prod",
+      "message": "no probes configured"
+    },
+    {
+      "severity": "INFO",
+      "resource": "Application/payments",
+      "namespace": "argocd",
+      "message": "sync lag observed"
+    }
+  ],
+  "traceSeeds": [
+    {
+      "kind": "Application",
+      "name": "payments",
+      "namespace": "argocd",
+      "owner": "ArgoCD",
+      "status": "OutOfSync",
+      "confidence": "high",
+      "traceCommand": "cub-scout trace application/payments -n argocd"
+    },
+    {
+      "kind": "Deployment",
+      "name": "checkout",
+      "namespace": "prod",
+      "owner": "Flux",
+      "status": "Ready",
+      "confidence": "high",
+      "traceCommand": "cub-scout trace deployment/checkout -n prod"
+    },
+    {
+      "kind": "Deployment",
+      "name": "debug-shell",
+      "namespace": "prod",
+      "owner": "Native",
+      "status": "NotReady",
+      "confidence": "low",
+      "traceCommand": "cub-scout trace deployment/debug-shell -n prod"
+    }
+  ],
+  "commandEvidence": [
+    {
+      "command": "cub-scout map list --json -n prod",
+      "purpose": "ownership and inventory baseline"
+    },
+    {
+      "command": "cub-scout scan --json -n prod",
+      "purpose": "risk findings and severity summary"
+    },
+    {
+      "command": "cub-scout doctor --format json -n prod",
+      "purpose": "compact health + ownership + risk summary"
+    }
+  ],
+  "truncated": false,
+  "sizeBytes": 2009
+}

--- a/test/ascii/context-pack/testdata/basic_input.json
+++ b/test/ascii/context-pack/testdata/basic_input.json
@@ -1,0 +1,56 @@
+{
+  "cluster": "kind-dev",
+  "namespace": "prod",
+  "entries": [
+    {
+      "id": "default/prod/apps/Deployment/checkout",
+      "clusterName": "kind-dev",
+      "namespace": "prod",
+      "kind": "Deployment",
+      "name": "checkout",
+      "apiVersion": "apps/v1",
+      "owner": "Flux",
+      "status": "Ready"
+    },
+    {
+      "id": "default/prod/apps/Deployment/debug-shell",
+      "clusterName": "kind-dev",
+      "namespace": "prod",
+      "kind": "Deployment",
+      "name": "debug-shell",
+      "apiVersion": "apps/v1",
+      "owner": "Native",
+      "status": "NotReady"
+    },
+    {
+      "id": "default/argocd/argoproj.io/Application/payments",
+      "clusterName": "kind-dev",
+      "namespace": "argocd",
+      "kind": "Application",
+      "name": "payments",
+      "apiVersion": "argoproj.io/v1alpha1",
+      "owner": "ArgoCD",
+      "status": "OutOfSync"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "critical",
+      "resource": "Deployment/checkout",
+      "namespace": "prod",
+      "message": "missing resource limits"
+    },
+    {
+      "severity": "warning",
+      "resource": "Deployment/debug-shell",
+      "namespace": "prod",
+      "message": "no probes configured"
+    },
+    {
+      "severity": "info",
+      "resource": "Application/payments",
+      "namespace": "argocd",
+      "message": "sync lag observed"
+    }
+  ]
+}

--- a/test/ascii/context_pack_test.go
+++ b/test/ascii/context_pack_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package ascii_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/confighub/cub-scout/test/ascii/golden"
+	"github.com/confighub/cub-scout/test/ascii/runner"
+)
+
+func TestContextPack_FormatJSON(t *testing.T) {
+	repoRoot := runner.RepoRoot(t)
+	fixtureAbs := filepath.Join(repoRoot, "test", "ascii", "context-pack", "testdata", "basic_input.json")
+
+	out := runner.RunWithEnv(t, repoRoot,
+		map[string]string{
+			"CUB_SCOUT_TEST_CONTEXT_PACK_INPUT_JSON": fixtureAbs,
+			"CUB_SCOUT_TEST_TIME":                    "2026-03-06T20:30:00Z",
+		},
+		"context-pack", "--format", "json", "--top-risks", "3", "--trace-seeds", "3", "--max-bytes", "8192",
+	)
+
+	goldenPath := filepath.Join(repoRoot, "test", "ascii", "context-pack", "basic.json.golden")
+	golden.AssertGolden(t, out, goldenPath)
+}


### PR DESCRIPTION
## Summary

Implements issue #212 with a new `context-pack` command (v2) that exports deterministic, bounded JSON evidence for AI-assisted workflows.

### What changed

- Added `cub-scout context-pack` command:
  - `--format json` (v2 model)
  - `--namespace/-n`
  - `--top-risks`
  - `--trace-seeds`
  - `--max-bytes` (bounded output)
- Context-pack v2 includes:
  - provenance + confidence markers
  - ownership summary
  - top risks
  - trace seeds with ready-to-run trace commands
  - command evidence references
  - truncation and payload size metadata
- Added deterministic fixture mode:
  - `CUB_SCOUT_TEST_CONTEXT_PACK_INPUT_JSON`
- Added tests:
  - `cmd/cub-scout/context_pack_test.go`
  - `test/ascii/context_pack_test.go`
  - JSON golden: `test/ascii/context-pack/basic.json.golden`
- Added docs:
  - `docs/howto/context-pack-v2.md`
  - linked from `docs/README.md`

## Proof-first evidence

Proof logs:
- `/tmp/cub-scout-regression/v1.5/issue-212/proof-matrix.md`
- `/tmp/cub-scout-regression/v1.5/issue-212/proof-results.md`

Scoped proof loop (3 consecutive passes):
- `go test ./cmd/cub-scout -run 'TestContextPack' -count=1`
- `go test ./test/ascii -run TestContextPack_FormatJSON -count=1`

Final pass after docs update:
- same command pair rerun (pass)

Baseline:
- `go build ./cmd/cub-scout`
- `go test ./cmd/cub-scout ./test/ascii -count=1`

## Contract notes

- Output is bounded by `--max-bytes` with deterministic truncation of `topRisks` and `traceSeeds`.
- For a fixed fixture input and fixed test time, output is deterministic.
- Cluster-mode scan failures degrade gracefully (warning + partial pack) instead of hard-failing.

Closes #212.
