### PR TITLE
demo: persist keep-mode worker lifecycle and optional history seeding

### DIFF
--- a/examples/argo-import-confighub-demo/README.md
+++ b/examples/argo-import-confighub-demo/README.md
@@ -16,6 +16,9 @@ ArgoCD's scope.
 # Full pipeline including ConfigHub import (~6 min, requires cub auth)
 ./demo.sh --live
 
+# Full pipeline + seeded synthetic history (demo storytelling)
+./demo.sh --live --seed-history
+
 # Keep cluster running for interactive exploration
 ./demo.sh --keep
 
@@ -36,6 +39,10 @@ Optional (demo storytelling only): seed tagged synthetic ChangeSet history.
 ```bash
 ../scripts/seed-connected-demo-history.sh --space argo-import-demo --allow-synthetic --apply
 ```
+
+When `--keep` is used with `--live`, the demo leaves the discovery worker
+running and prints a `demo-worker-lifecycle.sh stop --pid-file ...` command so
+connected state is preserved for extended sessions.
 
 ## Prerequisites
 

--- a/examples/argo-import-confighub-demo/demo.sh
+++ b/examples/argo-import-confighub-demo/demo.sh
@@ -10,6 +10,7 @@
 #   ./demo.sh --live         # Full import into ConfigHub (~6 min, requires cub auth)
 #   ./demo.sh --keep         # Keep cluster running for exploration
 #   ./demo.sh --live --keep  # Import + keep cluster
+#   ./demo.sh --live --seed-history  # Also seed tagged synthetic ChangeSet history
 #   ./demo.sh --live --confighub-url=http://localhost:9090  # Local dev override
 #
 # Prerequisites: docker, kind, kubectl, go
@@ -26,14 +27,21 @@ ARGOCD_VERSION="v3.3.2"
 ARGOCD_INSTALL_URL="https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml"
 KEEP=false
 LIVE=false
+SEED_HISTORY=false
 CONFIGHUB_URL_OVERRIDE=""
 WORKER_PID=""
 PORT_FORWARD_PID=""
+WORKER_LIFECYCLE_SCRIPT="$SCRIPT_DIR/../scripts/demo-worker-lifecycle.sh"
+VERIFY_CONNECTED_SCRIPT="$SCRIPT_DIR/../scripts/verify-connected-demo.sh"
+SEED_HISTORY_SCRIPT="$SCRIPT_DIR/../scripts/seed-connected-demo-history.sh"
+DISCOVERY_WORKER_PID_FILE=""
+DISCOVERY_WORKER_LOG=""
 
 for arg in "$@"; do
     case "$arg" in
         --keep) KEEP=true ;;
         --live) LIVE=true ;;
+        --seed-history) SEED_HISTORY=true ;;
         --confighub-url=*) CONFIGHUB_URL_OVERRIDE="${arg#*=}" ;;
     esac
 done
