### PR TITLE
examples: add fixture-driven connect-and-compare 60s flow

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -77,6 +77,7 @@ The `argo-import-confighub-demo` and `flux-import-confighub-demo` run against re
 |---------|---------|-------|
 | [mcp-gateway/](mcp-gateway/) | **MCP stdio server** | Serve read-only `map`/`trace`/`scan`/`explain` tools to AI clients |
 | [ai-integration/](ai-integration/) | **Per-tool AI integrations** | Reproducible Claude/Cursor/Copilot MCP + CLI examples (offline fixtures) |
+| [connect-and-compare/](connect-and-compare/) | **Connected value story** | 60-second fixture demo: doctor -> connect -> compare -> history |
 
 **Using AI tools?** Start with [Giving Your AI Eyes](ai-agent-quest/) — watch your AI reason about cluster state and hit the wall that ConfigHub removes.
 
@@ -162,6 +163,7 @@ Expected output for each example is in `test/fixtures/expected-output/examples/`
 | [fleet-import/](fleet-import/) | **Working** | Multi-cluster fleet aggregation | Learning fleet import, cross-cluster proposals |
 | [demo-data-adt/](demo-data-adt/) | **Working** | App-Deployment-Target model (multi-app × multi-env) | Learning ADT model, version skew, scan |
 | [new-user-puzzle-quest/](new-user-puzzle-quest/) | **Working** | Quest-style new-user walkthrough (AI-assisted) | Guided capability/discovery/import validation |
+| [connect-and-compare/](connect-and-compare/) | **Working** | 60-second connected-mode fixture flow | Standalone->connected value narrative for demos/recordings |
 | [workflows/](workflows/) | **Working** | Artifact + fleet demos (CI → local, env comparison) | CI/CD integration, sharing bundles, comparing environments |
 | [apptique-examples/](apptique-examples/) | **Working** | Real GitOps patterns (Flux, Argo) | Learning GitOps ownership |
 | [platform-example/](platform-example/) | **Working** | Full Flux learning environment (~35 resources) | Learning GitOps + orphan detection |

--- a/examples/connect-and-compare/README.md
+++ b/examples/connect-and-compare/README.md
@@ -1,0 +1,41 @@
+# Connect and Compare (60-second flow)
+
+Fixture-first demo for the v1.6 connected-mode story:
+
+1. `doctor` shows immediate standalone cluster signal.
+2. operator connects with `cub auth login`.
+3. compare view shows intent vs observed state using offline fixtures.
+4. `history` shows who changed what from ChangeSets.
+
+This example is deterministic and does not require a live cluster.
+
+## Run
+
+```bash
+# Generate demo output snapshots
+./examples/connect-and-compare/demo.sh
+
+# Verify generated output against committed snapshots
+./examples/connect-and-compare/demo.sh --verify
+```
+
+## Record
+
+```bash
+./examples/connect-and-compare/record-demo.sh
+```
+
+## Artifacts
+
+- `testdata/doctor_input.json`: fixture input for `cub-scout doctor`
+- `testdata/history_changesets.json`: fixture input for `cub-scout history`
+- `expected-output/`: committed expected snapshots for verification
+- `sample-output/`: generated output from the last local run (not committed)
+
+## Notes
+
+- Synthetic/demo history remains explicitly fixture-driven in this flow.
+- No ConfigHub write operations are executed by this example.
+- Compare step uses `cub-scout combined --git-path ... --bundle ... --json` to
+  produce deterministic intent-vs-observed evidence until `cub-scout compare`
+  lands as a dedicated command.

