### PR TITLE
feat(impact): add connected blast-radius preview command

### DIFF
--- a/cmd/cub-scout/impact.go
+++ b/cmd/cub-scout/impact.go
@@ -1,0 +1,260 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	impactFormat string
+	impactJSON   bool
+
+	loadImpactUnitCacheFn = fetchConfigHubUnits
+	errImpactNotConnected = errors.New("impact analysis requires ConfigHub")
+)
+
+type impactDependent struct {
+	Unit         string   `json:"unit"`
+	Environments []string `json:"environments,omitempty"`
+	Clusters     []string `json:"clusters,omitempty"`
+}
+
+type impactSummary struct {
+	DirectDependents     int    `json:"directDependents"`
+	EnvironmentsAffected int    `json:"environmentsAffected"`
+	ClustersAffected     int    `json:"clustersAffected"`
+	Risk                 string `json:"risk"`
+}
+
+type impactResult struct {
+	Unit       string            `json:"unit"`
+	Connected  bool              `json:"connected"`
+	Dependents []impactDependent `json:"dependents,omitempty"`
+	Summary    impactSummary     `json:"summary"`
+	Notes      []string          `json:"notes,omitempty"`
+}
+
+var impactCmd = &cobra.Command{
+	Use:   "impact <unit>",
+	Short: "Preview blast radius for a unit change (connected mode)",
+	Long: `Preview impact for one ConfigHub unit using dependency links.
+
+Examples:
+  cub-scout impact unit/shared-db-config
+  cub-scout impact shared-db-config --format md
+  cub-scout impact shared-db-config --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runImpact,
+}
+
+func init() {
+	rootCmd.AddCommand(impactCmd)
+	impactCmd.Flags().StringVar(&impactFormat, "format", "ascii", "Output format: ascii, json, md")
+	impactCmd.Flags().BoolVar(&impactJSON, "json", false, "Output as JSON (shorthand for --format json)")
+}
+
+func runImpact(cmd *cobra.Command, args []string) error {
+	cache, err := loadImpactUnitCacheFn()
+	if err != nil {
+		return fmt.Errorf("%w. Run: cub auth login", errImpactNotConnected)
+	}
+
+	result, err := buildImpactResult(cache, args[0])
+	if err != nil {
+		return err
+	}
+
+	format := strings.ToLower(strings.TrimSpace(impactFormat))
+	if format == "" {
+		format = "ascii"
+	}
+	if impactJSON {
+		format = "json"
+	}
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	case "md":
+		fmt.Print(renderImpactMarkdown(result))
+		return nil
+	case "ascii":
+		fmt.Print(renderImpactASCII(result))
+		return nil
+	default:
+		return fmt.Errorf("invalid --format %q (valid: ascii, json, md)", impactFormat)
+	}
+}
+
+func buildImpactResult(cache *cubUnitCache, rawUnit string) (impactResult, error) {
+	if cache == nil {
+		return impactResult{}, fmt.Errorf("impact cache unavailable")
+	}
+
+	unitSlug := normalizeImpactUnit(rawUnit)
+	unit := cache.getUnitBySlug(unitSlug)
+	if unit == nil {
+		return impactResult{}, fmt.Errorf("unit %q not found in connected ConfigHub context", unitSlug)
+	}
+
+	uniqueDependents := uniqueSortedStrings(unit.DependedBy)
+	dependents := make([]impactDependent, 0, len(uniqueDependents))
+	environments := make(map[string]struct{})
+	clusters := make(map[string]struct{})
+	notes := make([]string, 0, 2)
+
+	for _, dependentSlug := range uniqueDependents {
+		dependentUnit := cache.getUnitBySlug(dependentSlug)
+		if dependentUnit == nil {
+			notes = append(notes, fmt.Sprintf("Dependent unit %q was referenced but not found in current unit cache.", dependentSlug))
+			continue
+		}
+
+		envList := uniqueSortedStrings(append([]string{dependentUnit.Space}, dependentUnit.OtherSpaces...))
+		for _, env := range envList {
+			if env == "" {
+				continue
+			}
+			environments[env] = struct{}{}
+		}
+		clusterList := uniqueSortedStrings([]string{dependentUnit.TargetSlug})
+		for _, cluster := range clusterList {
+			if cluster == "" {
+				continue
+			}
+			clusters[cluster] = struct{}{}
+		}
+
+		dependents = append(dependents, impactDependent{
+			Unit:         dependentSlug,
+			Environments: envList,
+			Clusters:     clusterList,
+		})
+	}
+
+	risk := "LOW"
+	if len(dependents) > 0 {
+		risk = "MEDIUM"
+		for env := range environments {
+			if strings.Contains(strings.ToLower(env), "prod") {
+				risk = "HIGH"
+				break
+			}
+		}
+	} else {
+		notes = append(notes, "No dependent units found for this unit in the current ConfigHub link graph.")
+	}
+
+	return impactResult{
+		Unit:       unitSlug,
+		Connected:  true,
+		Dependents: dependents,
+		Summary: impactSummary{
+			DirectDependents:     len(dependents),
+			EnvironmentsAffected: len(environments),
+			ClustersAffected:     len(clusters),
+			Risk:                 risk,
+		},
+		Notes: notes,
+	}, nil
+}
+
+func normalizeImpactUnit(raw string) string {
+	unit := strings.TrimSpace(raw)
+	unit = strings.TrimPrefix(unit, "unit/")
+	return strings.TrimSpace(unit)
+}
+
+func renderImpactASCII(result impactResult) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Impact Preview: unit/%s\n\n", result.Unit))
+	b.WriteString("Blast Radius:\n")
+	b.WriteString(fmt.Sprintf("  Direct dependents: %d unit(s)\n", result.Summary.DirectDependents))
+	for _, dependent := range result.Dependents {
+		envs := "-"
+		if len(dependent.Environments) > 0 {
+			envs = strings.Join(dependent.Environments, ", ")
+		}
+		clusters := "-"
+		if len(dependent.Clusters) > 0 {
+			clusters = strings.Join(dependent.Clusters, ", ")
+		}
+		b.WriteString(fmt.Sprintf("    - %s (env: %s, clusters: %s)\n", dependent.Unit, envs, clusters))
+	}
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  Environments affected: %d\n", result.Summary.EnvironmentsAffected))
+	b.WriteString(fmt.Sprintf("  Clusters affected: %d\n", result.Summary.ClustersAffected))
+	b.WriteString(fmt.Sprintf("  Risk: %s\n", result.Summary.Risk))
+	if len(result.Notes) > 0 {
+		b.WriteString("\nNotes:\n")
+		for _, note := range result.Notes {
+			b.WriteString(fmt.Sprintf("  - %s\n", note))
+		}
+	}
+	return b.String()
+}
+
+func renderImpactMarkdown(result impactResult) string {
+	var b strings.Builder
+	b.WriteString("## Impact Preview\n\n")
+	b.WriteString(fmt.Sprintf("- Unit: `unit/%s`\n", result.Unit))
+	b.WriteString(fmt.Sprintf("- Direct dependents: `%d`\n", result.Summary.DirectDependents))
+	b.WriteString(fmt.Sprintf("- Environments affected: `%d`\n", result.Summary.EnvironmentsAffected))
+	b.WriteString(fmt.Sprintf("- Clusters affected: `%d`\n", result.Summary.ClustersAffected))
+	b.WriteString(fmt.Sprintf("- Risk: `%s`\n\n", result.Summary.Risk))
+
+	b.WriteString("### Dependents\n\n")
+	if len(result.Dependents) == 0 {
+		b.WriteString("- None\n")
+	} else {
+		b.WriteString("| Unit | Environments | Clusters |\n")
+		b.WriteString("|---|---|---|\n")
+		for _, dependent := range result.Dependents {
+			envs := "-"
+			if len(dependent.Environments) > 0 {
+				envs = strings.Join(dependent.Environments, ", ")
+			}
+			clusters := "-"
+			if len(dependent.Clusters) > 0 {
+				clusters = strings.Join(dependent.Clusters, ", ")
+			}
+			b.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` |\n", dependent.Unit, envs, clusters))
+		}
+	}
+
+	if len(result.Notes) > 0 {
+		b.WriteString("\n### Notes\n\n")
+		for _, note := range result.Notes {
+			b.WriteString("- " + note + "\n")
+		}
+	}
+	return b.String()
+}
+
+func uniqueSortedStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/cub-scout/impact_test.go
+++ b/cmd/cub-scout/impact_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestBuildImpactResult(t *testing.T) {
+	cache := &cubUnitCache{
+		units: map[string]*cubUnitInfo{
+			"shared-db-config": {
+				Slug:       "shared-db-config",
+				DependedBy: []string{"api-gateway", "worker-service"},
+			},
+			"api-gateway": {
+				Slug:       "api-gateway",
+				Space:      "payments-prod",
+				TargetSlug: "prod-east",
+				OtherSpaces: []string{
+					"payments-staging",
+				},
+			},
+			"worker-service": {
+				Slug:       "worker-service",
+				Space:      "payments-prod",
+				TargetSlug: "prod-west",
+			},
+		},
+	}
+
+	got, err := buildImpactResult(cache, "shared-db-config")
+	if err != nil {
+		t.Fatalf("buildImpactResult: %v", err)
+	}
+	if got.Unit != "shared-db-config" {
+		t.Fatalf("unit = %q, want shared-db-config", got.Unit)
+	}
+	if got.Summary.DirectDependents != 2 {
+		t.Fatalf("direct dependents = %d, want 2", got.Summary.DirectDependents)
+	}
+	if got.Summary.EnvironmentsAffected != 2 {
+		t.Fatalf("environments affected = %d, want 2", got.Summary.EnvironmentsAffected)
+	}
+	if got.Summary.ClustersAffected != 2 {
+		t.Fatalf("clusters affected = %d, want 2", got.Summary.ClustersAffected)
+	}
+	if got.Summary.Risk != "HIGH" {
+		t.Fatalf("risk = %q, want HIGH", got.Summary.Risk)
+	}
+}
+
+func TestRunImpactASCII(t *testing.T) {
+	restoreFlags := setImpactFlagState(impactFlagState{
+		format: "ascii",
+	})
+	defer restoreFlags()
+
+	restoreLoader := loadImpactUnitCacheFn
+	loadImpactUnitCacheFn = func() (*cubUnitCache, error) {
+		return &cubUnitCache{
+			units: map[string]*cubUnitInfo{
+				"shared-db-config": {
+					Slug:       "shared-db-config",
+					DependedBy: []string{"api-gateway"},
+				},
+				"api-gateway": {
+					Slug:       "api-gateway",
+					Space:      "payments-prod",
+					TargetSlug: "prod-east",
+				},
+			},
+		}, nil
+	}
+	defer func() { loadImpactUnitCacheFn = restoreLoader }()
+
+	out := captureStdout(t, func() {
+		if err := runImpact(&cobra.Command{}, []string{"unit/shared-db-config"}); err != nil {
+			t.Fatalf("runImpact: %v", err)
+		}
+	})
+
+	for _, needle := range []string{
+		"Impact Preview: unit/shared-db-config",
+		"Direct dependents: 1 unit(s)",
+		"Risk: HIGH",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("output missing %q:\n%s", needle, out)
+		}
+	}
+}
+
+func TestRunImpactNotConnected(t *testing.T) {
+	restoreFlags := setImpactFlagState(impactFlagState{
+		format: "ascii",
+	})
+	defer restoreFlags()
+
+	restoreLoader := loadImpactUnitCacheFn
+	loadImpactUnitCacheFn = func() (*cubUnitCache, error) {
+		return nil, errImpactNotConnected
+	}
+	defer func() { loadImpactUnitCacheFn = restoreLoader }()
+
+	err := runImpact(&cobra.Command{}, []string{"shared-db-config"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cub auth login") {
+		t.Fatalf("expected auth guidance, got: %v", err)
+	}
+}
+
+type impactFlagState struct {
+	format string
+	json   bool
+}
+
+func setImpactFlagState(state impactFlagState) func() {
+	prevFormat := impactFormat
+	prevJSON := impactJSON
+	impactFormat = state.format
+	impactJSON = state.json
+	return func() {
+		impactFormat = prevFormat
+		impactJSON = prevJSON
+	}
+}

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -28,6 +28,7 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `import` | Import workloads into ConfigHub |
 | `import-argocd` | Import an ArgoCD Application into ConfigHub |
 | `import-cluster-aggregator` | Aggregate imports from multiple clusters (GUI) |
+| `impact` | Connected blast-radius preview for one unit |
 | `map` | Interactive map of resources and ownership |
 | `parse-repo` | Parse a GitOps repository structure |
 | `patterns` | Pattern detection engine |
@@ -163,6 +164,15 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `--threshold` | Duration threshold for stuck (default: 5m) |
 | `--json` | Output as JSON |
 | `--verbose` | Show detailed output |
+
+---
+
+## `impact` Options
+
+| Option | Description |
+|--------|-------------|
+| `--format` | Output format (`ascii`, `json`, `md`) |
+| `--json` | Output as JSON |
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,6 +25,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `quickstart` | Guided first-run walkthrough | v1.4 |
 | `doctor` | One-command cluster health summary | v1.4 |
 | `explain` | Plain-English ownership and lineage for one resource | v1.4 |
+| `impact` | Connected blast-radius preview for one unit | v1.6 |
 | `trace` | Show GitOps ownership chain | v0.5 |
 | `scan` | Scan for misconfigurations | v0.5 |
 | `scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD | v0.19 |
@@ -249,6 +250,33 @@ cub-scout map orphans
 cub-scout map orphans -n default
 cub-scout map orphans --json
 ```
+
+---
+
+## impact
+
+Preview connected blast radius for a ConfigHub unit.
+
+```bash
+cub-scout impact <unit> [flags]
+```
+
+Requires ConfigHub authentication.
+
+### Examples
+
+```bash
+cub-scout impact unit/shared-db-config
+cub-scout impact shared-db-config --format md
+cub-scout impact shared-db-config --json
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format: `ascii`, `json`, `md` |
+| `--json` | Output as JSON (shorthand for `--format json`) |
 
 ---
 


### PR DESCRIPTION
## Summary
- add new connected CLI command: `cub-scout impact <unit>`
- compute blast-radius summary from ConfigHub unit/link cache:
  - direct dependent units
  - affected environments (spaces)
  - affected clusters (target slugs)
  - risk classification (`LOW|MEDIUM|HIGH`)
- support `--format ascii|json|md` and `--json`
- add clear connected-mode gating message: `impact analysis requires ConfigHub. Run: cub auth login`
- document command in `docs/reference/commands.md` and `docs/reference/command-matrix.md`

## Testing
- go test ./cmd/cub-scout -run 'TestBuildImpactResult|TestRunImpactASCII|TestRunImpactNotConnected' -count=1
- go test ./cmd/cub-scout -count=1
- go test ./pkg/agent -count=1
- go test ./test/unit -count=1
- go build ./cmd/cub-scout