@@ -68,10 +76,17 @@ cleanup() {
         kill "$PORT_FORWARD_PID" 2>/dev/null || true
         wait "$PORT_FORWARD_PID" 2>/dev/null || true
     fi
-    if [[ -n "$WORKER_PID" ]]; then
-        kill "$WORKER_PID" 2>/dev/null || true
-        wait "$WORKER_PID" 2>/dev/null || true
-        step "Worker stopped"
+    if [[ -n "$DISCOVERY_WORKER_PID_FILE" ]]; then
+        if $KEEP; then
+            bash "$WORKER_LIFECYCLE_SCRIPT" cleanup --pid-file "$DISCOVERY_WORKER_PID_FILE" --keep >/dev/null 2>&1 || true
+            step "Discovery worker left running"
+            if [[ -n "$DISCOVERY_WORKER_LOG" ]]; then
+                note "Discovery worker log: $DISCOVERY_WORKER_LOG"
+            fi
+        else
+            bash "$WORKER_LIFECYCLE_SCRIPT" cleanup --pid-file "$DISCOVERY_WORKER_PID_FILE" >/dev/null 2>&1 || true
+            step "Discovery worker stopped"
+        fi
     fi
     if $KEEP; then
         warn "Cluster '$CLUSTER_NAME' kept running. Delete with: kind delete cluster --name $CLUSTER_NAME"
@@ -125,6 +140,12 @@ if $LIVE; then
         fail "Could not determine ConfigHub URL. Set CONFIGHUB_URL or use --confighub-url=<url>"
         exit 1
     fi
+    for helper in "$WORKER_LIFECYCLE_SCRIPT" "$VERIFY_CONNECTED_SCRIPT" "$SEED_HISTORY_SCRIPT"; do
+        if [[ ! -f "$helper" ]]; then
+            fail "Missing helper script: $helper"
+            exit 1
+        fi
+    done
     step "ConfigHub: $CONFIGHUB_SERVER_URL"
     step "Auth OK (cub, curl, python3 present)"
 fi
@@ -301,6 +322,11 @@ if $LIVE; then
 
     SPACE="argo-import-demo"
     KUBE_CONTEXT=$(kubectl config current-context)
+    DISCOVERY_WORKER_SLUG="discovery-worker"
+    WORKER_STATE_DIR="${TMPDIR:-/tmp}/cub-scout-demo-workers"
+    mkdir -p "$WORKER_STATE_DIR"
+    DISCOVERY_WORKER_PID_FILE="$WORKER_STATE_DIR/${SPACE}-${DISCOVERY_WORKER_SLUG}.pid"
+    DISCOVERY_WORKER_LOG="$WORKER_STATE_DIR/${SPACE}-${DISCOVERY_WORKER_SLUG}.log"
 
     # Get ArgoCD auth token
     step "Getting ArgoCD auth token..."
@@ -337,11 +363,21 @@ if $LIVE; then
         step "Creating ConfigHub space '$SPACE'..."
         cub space create "$SPACE" 2>/dev/null || true
 
-        # Start discovery worker
+        # Start discovery worker with persistent lifecycle handling
         step "Starting discovery worker..."
-        cub worker run dev --space "$SPACE" >/dev/null 2>&1 &
-        WORKER_PID=$!
-        note "Discovery worker PID: $WORKER_PID"
+        if ! bash "$WORKER_LIFECYCLE_SCRIPT" start \
+            --space "$SPACE" \
+            --worker "$DISCOVERY_WORKER_SLUG" \
+            --target Kubernetes \
+            --pid-file "$DISCOVERY_WORKER_PID_FILE" \
+            --log-file "$DISCOVERY_WORKER_LOG"; then
+            warn "Discovery worker start failed. Log: $DISCOVERY_WORKER_LOG"
+            tail -n 20 "$DISCOVERY_WORKER_LOG" 2>/dev/null || true
+        fi
+        if [[ -f "$DISCOVERY_WORKER_PID_FILE" ]]; then
+            WORKER_PID="$(cat "$DISCOVERY_WORKER_PID_FILE" 2>/dev/null || true)"
+            note "Discovery worker PID: ${WORKER_PID:-unknown}"
+        fi
 
         # Deploy ArgoCD renderer in-cluster
         step "Deploying ArgoCD renderer worker in-cluster..."
@@ -428,6 +464,26 @@ if $LIVE; then
             warn "Targets not found - skipping cub gitops import"
             note "K8S_TARGET=$K8S_TARGET  RENDERER_TARGET=$RENDERER_TARGET"
         fi
+
+        step "Connected readiness check"
+        if ! bash "$VERIFY_CONNECTED_SCRIPT" --space "$SPACE" --renderer argocdrenderer; then
+            warn "Connected readiness check failed (inspect worker/target state before demoing history)"
+        fi
+
+        if $SEED_HISTORY; then
+            step "Seeding synthetic demo ChangeSet history"
+            seed_args=(--space "$SPACE" --allow-synthetic --apply)
+            if [[ -n "${CI:-}" ]]; then
+                seed_args+=(--allow-ci)
+            fi
+            if ! bash "$SEED_HISTORY_SCRIPT" "${seed_args[@]}"; then
+                warn "Synthetic history seeding failed"
+            else
+                note "Synthetic markers: demo=true, synthetic=true, source=cub-scout-demo-seed"
+            fi
+        else
+            note "Synthetic history seeding skipped (use --seed-history for storytelling demos)"
+        fi
     fi
 else
     banner "Act 4: The Pipeline (cub gitops import)"
@@ -446,6 +502,7 @@ else
     note "manifests with continuous updates. Acts 2-3 capture static snapshots only."
     echo ""
     note "  ./demo.sh --live                                 # with cub auth"
+    note "  ./demo.sh --live --seed-history                  # add synthetic history for demo storytelling"
     note "  ./demo.sh --live --confighub-url=http://localhost:9090  # local dev"
 fi
 
@@ -503,6 +560,9 @@ if $KEEP; then
     echo "    $CUB trace deploy/api -n myapp-prod   # Trace ownership chain"
     echo ""
     echo "  Teardown:"
+    if [[ -n "$DISCOVERY_WORKER_PID_FILE" ]]; then
+        echo "    bash \"$WORKER_LIFECYCLE_SCRIPT\" stop --pid-file \"$DISCOVERY_WORKER_PID_FILE\""
+    fi
     echo "    kind delete cluster --name $CLUSTER_NAME"
 else
     echo "Cluster torn down. Run with --keep to explore interactively."

--- a/examples/flux-import-confighub-demo/README.md
+++ b/examples/flux-import-confighub-demo/README.md
@@ -16,6 +16,9 @@ outside Flux's scope.
 # Full pipeline including ConfigHub import (~6 min, requires cub auth)
 ./demo.sh --live
 
+# Full pipeline + seeded synthetic history (demo storytelling)
+./demo.sh --live --seed-history
+
 # Keep cluster running for interactive exploration
 ./demo.sh --keep
 
@@ -36,6 +39,10 @@ Optional (demo storytelling only): seed tagged synthetic ChangeSet history.
 ```bash
 ../scripts/seed-connected-demo-history.sh --space flux-import-demo --allow-synthetic --apply
 ```
+
+When `--keep` is used with `--live`, the demo leaves the discovery worker
+running and prints a `demo-worker-lifecycle.sh stop --pid-file ...` command so
+connected state is preserved for extended sessions.
 
 ## Prerequisites
 

--- a/examples/flux-import-confighub-demo/demo.sh
+++ b/examples/flux-import-confighub-demo/demo.sh
@@ -11,6 +11,7 @@
 #   ./demo.sh --live         # Full import into ConfigHub (~6 min, requires cub auth)
 #   ./demo.sh --keep         # Keep cluster running for exploration
 #   ./demo.sh --live --keep  # Import + keep cluster
+#   ./demo.sh --live --seed-history  # Also seed tagged synthetic ChangeSet history
 #   ./demo.sh --live --confighub-url=http://localhost:9090  # Local dev override
 #
 # Prerequisites: docker, kind, kubectl, go, flux
@@ -24,13 +25,20 @@ D2_FIXTURES="$SCRIPT_DIR/fixtures"
 CLUSTER_NAME="flux-import-demo"
 KEEP=false
 LIVE=false
+SEED_HISTORY=false
 CONFIGHUB_URL_OVERRIDE=""
 WORKER_PID=""
+WORKER_LIFECYCLE_SCRIPT="$SCRIPT_DIR/../scripts/demo-worker-lifecycle.sh"
+VERIFY_CONNECTED_SCRIPT="$SCRIPT_DIR/../scripts/verify-connected-demo.sh"
+SEED_HISTORY_SCRIPT="$SCRIPT_DIR/../scripts/seed-connected-demo-history.sh"
+DISCOVERY_WORKER_PID_FILE=""
+DISCOVERY_WORKER_LOG=""
 
 for arg in "$@"; do
     case "$arg" in
         --keep) KEEP=true ;;
         --live) LIVE=true ;;
