### PR TITLE
feat(fleet): add cluster outlier detection command

### DIFF
--- a/cmd/cub-scout/fleet_outliers.go
+++ b/cmd/cub-scout/fleet_outliers.go
@@ -1,0 +1,302 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	fleetOutliersFormat string
+	fleetOutliersJSON   bool
+
+	loadFleetOutlierUnitsFn      = loadFleetOutlierUnits
+	errFleetOutliersNotConnected = errors.New("fleet views require ConfigHub")
+)
+
+type fleetUnitSnapshot struct {
+	UnitSlug string `json:"unitSlug"`
+	Cluster  string `json:"cluster"`
+	Revision int    `json:"revision"`
+	Space    string `json:"space,omitempty"`
+}
+
+type fleetOutlierFinding struct {
+	Kind        string `json:"kind"` // revision, missing
+	Unit        string `json:"unit"`
+	Revision    int    `json:"revision,omitempty"`
+	FleetNorm   int    `json:"fleetNorm,omitempty"`
+	PresentIn   int    `json:"presentIn,omitempty"`
+	Total       int    `json:"total,omitempty"`
+	Description string `json:"description"`
+}
+
+type fleetOutlierClusterReport struct {
+	Cluster  string                `json:"cluster"`
+	Outliers []fleetOutlierFinding `json:"outliers,omitempty"`
+}
+
+type fleetOutlierSummary struct {
+	ClusterCount        int `json:"clusterCount"`
+	OutlierClusterCount int `json:"outlierClusterCount"`
+}
+
+type fleetOutlierReport struct {
+	Summary   fleetOutlierSummary                   `json:"summary"`
+	Clusters  []string                              `json:"clusters"`
+	ByCluster map[string]*fleetOutlierClusterReport `json:"byCluster"`
+}
+
+var fleetTopCmd = &cobra.Command{
+	Use:   "fleet",
+	Short: "Fleet-level connected insights",
+}
+
+var fleetOutliersCmd = &cobra.Command{
+	Use:   "outliers",
+	Short: "Identify clusters that diverge from fleet norms",
+	Long: `Detect outlier clusters by comparing unit revision and unit presence across clusters.
+
+Examples:
+  cub-scout fleet outliers
+  cub-scout fleet outliers --format md
+  cub-scout fleet outliers --json`,
+	RunE: runFleetOutliers,
+}
+
+func init() {
+	fleetTopCmd.AddCommand(fleetOutliersCmd)
+	rootCmd.AddCommand(fleetTopCmd)
+
+	fleetOutliersCmd.Flags().StringVar(&fleetOutliersFormat, "format", "ascii", "Output format: ascii, json, md")
+	fleetOutliersCmd.Flags().BoolVar(&fleetOutliersJSON, "json", false, "Output as JSON (shorthand for --format json)")
+}
+
+func runFleetOutliers(cmd *cobra.Command, args []string) error {
+	units, err := loadFleetOutlierUnitsFn()
+	if err != nil {
+		return fmt.Errorf("%w. Run: cub auth login", errFleetOutliersNotConnected)
+	}
+
+	report, err := buildFleetOutlierReport(units)
+	if err != nil {
+		return err
+	}
+
+	format := strings.ToLower(strings.TrimSpace(fleetOutliersFormat))
+	if format == "" {
+		format = "ascii"
+	}
+	if fleetOutliersJSON {
+		format = "json"
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	case "md":
+		fmt.Print(renderFleetOutliersMarkdown(report))
+		return nil
+	case "ascii":
+		fmt.Print(renderFleetOutliersASCII(report))
+		return nil
+	default:
+		return fmt.Errorf("invalid --format %q (valid: ascii, json, md)", fleetOutliersFormat)
+	}
+}
+
+func loadFleetOutlierUnits() ([]fleetUnitSnapshot, error) {
+	cmd := exec.Command("cub", "unit", "list", "--json", "--quiet")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errFleetOutliersNotConnected
+	}
+
+	var unitList []struct {
+		Unit struct {
+			Slug            string `json:"Slug"`
+			HeadRevisionNum int    `json:"HeadRevisionNum"`
+			TargetSlug      string `json:"TargetSlug"`
+		} `json:"Unit"`
+		Space struct {
+			Slug string `json:"Slug"`
+		} `json:"Space"`
+	}
+	if err := json.Unmarshal(out, &unitList); err != nil {
+		return nil, fmt.Errorf("parse unit list: %w", err)
+	}
+
+	units := make([]fleetUnitSnapshot, 0, len(unitList))
+	for _, item := range unitList {
+		cluster := strings.TrimSpace(item.Unit.TargetSlug)
+		if cluster == "" {
+			continue
+		}
+		units = append(units, fleetUnitSnapshot{
+			UnitSlug: strings.TrimSpace(item.Unit.Slug),
+			Cluster:  cluster,
+			Revision: item.Unit.HeadRevisionNum,
+			Space:    strings.TrimSpace(item.Space.Slug),
+		})
+	}
+	return units, nil
+}
+
+func buildFleetOutlierReport(units []fleetUnitSnapshot) (fleetOutlierReport, error) {
+	clusterSet := make(map[string]struct{})
+	unitClusters := make(map[string]map[string]int)
+	for _, unit := range units {
+		if strings.TrimSpace(unit.UnitSlug) == "" || strings.TrimSpace(unit.Cluster) == "" {
+			continue
+		}
+		clusterSet[unit.Cluster] = struct{}{}
+		if unitClusters[unit.UnitSlug] == nil {
+			unitClusters[unit.UnitSlug] = map[string]int{}
+		}
+		unitClusters[unit.UnitSlug][unit.Cluster] = unit.Revision
+	}
+
+	clusters := make([]string, 0, len(clusterSet))
+	for cluster := range clusterSet {
+		clusters = append(clusters, cluster)
+	}
+	sort.Strings(clusters)
+	if len(clusters) < 2 {
+		return fleetOutlierReport{}, fmt.Errorf("fleet comparison requires 2+ clusters")
+	}
+
+	report := fleetOutlierReport{
+		Summary: fleetOutlierSummary{
+			ClusterCount: len(clusters),
+		},
+		Clusters:  clusters,
+		ByCluster: map[string]*fleetOutlierClusterReport{},
+	}
+	for _, cluster := range clusters {
+		report.ByCluster[cluster] = &fleetOutlierClusterReport{
+			Cluster:  cluster,
+			Outliers: make([]fleetOutlierFinding, 0),
+		}
+	}
+
+	unitNames := make([]string, 0, len(unitClusters))
+	for unit := range unitClusters {
+		unitNames = append(unitNames, unit)
+	}
+	sort.Strings(unitNames)
+
+	for _, unit := range unitNames {
+		perCluster := unitClusters[unit]
+		norm := modeRevision(perCluster)
+		presentIn := len(perCluster)
+
+		for _, cluster := range clusters {
+			revision, exists := perCluster[cluster]
+			if !exists {
+				report.ByCluster[cluster].Outliers = append(report.ByCluster[cluster].Outliers, fleetOutlierFinding{
+					Kind:        "missing",
+					Unit:        unit,
+					PresentIn:   presentIn,
+					Total:       len(clusters),
+					Description: fmt.Sprintf("Missing: unit/%s (present in %d/%d clusters)", unit, presentIn, len(clusters)),
+				})
+				continue
+			}
+			if revision == norm {
+				continue
+			}
+			delta := norm - revision
+			report.ByCluster[cluster].Outliers = append(report.ByCluster[cluster].Outliers, fleetOutlierFinding{
+				Kind:      "revision",
+				Unit:      unit,
+				Revision:  revision,
+				FleetNorm: norm,
+				Description: fmt.Sprintf("unit/%s: revision %d (fleet norm: %d) — %d revision(s) behind",
+					unit, revision, norm, delta),
+			})
+		}
+	}
+
+	for _, cluster := range clusters {
+		sort.Slice(report.ByCluster[cluster].Outliers, func(i, j int) bool {
+			left := report.ByCluster[cluster].Outliers[i]
+			right := report.ByCluster[cluster].Outliers[j]
+			if left.Kind != right.Kind {
+				return left.Kind < right.Kind
+			}
+			return left.Unit < right.Unit
+		})
+		if len(report.ByCluster[cluster].Outliers) > 0 {
+			report.Summary.OutlierClusterCount++
+		}
+	}
+
+	return report, nil
+}
+
+func modeRevision(perCluster map[string]int) int {
+	counts := make(map[int]int)
+	norm := 0
+	normCount := -1
+	for _, rev := range perCluster {
+		counts[rev]++
+	}
+	for rev, count := range counts {
+		if count > normCount || (count == normCount && rev > norm) {
+			norm = rev
+			normCount = count
+		}
+	}
+	return norm
+}
+
+func renderFleetOutliersASCII(report fleetOutlierReport) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Fleet Outliers (%d clusters)\n\n", report.Summary.ClusterCount))
+	b.WriteString("Outliers detected:\n")
+	for _, cluster := range report.Clusters {
+		clusterReport := report.ByCluster[cluster]
+		if clusterReport == nil || len(clusterReport.Outliers) == 0 {
+			b.WriteString(fmt.Sprintf("  %s %s: consistent\n", SymOK, cluster))
+			continue
+		}
+		b.WriteString(fmt.Sprintf("  %s %s:\n", SymWarning, cluster))
+		for _, outlier := range clusterReport.Outliers {
+			b.WriteString(fmt.Sprintf("    - %s\n", outlier.Description))
+		}
+	}
+	return b.String()
+}
+
+func renderFleetOutliersMarkdown(report fleetOutlierReport) string {
+	var b strings.Builder
+	b.WriteString("## Fleet Outliers\n\n")
+	b.WriteString(fmt.Sprintf("- Clusters: `%d`\n", report.Summary.ClusterCount))
+	b.WriteString(fmt.Sprintf("- Outlier clusters: `%d`\n\n", report.Summary.OutlierClusterCount))
+	b.WriteString("| Cluster | Status | Findings |\n")
+	b.WriteString("|---|---|---|\n")
+	for _, cluster := range report.Clusters {
+		clusterReport := report.ByCluster[cluster]
+		if clusterReport == nil || len(clusterReport.Outliers) == 0 {
+			b.WriteString(fmt.Sprintf("| `%s` | consistent | - |\n", cluster))
+			continue
+		}
+		findings := make([]string, 0, len(clusterReport.Outliers))
+		for _, outlier := range clusterReport.Outliers {
+			findings = append(findings, outlier.Description)
+		}
+		b.WriteString(fmt.Sprintf("| `%s` | outlier | %s |\n", cluster, strings.Join(findings, "<br>")))
+	}
+	return b.String()
+}