--- a/examples/connect-and-compare/demo.sh
+++ b/examples/connect-and-compare/demo.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# connect-and-compare demo (fixture-first, no live cluster required)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+OUTPUT_DIR="$SCRIPT_DIR/sample-output"
+VERIFY=false
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [--output-dir <path>] [--verify]
+
+Options:
+  --output-dir <path>  Write generated snapshots to this directory
+                       (default: examples/connect-and-compare/sample-output)
+  --verify             Compare generated snapshots with expected-output/
+  -h, --help           Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            [[ $# -ge 2 ]] || { echo "missing value for --output-dir" >&2; usage; exit 2; }
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --output-dir=*)
+            OUTPUT_DIR="${1#*=}"
+            shift
+            ;;
+        --verify)
+            VERIFY=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -n "${CUB_SCOUT_BIN:-}" ]]; then
+    CUB="$CUB_SCOUT_BIN"
+elif [[ -x "$REPO_ROOT/cub-scout" ]]; then
+    CUB="$REPO_ROOT/cub-scout"
+else
+    echo "building cub-scout binary..."
+    (cd "$REPO_ROOT" && go build -o cub-scout ./cmd/cub-scout)
+    CUB="$REPO_ROOT/cub-scout"
+fi
+
+if [[ ! -x "$CUB" ]]; then
+    echo "cub-scout binary is not executable: $CUB" >&2
+    exit 1
+fi
+
+DOCTOR_FIXTURE="$SCRIPT_DIR/testdata/doctor_input.json"
+HISTORY_FIXTURE="$SCRIPT_DIR/testdata/history_changesets.json"
+GIT_FIXTURE="$REPO_ROOT/examples/combined-git-live/git-repo"
+BUNDLE_FIXTURE="$REPO_ROOT/examples/workflows/fleet-demo/bundles/dev"
+EXPECTED_DIR="$SCRIPT_DIR/expected-output"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "[1/4] Standalone snapshot: doctor"
+CUB_SCOUT_TEST_DOCTOR_INPUT_JSON="$DOCTOR_FIXTURE" "$CUB" doctor --format ascii > "$OUTPUT_DIR/01-doctor.txt"
+
+echo "[2/4] Connect step (operator action)"
+cat > "$OUTPUT_DIR/02-connect.txt" <<'STEP2'
+$ cub auth login
+Connected mode established (fixture replay path for demo).
+STEP2
+
+echo "[3/4] Compare step: Git intent vs bundle snapshot"
+"$CUB" combined --git-path "$GIT_FIXTURE" --bundle "$BUNDLE_FIXTURE" --json > "$OUTPUT_DIR/03-compare.json"
+
+echo "[4/4] History step: ConfigHub ChangeSet timeline"
+CUB_SCOUT_TEST_HISTORY_JSON="$HISTORY_FIXTURE" "$CUB" history deploy/checkout -n prod --since 3650d --format ascii > "$OUTPUT_DIR/04-history.txt"
+
+if [[ "$VERIFY" == "true" ]]; then
+    diff -u "$EXPECTED_DIR/01-doctor.txt" "$OUTPUT_DIR/01-doctor.txt"
+    diff -u "$EXPECTED_DIR/03-compare.json" "$OUTPUT_DIR/03-compare.json"
+    diff -u "$EXPECTED_DIR/04-history.txt" "$OUTPUT_DIR/04-history.txt"
+    echo "All snapshots match expected output"
+fi
+
+echo "Demo artifacts written to: $OUTPUT_DIR"

--- a/examples/connect-and-compare/expected-output/01-doctor.txt
+++ b/examples/connect-and-compare/expected-output/01-doctor.txt
@@ -1,0 +1,26 @@
+Cluster: kind-connect-demo (namespace: all)
+Resources: 5 total
+
+Ownership:
+  Flux: 3 (60%)
+  ArgoCD: 1 (20%)
+  Helm: 0 (0%)
+  Native: 1 (20%)  <- 1 unmanaged
+
+Health:
+  Healthy: 2
+  Warning: 3
+  Error: 0
+
+Risks: 3 findings (1 CRITICAL, 1 WARNING, 1 INFO)
+Drift: 2 resources drifted from declared state
+
+Top Issues:
+  1. Deployment/checkout (ns: prod) - image tag drifted from approved release [CRITICAL]
+  2. Deployment/worker (ns: prod) - resource limits are missing [WARNING]
+  3. ConfigMap/manual-hotfix (ns: prod) - manual patch detected [INFO]
+
+TRY NEXT:
+  - Review unmanaged resources: cub-scout map orphans
+  - Explain your top issue: cub-scout explain deployment/checkout -n prod
+  - Run the guided path: cub-scout quickstart --yes

--- a/examples/connect-and-compare/expected-output/03-compare.json
+++ b/examples/connect-and-compare/expected-output/03-compare.json
@@ -1,0 +1,42 @@
+{
+  "gitRepo": {
+    "type": "single-repo"
+  },
+  "cluster": {
+    "namespace": "api",
+    "model": "hub-appspace",
+    "workloads": [
+      {
+        "kind": "Deployment",
+        "namespace": "api",
+        "name": "api-server",
+        "owner": "Native",
+        "connected": false,
+        "ready": false,
+        "replicas": 0
+      }
+    ],
+    "suggestion": {
+      "appSpace": "api-team",
+      "units": [
+        {
+          "slug": "api",
+          "app": "api",
+          "variant": "default",
+          "workloads": [
+            "api/api-server"
+          ]
+        }
+      ]
+    }
+  },
+  "alignment": [
+    {
+      "app": "api-server",
+      "status": "cluster-only",
+      "workloads": [
+        "api/api-server"
+      ]
+    }
+  ]
+}

