### PR TITLE
cli: add compare alias for combined and wire demo usage

### DIFF
--- a/cmd/cub-scout/combined.go
+++ b/cmd/cub-scout/combined.go
@@ -95,6 +95,9 @@ Examples:
 }
 
 func init() {
+	// compare is the user-facing name for intent-vs-observed workflows.
+	combinedCmd.Aliases = []string{"compare"}
+
 	combinedCmd.Flags().StringVar(&combinedGitURL, "git-url", "", "Git repository URL to parse")
 	combinedCmd.Flags().StringVar(&combinedGitPath, "git-path", "", "Local path to Git repository")
 	combinedCmd.Flags().StringVar(&combinedGitURLCompare, "git-url-compare", "", "Right-side Git repository URL for Git↔Git compare")

--- a/cmd/cub-scout/compare_alias_test.go
+++ b/cmd/cub-scout/compare_alias_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompareAliasRegisteredOnCombined(t *testing.T) {
+	if combinedCmd == nil {
+		t.Fatal("combinedCmd is nil")
+	}
+
+	found := false
+	for _, alias := range combinedCmd.Aliases {
+		if alias == "compare" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected combined command to expose \"compare\" alias")
+	}
+}
+
+func TestCompareAliasHelp(t *testing.T) {
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"compare", "--help"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("compare --help returned error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "combined") {
+		t.Fatalf("expected compare help output to route through combined command, got:\n%s", out)
+	}
+}

--- a/examples/connect-and-compare/README.md
+++ b/examples/connect-and-compare/README.md
@@ -36,6 +36,5 @@ This example is deterministic and does not require a live cluster.
 
 - Synthetic/demo history remains explicitly fixture-driven in this flow.
 - No ConfigHub write operations are executed by this example.
-- Compare step uses `cub-scout combined --git-path ... --bundle ... --json` to
-  produce deterministic intent-vs-observed evidence until `cub-scout compare`
-  lands as a dedicated command.
+- Compare step uses `cub-scout compare --git-path ... --bundle ... --json` for
+  deterministic intent-vs-observed evidence from offline fixtures.

--- a/examples/connect-and-compare/demo.sh
+++ b/examples/connect-and-compare/demo.sh
@@ -81,7 +81,7 @@ Connected mode established (fixture replay path for demo).
 STEP2
 
 echo "[3/4] Compare step: Git intent vs bundle snapshot"
-"$CUB" combined --git-path "$GIT_FIXTURE" --bundle "$BUNDLE_FIXTURE" --json > "$OUTPUT_DIR/03-compare.json"
+"$CUB" compare --git-path "$GIT_FIXTURE" --bundle "$BUNDLE_FIXTURE" --json > "$OUTPUT_DIR/03-compare.json"
 
 echo "[4/4] History step: ConfigHub ChangeSet timeline"
 CUB_SCOUT_TEST_HISTORY_JSON="$HISTORY_FIXTURE" "$CUB" history deploy/checkout -n prod --since 3650d --format ascii > "$OUTPUT_DIR/04-history.txt"

--- a/test/unit/connect_and_compare_example_contract_test.go
+++ b/test/unit/connect_and_compare_example_contract_test.go
@@ -38,6 +38,21 @@ func TestConnectAndCompareExample_IndexedInExamplesREADME(t *testing.T) {
 	}
 }
 
+func TestConnectAndCompareDemoScript_UsesCompareCommand(t *testing.T) {
+	path := filepath.Join("..", "..", "examples", "connect-and-compare", "demo.sh")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read demo script: %v", err)
+	}
+	script := string(content)
+	if !strings.Contains(script, " compare ") {
+		t.Fatalf("expected connect-and-compare demo to call `cub-scout compare` alias")
+	}
+	if strings.Contains(script, " combined ") {
+		t.Fatalf("connect-and-compare demo should avoid direct `combined` invocation")
+	}
+}
+
 func TestConnectAndCompareDemoScript_VerifySnapshots(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {


### PR DESCRIPTION
## Scope
- Adds `compare` as an alias for the existing `combined` command.
- Updates `examples/connect-and-compare` to invoke `cub-scout compare` directly.
- Adds tests for alias registration/help and demo-script command usage.

## Success Criteria
- `cub-scout compare --help` works and routes to combined behavior.
- Existing combined behavior and output contracts remain unchanged.
- Connect-and-compare demo script no longer calls `combined` directly.

## Graceful Degradation
- Alias reuses existing combined implementation (no new API surface).
- No schema/output shape changes introduced.

## Tests Added/Updated
- `cmd/cub-scout/compare_alias_test.go`
  - alias is registered on combined command
  - `compare --help` executes successfully
- `test/unit/connect_and_compare_example_contract_test.go`
  - demo script must use `compare` alias and avoid direct `combined`
  - existing `--verify` flow still validated end-to-end

## Commands Run
- Red runs:
  - `go test ./cmd/cub-scout -run 'TestCompareAlias' -count=1` (expected fail pre-change)
  - `go test ./test/unit -run 'TestConnectAndCompareDemoScript_UsesCompareCommand' -count=1` (expected fail pre-change)
- Scoped verification (pass x3):
  - `go test ./cmd/cub-scout -run 'TestCompareAlias' -count=1`
  - `go test ./test/unit -run 'TestConnectAndCompareDemoScript_UsesCompareCommand|TestConnectAndCompareDemoScript_VerifySnapshots' -count=1`
- Final baseline:
  - `go build ./cmd/cub-scout`
  - `go test ./cmd/cub-scout ./test/unit -count=1`

Proof logs:
- `/tmp/cub-scout-regression/v1.6/issue-226-compare-alias/proof-matrix.md`
- `/tmp/cub-scout-regression/v1.6/issue-226-compare-alias/proof-results.md`

Refs: #226, #230
