### PR TITLE
feat: add break-glass audit trail command + import audit reasons

### DIFF
--- a/cmd/cub-scout/audit.go
+++ b/cmd/cub-scout/audit.go
@@ -1,0 +1,424 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/hub"
+	"github.com/spf13/cobra"
+)
+
+var (
+	auditListNamespace string
+	auditListFormat    string
+	auditListSince     string
+)
+
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Break-glass audit trail tools",
+}
+
+var auditListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List break-glass accept/reject decisions",
+	Long: `List break-glass decisions from connected ConfigHub ChangeSet history.
+
+Examples:
+  cub-scout audit list
+  cub-scout audit list -n prod --since 7d
+  cub-scout audit list --format md
+  cub-scout audit list --json`,
+	RunE: runAuditList,
+}
+
+func init() {
+	auditCmd.AddCommand(auditListCmd)
+	rootCmd.AddCommand(auditCmd)
+
+	auditListCmd.Flags().StringVarP(&auditListNamespace, "namespace", "n", "", "Namespace scope (optional)")
+	auditListCmd.Flags().StringVar(&auditListFormat, "format", "ascii", "Output format: ascii, json, md")
+	auditListCmd.Flags().StringVar(&auditListSince, "since", "7d", "Lookback window (examples: 24h, 7d, 2w)")
+	auditListCmd.Flags().Bool("json", false, "Output as JSON (shorthand for --format json)")
+}
+
+var errAuditDisconnected = errors.New("audit requires ConfigHub connection. Run: cub auth login")
+
+type auditListQuery struct {
+	Namespace string
+	Since     string
+	Window    time.Duration
+	Now       time.Time
+}
+
+type auditEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Actor     string    `json:"actor"`
+	Reason    string    `json:"reason"`
+	What      string    `json:"what"`
+	ChangeSet string    `json:"changeset,omitempty"`
+}
+
+type auditListResult struct {
+	Namespace string       `json:"namespace,omitempty"`
+	Since     string       `json:"since"`
+	Entries   []auditEntry `json:"entries"`
+}
+
+var (
+	requireAuditConnectedFn = requireAuditConnected
+	fetchAuditEntriesFn     = fetchAuditEntries
+	auditNowFn              = time.Now
+	runAuditCubCommand      = runHistoryCubCommandImpl
+)
+
+func runAuditList(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(auditListFormat))
+	if cmd != nil {
+		if jsonFlag, err := cmd.Flags().GetBool("json"); err == nil && jsonFlag {
+			format = "json"
+		}
+	}
+	if format == "" {
+		format = "ascii"
+	}
+	if format != "ascii" && format != "json" && format != "md" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json, md)", auditListFormat)
+	}
+
+	window, err := parseHistorySince(auditListSince)
+	if err != nil {
+		return err
+	}
+
+	query := auditListQuery{
+		Namespace: strings.TrimSpace(auditListNamespace),
+		Since:     strings.TrimSpace(auditListSince),
+		Window:    window,
+		Now:       auditNowFn().UTC(),
+	}
+
+	entries, err := resolveAuditEntries(cmd.Context(), query)
+	if err != nil {
+		return err
+	}
+
+	result := auditListResult{
+		Namespace: query.Namespace,
+		Since:     query.Since,
+		Entries:   entries,
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	case "md":
+		fmt.Print(renderAuditMarkdown(result))
+		return nil
+	default:
+		fmt.Print(renderAuditASCII(result))
+		return nil
+	}
+}
+
+func resolveAuditEntries(ctx context.Context, q auditListQuery) ([]auditEntry, error) {
+	if fixture := strings.TrimSpace(os.Getenv("CUB_SCOUT_TEST_AUDIT_JSON")); fixture != "" {
+		raw, err := os.ReadFile(fixture)
+		if err != nil {
+			return nil, fmt.Errorf("read audit fixture %q: %w", fixture, err)
+		}
+		entries, err := buildAuditEntriesFromChangeSets(string(raw), q.Namespace, q.Now.Add(-q.Window))
+		if err != nil {
+			return nil, fmt.Errorf("parse audit fixture %q: %w", fixture, err)
+		}
+		return entries, nil
+	}
+
+	if err := requireAuditConnectedFn(); err != nil {
+		return nil, err
+	}
+
+	return fetchAuditEntriesFn(ctx, q)
+}
+
+func requireAuditConnected() error {
+	if err := hub.NewClient().RequireConnected(); err != nil {
+		return errAuditDisconnected
+	}
+	if _, err := exec.LookPath("cub"); err != nil {
+		return fmt.Errorf("audit requires cub CLI for connected queries: %w", err)
+	}
+	return nil
+}
+
+func fetchAuditEntries(ctx context.Context, q auditListQuery) ([]auditEntry, error) {
+	args := []string{"changeset", "list", "--json", "--contains", "break-glass"}
+	if space := detectHistorySpace(ctx); space != "" {
+		args = append(args, "--space", space)
+	}
+
+	raw, err := runAuditCubCommand(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("fetch break-glass audit history: %w", err)
+	}
+
+	return buildAuditEntriesFromChangeSets(raw, q.Namespace, q.Now.Add(-q.Window))
+}
+
+func buildAuditEntriesFromChangeSets(raw, namespace string, cutoff time.Time) ([]auditEntry, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return nil, nil
+	}
+
+	var payload interface{}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("parse changeset list json: %w", err)
+	}
+
+	namespace = strings.TrimSpace(namespace)
+	items := historyExtractItems(payload)
+	entries := make([]auditEntry, 0, len(items))
+	for _, item := range items {
+		ts, ok := historyExtractTime(item, "CreatedAt", "createdAt", "Timestamp", "timestamp", "UpdatedAt", "updatedAt")
+		if !ok {
+			continue
+		}
+		ts = ts.UTC()
+		if ts.Before(cutoff) {
+			continue
+		}
+
+		if !auditItemIsBreakGlass(item) {
+			continue
+		}
+		if namespace != "" && !auditItemMatchesNamespace(item, namespace) {
+			continue
+		}
+
+		actor := historyActor(item)
+		if actor == "" {
+			actor = "unknown"
+		}
+
+		reason := auditItemReason(item)
+		if reason == "" {
+			reason = "break-glass decision recorded"
+		}
+		what := auditItemWhat(item)
+		if what == "" {
+			what = "decision details unavailable"
+		}
+
+		entries = append(entries, auditEntry{
+			Timestamp: ts,
+			Actor:     actor,
+			Reason:    reason,
+			What:      what,
+			ChangeSet: historyFirstString(item, "Slug", "slug", "Name", "name", "ID", "id"),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.After(entries[j].Timestamp)
+	})
+	return entries, nil
+}
+
+func auditItemIsBreakGlass(item map[string]interface{}) bool {
+	allText := strings.ToLower(strings.Join([]string{
+		historyFirstString(item, "Slug", "slug", "Name", "name"),
+		historyFirstString(item, "Description", "description", "Summary", "summary", "Message", "message", "What", "what"),
+	}, " "))
+	if strings.Contains(allText, "break-glass") || strings.Contains(allText, "break glass") {
+		return true
+	}
+
+	for _, key := range []string{"Labels", "labels", "Annotations", "annotations"} {
+		raw, ok := item[key]
+		if !ok || raw == nil {
+			continue
+		}
+		labels, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for k, v := range labels {
+			lk := strings.ToLower(strings.TrimSpace(k))
+			lv := strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", v)))
+			if strings.Contains(lk, "break-glass") || strings.Contains(lk, "break_glass") {
+				if lv == "" || lv == "true" || lv == "1" || lv == "yes" {
+					return true
+				}
+			}
+			if strings.Contains(lv, "break-glass") || strings.Contains(lv, "break glass") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func auditItemMatchesNamespace(item map[string]interface{}, namespace string) bool {
+	namespace = strings.ToLower(strings.TrimSpace(namespace))
+	if namespace == "" {
+		return true
+	}
+
+	if strings.EqualFold(historyFirstString(item, "Namespace", "namespace"), namespace) {
+		return true
+	}
+
+	text := strings.ToLower(strings.Join([]string{
+		historyFirstString(item, "Description", "description", "Summary", "summary", "Message", "message", "What", "what"),
+	}, " "))
+	if strings.Contains(text, namespace) {
+		return true
+	}
+
+	for _, key := range []string{"Labels", "labels", "Annotations", "annotations"} {
+		raw, ok := item[key]
+		if !ok || raw == nil {
+			continue
+		}
+		labels, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for k, v := range labels {
+			lk := strings.ToLower(strings.TrimSpace(k))
+			lv := strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", v)))
+			if lk == "namespace" || lk == "k8s-namespace" || lk == "resource-namespace" {
+				if lv == namespace {
+					return true
+				}
+			}
+			if strings.Contains(lv, namespace) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func auditItemReason(item map[string]interface{}) string {
+	reason := historyFirstString(item, "Reason", "reason")
+	if reason != "" {
+		return reason
+	}
+
+	desc := historyFirstString(item, "Description", "description", "Summary", "summary", "Message", "message")
+	if desc == "" {
+		return ""
+	}
+
+	clean := strings.TrimSpace(desc)
+	lower := strings.ToLower(clean)
+	for _, prefix := range []string{"break-glass accept:", "break glass accept:", "break-glass decision:", "break glass decision:", "break-glass:"} {
+		if strings.HasPrefix(lower, prefix) {
+			clean = strings.TrimSpace(clean[len(prefix):])
+			break
+		}
+	}
+	return clean
+}
+
+func auditItemWhat(item map[string]interface{}) string {
+	return strings.TrimSpace(historyFirstString(item, "What", "what", "Change", "change", "Summary", "summary", "Description", "description", "Message", "message"))
+}
+
+func renderAuditASCII(result auditListResult) string {
+	var b strings.Builder
+	if result.Namespace != "" {
+		b.WriteString(fmt.Sprintf("Break-Glass Audit (last %s, namespace: %s)\n", result.Since, result.Namespace))
+	} else {
+		b.WriteString(fmt.Sprintf("Break-Glass Audit (last %s)\n", result.Since))
+	}
+
+	if len(result.Entries) == 0 {
+		b.WriteString("No break-glass decisions recorded for this scope\n")
+		return b.String()
+	}
+
+	for _, entry := range result.Entries {
+		changeSet := strings.TrimSpace(entry.ChangeSet)
+		if changeSet == "" {
+			changeSet = "-"
+		}
+		actor := strings.TrimSpace(entry.Actor)
+		if actor == "" {
+			actor = "unknown"
+		}
+		reason := strings.TrimSpace(entry.Reason)
+		if reason == "" {
+			reason = "break-glass decision recorded"
+		}
+		what := strings.TrimSpace(entry.What)
+		if what == "" {
+			what = "decision details unavailable"
+		}
+		b.WriteString(fmt.Sprintf("  %s  reason: %s\n", entry.Timestamp.Format("2006-01-02 15:04"), reason))
+		b.WriteString(fmt.Sprintf("              what: %s\n", what))
+		b.WriteString(fmt.Sprintf("              by: %s  changeset: %s\n", actor, changeSet))
+	}
+
+	return b.String()
+}
+
+func renderAuditMarkdown(result auditListResult) string {
+	var b strings.Builder
+	b.WriteString("# Break-Glass Audit\n\n")
+	if result.Namespace != "" {
+		b.WriteString(fmt.Sprintf("- Namespace: `%s`\n", result.Namespace))
+	}
+	b.WriteString(fmt.Sprintf("- Since: `%s`\n\n", result.Since))
+
+	if len(result.Entries) == 0 {
+		b.WriteString("No break-glass decisions recorded for this scope.\n")
+		return b.String()
+	}
+
+	b.WriteString("| Time (UTC) | Reason | What | Actor | ChangeSet |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	for _, entry := range result.Entries {
+		reason := strings.TrimSpace(entry.Reason)
+		if reason == "" {
+			reason = "break-glass decision recorded"
+		}
+		what := strings.TrimSpace(entry.What)
+		if what == "" {
+			what = "decision details unavailable"
+		}
+		actor := strings.TrimSpace(entry.Actor)
+		if actor == "" {
+			actor = "unknown"
+		}
+		changeSet := strings.TrimSpace(entry.ChangeSet)
+		if changeSet == "" {
+			changeSet = "-"
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
+			entry.Timestamp.Format(time.RFC3339),
+			historyEscapeMarkdown(reason),
+			historyEscapeMarkdown(what),
+			historyEscapeMarkdown(actor),
+			historyEscapeMarkdown(changeSet),
+		))
+	}
+
+	return b.String()
+}

--- a/cmd/cub-scout/audit_test.go
+++ b/cmd/cub-scout/audit_test.go
@@ -1,0 +1,165 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAuditCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "audit" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("audit command is not registered on rootCmd")
+	}
+}
+
+func TestBuildAuditEntriesFromChangeSets_FiltersAndSorts(t *testing.T) {
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-7 * 24 * time.Hour)
+
+	raw := `[
+	  {
+	    "Slug": "CS-1002",
+	    "CreatedAt": "2026-03-06T11:30:00Z",
+	    "Description": "break-glass accept: approved by sre lead",
+	    "CreatedBy": {"Slug":"alex"},
+	    "Labels": {"break-glass":"true", "namespace":"prod"}
+	  },
+	  {
+	    "Slug": "CS-1001",
+	    "CreatedAt": "2026-03-05T08:20:00Z",
+	    "Description": "Break-Glass decision: reject temporary hotfix",
+	    "CreatedBy": "oncall@example.com",
+	    "Labels": {"source":"cub-scout-import"}
+	  },
+	  {
+	    "Slug": "CS-0998",
+	    "CreatedAt": "2026-03-04T08:20:00Z",
+	    "Description": "regular rollout",
+	    "CreatedBy": "release-bot"
+	  },
+	  {
+	    "Slug": "CS-0800",
+	    "CreatedAt": "2026-01-01T08:20:00Z",
+	    "Description": "break-glass accept: too old",
+	    "CreatedBy": "ops"
+	  }
+	]`
+
+	got, err := buildAuditEntriesFromChangeSets(raw, "prod", cutoff)
+	if err != nil {
+		t.Fatalf("buildAuditEntriesFromChangeSets() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(got))
+	}
+	if got[0].ChangeSet != "CS-1002" {
+		t.Fatalf("changeset = %q, want CS-1002", got[0].ChangeSet)
+	}
+	if got[0].Actor != "alex" {
+		t.Fatalf("actor = %q, want alex", got[0].Actor)
+	}
+	if !strings.Contains(strings.ToLower(got[0].Reason), "approved") {
+		t.Fatalf("reason = %q, want approved text", got[0].Reason)
+	}
+}
+
+func TestRenderAuditASCII_Empty(t *testing.T) {
+	out := renderAuditASCII(auditListResult{Since: "7d", Namespace: "prod"})
+	if !strings.Contains(out, "No break-glass decisions") {
+		t.Fatalf("expected empty message, got:\n%s", out)
+	}
+}
+
+func TestRunAuditList_NotConnected(t *testing.T) {
+	restore := withAuditListFlagsForTest()
+	defer restore()
+
+	prevRequire := requireAuditConnectedFn
+	requireAuditConnectedFn = func() error { return errAuditDisconnected }
+	defer func() { requireAuditConnectedFn = prevRequire }()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runAuditList(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when not connected")
+	}
+	if !strings.Contains(err.Error(), "audit requires ConfigHub connection") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunAuditList_JSONOutput(t *testing.T) {
+	restore := withAuditListFlagsForTest()
+	defer restore()
+
+	prevRequire := requireAuditConnectedFn
+	requireAuditConnectedFn = func() error { return nil }
+	defer func() { requireAuditConnectedFn = prevRequire }()
+
+	prevFetch := fetchAuditEntriesFn
+	fetchAuditEntriesFn = func(ctx context.Context, q auditListQuery) ([]auditEntry, error) {
+		return []auditEntry{
+			{
+				Timestamp: time.Date(2026, 3, 7, 10, 0, 0, 0, time.UTC),
+				Actor:     "sre-lead",
+				Reason:    "approved by SRE lead for Q1 migration",
+				What:      "imported unit payments-api",
+				ChangeSet: "CS-1234",
+			},
+		}, nil
+	}
+	defer func() { fetchAuditEntriesFn = prevFetch }()
+
+	auditListFormat = "json"
+	auditListSince = "7d"
+	auditListNamespace = "prod"
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	out := captureStdout(t, func() {
+		if err := runAuditList(cmd, nil); err != nil {
+			t.Fatalf("runAuditList() error = %v", err)
+		}
+	})
+
+	var payload auditListResult
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("json decode output: %v\n%s", err, out)
+	}
+	if payload.Namespace != "prod" {
+		t.Fatalf("namespace = %q, want prod", payload.Namespace)
+	}
+	if len(payload.Entries) != 1 || payload.Entries[0].ChangeSet != "CS-1234" {
+		t.Fatalf("unexpected entries: %+v", payload.Entries)
+	}
+}
+
+func withAuditListFlagsForTest() func() {
+	prevFormat := auditListFormat
+	prevNamespace := auditListNamespace
+	prevSince := auditListSince
+	auditListFormat = "ascii"
+	auditListNamespace = ""
+	auditListSince = "7d"
+	return func() {
+		auditListFormat = prevFormat
+		auditListNamespace = prevNamespace
+		auditListSince = prevSince
+	}
+}

--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -25,15 +25,16 @@ import (
 )
 
 var (
-	importNamespace  string
-	importDryRun     bool
-	importYes        bool
-	importJSON       bool
-	importNoLog      bool
-	importWizard     bool
-	importConnect    bool
-	importNoConnect  bool
-	importFromBundle string
+	importNamespace   string
+	importDryRun      bool
+	importYes         bool
+	importJSON        bool
+	importNoLog       bool
+	importWizard      bool
+	importConnect     bool
+	importNoConnect   bool
+	importFromBundle  string
+	importAuditReason string
 )
 
 var listUnitSlugsForSpace = fetchUnitSlugsForSpace
@@ -52,6 +53,11 @@ type gitOpsDelegationResult struct {
 	FluxDelegated bool
 	ArgoReason    string
 	FluxReason    string
+}
+
+type importAuditContext struct {
+	ChangeSetSlug string
+	Reason        string
 }
 
 func (r gitOpsDelegationResult) AnyDelegated() bool {
@@ -192,6 +198,7 @@ func init() {
 	importCmd.Flags().BoolVar(&importConnect, "connect", false, "After import, start worker and set targets")
 	importCmd.Flags().BoolVar(&importNoConnect, "no-connect", false, "Do not start worker/targets after import")
 	importCmd.Flags().StringVar(&importFromBundle, "from-bundle", "", "Import from a debug bundle directory instead of live cluster discovery")
+	importCmd.Flags().StringVar(&importAuditReason, "audit-reason", "", "Record break-glass decision reason in connected audit history (max 512 chars)")
 
 	rootCmd.AddCommand(importCmd)
 }
@@ -212,6 +219,10 @@ func runImport(cmd *cobra.Command, args []string) error {
 	// JSON mode = dry-run (never change anything when outputting JSON)
 	if importJSON {
 		importDryRun = true
+	}
+
+	if _, err := normalizeImportAuditReason(importAuditReason); err != nil {
+		return err
 	}
 
 	// Bundle import path bypasses live cluster discovery.
@@ -385,7 +396,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 		proposalToApply = SuggestFullProposal(nil, scoutWorkloads, proposal.AppSpace)
 	}
 
-	return applyImportWithLogger(proposalToApply, scoutWorkloads, logger, shouldConnect)
+	return applyImportWithLogger(proposalToApply, scoutWorkloads, logger, shouldConnect, importAuditReason)
 }
 
 func runImportFromBundle(bundlePath string) error {
@@ -431,7 +442,7 @@ func runImportFromBundle(bundlePath string) error {
 		fmt.Println("\nTip: add --connect to start worker/targets now and avoid detached units.")
 	}
 
-	return applyImportWithLogger(proposal, workloads, nil, shouldConnect)
+	return applyImportWithLogger(proposal, workloads, nil, shouldConnect, importAuditReason)
 }
 
 // resolveImportConnectionMode determines whether import should auto-connect workers/targets
@@ -447,6 +458,115 @@ func resolveImportConnectionMode(importYes, importConnect, importNoConnect bool)
 
 	showConnectHint := importYes && !importConnect && !importNoConnect
 	return shouldConnect, showConnectHint
+}
+
+func normalizeImportAuditReason(raw string) (string, error) {
+	reason := strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+	if reason == "" {
+		return "", nil
+	}
+	if len([]rune(reason)) > 512 {
+		return "", fmt.Errorf("--audit-reason exceeds 512 characters")
+	}
+	return reason, nil
+}
+
+func createImportAuditContext(proposal *FullProposal, workloads []WorkloadInfo, reason string, logger *ImportLogger) (*importAuditContext, error) {
+	if proposal == nil || strings.TrimSpace(proposal.AppSpace) == "" {
+		return nil, fmt.Errorf("cannot create break-glass audit context without app space")
+	}
+
+	changeSetSlug := fmt.Sprintf("break-glass-%s", time.Now().UTC().Format("20060102-150405"))
+	description := buildBreakGlassChangesetDescription(reason, workloads)
+
+	args := []string{
+		"changeset", "create",
+		"--space", proposal.AppSpace,
+		changeSetSlug,
+		"--description", description,
+		"--label", "break-glass=true",
+		"--label", "source=cub-scout-import",
+		"--label", "workflow=break-glass",
+		"--allow-exists",
+		"--quiet",
+	}
+
+	namespaces := collectBreakGlassNamespaces(workloads)
+	if len(namespaces) == 1 {
+		args = append(args, "--label", fmt.Sprintf("namespace=%s", namespaces[0]))
+	}
+
+	cmd := exec.Command("cub", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(output))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("create break-glass audit changeset: %s", msg)
+	}
+
+	fmt.Printf("Audit: recorded break-glass decision in changeset %s\n", changeSetSlug)
+	if logger != nil {
+		logger.Log("Audit changeset created: %s (%s)", changeSetSlug, description)
+	}
+
+	return &importAuditContext{
+		ChangeSetSlug: changeSetSlug,
+		Reason:        reason,
+	}, nil
+}
+
+func collectBreakGlassNamespaces(workloads []WorkloadInfo) []string {
+	set := make(map[string]struct{})
+	for _, workload := range workloads {
+		ns := strings.TrimSpace(workload.Namespace)
+		if ns == "" {
+			continue
+		}
+		set[ns] = struct{}{}
+	}
+	namespaces := make([]string, 0, len(set))
+	for ns := range set {
+		namespaces = append(namespaces, ns)
+	}
+	sort.Strings(namespaces)
+	return namespaces
+}
+
+func buildBreakGlassChangesetDescription(reason string, workloads []WorkloadInfo) string {
+	namespaces := collectBreakGlassNamespaces(workloads)
+	scope := "all namespaces"
+	if len(namespaces) > 0 {
+		scope = strings.Join(namespaces, ",")
+	}
+
+	text := fmt.Sprintf(
+		"break-glass decision: accept unmanaged resources via cub-scout import; namespaces=%s; workloads=%d; reason=%s",
+		scope,
+		len(workloads),
+		reason,
+	)
+	if len([]rune(text)) > 512 {
+		runes := []rune(text)
+		text = string(runes[:509]) + "..."
+	}
+	return text
+}
+
+func buildBreakGlassChangeDescription(reason string, unit UnitProposal) string {
+	workloadCount := len(unit.Workloads)
+	text := fmt.Sprintf(
+		"break-glass accept: unit=%s workloads=%d reason=%s",
+		strings.TrimSpace(unit.Slug),
+		workloadCount,
+		reason,
+	)
+	if len([]rune(text)) > 512 {
+		runes := []rune(text)
+		text = string(runes[:509]) + "..."
+	}
+	return text
 }
 
 func buildImportFromBundlePreview(bundlePath string) (*FullProposal, []WorkloadInfo, []string, error) {
@@ -1251,7 +1371,14 @@ func runGitOpsImportForNamespaces(space, k8sTarget, rendererTarget string, names
 	return nil
 }
 
-func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, logger *ImportLogger, shouldConnect bool) error {
+func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, logger *ImportLogger, shouldConnect bool, auditReason string) error {
+	normalizedReason, err := normalizeImportAuditReason(auditReason)
+	if err != nil {
+		return err
+	}
+
+	var auditCtx *importAuditContext
+
 	// Index workloads
 	workloadIndex := make(map[string]WorkloadInfo)
 	for _, w := range workloads {
@@ -1284,6 +1411,13 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 		fmt.Println("(exists)")
 		if logger != nil {
 			logger.Log("App already exists: %s", proposal.AppSpace)
+		}
+	}
+
+	if normalizedReason != "" {
+		auditCtx, err = createImportAuditContext(proposal, workloads, normalizedReason, logger)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1328,7 +1462,7 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
 		}
 
-		if err := createUnitWithManifestSimple(proposal.AppSpace, unit.Slug, labels, manifest); err != nil {
+		if err := createUnitWithManifestSimple(proposal.AppSpace, unit, labels, manifest, auditCtx); err != nil {
 			fmt.Printf("✗ (%v)\n", err)
 			if logger != nil {
 				logger.Log("  FAILED: create deployment: %v", err)
@@ -1461,8 +1595,15 @@ func stripServerSideFields(yamlData []byte) ([]byte, error) {
 	return []byte(strings.Join(result, "\n")), nil
 }
 
-func createUnitWithManifestSimple(space, slug string, labels []string, manifest []byte) error {
+func createUnitWithManifestSimple(space string, unit UnitProposal, labels []string, manifest []byte, auditCtx *importAuditContext) error {
+	slug := strings.TrimSpace(unit.Slug)
 	args := []string{"unit", "create", "--space", space}
+	if auditCtx != nil && strings.TrimSpace(auditCtx.ChangeSetSlug) != "" {
+		args = append(args, "--changeset", auditCtx.ChangeSetSlug)
+		if changeDesc := buildBreakGlassChangeDescription(auditCtx.Reason, unit); changeDesc != "" {
+			args = append(args, "--change-desc", changeDesc)
+		}
+	}
 	for _, l := range labels {
 		args = append(args, "--label", l)
 	}

--- a/cmd/cub-scout/import_audit_test.go
+++ b/cmd/cub-scout/import_audit_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestImportCommandHasAuditReasonFlag(t *testing.T) {
+	flag := importCmd.Flags().Lookup("audit-reason")
+	if flag == nil {
+		t.Fatal("expected --audit-reason flag to be registered on import command")
+	}
+}
+
+func TestNormalizeImportAuditReason(t *testing.T) {
+	got, err := normalizeImportAuditReason("  approved by SRE lead for Q1 migration  ")
+	if err != nil {
+		t.Fatalf("normalizeImportAuditReason() error = %v", err)
+	}
+	if got != "approved by SRE lead for Q1 migration" {
+		t.Fatalf("normalized reason = %q", got)
+	}
+}
+
+func TestNormalizeImportAuditReason_RejectsTooLong(t *testing.T) {
+	_, err := normalizeImportAuditReason(strings.Repeat("a", 513))
+	if err == nil {
+		t.Fatal("expected length validation error")
+	}
+	if !strings.Contains(err.Error(), "512") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/cub-scout/import_bundle_test.go
+++ b/cmd/cub-scout/import_bundle_test.go
@@ -506,28 +506,30 @@ func TestLinkUnitWorkloadsToCluster(t *testing.T) {
 }
 
 type importFlagState struct {
-	namespace  string
-	dryRun     bool
-	yes        bool
-	json       bool
-	noLog      bool
-	wizard     bool
-	connect    bool
-	noConnect  bool
-	fromBundle string
+	namespace   string
+	dryRun      bool
+	yes         bool
+	json        bool
+	noLog       bool
+	wizard      bool
+	connect     bool
+	noConnect   bool
+	fromBundle  string
+	auditReason string
 }
 
 func setImportFlagState(next importFlagState) func() {
 	prev := importFlagState{
-		namespace:  importNamespace,
-		dryRun:     importDryRun,
-		yes:        importYes,
-		json:       importJSON,
-		noLog:      importNoLog,
-		wizard:     importWizard,
-		connect:    importConnect,
-		noConnect:  importNoConnect,
-		fromBundle: importFromBundle,
+		namespace:   importNamespace,
+		dryRun:      importDryRun,
+		yes:         importYes,
+		json:        importJSON,
+		noLog:       importNoLog,
+		wizard:      importWizard,
+		connect:     importConnect,
+		noConnect:   importNoConnect,
+		fromBundle:  importFromBundle,
+		auditReason: importAuditReason,
 	}
 
 	importNamespace = next.namespace
@@ -539,6 +541,7 @@ func setImportFlagState(next importFlagState) func() {
 	importConnect = next.connect
 	importNoConnect = next.noConnect
 	importFromBundle = next.fromBundle
+	importAuditReason = next.auditReason
 
 	return func() {
 		importNamespace = prev.namespace
@@ -550,6 +553,7 @@ func setImportFlagState(next importFlagState) func() {
 		importConnect = prev.connect
 		importNoConnect = prev.noConnect
 		importFromBundle = prev.fromBundle
+		importAuditReason = prev.auditReason
 	}
 }
 

--- a/cmd/cub-scout/import_wizard.go
+++ b/cmd/cub-scout/import_wizard.go
@@ -1706,7 +1706,7 @@ func (m ImportWizardModel) applyNextUnitCmd(unitIndex int) tea.Cmd {
 			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
 		}
 
-		if err := createUnitWithManifestSimple(m.proposal.AppSpace, unit.Slug, labels, manifest); err != nil {
+		if err := createUnitWithManifestSimple(m.proposal.AppSpace, unit, labels, manifest, nil); err != nil {
 			return wizardApplyProgressMsg{unitSlug: unit.Slug, success: false, err: err.Error()}
 		}
 

--- a/cmd/cub-scout/smoke_test.go
+++ b/cmd/cub-scout/smoke_test.go
@@ -86,6 +86,12 @@ func TestSmoke_CLIHelp(t *testing.T) {
 			wantContains: []string{"history", "ChangeSets", "Usage:"},
 		},
 		{
+			name:         "audit list help",
+			args:         []string{"audit", "list", "--help"},
+			wantExitCode: 0,
+			wantContains: []string{"audit list", "break-glass", "Usage:"},
+		},
+		{
 			name:         "debug help",
 			args:         []string{"debug", "--help"},
 			wantExitCode: 0,
@@ -149,7 +155,7 @@ func TestSmoke_RootCommand(t *testing.T) {
 	}
 
 	// Verify key subcommands exist
-	expectedCmds := []string{"version", "completion", "map", "quickstart", "scan", "trace", "status", "history"}
+	expectedCmds := []string{"version", "completion", "map", "quickstart", "scan", "trace", "status", "history", "audit"}
 	for _, name := range expectedCmds {
 		found := false
 		for _, cmd := range rootCmd.Commands() {

--- a/docs/howto/break-glass-to-managed.md
+++ b/docs/howto/break-glass-to-managed.md
@@ -109,8 +109,12 @@ The break-glass change was correct and should be permanent.
 # Preview what would be imported
 ./cub-scout import -n <namespace> --dry-run
 
-# Import the resource to ConfigHub
-./cub-scout import deploy/<name> -n <namespace>
+# Import into ConfigHub and record decision reason
+./cub-scout import -n <namespace> \
+  --audit-reason "approved by sre lead for Q1 migration"
+
+# Review break-glass decision history
+./cub-scout audit list -n <namespace> --since 7d
 ```
 
 This creates a ConfigHub Unit, publishes an OCI artifact, and Flux/ArgoCD reconciles from ConfigHub. The resource is now versioned and repeatable.

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -12,6 +12,7 @@ Complete reference of all commands, options, TUI keys, and availability.
 | Command | Description |
 |---------|-------------|
 | `app-space` | Manage App Spaces |
+| `audit` | Break-glass audit trail tools |
 | `apply` | Apply a proposal from JSON (GUI) |
 | `bundle` | Work with debug bundles |
 | `catalog` | Manage bundle catalogs |
@@ -206,6 +207,21 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `--json` | Output as JSON |
 | `-y, --yes` | Skip confirmation |
 | `--no-log` | Disable logging to file |
+| `--connect` | After import, start worker and set targets |
+| `--no-connect` | Do not start worker/targets after import |
+| `--from-bundle` | Import from a debug bundle directory |
+| `--audit-reason` | Break-glass decision reason (connected audit trail) |
+
+---
+
+## `audit list` Options
+
+| Option | Description |
+|--------|-------------|
+| `-n, --namespace` | Namespace scope (optional) |
+| `--since` | Lookback window (`24h`, `7d`, `2w`) |
+| `--format` | Output format (`ascii`, `json`, `md`) |
+| `--json` | Output as JSON |
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -37,6 +37,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `health` | Scout-style health check | v0.5 |
 | `status` | Show connection status and cluster info | v1.0 |
 | `history` | Show connected change history from ConfigHub ChangeSets | v1.4 |
+| `audit list` | Show connected break-glass accept/reject audit trail | v1.6 |
 | `connect` | Quickly configure kube context from server URL or kubeconfig | v1.0 |
 | `setup` | Set up shell completions | v0.19 |
 | `mcp serve` | Serve read-only MCP tools over stdio | v1.4 |
@@ -747,7 +748,10 @@ cub-scout import [flags]
 | `--json` | Output proposal JSON (implies dry-run) |
 | `--no-log` | Disable local import log file |
 | `-w, --wizard` | Launch interactive import wizard |
+| `--connect` | After import, start worker and set targets |
+| `--no-connect` | Do not auto-start worker/targets after import |
 | `--from-bundle` | Import proposal/apply from a debug bundle directory (offline path, no cluster discovery) |
+| `--audit-reason` | Record break-glass decision reason in connected audit history (max 512 chars) |
 
 ### Canonical Migration Path
 
@@ -763,6 +767,9 @@ cub-scout import -n payments-prod --dry-run
 # Execute namespace import
 cub-scout import -n payments-prod
 
+# Execute import with explicit break-glass audit reason
+cub-scout import -n payments-prod --audit-reason "approved by sre lead for Q1 migration"
+
 # Non-interactive import
 cub-scout import -n payments-prod -y
 
@@ -777,6 +784,9 @@ cub-scout import --from-bundle ./debug-bundle --dry-run --json
 - `evidence.source`: `cluster` or `bundle`
 - `evidence.bundlePath`: set when source is `bundle`
 - `workloads[].connected`: true when the workload is already linked by `confighub.com/UnitSlug` or when a proposed unit slug already exists in the target App Space.
+
+Connected audit note:
+- `--audit-reason` writes a break-glass ChangeSet entry so `cub-scout audit list` can show who/when/why/what.
 
 ---
 
@@ -946,6 +956,44 @@ cub-scout history deploy/my-app --since 2w --format md
 - Requires ConfigHub authentication (`cub auth login`).
 - Uses read-only ChangeSet queries under the hood.
 - If no history is found, output clearly notes the resource may not be imported yet.
+
+---
+
+## audit list
+
+Show connected break-glass accept/reject decisions from ConfigHub ChangeSets.
+
+```bash
+cub-scout audit list [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-n, --namespace` | Optional namespace scope |
+| `--since` | Lookback window (examples: `24h`, `7d`, `2w`) |
+| `--format` | Output format: `ascii`, `json`, `md` |
+| `--json` | Output as JSON (shorthand for `--format json`) |
+
+### Examples
+
+```bash
+# Show recent break-glass decisions
+cub-scout audit list
+
+# Filter by namespace and window
+cub-scout audit list -n prod --since 7d
+
+# Export machine-readable output
+cub-scout audit list --format json
+```
+
+### Connected Mode Notes
+
+- Requires ConfigHub authentication (`cub auth login`).
+- Uses read-only ChangeSet queries filtered to break-glass records.
+- If no records are found, output reports: `No break-glass decisions recorded for this scope`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add new connected `audit list` command (`--format ascii|json|md`, `--json`, `--since`, `-n/--namespace`) for break-glass decision history
- add `import --audit-reason` (max 512 chars) and create a break-glass ChangeSet in ConfigHub when provided
- wire imported unit creation into that ChangeSet via `--changeset` and per-unit `--change-desc` so who/when/why/what are queryable
- add disconnected/empty-state handling and fixture mode for audit parsing (`CUB_SCOUT_TEST_AUDIT_JSON`)
- update command docs + break-glass how-to examples to include audit workflow

## Tests
- `go test ./cmd/cub-scout -run 'Test(Audit|ImportCommandHasAuditReasonFlag|NormalizeImportAuditReason|Smoke_)' -count=1`
- `go test ./cmd/cub-scout -count=1`
- `go test ./test/unit -count=1`
- `go test ./pkg/agent -count=1`
- `go build ./cmd/cub-scout`

Closes #231