--- a/examples/connect-and-compare/expected-output/04-history.txt
+++ b/examples/connect-and-compare/expected-output/04-history.txt
@@ -1,0 +1,4 @@
+Change History (last 3650d): deploy/checkout (namespace: prod)
+  2026-03-06 09:15  image: checkout:v2.4.0 -> checkout:v2.4.1  by: release-bot  changeset: CS-9012
+  2026-03-05 18:40  replicas: 2 -> 3  by: sre-oncall@example.com  changeset: CS-9007
+  2026-03-03 08:05  old change outside 24h window  by: alex  changeset: CS-8998

--- a/examples/connect-and-compare/record-demo.sh
+++ b/examples/connect-and-compare/record-demo.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Record the fixture-driven connect-and-compare flow with asciinema.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CAST_PATH="$SCRIPT_DIR/connect-and-compare.cast"
+
+if ! command -v asciinema >/dev/null 2>&1; then
+    echo "asciinema not found. Install with: brew install asciinema" >&2
+    exit 1
+fi
+
+asciinema rec "$CAST_PATH" -c "bash '$SCRIPT_DIR/demo.sh' --verify"
+echo "Recording saved to: $CAST_PATH"

--- a/examples/connect-and-compare/testdata/doctor_input.json
+++ b/examples/connect-and-compare/testdata/doctor_input.json
@@ -1,0 +1,31 @@
+{
+  "cluster": "kind-connect-demo",
+  "namespace": "all",
+  "entries": [
+    {"kind": "Deployment", "name": "checkout", "namespace": "prod", "owner": "Flux", "status": "Ready"},
+    {"kind": "Service", "name": "checkout", "namespace": "prod", "owner": "Flux", "status": "Ready"},
+    {"kind": "Deployment", "name": "worker", "namespace": "prod", "owner": "Flux", "status": "Drifted"},
+    {"kind": "ConfigMap", "name": "manual-hotfix", "namespace": "prod", "owner": "Native", "status": "Pending"},
+    {"kind": "Application", "name": "checkout", "namespace": "argocd", "owner": "ArgoCD", "status": "NotReady"}
+  ],
+  "findings": [
+    {
+      "severity": "critical",
+      "resource": "Deployment/checkout",
+      "namespace": "prod",
+      "message": "image tag drifted from approved release"
+    },
+    {
+      "severity": "warning",
+      "resource": "Deployment/worker",
+      "namespace": "prod",
+      "message": "resource limits are missing"
+    },
+    {
+      "severity": "info",
+      "resource": "ConfigMap/manual-hotfix",
+      "namespace": "prod",
+      "message": "manual patch detected"
+    }
+  ]
+}

--- a/examples/connect-and-compare/testdata/history_changesets.json
+++ b/examples/connect-and-compare/testdata/history_changesets.json
@@ -1,0 +1,24 @@
+[
+  {
+    "Slug": "CS-9012",
+    "CreatedAt": "2026-03-06T09:15:00Z",
+    "Description": "image: checkout:v2.4.0 -> checkout:v2.4.1",
+    "CreatedBy": {
+      "Slug": "release-bot"
+    }
+  },
+  {
+    "Slug": "CS-9007",
+    "CreatedAt": "2026-03-05T18:40:00Z",
+    "Description": "replicas: 2 -> 3",
+    "CreatedBy": {
+      "Email": "sre-oncall@example.com"
+    }
+  },
+  {
+    "Slug": "CS-8998",
+    "CreatedAt": "2026-03-03T08:05:00Z",
+    "Description": "old change outside 24h window",
+    "CreatedBy": "alex"
+  }
+]