--- a/cmd/cub-scout/fleet_outliers_test.go
+++ b/cmd/cub-scout/fleet_outliers_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestBuildFleetOutlierReport(t *testing.T) {
+	units := []fleetUnitSnapshot{
+		{UnitSlug: "api-gateway", Cluster: "us-east-1", Revision: 14},
+		{UnitSlug: "api-gateway", Cluster: "us-west-2", Revision: 14},
+		{UnitSlug: "api-gateway", Cluster: "eu-west-1", Revision: 12},
+		{UnitSlug: "worker-service", Cluster: "us-east-1", Revision: 9},
+		{UnitSlug: "worker-service", Cluster: "us-west-2", Revision: 9},
+	}
+
+	report, err := buildFleetOutlierReport(units)
+	if err != nil {
+		t.Fatalf("buildFleetOutlierReport: %v", err)
+	}
+	if report.Summary.ClusterCount != 3 {
+		t.Fatalf("cluster count = %d, want 3", report.Summary.ClusterCount)
+	}
+
+	cluster := report.ByCluster["eu-west-1"]
+	if cluster == nil {
+		t.Fatal("expected eu-west-1 cluster report")
+	}
+	if len(cluster.Outliers) < 2 {
+		t.Fatalf("expected eu-west-1 outliers, got %#v", cluster.Outliers)
+	}
+}
+
+func TestRunFleetOutliersASCII(t *testing.T) {
+	restoreFlags := setFleetOutlierFlagState(fleetOutlierFlagState{
+		format: "ascii",
+	})
+	defer restoreFlags()
+
+	restoreLoader := loadFleetOutlierUnitsFn
+	loadFleetOutlierUnitsFn = func() ([]fleetUnitSnapshot, error) {
+		return []fleetUnitSnapshot{
+			{UnitSlug: "api-gateway", Cluster: "us-east-1", Revision: 14},
+			{UnitSlug: "api-gateway", Cluster: "us-west-2", Revision: 12},
+		}, nil
+	}
+	defer func() { loadFleetOutlierUnitsFn = restoreLoader }()
+
+	out := captureStdout(t, func() {
+		if err := runFleetOutliers(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runFleetOutliers: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Fleet Outliers") {
+		t.Fatalf("expected fleet outlier header:\n%s", out)
+	}
+	if !strings.Contains(out, "us-west-2") {
+		t.Fatalf("expected divergent cluster in output:\n%s", out)
+	}
+}
+
+func TestRunFleetOutliersNotConnected(t *testing.T) {
+	restoreFlags := setFleetOutlierFlagState(fleetOutlierFlagState{
+		format: "ascii",
+	})
+	defer restoreFlags()
+
+	restoreLoader := loadFleetOutlierUnitsFn
+	loadFleetOutlierUnitsFn = func() ([]fleetUnitSnapshot, error) {
+		return nil, errFleetOutliersNotConnected
+	}
+	defer func() { loadFleetOutlierUnitsFn = restoreLoader }()
+
+	err := runFleetOutliers(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cub auth login") {
+		t.Fatalf("expected auth guidance, got: %v", err)
+	}
+}
+
+type fleetOutlierFlagState struct {
+	format string
+	json   bool
+}
+
+func setFleetOutlierFlagState(state fleetOutlierFlagState) func() {
+	prevFormat := fleetOutliersFormat
+	prevJSON := fleetOutliersJSON
+	fleetOutliersFormat = state.format
+	fleetOutliersJSON = state.json
+	return func() {
+		fleetOutliersFormat = prevFormat
+		fleetOutliersJSON = prevJSON
+	}
+}

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -22,6 +22,7 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `demo` | Run interactive demos |
 | `discover` | Discover resources (alias for `map workloads`) |
 | `drift` | Detect drift between desired and live state |
+| `fleet` | Fleet-level connected insights |
 | `gitops` | GitOps status and diagnostics |
 | `graph` | Resource graph operations |
 | `health` | Check cluster issues (alias for `map issues`) |
@@ -168,6 +169,15 @@ Complete reference of all commands, options, TUI keys, and availability.
 ---
 
 ## `impact` Options
+
+| Option | Description |
+|--------|-------------|
+| `--format` | Output format (`ascii`, `json`, `md`) |
+| `--json` | Output as JSON |
+
+---
+
+## `fleet outliers` Options
 
 | Option | Description |
 |--------|-------------|

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -26,6 +26,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `doctor` | One-command cluster health summary | v1.4 |
 | `explain` | Plain-English ownership and lineage for one resource | v1.4 |
 | `impact` | Connected blast-radius preview for one unit | v1.6 |
+| `fleet outliers` | Connected cluster-drift outlier report | v1.6 |
 | `trace` | Show GitOps ownership chain | v0.5 |
 | `scan` | Scan for misconfigurations | v0.5 |
 | `scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD | v0.19 |
@@ -269,6 +270,33 @@ Requires ConfigHub authentication.
 cub-scout impact unit/shared-db-config
 cub-scout impact shared-db-config --format md
 cub-scout impact shared-db-config --json
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format: `ascii`, `json`, `md` |
+| `--json` | Output as JSON (shorthand for `--format json`) |
+
+---
+
+## fleet outliers
+
+Identify clusters that diverge from fleet norms (connected mode).
+
+```bash
+cub-scout fleet outliers [flags]
+```
+
+Requires ConfigHub authentication and at least two clusters with target data.
+
+### Examples
+
+```bash
+cub-scout fleet outliers
+cub-scout fleet outliers --format md
+cub-scout fleet outliers --json
 ```
 
 ### Flags


### PR DESCRIPTION
## Summary
- add new top-level `fleet` command with `fleet outliers` subcommand
- implement outlier detection across clusters using connected unit snapshots:
  - revision divergence from fleet norm (mode)
  - missing unit presence by cluster
- support `--format ascii|json|md` and `--json`
- add graceful degradation:
  - not connected => `fleet views require ConfigHub. Run: cub auth login`
  - fewer than 2 clusters => explicit `fleet comparison requires 2+ clusters`
- document command in command reference + command matrix

## Testing
- go test ./cmd/cub-scout -run 'TestBuildFleetOutlierReport|TestRunFleetOutliersASCII|TestRunFleetOutliersNotConnected' -count=1
- go test ./cmd/cub-scout -count=1
- go test ./pkg/agent -count=1
- go test ./test/unit -count=1
- go build ./cmd/cub-scout
