### PR TITLE
map: add local history timeline panel (h)

### DIFF
--- a/cmd/cub-scout/localcluster.go
+++ b/cmd/cub-scout/localcluster.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -195,6 +196,11 @@ type LocalClusterModel struct {
 	scanFindings   []scanFinding  // Parsed findings
 	scanCategories map[string]int // Category counts
 
+	// History panel mode (connected timeline)
+	historyPanelLoading bool          // Is history query running
+	historyPanelError   error         // History query error
+	historyPanelResult  historyResult // Last loaded history timeline
+
 	// Cross-reference navigation
 	xrefMode       bool       // In cross-reference view mode
 	xrefItems      []xrefItem // Cross-reference items
@@ -293,6 +299,7 @@ const (
 	viewIssues
 	viewBypass
 	viewSprawl
+	viewHistory
 	viewMaps
 	viewTracePicker  // Trace resource picker
 	viewTraceResult  // Trace result display
@@ -328,6 +335,7 @@ type localKeyMap struct {
 	Issues    key.Binding
 	Bypass    key.Binding
 	Sprawl    key.Binding
+	History   key.Binding
 	Maps      key.Binding
 	// Actions on selected resource
 	Trace key.Binding
@@ -381,6 +389,7 @@ func defaultLocalKeyMap() localKeyMap {
 		Issues:        key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "issues")),
 		Bypass:        key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "bypass")),
 		Sprawl:        key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "sprawl")),
+		History:       key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "history")),
 		Maps:          key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "maps")),
 		Trace:         key.NewBinding(key.WithKeys("T"), key.WithHelp("T", "trace")),
 		Scan:          key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "scan")),