--- a/test/unit/connect_and_compare_example_contract_test.go
+++ b/test/unit/connect_and_compare_example_contract_test.go
@@ -1,0 +1,70 @@
+package unit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConnectAndCompareExample_ArtifactsExist(t *testing.T) {
+	required := []string{
+		filepath.Join("..", "..", "examples", "connect-and-compare", "README.md"),
+		filepath.Join("..", "..", "examples", "connect-and-compare", "demo.sh"),
+		filepath.Join("..", "..", "examples", "connect-and-compare", "record-demo.sh"),
+		filepath.Join("..", "..", "examples", "connect-and-compare", "testdata", "doctor_input.json"),
+		filepath.Join("..", "..", "examples", "connect-and-compare", "testdata", "history_changesets.json"),
+		filepath.Join("..", "..", "examples", "connect-and-compare", "expected-output", "01-doctor.txt"),
+		filepath.Join("..", "..", "examples", "connect-and-compare", "expected-output", "03-compare.json"),
+		filepath.Join("..", "..", "examples", "connect-and-compare", "expected-output", "04-history.txt"),
+	}
+
+	for _, p := range required {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("missing required connect-and-compare artifact %s: %v", p, err)
+		}
+	}
+}
+
+func TestConnectAndCompareExample_IndexedInExamplesREADME(t *testing.T) {
+	examplesIndexPath := filepath.Join("..", "..", "examples", "README.md")
+	content, err := os.ReadFile(examplesIndexPath)
+	if err != nil {
+		t.Fatalf("read examples index: %v", err)
+	}
+	if !strings.Contains(string(content), "connect-and-compare/") {
+		t.Fatalf("examples index missing connect-and-compare link in %s", examplesIndexPath)
+	}
+}
+
+func TestConnectAndCompareDemoScript_VerifySnapshots(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	scriptPath := filepath.Join(repoRoot, "examples", "connect-and-compare", "demo.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("demo script missing: %v", err)
+	}
+
+	binPath := filepath.Join(t.TempDir(), "cub-scout")
+	buildCmd := exec.Command("go", "build", "-o", binPath, "./cmd/cub-scout")
+	buildCmd.Dir = repoRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build cub-scout: %v\n%s", err, string(out))
+	}
+
+	outDir := filepath.Join(t.TempDir(), "run-output")
+	runCmd := exec.Command("bash", scriptPath, "--output-dir", outDir, "--verify")
+	runCmd.Dir = repoRoot
+	runCmd.Env = append(os.Environ(), "CUB_SCOUT_BIN="+binPath)
+
+	out, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("demo script failed: %v\n%s", err, string(out))
+	}
+	if !strings.Contains(string(out), "All snapshots match expected output") {
+		t.Fatalf("expected snapshot verification success message, got:\n%s", string(out))
+	}
+}


### PR DESCRIPTION
## Scope
- Adds `examples/connect-and-compare/` as a deterministic, fixture-first 60-second connected-value demo.
- Captures the sequence: `doctor` -> connect step -> compare evidence -> `history`.
- Adds output snapshot verification and asciinema recording helper.

## Success Criteria
- Example runs without a live cluster.
- `demo.sh --verify` reproduces committed snapshots exactly.
- Example is discoverable from `examples/README.md`.

## Graceful Degradation
- Builds local `cub-scout` binary when not provided.
- Uses fixture env inputs for `doctor` and `history` to avoid live dependency.
- Compare step uses offline `combined --git-path ... --bundle ... --json` path.

## Tests Added
- `test/unit/connect_and_compare_example_contract_test.go`
  - required artifacts exist
  - `examples/README.md` index link exists
  - demo script runs end-to-end with `--verify` and succeeds

## Example Artifacts
- `examples/connect-and-compare/README.md`
- `examples/connect-and-compare/demo.sh`
- `examples/connect-and-compare/record-demo.sh`
- `examples/connect-and-compare/testdata/doctor_input.json`
- `examples/connect-and-compare/testdata/history_changesets.json`
- `examples/connect-and-compare/expected-output/01-doctor.txt`
- `examples/connect-and-compare/expected-output/03-compare.json`
- `examples/connect-and-compare/expected-output/04-history.txt`

## Commands Run
- Red run:
  - `go test ./test/unit -run 'TestConnectAndCompareExample_|TestConnectAndCompareDemoScript_' -count=1` (expected fail pre-implementation)
- Scoped verification:
  - `go test ./test/unit -run 'TestConnectAndCompareExample_|TestConnectAndCompareDemoScript_' -count=1` (pass x3)
- Final baseline:
  - `go build ./cmd/cub-scout`
  - `go test ./test/unit -count=1`

Proof logs:
- `/tmp/cub-scout-regression/v1.6/issue-230-connect-and-compare/proof-matrix.md`
- `/tmp/cub-scout-regression/v1.6/issue-230-connect-and-compare/proof-results.md`

Ref: #230
