### PR TITLE
compare: add resource mode with LIVE-only fallback

### DIFF
--- a/cmd/cub-scout/combined.go
+++ b/cmd/cub-scout/combined.go
@@ -23,6 +23,7 @@ var (
 	combinedGitPathCompare string
 	combinedNamespace      string
 	combinedBundle         string
+	combinedFormat         string
 	combinedJSON           bool
 	combinedSuggest        bool
 	combinedApply          bool
@@ -70,6 +71,12 @@ Use --suggest to generate a full App model proposal.
 Use --apply to create the App and Deployments in ConfigHub.
 
 Examples:
+  # Compare one live resource (resource mode)
+  cub-scout compare deploy/my-app -n prod --format ascii
+
+  # Compare one live resource with JSON output
+  cub-scout compare deploy/my-app -n prod --format json
+
   # Combine Git repo with current cluster
   cub-scout combined --git-url https://github.com/org/gitops-repo --namespace demo
 
@@ -104,6 +111,7 @@ func init() {
 	combinedCmd.Flags().StringVar(&combinedGitPathCompare, "git-path-compare", "", "Right-side local Git repository path for Git↔Git compare")
 	combinedCmd.Flags().StringVarP(&combinedNamespace, "namespace", "n", "", "Namespace to scan in cluster")
 	combinedCmd.Flags().StringVar(&combinedBundle, "bundle", "", "Debug bundle directory to use as cluster snapshot (offline)")
+	combinedCmd.Flags().StringVar(&combinedFormat, "format", "ascii", "Output format for resource compare mode: ascii, json, md")
 	combinedCmd.Flags().BoolVar(&combinedJSON, "json", false, "Output as JSON")
 	combinedCmd.Flags().BoolVar(&combinedSuggest, "suggest", false, "Generate App model proposal")
 	combinedCmd.Flags().BoolVar(&combinedApply, "apply", false, "Create App and Deployments in ConfigHub")
@@ -113,6 +121,10 @@ func init() {
 }
 
 func runCombined(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return runCombinedResourceCompare(cmd, args)
+	}
+
 	result := &CombinedResult{}
 
 	// Parse left-side Git repo (primary).

--- a/cmd/cub-scout/combined_bundle_test.go
+++ b/cmd/cub-scout/combined_bundle_test.go
@@ -161,6 +161,7 @@ type combinedFlagState struct {
 	gitPathCompare string
 	namespace      string
 	bundle         string
+	format         string
 	json           bool
 	suggest        bool
 	apply          bool
@@ -175,6 +176,7 @@ func setCombinedFlagState(next combinedFlagState) func() {
 		gitPathCompare: combinedGitPathCompare,
 		namespace:      combinedNamespace,
 		bundle:         combinedBundle,
+		format:         combinedFormat,
 		json:           combinedJSON,
 		suggest:        combinedSuggest,
 		apply:          combinedApply,
@@ -187,6 +189,7 @@ func setCombinedFlagState(next combinedFlagState) func() {
 	combinedGitPathCompare = next.gitPathCompare
 	combinedNamespace = next.namespace
 	combinedBundle = next.bundle
+	combinedFormat = next.format
 	combinedJSON = next.json
 	combinedSuggest = next.suggest
 	combinedApply = next.apply
@@ -199,6 +202,7 @@ func setCombinedFlagState(next combinedFlagState) func() {
 		combinedGitPathCompare = prev.gitPathCompare
 		combinedNamespace = prev.namespace
 		combinedBundle = prev.bundle
+		combinedFormat = prev.format
 		combinedJSON = prev.json
 		combinedSuggest = prev.suggest
 		combinedApply = prev.apply

--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -1,0 +1,312 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/confighub/cub-scout/pkg/hub"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+type compareSideSummary struct {
+	Source          string   `json:"source"`
+	APIVersion      string   `json:"apiVersion,omitempty"`
+	Kind            string   `json:"kind,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Namespace       string   `json:"namespace,omitempty"`
+	Generation      int64    `json:"generation,omitempty"`
+	ResourceVersion string   `json:"resourceVersion,omitempty"`
+	Replicas        *int64   `json:"replicas,omitempty"`
+	Images          []string `json:"images,omitempty"`
+	LabelCount      int      `json:"labelCount,omitempty"`
+	AnnotationCount int      `json:"annotationCount,omitempty"`
+}
+
+type compareResourceResult struct {
+	Resource  string              `json:"resource"`
+	Namespace string              `json:"namespace,omitempty"`
+	Mode      string              `json:"mode"`
+	Connected bool                `json:"connected"`
+	Dry       *compareSideSummary `json:"dry,omitempty"`
+	Wet       *compareSideSummary `json:"wet,omitempty"`
+	Live      compareSideSummary  `json:"live"`
+	Notes     []string            `json:"notes,omitempty"`
+}
+
+var (
+	loadCompareLiveSnapshotFn = loadCompareLiveSnapshot
+	compareConnectedFn        = isCompareConnected
+)
+
+func runCombinedResourceCompare(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("resource compare mode expects exactly one resource argument (kind/name)")
+	}
+	if err := validateCombinedResourceCompareFlags(); err != nil {
+		return err
+	}
+
+	format := strings.ToLower(strings.TrimSpace(combinedFormat))
+	if format == "" {
+		format = "ascii"
+	}
+	if combinedJSON {
+		format = "json"
+	}
+	if format != "ascii" && format != "json" && format != "md" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json, md)", combinedFormat)
+	}
+
+	result, err := buildCompareResourceResult(cmd.Context(), args[0], strings.TrimSpace(combinedNamespace))
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	case "md":
+		fmt.Print(renderCompareResourceMarkdown(result))
+		return nil
+	default:
+		fmt.Print(renderCompareResourceASCII(result))
+		return nil
+	}
+}
+
+func validateCombinedResourceCompareFlags() error {
+	if strings.TrimSpace(combinedGitURL) != "" ||
+		strings.TrimSpace(combinedGitPath) != "" ||
+		strings.TrimSpace(combinedGitURLCompare) != "" ||
+		strings.TrimSpace(combinedGitPathCompare) != "" ||
+		strings.TrimSpace(combinedBundle) != "" ||
+		combinedSuggest ||
+		combinedApply ||
+		combinedDryRun {
+		return fmt.Errorf("resource compare mode cannot be combined with --git-* / --bundle / --suggest / --apply / --dry-run")
+	}
+	return nil
+}
+
+func buildCompareResourceResult(ctx context.Context, resourceArg, namespace string) (compareResourceResult, error) {
+	kindRaw, name, err := parseResourceArg(resourceArg)
+	if err != nil {
+		return compareResourceResult{}, err
+	}
+
+	kind := normalizeKind(kindRaw)
+	ns := strings.TrimSpace(namespace)
+	if ns == "" {
+		ns = "default"
+	}
+
+	live, err := loadCompareLiveSnapshotFn(ctx, kind, name, ns)
+	if err != nil {
+		return compareResourceResult{}, fmt.Errorf("load LIVE snapshot for %s/%s in namespace %s: %w", kind, name, ns, err)
+	}
+	if strings.TrimSpace(live.Source) == "" {
+		live.Source = "cluster"
+	}
+
+	connected := compareConnectedFn()
+	notes := make([]string, 0, 2)
+	if connected {
+		notes = append(notes, "Connected mode detected; DRY/WET expected-state comparison wiring is pending in this command.")
+	} else {
+		notes = append(notes, "Connect to ConfigHub to unlock DRY/WET/LIVE expected-state comparison.")
+	}
+
+	return compareResourceResult{
+		Resource:  kind + "/" + name,
+		Namespace: ns,
+		Mode:      "live-only",
+		Connected: connected,
+		Live:      live,
+		Notes:     notes,
+	}, nil
+}
+
+func isCompareConnected() bool {
+	return hub.NewClient().RequireConnected() == nil
+}
+
+func loadCompareLiveSnapshot(ctx context.Context, kind, name, namespace string) (compareSideSummary, error) {
+	cfg, err := buildConfig()
+	if err != nil {
+		return compareSideSummary{}, fmt.Errorf("build kubernetes config: %w", err)
+	}
+
+	gvr := kindToGVR(kind)
+	if gvr.Resource == "" {
+		return compareSideSummary{}, fmt.Errorf("unsupported resource kind %q for compare mode", kind)
+	}
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return compareSideSummary{}, fmt.Errorf("build dynamic client: %w", err)
+	}
+
+	obj, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		return compareSideSummary{}, err
+	}
+
+	return summarizeCompareLiveObject(obj), nil
+}
+
+func summarizeCompareLiveObject(obj *unstructured.Unstructured) compareSideSummary {
+	out := compareSideSummary{
+		Source:          "cluster",
+		APIVersion:      obj.GetAPIVersion(),
+		Kind:            obj.GetKind(),
+		Name:            obj.GetName(),
+		Namespace:       obj.GetNamespace(),
+		Generation:      obj.GetGeneration(),
+		ResourceVersion: obj.GetResourceVersion(),
+		LabelCount:      len(obj.GetLabels()),
+		AnnotationCount: len(obj.GetAnnotations()),
+		Images:          extractCompareImages(obj.Object),
+	}
+	if replicas, ok, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas"); ok {
+		out.Replicas = &replicas
+	}
+	return out
+}
+
+func extractCompareImages(obj map[string]interface{}) []string {
+	containers, ok, _ := unstructured.NestedSlice(obj, "spec", "template", "spec", "containers")
+	if !ok || len(containers) == 0 {
+		return nil
+	}
+
+	images := make([]string, 0, len(containers))
+	for _, item := range containers {
+		container, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		raw, ok := container["image"].(string)
+		if !ok {
+			continue
+		}
+		image := strings.TrimSpace(raw)
+		if image == "" {
+			continue
+		}
+		images = append(images, image)
+	}
+	sort.Strings(images)
+	return images
+}
+
+func renderCompareResourceASCII(result compareResourceResult) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("Compare Resource: %s", result.Resource))
+	if result.Namespace != "" {
+		b.WriteString(fmt.Sprintf(" (namespace: %s)", result.Namespace))
+	}
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("Mode: %s\n", result.Mode))
+	if result.Connected {
+		b.WriteString("Connection: connected\n")
+	} else {
+		b.WriteString("Connection: standalone\n")
+	}
+
+	b.WriteString("\nLIVE (cluster)\n")
+	b.WriteString(fmt.Sprintf("  apiVersion: %s\n", valueOrDash(result.Live.APIVersion)))
+	b.WriteString(fmt.Sprintf("  kind: %s\n", valueOrDash(result.Live.Kind)))
+	b.WriteString(fmt.Sprintf("  name: %s\n", valueOrDash(result.Live.Name)))
+	b.WriteString(fmt.Sprintf("  namespace: %s\n", valueOrDash(result.Live.Namespace)))
+	if result.Live.Generation > 0 {
+		b.WriteString(fmt.Sprintf("  generation: %d\n", result.Live.Generation))
+	}
+	if result.Live.Replicas != nil {
+		b.WriteString(fmt.Sprintf("  replicas: %d\n", *result.Live.Replicas))
+	}
+	if len(result.Live.Images) > 0 {
+		b.WriteString("  images:\n")
+		for _, image := range result.Live.Images {
+			b.WriteString(fmt.Sprintf("    - %s\n", image))
+		}
+	}
+
+	if len(result.Notes) > 0 {
+		b.WriteString("\nNotes:\n")
+		for _, note := range result.Notes {
+			b.WriteString(fmt.Sprintf("  - %s\n", note))
+		}
+	}
+
+	return b.String()
+}
+
+func renderCompareResourceMarkdown(result compareResourceResult) string {
+	var b strings.Builder
+
+	b.WriteString("## Compare Resource\n\n")
+	b.WriteString(fmt.Sprintf("- Resource: `%s`\n", result.Resource))
+	if result.Namespace != "" {
+		b.WriteString(fmt.Sprintf("- Namespace: `%s`\n", result.Namespace))
+	}
+	b.WriteString(fmt.Sprintf("- Mode: `%s`\n", result.Mode))
+	if result.Connected {
+		b.WriteString("- Connection: `connected`\n\n")
+	} else {
+		b.WriteString("- Connection: `standalone`\n\n")
+	}
+
+	b.WriteString("### LIVE (cluster)\n\n")
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("|---|---|\n")
+	b.WriteString(fmt.Sprintf("| apiVersion | %s |\n", mdValueOrDash(result.Live.APIVersion)))
+	b.WriteString(fmt.Sprintf("| kind | %s |\n", mdValueOrDash(result.Live.Kind)))
+	b.WriteString(fmt.Sprintf("| name | %s |\n", mdValueOrDash(result.Live.Name)))
+	b.WriteString(fmt.Sprintf("| namespace | %s |\n", mdValueOrDash(result.Live.Namespace)))
+	if result.Live.Generation > 0 {
+		b.WriteString(fmt.Sprintf("| generation | %d |\n", result.Live.Generation))
+	}
+	if result.Live.Replicas != nil {
+		b.WriteString(fmt.Sprintf("| replicas | %d |\n", *result.Live.Replicas))
+	}
+	if len(result.Live.Images) > 0 {
+		b.WriteString(fmt.Sprintf("| images | `%s` |\n", strings.Join(result.Live.Images, "`, `")))
+	}
+
+	if len(result.Notes) > 0 {
+		b.WriteString("\n### Notes\n\n")
+		for _, note := range result.Notes {
+			b.WriteString(fmt.Sprintf("- %s\n", note))
+		}
+	}
+
+	return b.String()
+}
+
+func valueOrDash(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return "-"
+	}
+	return raw
+}
+
+func mdValueOrDash(raw string) string {
+	value := valueOrDash(raw)
+	if value == "-" {
+		return value
+	}
+	return "`" + value + "`"
+}

--- a/cmd/cub-scout/compare_resource_mode_test.go
+++ b/cmd/cub-scout/compare_resource_mode_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestBuildCompareResourceResult_Standalone(t *testing.T) {
+	restoreFlags := setCombinedFlagState(combinedFlagState{
+		namespace: "prod",
+		format:    "json",
+	})
+	defer restoreFlags()
+
+	restoreLive := loadCompareLiveSnapshotFn
+	loadCompareLiveSnapshotFn = func(ctx context.Context, kind, name, namespace string) (compareSideSummary, error) {
+		replicas := int64(3)
+		return compareSideSummary{
+			Source:     "cluster",
+			APIVersion: "apps/v1",
+			Kind:       kind,
+			Name:       name,
+			Namespace:  namespace,
+			Replicas:   &replicas,
+			Images:     []string{"ghcr.io/acme/api:v1"},
+		}, nil
+	}
+	defer func() { loadCompareLiveSnapshotFn = restoreLive }()
+
+	restoreConnected := compareConnectedFn
+	compareConnectedFn = func() bool { return false }
+	defer func() { compareConnectedFn = restoreConnected }()
+
+	result, err := buildCompareResourceResult(context.Background(), "deploy/api", "prod")
+	if err != nil {
+		t.Fatalf("buildCompareResourceResult: %v", err)
+	}
+	if result.Resource != "Deployment/api" {
+		t.Fatalf("result.Resource = %q, want Deployment/api", result.Resource)
+	}
+	if result.Mode != "live-only" {
+		t.Fatalf("result.Mode = %q, want live-only", result.Mode)
+	}
+	if result.Connected {
+		t.Fatal("expected result.Connected=false")
+	}
+	if result.Live.Replicas == nil || *result.Live.Replicas != 3 {
+		t.Fatalf("result.Live.Replicas = %#v, want 3", result.Live.Replicas)
+	}
+	if !strings.Contains(strings.Join(result.Notes, "\n"), "Connect to ConfigHub") {
+		t.Fatalf("expected upsell note in %v", result.Notes)
+	}
+}
+
+func TestBuildCompareResourceResult_Connected(t *testing.T) {
+	restoreLive := loadCompareLiveSnapshotFn
+	loadCompareLiveSnapshotFn = func(ctx context.Context, kind, name, namespace string) (compareSideSummary, error) {
+		return compareSideSummary{
+			Source:     "cluster",
+			APIVersion: "apps/v1",
+			Kind:       kind,
+			Name:       name,
+			Namespace:  namespace,
+		}, nil
+	}
+	defer func() { loadCompareLiveSnapshotFn = restoreLive }()
+
+	restoreConnected := compareConnectedFn
+	compareConnectedFn = func() bool { return true }
+	defer func() { compareConnectedFn = restoreConnected }()
+
+	result, err := buildCompareResourceResult(context.Background(), "deployment/api", "prod")
+	if err != nil {
+		t.Fatalf("buildCompareResourceResult: %v", err)
+	}
+	if !result.Connected {
+		t.Fatal("expected result.Connected=true")
+	}
+	if !strings.Contains(strings.Join(result.Notes, "\n"), "Connected mode detected") {
+		t.Fatalf("expected connected-mode note in %v", result.Notes)
+	}
+}
+
+func TestRunCombined_ResourceCompareRejectsGitFlags(t *testing.T) {
+	restoreFlags := setCombinedFlagState(combinedFlagState{
+		gitPath:   "/tmp/repo",
+		namespace: "prod",
+	})
+	defer restoreFlags()
+
+	err := runCombined(&cobra.Command{}, []string{"deploy/api"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined with --git-*") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCombined_ResourceCompareJSONOutput(t *testing.T) {
+	restoreFlags := setCombinedFlagState(combinedFlagState{
+		namespace: "prod",
+		format:    "json",
+	})
+	defer restoreFlags()
+
+	restoreLive := loadCompareLiveSnapshotFn
+	loadCompareLiveSnapshotFn = func(ctx context.Context, kind, name, namespace string) (compareSideSummary, error) {
+		return compareSideSummary{
+			Source:     "cluster",
+			APIVersion: "apps/v1",
+			Kind:       kind,
+			Name:       name,
+			Namespace:  namespace,
+		}, nil
+	}
+	defer func() { loadCompareLiveSnapshotFn = restoreLive }()
+
+	restoreConnected := compareConnectedFn
+	compareConnectedFn = func() bool { return false }
+	defer func() { compareConnectedFn = restoreConnected }()
+
+	out := captureStdout(t, func() {
+		if err := runCombined(&cobra.Command{}, []string{"deploy/api"}); err != nil {
+			t.Fatalf("runCombined: %v", err)
+		}
+	})
+
+	var payload compareResourceResult
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse compare json: %v\n%s", err, out)
+	}
+	if payload.Live.Name != "api" {
+		t.Fatalf("payload.Live.Name = %q, want api", payload.Live.Name)
+	}
+	if payload.Live.Namespace != "prod" {
+		t.Fatalf("payload.Live.Namespace = %q, want prod", payload.Live.Namespace)
+	}
+}

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -15,7 +15,7 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `apply` | Apply a proposal from JSON (GUI) |
 | `bundle` | Work with debug bundles |
 | `catalog` | Manage bundle catalogs |
-| `combined` | Show Git repo structure + cluster workloads aligned |
+| `combined` (`compare`) | Show Git repo + cluster alignment, or resource LIVE snapshot mode |
 | `completion` | Generate shell completion script |
 | `connect` | Quickly configure kube context from server URL or kubeconfig |
 | `debug` | Guided GitOps debugging wizard |
@@ -234,10 +234,14 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `--git-path-compare` | Right-side local Git repository path for Git↔Git compare |
 | `-n, --namespace` | Namespace to scan |
 | `--bundle` | Debug bundle directory as offline cluster snapshot |
+| `--format` | Resource compare format (`ascii`, `json`, `md`) |
 | `--suggest` | Generate Hub/App Space proposal |
 | `--apply` | Create App Space and Units |
 | `--dry-run` | Show without making changes |
 | `--json` | Output as JSON |
+
+Resource compare mode uses one positional argument:
+- `cub-scout compare <kind/name> -n <namespace> --format ascii|json|md`
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -30,7 +30,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD | v0.19 |
 | `tree` | Hierarchical resource views | v0.5 |
 | `import` | Import workloads into ConfigHub | v1.0 |
-| `combined` | Compare Git and cluster/bundle structures | v1.0 |
+| `combined` (`compare`) | Compare Git and cluster/bundle structures, or show LIVE snapshot for one resource | v1.0 |
 | `discover` | Scout-style workload discovery | v0.5 |
 | `health` | Scout-style health check | v0.5 |
 | `status` | Show connection status and cluster info | v1.0 |
@@ -726,6 +726,8 @@ cub-scout import --from-bundle ./debug-bundle --dry-run --json
 
 Show alignment across Git, live cluster, bundle snapshots, and Git↔Git compare.
 
+Alias: `compare`
+
 ```bash
 cub-scout combined [flags]
 ```
@@ -740,6 +742,7 @@ cub-scout combined [flags]
 | `--git-path-compare` | Right-side local Git repository path for Git↔Git compare |
 | `-n, --namespace` | Namespace to scan from live cluster |
 | `--bundle` | Use debug bundle directory as offline cluster snapshot |
+| `--format` | Resource compare output format: `ascii`, `json`, `md` |
 | `--suggest` | Generate App model proposal |
 | `--apply` | Apply proposal to ConfigHub |
 | `--dry-run` | Preview apply behavior without making changes |
@@ -748,6 +751,10 @@ cub-scout combined [flags]
 ### Examples
 
 ```bash
+# Resource compare mode (LIVE snapshot + connected upsell/degradation notes)
+cub-scout compare deploy/checkout -n prod --format ascii
+cub-scout compare deploy/checkout -n prod --format json
+
 # Git ↔ live cluster compare
 cub-scout combined --git-path ./repo --namespace payments --json
 


### PR DESCRIPTION
## Summary
- add positional resource mode to `combined`/`compare` when invoked as `compare <kind/name>`
- add `--format ascii|json|md` support for resource mode (with `--json` compatibility)
- enforce flag boundaries so resource mode cannot be mixed with git/bundle/suggest/apply flows
- implement honest LIVE-only output model (no synthetic DRY/WET data)
- include connected/standalone notes for graceful degradation and upsell path
- update command reference docs for alias + resource mode usage

## Testing
- go test ./cmd/cub-scout -run 'TestBuildCompareResourceResult_|TestRunCombined_ResourceCompare|TestCompareAlias|TestCombined' -count=1
- go test ./cmd/cub-scout -count=1
- go test ./test/unit -count=1
- go build ./cmd/cub-scout