@@ -431,6 +440,11 @@ type scanResultMsg struct {
 	err        error
 	findings   []scanFinding  // Parsed findings for category display
 	categories map[string]int // Category counts
+}
+
+type localHistoryLoadedMsg struct {
+	result historyResult
+	err    error
 }
 
 type graphExportMsg struct {
@@ -1120,6 +1134,13 @@ func (m LocalClusterModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.scanCategories = msg.categories
 		return m, nil
 
+	case localHistoryLoadedMsg:
+		m.historyPanelLoading = false
+		m.historyPanelError = msg.err
+		m.historyPanelResult = msg.result
+		m.updatePanelContent()
+		return m, nil
+
 	case graphExportMsg:
 		if msg.err != nil {
 			m.statusMsg = fmt.Sprintf("Graph export failed (%s): %v", msg.format, msg.err)
@@ -1489,6 +1510,8 @@ func (m LocalClusterModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case key.Matches(msg, m.keymap.Sprawl):
 					m.panelView = viewSprawl
 					m.updatePanelContent()
+				case key.Matches(msg, m.keymap.History):
+					return m, m.openHistoryPanel()
 				case key.Matches(msg, m.keymap.Suspended):
 					m.panelView = viewSuspended
 					m.updatePanelContent()
@@ -1652,6 +1675,11 @@ func (m LocalClusterModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.panelView = viewSprawl
 			m.userHasNavigated = true
 			m.updatePanelContent()
+			return m, nil
+
+		case key.Matches(msg, m.keymap.History):
+			m.userHasNavigated = true
+			return m, m.openHistoryPanel()
 
 		case key.Matches(msg, m.keymap.Suspended):
 			m.panelMode = true
@@ -2048,6 +2076,8 @@ func (m *LocalClusterModel) updatePanelContent() {
 		content = m.getPanelBypass()
 	case viewSprawl:
 		content = m.getPanelSprawl()
+	case viewHistory:
+		content = m.getPanelHistory()
 	case viewSuspended:
 		content = m.getPanelSuspended()
 	case viewApps:
@@ -2086,6 +2116,8 @@ func (m LocalClusterModel) getPanelTitle() string {
 		return "BYPASS"
 	case viewSprawl:
 		return "SPRAWL"
+	case viewHistory:
+		return "HISTORY"
 	case viewSuspended:
 		return "SUSPENDED"
 	case viewApps:
@@ -2443,6 +2475,7 @@ func (m LocalClusterModel) renderHelp() string {
 	b.WriteString("  " + lcNameStyle.Render("u") + "  sUspended (paused/forgotten resources)\n")
 	b.WriteString("  " + lcNameStyle.Render("b") + "  Bypass (factory bypass detection)\n")
 	b.WriteString("  " + lcNameStyle.Render("x") + "  Sprawl (config sprawl analysis)\n")
+	b.WriteString("  " + lcNameStyle.Render("h") + "  History timeline (connected ChangeSets)\n")
 	b.WriteString("  " + lcNameStyle.Render("D") + "  Dependencies (upstream/downstream)\n")
 	b.WriteString("  " + lcNameStyle.Render("G") + "  Git sources (forward trace)\n")
 	b.WriteString("  " + lcNameStyle.Render("4") + "  Cluster Data (all data sources TUI reads)\n")
@@ -2836,6 +2869,11 @@ func (m LocalClusterModel) getSuggestionContext() string {
 			return fmt.Sprintf("Drifted: %s %s/%s", g.Kind, g.Namespace, g.Name)
 		}
 		return "Drift panel"
+	case viewHistory:
+		if target, namespace, ok := m.historyPanelTarget(); ok {
+			return fmt.Sprintf("History: %s (ns: %s)", target, namespace)
+		}
+		return "History panel"
 	default:
 		return "Dashboard"
 	}
@@ -2907,7 +2945,7 @@ func (m LocalClusterModel) renderSplitView() string {
 	if nsIndicator != "" {
 		b.WriteString(nsIndicator + " " + lcDimStyle.Render("|") + " ")
 	}
-	footer := "[]/[]ns [w]ork [p]ipe [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]"
+	footer := "[]/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]"
 	if m.panelView == viewMaps {
 		footer = "[]/[]ns [e]xport html [E]xport svg | Tab:focus Esc:close [H]ub [?] [q]"
 	}
@@ -3121,6 +3159,141 @@ func (m LocalClusterModel) getPanelPipelines() string {
 		b.WriteString("\n")
 	}
 
+	return b.String()
+}
+
+func (m LocalClusterModel) historyPanelTarget() (resource, namespace string, ok bool) {
+	entries := m.getFilteredEntries()
+	if len(entries) == 0 {
+		return "", "", false
+	}
+	idx := m.cursor
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(entries) {
+		idx = len(entries) - 1
+	}
+	selected := entries[idx]
+	kind := strings.ToLower(strings.TrimSpace(selected.Kind))
+	name := strings.TrimSpace(selected.Name)
+	namespace = strings.TrimSpace(selected.Namespace)
+	if kind == "" || name == "" {
+		return "", "", false
+	}
+	return kind + "/" + name, namespace, true
+}
+
+func (m *LocalClusterModel) openHistoryPanel() tea.Cmd {
+	m.panelMode = true
+	m.panelView = viewHistory
+	m.historyPanelLoading = true
+	m.historyPanelError = nil
+	m.historyPanelResult = historyResult{}
+	m.updatePanelContent()
+	return m.runHistoryPanel()
+}
+
+func (m LocalClusterModel) runHistoryPanel() tea.Cmd {
+	resource, namespace, ok := m.historyPanelTarget()
+	if !ok {
+		return func() tea.Msg {
+			return localHistoryLoadedMsg{err: fmt.Errorf("no workload selected for history")}
+		}
+	}
+
+	return func() tea.Msg {
+		window, err := parseHistorySince("7d")
+		if err != nil {
+			return localHistoryLoadedMsg{err: err}
+		}
+		query := historyQuery{
+			Resource:  resource,
+			Namespace: namespace,
+			Since:     "7d",
+			Window:    window,
+			Now:       historyNowFn().UTC(),
+		}
+		entries, err := resolveHistoryEntries(context.Background(), query)
+		if err != nil {
+			return localHistoryLoadedMsg{err: err}
+		}
+		return localHistoryLoadedMsg{
+			result: historyResult{
+				Resource:  resource,
+				Namespace: namespace,
+				Since:     query.Since,
+				Entries:   entries,
+			},
+		}
+	}
+}
+
+func (m LocalClusterModel) getPanelHistory() string {
+	var b strings.Builder
+
+	resource, namespace, hasTarget := m.historyPanelTarget()
+	if hasTarget {
+		b.WriteString(fmt.Sprintf("Target: %s", resource))
+		if namespace != "" {
+			b.WriteString(fmt.Sprintf(" (namespace: %s)", namespace))
+		}
+		b.WriteString("\n")
+	}
+
+	if m.historyPanelLoading {
+		b.WriteString(lcDimStyle.Render("Loading connected change history..."))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	if m.historyPanelError != nil {
+		if errors.Is(m.historyPanelError, errHistoryDisconnected) {
+			b.WriteString(lcWarnStyle.Render("History requires ConfigHub connection."))
+			b.WriteString("\n")
+			b.WriteString(lcDimStyle.Render("Run: cub auth login, then press h again."))
+			b.WriteString("\n")
+			return b.String()
+		}
+		b.WriteString(lcErrStyle.Render("History load failed: " + m.historyPanelError.Error()))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	if m.historyPanelResult.Resource == "" {
+		if !hasTarget {
+			b.WriteString(lcDimStyle.Render("No workload selected. Move cursor in workloads and press h."))
+			b.WriteString("\n")
+		}
+		return b.String()
+	}
+
+	b.WriteString(fmt.Sprintf("Window: %s\n\n", m.historyPanelResult.Since))
+	if len(m.historyPanelResult.Entries) == 0 {
+		b.WriteString(lcDimStyle.Render("No history available — resource not yet imported to ConfigHub."))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	for _, entry := range m.historyPanelResult.Entries {
+		actor := strings.TrimSpace(entry.Actor)
+		if actor == "" {
+			actor = "unknown"
+		}
+		changeSet := strings.TrimSpace(entry.ChangeSet)
+		if changeSet == "" {
+			changeSet = "-"
+		}
+		b.WriteString(fmt.Sprintf("%s  %s\n",
+			entry.Timestamp.Format("2006-01-02 15:04"),
+			entry.Change))
+		b.WriteString(lcDimStyle.Render(fmt.Sprintf("  by: %s  changeset: %s", actor, changeSet)))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(lcDimStyle.Render("Tip: run `cub-scout history <resource> -n <namespace> --format md` for shareable output."))
+	b.WriteString("\n")
 	return b.String()
 }
 
@@ -5024,7 +5197,7 @@ func (m LocalClusterModel) renderDashboard() string {
 	if nsIndicator != "" {
 		b.WriteString(nsIndicator + " " + lcDimStyle.Render("|") + " ")
 	}
-	b.WriteString(lcDimStyle.Render("[:]cmd []/[]ns [w]ork [p]ipe [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]"))
+	b.WriteString(lcDimStyle.Render("[:]cmd []/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]"))
 	b.WriteString("\n")
 
 	// Show active query or status message

--- a/cmd/cub-scout/localcluster_test.go
+++ b/cmd/cub-scout/localcluster_test.go
@@ -268,6 +268,69 @@ func TestLocalClusterSprawl(t *testing.T) {
 	}
 }
 
+// TestLocalClusterHistory tests 'h' key for history timeline view.
+func TestLocalClusterHistory(t *testing.T) {
+	m := testLocalModel()
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+	time.Sleep(50 * time.Millisecond)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	time.Sleep(50 * time.Millisecond)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	finalModel := tm.FinalModel(t, teatest.WithFinalTimeout(2*time.Second))
+
+	fm := finalModel.(LocalClusterModel)
+	if !fm.panelMode || fm.panelView != viewHistory {
+		t.Errorf("expected history view, got panelMode=%v view=%v", fm.panelMode, fm.panelView)
+	}
+}
+
+func TestLocalClusterRunHistoryPanel_UsesFixture(t *testing.T) {
+	m := testLocalModel()
+	m.cursor = 0 // deployment/nginx in default namespace
+
+	fixturePath := filepath.Join(t.TempDir(), "history.json")
+	fixtureJSON := `[
+	  {
+	    "Slug": "CS-TEST-1",
+	    "CreatedAt": "2030-03-05T18:40:00Z",
+	    "Description": "replicas: 2 -> 3",
+	    "CreatedBy": {"Slug":"release-bot"}
+	  }
+	]`
+	if err := os.WriteFile(fixturePath, []byte(fixtureJSON), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Setenv("CUB_SCOUT_TEST_HISTORY_JSON", fixturePath)
+
+	cmd := m.runHistoryPanel()
+	if cmd == nil {
+		t.Fatal("expected history panel command")
+	}
+	msg := cmd()
+	loaded, ok := msg.(localHistoryLoadedMsg)
+	if !ok {
+		t.Fatalf("expected localHistoryLoadedMsg, got %T", msg)
+	}
+	if loaded.err != nil {
+		t.Fatalf("history panel load error: %v", loaded.err)
+	}
+	if loaded.result.Resource != "deployment/nginx" {
+		t.Fatalf("result resource = %q, want deployment/nginx", loaded.result.Resource)
+	}
+	if loaded.result.Namespace != "default" {
+		t.Fatalf("result namespace = %q, want default", loaded.result.Namespace)
+	}
+	if len(loaded.result.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(loaded.result.Entries))
+	}
+	if loaded.result.Entries[0].ChangeSet != "CS-TEST-1" {
+		t.Fatalf("changeset = %q, want CS-TEST-1", loaded.result.Entries[0].ChangeSet)
+	}
+}
+
 // TestLocalClusterApps tests 'a' key for apps view.
 func TestLocalClusterApps(t *testing.T) {
 	m := testLocalModel()

--- a/docs/getting-started/first-map.md
+++ b/docs/getting-started/first-map.md
@@ -35,7 +35,7 @@ cub-scout map
 │                            │                                                 │
 └────────────────────────────┴─────────────────────────────────────────────────┘
 
-Keys: [s]tatus [w]orkloads [o]rphans [4]deep-dive  [↑↓] navigate  [T]race  [q]uit
+Keys: [s]tatus [w]orkloads [o]rphans [h]istory [4]deep-dive  [↑↓] navigate  [T]race  [q]uit
 ```
 
 ---

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -273,8 +273,8 @@ Press `?` in the TUI to see this help.
 |-----|--------|
 | `↑`/`k` | Move up |
 | `↓`/`j` | Move down |
-| `←`/`h` | Collapse / go to parent |
-| `→`/`l` | Expand |
+| `←` | Collapse / go to parent |
+| `→` | Expand |
 | `Enter` | Cross-references (in panel view) |
 | `Tab` | Cycle views |
 | `[` | Previous namespace |
@@ -290,6 +290,7 @@ Press `?` in the TUI to see this help.
 | `w` | Workloads | Workloads by owner |
 | `a` | Apps | Grouped by app label + variant |
 | `p` | Pipelines | GitOps deployers (Flux, ArgoCD) |
+| `h` | History | Connected ChangeSet timeline |
 | `d` | Drift | Resources diverged from desired state |
 | `o` | Orphans | Native resources (not GitOps-managed) |
 | `c` | Crashes | Failing pods |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -81,6 +81,7 @@ cub-scout map [flags]
 | `H` | Hub view (ConfigHub hierarchy) |
 | `j/k` | Navigate up/down |
 | `Enter` | Select/expand |
+| `h` | Open history timeline panel (connected ChangeSets) |
 | `T` | Trace selected resource |
 | `e` | Export graph as HTML (Maps view) |
 | `E` | Export graph as SVG (Maps view) |

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -5,8 +5,8 @@ Complete reference for all TUI keyboard shortcuts.
 ## Quick Reference
 
 ```
-Navigation:  ↑/k ↓/j ←/h →/l  Enter  Tab  ]/[ (namespace)
-Views:       s w p d o c i u a b x M D G 4 5/A (Hub: P Panel, g Suggest, B Hub/AppSpace, a Toggle)
+Navigation:  ↑/k ↓/j ← →  Enter  Tab  ]/[ (namespace)
+Views:       s w p h d o c i u a b x M D G 4 5/A (Hub: P Panel, g Suggest, B Hub/AppSpace, a Toggle)
 Actions:     T (trace) S (scan) f/F (fix) i (import) / Q :
 Help:        ? (help)  q (quit)
 ```
@@ -19,8 +19,8 @@ Help:        ? (help)  q (quit)
 |-----|--------|
 | `↑` or `k` | Move up |
 | `↓` or `j` | Move down |
-| `←` or `h` | Collapse / go back |
-| `→` or `l` | Expand / go forward |
+| `←` | Collapse / go back |
+| `→` | Expand / go forward |
 | `Enter` | Select / load details / cross-references |
 | `Tab` | Switch focus (list ↔ details) |
 | `]` | Next namespace |
@@ -36,6 +36,7 @@ Help:        ? (help)  q (quit)
 | `s` | Status | Health dashboard |
 | `w` | Workloads | Resources by owner |
 | `p` | Pipelines | GitOps deployers |
+| `h` | History | Connected ChangeSet timeline |
 | `P` | Pipelines (enhanced) | Visual flow with type grouping |
 | `d` | Drift | Out-of-sync resources |
 | `D` | Dependencies | Upstream/downstream relations |
@@ -132,9 +133,9 @@ Help:        ? (help)  q (quit)
 
 ---
 
-## Vim-Style Navigation
+## Vim-Style Navigation (Hub Tree)
 
-The TUI supports vim-style navigation:
+ConfigHub Hub tree navigation supports vim-style keys:
 
 | Vim Key | Standard Key | Action |
 |---------|--------------|--------|
@@ -220,8 +221,8 @@ Print this and keep handy:
 │  NAVIGATION       VIEWS              ACTIONS                    │
 │  ↑/k  Up          s  Status          T  Trace                   │
 │  ↓/j  Down        w  Workloads       S  Scan                    │
-│  ←/h  Collapse    p  Pipelines       f  Preview fix             │
-│  →/l  Expand      d  Drift           F  Apply fix               │
+│  ←    Collapse    p  Pipelines       f  Preview fix             │
+│  →    Expand      h  History         F  Apply fix               │
 │  Tab  Focus       o  Orphans         i  Import                  │
 │  Enter Select     c  Crashes         /  Search                  │
 │  ]/[  Namespace   u  Suspended       Q  Queries                 │

--- a/docs/reference/views.md
+++ b/docs/reference/views.md
@@ -9,6 +9,7 @@ Complete reference for all interactive TUI views.
 | `s` | Status | Health dashboard |
 | `w` | Workloads | Resources by owner |
 | `p` | Pipelines | GitOps deployers |
+| `h` | History | Connected ChangeSet timeline |
 | `d` | Drift | Out-of-sync resources |
 | `o` | Orphans | Native resources |
 | `c` | Crashes | Failing workloads |
@@ -124,6 +125,17 @@ See: `docs/reference/pipeline-source-resolution.md`
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+---
+
+## History View (`h`)
+
+**Purpose:** Show connected change history for the currently selected workload.
+
+**Content:**
+- ChangeSet timeline entries from ConfigHub
+- Timestamp, actor, and summary details when available
+- Clear fallback messaging when connected history is unavailable
 
 ---
 

--- a/test/ascii/tui/error_no_data.txt
+++ b/test/ascii/tui/error_no_data.txt
@@ -13,6 +13,6 @@
   No workloads found
 
 ────────────────────────────────────────────────────────────────
-ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
+ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
 
 💡 Want more? Press H for ConfigHub hierarchy, I to import workloads

--- a/test/ascii/tui/filter_strip.txt
+++ b/test/ascii/tui/filter_strip.txt
@@ -21,6 +21,6 @@ Filters: owner=Flux depth=2
   ████████████████████░░░░
 
 ────────────────────────────────────────────────────────────────
-ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
+ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
 
 💡 Want more? Press H for ConfigHub hierarchy, I to import workloads

--- a/test/ascii/tui/help_120x40.txt
+++ b/test/ascii/tui/help_120x40.txt
@@ -14,6 +14,7 @@ VIEWS
   u  sUspended (paused/forgotten resources)
   b  Bypass (factory bypass detection)
   x  Sprawl (config sprawl analysis)
+  h  History timeline (connected ChangeSets)
   D  Dependencies (upstream/downstream)
   G  Git sources (forward trace)
   4  Cluster Data (all data sources TUI reads)

--- a/test/ascii/tui/help_80x24.txt
+++ b/test/ascii/tui/help_80x24.txt
@@ -14,6 +14,7 @@ VIEWS
   u  sUspended (paused/forgotten resources)
   b  Bypass (factory bypass detection)
   x  Sprawl (config sprawl analysis)
+  h  History timeline (connected ChangeSets)
   D  Dependencies (upstream/downstream)
   G  Git sources (forward trace)
   4  Cluster Data (all data sources TUI reads)

--- a/test/ascii/tui/main_view_120x40.txt
+++ b/test/ascii/tui/main_view_120x40.txt
@@ -20,6 +20,6 @@
   ████████████████████░░░░
 
 ────────────────────────────────────────────────────────────────
-ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
+ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
 
 💡 Want more? Press H for ConfigHub hierarchy, I to import workloads

--- a/test/ascii/tui/main_view_80x24.txt
+++ b/test/ascii/tui/main_view_80x24.txt
@@ -20,6 +20,6 @@
   ████████████████████░░░░
 
 ────────────────────────────────────────────────────────────────
-ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
+ns: All (8) | [:]cmd []/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph [T]race [S]can | [H]ub [?] [q]
 
 💡 Want more? Press H for ConfigHub hierarchy, I to import workloads

--- a/test/ascii/tui/workloads_120x40.txt
+++ b/test/ascii/tui/workloads_120x40.txt
@@ -33,4 +33,4 @@
 │                                                          │ │                                                          │
 │                                                          │ │                                                          │
 ╰──────────────────────────────────────────────────────────╯ ╰──────────────────────────────────────────────────────────╯
-ns: All (8) | []/[]ns [w]ork [p]ipe [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]
+ns: All (8) | []/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]

--- a/test/ascii/tui/workloads_80x24.txt
+++ b/test/ascii/tui/workloads_80x24.txt
@@ -17,4 +17,4 @@
 │                                      │ │                                      │
 │                                      │ │                                      │
 ╰──────────────────────────────────────╯ ╰──────────────────────────────────────╯
-ns: All (8) | []/[]ns [w]ork [p]ipe [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]
+ns: All (8) | []/[]ns [w]ork [p]ipe [h]ist [d]rift [o]rph | Tab:focus Esc:close [H]ub [?] [q]


### PR DESCRIPTION
## Summary
- add a connected history timeline panel to local cluster TUI (`h`)
- load history asynchronously via existing connected history resolver with fixture override support
- add dedicated localcluster tests for keybinding + fixture history load path
- update TUI snapshots for footer/help key hints
- update docs/reference and getting-started keybinding text to include history view

## Testing
- go test ./cmd/cub-scout -run 'TestLocalClusterHistory|TestLocalClusterRunHistoryPanel_UsesFixture|TestTUISnapshot_' -count=1
- go test ./test/unit -count=1
- go build ./cmd/cub-scout