+        --seed-history) SEED_HISTORY=true ;;
         --confighub-url=*) CONFIGHUB_URL_OVERRIDE="${arg#*=}" ;;
     esac
 done
@@ -51,10 +59,17 @@ warn()    { echo -e "${YELLOW}!!${NC} $1"; }
 fail()    { echo -e "${RED}!!${NC} $1"; }
 
 cleanup() {
-    if [[ -n "$WORKER_PID" ]]; then
-        kill "$WORKER_PID" 2>/dev/null || true
-        wait "$WORKER_PID" 2>/dev/null || true
-        step "Worker stopped"
+    if [[ -n "$DISCOVERY_WORKER_PID_FILE" ]]; then
+        if $KEEP; then
+            bash "$WORKER_LIFECYCLE_SCRIPT" cleanup --pid-file "$DISCOVERY_WORKER_PID_FILE" --keep >/dev/null 2>&1 || true
+            step "Discovery worker left running"
+            if [[ -n "$DISCOVERY_WORKER_LOG" ]]; then
+                note "Discovery worker log: $DISCOVERY_WORKER_LOG"
+            fi
+        else
+            bash "$WORKER_LIFECYCLE_SCRIPT" cleanup --pid-file "$DISCOVERY_WORKER_PID_FILE" >/dev/null 2>&1 || true
+            step "Discovery worker stopped"
+        fi
     fi
     if $KEEP; then
         warn "Cluster '$CLUSTER_NAME' kept running. Delete with: kind delete cluster --name $CLUSTER_NAME"
@@ -108,6 +123,12 @@ if $LIVE; then
         fail "Could not determine ConfigHub URL. Set CONFIGHUB_URL or use --confighub-url=<url>"
         exit 1
     fi
+    for helper in "$WORKER_LIFECYCLE_SCRIPT" "$VERIFY_CONNECTED_SCRIPT" "$SEED_HISTORY_SCRIPT"; do
+        if [[ ! -f "$helper" ]]; then
+            fail "Missing helper script: $helper"
+            exit 1
+        fi
+    done
     step "ConfigHub: $CONFIGHUB_SERVER_URL"
     step "Auth OK (cub present)"
 fi
@@ -288,23 +309,28 @@ if $LIVE; then
     SPACE="flux-import-demo"
     DISCOVERY_WORKER_SLUG="discovery-worker"
     RENDERER_WORKER_SLUG="flux-renderer-worker"
-    DISCOVERY_LOG="${TMPDIR:-/tmp}/flux-import-demo-discovery-worker.log"
+    WORKER_STATE_DIR="${TMPDIR:-/tmp}/cub-scout-demo-workers"
+    mkdir -p "$WORKER_STATE_DIR"
+    DISCOVERY_WORKER_PID_FILE="$WORKER_STATE_DIR/${SPACE}-${DISCOVERY_WORKER_SLUG}.pid"
+    DISCOVERY_WORKER_LOG="$WORKER_STATE_DIR/${SPACE}-${DISCOVERY_WORKER_SLUG}.log"
     step "Creating ConfigHub space '$SPACE'..."
     cub space create "$SPACE" 2>/dev/null || warn "Space may already exist"
     echo ""
 
-    # Start discovery worker
-    step "Recreating discovery worker '$DISCOVERY_WORKER_SLUG'..."
-    cub worker delete --space "$SPACE" "$DISCOVERY_WORKER_SLUG" >/dev/null 2>&1 || true
-    cub worker create --space "$SPACE" "$DISCOVERY_WORKER_SLUG" >/dev/null
-
+    # Start discovery worker with persistent lifecycle handling
     step "Starting discovery worker..."
-    cub worker run --space "$SPACE" -t Kubernetes "$DISCOVERY_WORKER_SLUG" >"$DISCOVERY_LOG" 2>&1 &
-    WORKER_PID=$!
-    sleep 5
-    if ! kill -0 "$WORKER_PID" 2>/dev/null; then
-        warn "Discovery worker exited early. Log: $DISCOVERY_LOG"
-        tail -n 20 "$DISCOVERY_LOG" || true
+    if ! bash "$WORKER_LIFECYCLE_SCRIPT" start \
+        --space "$SPACE" \
+        --worker "$DISCOVERY_WORKER_SLUG" \
+        --target Kubernetes \
+        --pid-file "$DISCOVERY_WORKER_PID_FILE" \
+        --log-file "$DISCOVERY_WORKER_LOG"; then
+        warn "Discovery worker start failed. Log: $DISCOVERY_WORKER_LOG"
+        tail -n 20 "$DISCOVERY_WORKER_LOG" 2>/dev/null || true
+    fi
+    if [[ -f "$DISCOVERY_WORKER_PID_FILE" ]]; then
+        WORKER_PID="$(cat "$DISCOVERY_WORKER_PID_FILE" 2>/dev/null || true)"
+        note "Discovery worker PID: ${WORKER_PID:-unknown}"
     fi
 
     # Deploy kustomize renderer in-cluster
@@ -399,6 +425,26 @@ if $LIVE; then
     else
         warn "Targets not found - skipping cub gitops discover/import"
     fi
+
+    step "Connected readiness check"
+    if ! bash "$VERIFY_CONNECTED_SCRIPT" --space "$SPACE" --renderer fluxrenderer; then
+        warn "Connected readiness check failed (inspect worker/target state before demoing history)"
+    fi
+
+    if $SEED_HISTORY; then
+        step "Seeding synthetic demo ChangeSet history"
+        seed_args=(--space "$SPACE" --allow-synthetic --apply)
+        if [[ -n "${CI:-}" ]]; then
+            seed_args+=(--allow-ci)
+        fi
+        if ! bash "$SEED_HISTORY_SCRIPT" "${seed_args[@]}"; then
+            warn "Synthetic history seeding failed"
+        else
+            note "Synthetic markers: demo=true, synthetic=true, source=cub-scout-demo-seed"
+        fi
+    else
+        note "Synthetic history seeding skipped (use --seed-history for storytelling demos)"
+    fi
 else
     banner "Act 4: The Pipeline (cub gitops import)"
     note "Not running - add --live to enable (requires ConfigHub auth)"
@@ -416,6 +462,7 @@ else
     note "manifests with continuous updates. Acts 2-3 capture static snapshots only."
     echo ""
     note "  ./demo.sh --live                                 # with cub auth"
+    note "  ./demo.sh --live --seed-history                  # add synthetic history for demo storytelling"
     note "  ./demo.sh --live --confighub-url=http://localhost:9090  # local dev"
 fi
 
@@ -473,6 +520,9 @@ if $KEEP; then
     echo "    $CUB gitops status                    # Flux health dashboard"
     echo ""
     echo "  Teardown:"
+    if [[ -n "$DISCOVERY_WORKER_PID_FILE" ]]; then
+        echo "    bash \"$WORKER_LIFECYCLE_SCRIPT\" stop --pid-file \"$DISCOVERY_WORKER_PID_FILE\""
+    fi
     echo "    kind delete cluster --name $CLUSTER_NAME"
 else
     echo "Cluster torn down. Run with --keep to explore interactively."

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -14,6 +14,26 @@ Fail-fast checks for `--live` demo runs (workers, targets, connected workloads):
 ./verify-connected-demo.sh --space flux-import-demo --renderer fluxrenderer
 ```
 
+## Demo Worker Lifecycle
+
+Manage detached discovery workers for long-running `--live --keep` demos:
+
+```bash
+# Start detached discovery worker
+./demo-worker-lifecycle.sh start \
+  --space argo-import-demo \
+  --worker discovery-worker \
+  --target Kubernetes \
+  --pid-file /tmp/cub-scout-demo-workers/argo-import-demo-discovery-worker.pid \
+  --log-file /tmp/cub-scout-demo-workers/argo-import-demo-discovery-worker.log
+
+# Keep running during cleanup
+./demo-worker-lifecycle.sh cleanup --pid-file /tmp/cub-scout-demo-workers/argo-import-demo-discovery-worker.pid --keep
+
+# Stop explicitly when done
+./demo-worker-lifecycle.sh stop --pid-file /tmp/cub-scout-demo-workers/argo-import-demo-discovery-worker.pid
+```
+
 ## Synthetic History Seed (Demo Only)
 
 Create tagged synthetic ChangeSets for storytelling demos.

--- a/examples/scripts/demo-worker-lifecycle.sh
+++ b/examples/scripts/demo-worker-lifecycle.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# demo-worker-lifecycle.sh - Manage discovery worker process lifecycle for demos.
+#
+# Commands:
+#   start   create worker if needed and launch `cub worker run` as detached process
+#   stop    stop detached worker process tracked by pid file
+#   cleanup stop unless --keep is provided
+
+set -euo pipefail
+
+MODE="${1:-}"
+if [[ $# -gt 0 ]]; then
+    shift
+fi
+
+SPACE=""
+WORKER=""
+TARGET="Kubernetes"
+PID_FILE=""
+LOG_FILE=""
+KEEP=false
+
+usage() {
+    cat <<USAGE
+Usage:
+  $(basename "$0") start --space <slug> --worker <slug> --pid-file <path> --log-file <path> [--target <type>]
+  $(basename "$0") stop --pid-file <path>
+  $(basename "$0") cleanup --pid-file <path> [--keep]
+
+Commands:
+  start    Launch detached worker process and write PID to file
+  stop     Stop worker process referenced by PID file
+  cleanup  Stop worker unless --keep is set
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --space)
+            [[ $# -ge 2 ]] || { echo "missing value for --space" >&2; usage; exit 2; }
+            SPACE="$2"
+            shift 2
+            ;;
+        --space=*)
+            SPACE="${1#*=}"
+            shift
+            ;;
+        --worker)
+            [[ $# -ge 2 ]] || { echo "missing value for --worker" >&2; usage; exit 2; }
+            WORKER="$2"
+            shift 2
+            ;;
+        --worker=*)
+            WORKER="${1#*=}"
+            shift
+            ;;
+        --target)
+            [[ $# -ge 2 ]] || { echo "missing value for --target" >&2; usage; exit 2; }
+            TARGET="$2"
+            shift 2
+            ;;
+        --target=*)
+            TARGET="${1#*=}"
+            shift
+            ;;
+        --pid-file)
+            [[ $# -ge 2 ]] || { echo "missing value for --pid-file" >&2; usage; exit 2; }
+            PID_FILE="$2"
+            shift 2
+            ;;
+        --pid-file=*)
+            PID_FILE="${1#*=}"
+            shift
+            ;;
+        --log-file)
+            [[ $# -ge 2 ]] || { echo "missing value for --log-file" >&2; usage; exit 2; }
+            LOG_FILE="$2"
+            shift 2
+            ;;
+        --log-file=*)
+            LOG_FILE="${1#*=}"
+            shift
+            ;;
+        --keep)
+            KEEP=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+require_pid_file() {
+    if [[ -z "$PID_FILE" ]]; then
+        echo "--pid-file is required" >&2
+        exit 2
+    fi
+}
+
+pid_from_file() {
+    local pid_raw=""
+    if [[ ! -f "$PID_FILE" ]]; then
+        echo ""
+        return
+    fi
+    pid_raw="$(tr -d '[:space:]' <"$PID_FILE" 2>/dev/null || true)"
+    if [[ "$pid_raw" =~ ^[0-9]+$ ]]; then
+        echo "$pid_raw"
+        return
+    fi
+    echo ""
+}
+
+stop_worker() {
+    require_pid_file
+    local pid=""
+    pid="$(pid_from_file)"
+    if [[ -z "$pid" ]]; then
+        rm -f "$PID_FILE"
+        echo "no running worker pid tracked"
+        return
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+        rm -f "$PID_FILE"
+        echo "worker already stopped pid=$pid"
+        return
+    fi
+
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+    echo "stopped worker pid=$pid"
+}
+
+start_worker() {
+    if [[ -z "$SPACE" || -z "$WORKER" || -z "$PID_FILE" || -z "$LOG_FILE" ]]; then
+        echo "start requires --space, --worker, --pid-file, and --log-file" >&2
+        exit 2
+    fi
+    if ! command -v cub >/dev/null 2>&1; then
+        echo "cub CLI not found in PATH" >&2
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$PID_FILE")"
+    mkdir -p "$(dirname "$LOG_FILE")"
+
+    local existing_pid=""
+    existing_pid="$(pid_from_file)"
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+        echo "worker already running pid=$existing_pid"
+        return
+    fi
+    rm -f "$PID_FILE"
+
+    cub worker create --space "$SPACE" "$WORKER" >/dev/null 2>&1 || true
+    nohup cub worker run --space "$SPACE" -t "$TARGET" "$WORKER" >>"$LOG_FILE" 2>&1 < /dev/null &
+    local pid="$!"
+    echo "$pid" >"$PID_FILE"
+
+    sleep 0.2
+    if ! kill -0 "$pid" 2>/dev/null; then
+        rm -f "$PID_FILE"
+        echo "worker process exited early (see log: $LOG_FILE)" >&2
+        exit 1
+    fi
+
+    echo "started worker pid=$pid space=$SPACE worker=$WORKER target=$TARGET log=$LOG_FILE"
+}
+
+case "$MODE" in
+    start)
+        start_worker
+        ;;
+    stop)
+        stop_worker
+        ;;
+    cleanup)
+        require_pid_file
+        if [[ "$KEEP" == "true" ]]; then
+            echo "keeping worker process running (pid file: $PID_FILE)"
+        else
+            stop_worker
+        fi
+        ;;
+    ""|-h|--help)
+        usage
+        exit 2
+        ;;
+    *)
+        echo "unknown command: $MODE" >&2
+        usage
+        exit 2
+        ;;
+esac

--- a/test/unit/demo_scripts_connected_lifecycle_contract_test.go
+++ b/test/unit/demo_scripts_connected_lifecycle_contract_test.go
@@ -1,0 +1,52 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestArgoFluxDemoScripts_UseWorkerLifecycleHelper(t *testing.T) {
+	scripts := []string{
+		filepath.Join("..", "..", "examples", "argo-import-confighub-demo", "demo.sh"),
+		filepath.Join("..", "..", "examples", "flux-import-confighub-demo", "demo.sh"),
+	}
+	for _, path := range scripts {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		script := string(content)
+		if !strings.Contains(script, "demo-worker-lifecycle.sh") {
+			t.Fatalf("%s must invoke demo-worker-lifecycle.sh for discovery worker lifecycle", path)
+		}
+		if !strings.Contains(script, "--pid-file") {
+			t.Fatalf("%s must manage worker pid file for cleanup/keep behavior", path)
+		}
+	}
+}
+
+func TestArgoFluxDemoScripts_ExposeSeedHistoryFlag(t *testing.T) {
+	scripts := []string{
+		filepath.Join("..", "..", "examples", "argo-import-confighub-demo", "demo.sh"),
+		filepath.Join("..", "..", "examples", "flux-import-confighub-demo", "demo.sh"),
+	}
+	for _, path := range scripts {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		script := string(content)
+		required := []string{
+			"--seed-history",
+			"seed-connected-demo-history.sh",
+			"--allow-synthetic",
+		}
+		for _, needle := range required {
+			if !strings.Contains(script, needle) {
+				t.Fatalf("%s missing %q integration", path, needle)
+			}
+		}
+	}
+}

--- a/test/unit/demo_worker_lifecycle_script_test.go
+++ b/test/unit/demo_worker_lifecycle_script_test.go
@@ -1,0 +1,148 @@
+package unit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestDemoWorkerLifecycleScript_StartStop(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "scripts", "demo-worker-lifecycle.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	mockBinDir := t.TempDir()
+	callsLog := filepath.Join(t.TempDir(), "calls.log")
+	pidFile := filepath.Join(t.TempDir(), "demo-worker.pid")
+	logFile := filepath.Join(t.TempDir(), "demo-worker.log")
+
+	writeExecutableLifecycle(t, filepath.Join(mockBinDir, "cub"), `#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$MOCK_CALLS_LOG"
+if [[ "$1" == "worker" && "$2" == "run" ]]; then
+  sleep 30
+  exit 0
+fi
+exit 0
+`)
+
+	start := exec.Command("bash", scriptPath,
+		"start",
+		"--space", "demo-space",
+		"--worker", "discovery-worker",
+		"--target", "Kubernetes",
+		"--pid-file", pidFile,
+		"--log-file", logFile,
+	)
+	start.Env = append(os.Environ(),
+		"MOCK_CALLS_LOG="+callsLog,
+		"PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := start.CombinedOutput()
+	if err != nil {
+		t.Fatalf("start failed: %v\n%s", err, string(out))
+	}
+
+	pidRaw, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidRaw)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("expected valid pid in pid file, got %q", strings.TrimSpace(string(pidRaw)))
+	}
+
+	stop := exec.Command("bash", scriptPath, "stop", "--pid-file", pidFile)
+	stop.Env = append(os.Environ(), "PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err = stop.CombinedOutput()
+	if err != nil {
+		t.Fatalf("stop failed: %v\n%s", err, string(out))
+	}
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Fatalf("expected pid file to be removed after stop, got err=%v", err)
+	}
+
+	data, err := os.ReadFile(callsLog)
+	if err != nil {
+		t.Fatalf("read calls log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "worker create --space demo-space discovery-worker") {
+		t.Fatalf("expected worker create call, got:\n%s", log)
+	}
+	if !strings.Contains(log, "worker run --space demo-space -t Kubernetes discovery-worker") {
+		t.Fatalf("expected worker run call, got:\n%s", log)
+	}
+}
+
+func TestDemoWorkerLifecycleScript_CleanupKeepDoesNotStop(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "examples", "scripts", "demo-worker-lifecycle.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing: %v", err)
+	}
+
+	mockBinDir := t.TempDir()
+	pidFile := filepath.Join(t.TempDir(), "demo-worker.pid")
+	logFile := filepath.Join(t.TempDir(), "demo-worker.log")
+
+	writeExecutableLifecycle(t, filepath.Join(mockBinDir, "cub"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "worker" && "$2" == "run" ]]; then
+  sleep 30
+  exit 0
+fi
+exit 0
+`)
+
+	start := exec.Command("bash", scriptPath,
+		"start",
+		"--space", "demo-space",
+		"--worker", "discovery-worker",
+		"--target", "Kubernetes",
+		"--pid-file", pidFile,
+		"--log-file", logFile,
+	)
+	start.Env = append(os.Environ(), "PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := start.CombinedOutput()
+	if err != nil {
+		t.Fatalf("start failed: %v\n%s", err, string(out))
+	}
+
+	cleanup := exec.Command("bash", scriptPath, "cleanup", "--pid-file", pidFile, "--keep")
+	cleanup.Env = append(os.Environ(), "PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err = cleanup.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cleanup failed: %v\n%s", err, string(out))
+	}
+	if !strings.Contains(string(out), "keeping worker process running") {
+		t.Fatalf("expected keep message, got:\n%s", string(out))
+	}
+	if _, err := os.Stat(pidFile); err != nil {
+		t.Fatalf("expected pid file to remain when keep is set: %v", err)
+	}
+
+	stop := exec.Command("bash", scriptPath, "stop", "--pid-file", pidFile)
+	stop.Env = append(os.Environ(), "PATH="+mockBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if out, err := stop.CombinedOutput(); err != nil {
+		t.Fatalf("stop failed: %v\n%s", err, string(out))
+	}
+}
+
+func writeExecutableLifecycle(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		mode = 0o644
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Scope
- Follow-up hardening for connected demo reliability (remaining #253 items) and issue #230 demo readiness.
- Adds persistent discovery-worker lifecycle handling for `--live --keep` sessions.
- Adds explicit `--seed-history` path for tagged synthetic ChangeSet demo data.

## Success Criteria
- `--live --keep` demo runs keep the discovery worker alive after script exit.
- Non-keep demo runs still stop worker cleanly in trap cleanup.
- Synthetic history seeding is not automatic; it only runs when `--seed-history` is specified.
- Argo and Flux demo scripts share the same lifecycle + seeding contract.

## Graceful Degradation
- If lifecycle helper scripts are missing, demos fail early in preflight (clear error).
- If worker start fails, demos continue with warning and log pointer.
- If readiness/seeding fails, demos continue with warning (no destructive fallback).
- Synthetic data remains tagged (`demo=true`, `synthetic=true`, `source=cub-scout-demo-seed`) and CI apply still requires explicit allow.

## Tests Added
- `test/unit/demo_worker_lifecycle_script_test.go`
  - start/stop lifecycle behavior with mocked `cub`
  - keep-cleanup behavior leaves worker process intact
- `test/unit/demo_scripts_connected_lifecycle_contract_test.go`
  - Argo/Flux demo scripts must wire lifecycle helper + pid files
  - Argo/Flux demo scripts must expose `--seed-history` and synthetic seed integration

## Examples/Docs Updated
- `examples/argo-import-confighub-demo/demo.sh`
- `examples/flux-import-confighub-demo/demo.sh`
- `examples/scripts/demo-worker-lifecycle.sh`
- `examples/argo-import-confighub-demo/README.md`
- `examples/flux-import-confighub-demo/README.md`
- `examples/scripts/README.md`

## Commands Run
- Red (tests-first):
  - `go test ./test/unit -run 'TestDemoWorkerLifecycleScript_|TestArgoFluxDemoScripts_' -count=1` (expected fail before implementation)
- Verification loop:
  - `go test ./test/unit -run 'TestDemoWorkerLifecycleScript_|TestArgoFluxDemoScripts_' -count=1` (pass x3)
- Baseline:
  - `go build ./cmd/cub-scout`
  - `go test ./test/unit -count=1`
- Post-format verification:
  - `go test ./test/unit -run 'TestDemoWorkerLifecycleScript_|TestArgoFluxDemoScripts_' -count=1`
  - `go test ./test/unit -count=1`

Proof logs:
- `/tmp/cub-scout-regression/v1.6/issue-230/proof-matrix.md`
- `/tmp/cub-scout-regression/v1.6/issue-230/proof-results.md`

Refs: #230
