### PR TITLE
feat: add compare three-way scope command

### DIFF
--- a/cmd/cub-scout/compare_three_way.go
+++ b/cmd/cub-scout/compare_three_way.go
@@ -1,0 +1,402 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type threeWayScopeType string
+
+const (
+	threeWayScopeResource  threeWayScopeType = "resource"
+	threeWayScopeNamespace threeWayScopeType = "namespace"
+	threeWayScopeCluster   threeWayScopeType = "cluster"
+)
+
+type threeWayScope struct {
+	ScopeType  threeWayScopeType
+	ScopeValue string
+}
+
+type threeWayTarget struct {
+	ResourceArg string
+	Namespace   string
+}
+
+type threeWayResourceEntry struct {
+	Result   compareResourceResult `json:"result"`
+	Severity string                `json:"severity"`
+	Causes   []string              `json:"causes,omitempty"`
+}
+
+type threeWaySummary struct {
+	TotalResources      int            `json:"totalResources"`
+	ConnectedResources  int            `json:"connectedResources"`
+	DryWetLiveResources int            `json:"dryWetLiveResources"`
+	MismatchedResources int            `json:"mismatchedResources"`
+	SeverityCounts      map[string]int `json:"severityCounts"`
+	CauseBuckets        map[string]int `json:"causeBuckets"`
+}
+
+type threeWayReport struct {
+	Scope     string                  `json:"scope"`
+	Summary   threeWaySummary         `json:"summary"`
+	Resources []threeWayResourceEntry `json:"resources"`
+}
+
+var (
+	compareThreeWayScopeRaw string
+	compareThreeWayFormat   string
+	compareThreeWayJSON     bool
+
+	buildThreeWayResourceResultFn = buildCompareResourceResult
+	discoverThreeWayNamespacesFn  = discoverNamespacesWithWorkloads
+	discoverThreeWayWorkloadsFn   = discoverWorkloads
+)
+
+var compareThreeWayCmd = &cobra.Command{
+	Use:   "three-way",
+	Short: "Compare intent vs rendered vs observed state",
+	Long: `Connected three-way comparison (DRY/WET/LIVE) for a selected scope.
+
+Supported scopes:
+  deploy/my-app            (resource)
+  resource:deploy/my-app   (resource)
+  namespace/prod           (namespace)
+  cluster                  (all namespaces)
+
+Examples:
+  cub-scout compare three-way --scope deploy/payment-api -n prod
+  cub-scout compare three-way --scope namespace/prod --format json
+  cub-scout compare three-way --scope cluster --format md`,
+	RunE: runCompareThreeWay,
+}
+
+func init() {
+	combinedCmd.AddCommand(compareThreeWayCmd)
+
+	compareThreeWayCmd.Flags().StringVar(&compareThreeWayScopeRaw, "scope", "", "Scope: <kind/name>, resource:<kind/name>, namespace/<ns>, or cluster")
+	compareThreeWayCmd.Flags().StringVarP(&combinedNamespace, "namespace", "n", "", "Namespace override for resource scope")
+	compareThreeWayCmd.Flags().StringVar(&compareThreeWayFormat, "format", "ascii", "Output format: ascii, json, md")
+	compareThreeWayCmd.Flags().BoolVar(&compareThreeWayJSON, "json", false, "Output as JSON (shorthand for --format json)")
+}
+
+func runCompareThreeWay(cmd *cobra.Command, args []string) error {
+	scope, err := parseThreeWayScope(compareThreeWayScopeRaw)
+	if err != nil {
+		return err
+	}
+
+	format := strings.ToLower(strings.TrimSpace(compareThreeWayFormat))
+	if format == "" {
+		format = "ascii"
+	}
+	if compareThreeWayJSON {
+		format = "json"
+	}
+	if format != "ascii" && format != "json" && format != "md" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json, md)", compareThreeWayFormat)
+	}
+
+	report, err := buildThreeWayReport(cmd.Context(), scope)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	case "md":
+		fmt.Print(renderThreeWayMarkdown(report))
+		return nil
+	default:
+		fmt.Print(renderThreeWayASCII(report))
+		return nil
+	}
+}
+
+func parseThreeWayScope(raw string) (threeWayScope, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return threeWayScope{}, fmt.Errorf("--scope is required")
+	}
+
+	lower := strings.ToLower(value)
+	switch {
+	case lower == "cluster":
+		return threeWayScope{ScopeType: threeWayScopeCluster, ScopeValue: "cluster"}, nil
+	case strings.HasPrefix(lower, "namespace/"):
+		ns := strings.TrimSpace(value[len("namespace/"):])
+		if ns == "" {
+			return threeWayScope{}, fmt.Errorf("invalid namespace scope %q", raw)
+		}
+		return threeWayScope{ScopeType: threeWayScopeNamespace, ScopeValue: ns}, nil
+	case strings.HasPrefix(lower, "resource:"):
+		resource := strings.TrimSpace(value[len("resource:"):])
+		if _, _, err := parseResourceArg(resource); err != nil {
+			return threeWayScope{}, err
+		}
+		return threeWayScope{ScopeType: threeWayScopeResource, ScopeValue: resource}, nil
+	case strings.HasPrefix(lower, "resource/"):
+		resource := strings.TrimSpace(value[len("resource/"):])
+		if _, _, err := parseResourceArg(resource); err != nil {
+			return threeWayScope{}, err
+		}
+		return threeWayScope{ScopeType: threeWayScopeResource, ScopeValue: resource}, nil
+	case strings.HasPrefix(lower, "unit/") || strings.HasPrefix(lower, "app/"):
+		return threeWayScope{}, fmt.Errorf("scope %q is not supported yet (supported: resource, namespace, cluster)", raw)
+	default:
+		if _, _, err := parseResourceArg(value); err != nil {
+			return threeWayScope{}, fmt.Errorf("invalid --scope %q (examples: deploy/api, namespace/prod, cluster)", raw)
+		}
+		return threeWayScope{ScopeType: threeWayScopeResource, ScopeValue: value}, nil
+	}
+}
+
+func buildThreeWayReport(ctx context.Context, scope threeWayScope) (threeWayReport, error) {
+	targets, err := collectThreeWayTargets(scope)
+	if err != nil {
+		return threeWayReport{}, err
+	}
+
+	entries := make([]threeWayResourceEntry, 0, len(targets))
+	summary := threeWaySummary{
+		SeverityCounts: map[string]int{},
+		CauseBuckets:   map[string]int{},
+	}
+
+	for _, target := range targets {
+		result, err := buildThreeWayResourceResultFn(ctx, target.ResourceArg, target.Namespace)
+		if err != nil {
+			return threeWayReport{}, err
+		}
+		if strings.TrimSpace(result.Resource) == "" {
+			result.Resource = target.ResourceArg
+		}
+		if strings.TrimSpace(result.Namespace) == "" {
+			result.Namespace = target.Namespace
+		}
+
+		severity, causes := classifyThreeWayResult(result)
+		entry := threeWayResourceEntry{
+			Result:   result,
+			Severity: severity,
+			Causes:   causes,
+		}
+		entries = append(entries, entry)
+
+		summary.TotalResources++
+		if result.Connected {
+			summary.ConnectedResources++
+		}
+		if result.Mode == "dry-wet-live" {
+			summary.DryWetLiveResources++
+		}
+		if len(result.Mismatches) > 0 {
+			summary.MismatchedResources++
+		}
+		summary.SeverityCounts[severity]++
+		for _, cause := range causes {
+			summary.CauseBuckets[cause]++
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		left := strings.ToLower(entries[i].Result.Namespace + "/" + entries[i].Result.Resource)
+		right := strings.ToLower(entries[j].Result.Namespace + "/" + entries[j].Result.Resource)
+		return left < right
+	})
+
+	return threeWayReport{
+		Scope:     scope.String(),
+		Summary:   summary,
+		Resources: entries,
+	}, nil
+}
+
+func collectThreeWayTargets(scope threeWayScope) ([]threeWayTarget, error) {
+	switch scope.ScopeType {
+	case threeWayScopeResource:
+		kindRaw, name, err := parseResourceArg(scope.ScopeValue)
+		if err != nil {
+			return nil, err
+		}
+		ns := strings.TrimSpace(combinedNamespace)
+		return []threeWayTarget{{
+			ResourceArg: normalizeKind(kindRaw) + "/" + name,
+			Namespace:   ns,
+		}}, nil
+	case threeWayScopeNamespace:
+		ns := strings.TrimSpace(scope.ScopeValue)
+		workloads, err := discoverThreeWayWorkloadsFn(ns)
+		if err != nil {
+			return nil, err
+		}
+		return workloadsToThreeWayTargets(workloads, ns), nil
+	case threeWayScopeCluster:
+		namespaces, err := discoverThreeWayNamespacesFn()
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(namespaces)
+		targets := make([]threeWayTarget, 0)
+		for _, ns := range namespaces {
+			workloads, err := discoverThreeWayWorkloadsFn(ns)
+			if err != nil {
+				return nil, err
+			}
+			targets = append(targets, workloadsToThreeWayTargets(workloads, ns)...)
+		}
+		return targets, nil
+	default:
+		return nil, fmt.Errorf("unsupported scope type %q", scope.ScopeType)
+	}
+}
+
+func workloadsToThreeWayTargets(workloads []WorkloadInfo, namespace string) []threeWayTarget {
+	targets := make([]threeWayTarget, 0, len(workloads))
+	for _, workload := range workloads {
+		kind := normalizeKind(workload.Kind)
+		name := strings.TrimSpace(workload.Name)
+		if kind == "" || name == "" {
+			continue
+		}
+		ns := strings.TrimSpace(workload.Namespace)
+		if ns == "" {
+			ns = strings.TrimSpace(namespace)
+		}
+		targets = append(targets, threeWayTarget{
+			ResourceArg: kind + "/" + name,
+			Namespace:   ns,
+		})
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		left := strings.ToLower(targets[i].Namespace + "/" + targets[i].ResourceArg)
+		right := strings.ToLower(targets[j].Namespace + "/" + targets[j].ResourceArg)
+		return left < right
+	})
+	return targets
+}
+
+func classifyThreeWayResult(result compareResourceResult) (string, []string) {
+	causes := make(map[string]struct{})
+	if len(result.Mismatches) > 0 {
+		causes["state-mismatch"] = struct{}{}
+	}
+
+	for _, note := range result.Notes {
+		lower := strings.ToLower(note)
+		switch {
+		case strings.Contains(lower, "connect to confighub"):
+			causes["disconnected"] = struct{}{}
+		case strings.Contains(lower, "not linked"):
+			causes["unlinked"] = struct{}{}
+		case strings.Contains(lower, "snapshot unavailable"):
+			causes["missing-snapshots"] = struct{}{}
+		case strings.Contains(lower, "lookup failed"):
+			causes["lookup-failed"] = struct{}{}
+		}
+	}
+
+	severity := "ok"
+	if len(result.Mismatches) > 0 {
+		severity = "warning"
+	} else if !result.Connected || len(result.Notes) > 0 {
+		severity = "info"
+	}
+
+	out := make([]string, 0, len(causes))
+	for cause := range causes {
+		out = append(out, cause)
+	}
+	sort.Strings(out)
+	return severity, out
+}
+
+func renderThreeWayASCII(report threeWayReport) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Three-Way Compare: %s\n", report.Scope))
+	b.WriteString(fmt.Sprintf("Resources: %d  Connected: %d  DRY/WET/LIVE: %d  Mismatched: %d\n",
+		report.Summary.TotalResources,
+		report.Summary.ConnectedResources,
+		report.Summary.DryWetLiveResources,
+		report.Summary.MismatchedResources,
+	))
+
+	if len(report.Resources) == 0 {
+		b.WriteString("No resources matched this scope\n")
+		return b.String()
+	}
+
+	for _, entry := range report.Resources {
+		b.WriteString(fmt.Sprintf("\n- %s (%s) severity=%s mismatches=%d\n",
+			entry.Result.Resource,
+			entry.Result.Namespace,
+			entry.Severity,
+			len(entry.Result.Mismatches),
+		))
+		if len(entry.Causes) > 0 {
+			b.WriteString("  causes: " + strings.Join(entry.Causes, ", ") + "\n")
+		}
+		for _, note := range entry.Result.Notes {
+			b.WriteString("  note: " + note + "\n")
+		}
+	}
+	return b.String()
+}
+
+func renderThreeWayMarkdown(report threeWayReport) string {
+	var b strings.Builder
+	b.WriteString("# Three-Way Compare\n\n")
+	b.WriteString(fmt.Sprintf("- Scope: `%s`\n", report.Scope))
+	b.WriteString(fmt.Sprintf("- Resources: `%d`\n", report.Summary.TotalResources))
+	b.WriteString(fmt.Sprintf("- Connected: `%d`\n", report.Summary.ConnectedResources))
+	b.WriteString(fmt.Sprintf("- DRY/WET/LIVE: `%d`\n", report.Summary.DryWetLiveResources))
+	b.WriteString(fmt.Sprintf("- Mismatched: `%d`\n\n", report.Summary.MismatchedResources))
+
+	if len(report.Resources) == 0 {
+		b.WriteString("No resources matched this scope.\n")
+		return b.String()
+	}
+
+	b.WriteString("| Resource | Namespace | Mode | Severity | Mismatches | Causes |\n")
+	b.WriteString("|---|---|---|---|---:|---|\n")
+	for _, entry := range report.Resources {
+		causes := strings.Join(entry.Causes, ",")
+		if causes == "" {
+			causes = "-"
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %d | %s |\n",
+			historyEscapeMarkdown(entry.Result.Resource),
+			historyEscapeMarkdown(entry.Result.Namespace),
+			historyEscapeMarkdown(entry.Result.Mode),
+			historyEscapeMarkdown(entry.Severity),
+			len(entry.Result.Mismatches),
+			historyEscapeMarkdown(causes),
+		))
+	}
+	return b.String()
+}
+
+func (scope threeWayScope) String() string {
+	switch scope.ScopeType {
+	case threeWayScopeResource:
+		return scope.ScopeValue
+	case threeWayScopeNamespace:
+		return "namespace/" + scope.ScopeValue
+	default:
+		return scope.ScopeValue
+	}
+}

--- a/cmd/cub-scout/compare_three_way_test.go
+++ b/cmd/cub-scout/compare_three_way_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCompareThreeWayCommandRegistered(t *testing.T) {
+	var compare *cobra.Command
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "combined" {
+			compare = cmd
+			break
+		}
+	}
+	if compare == nil {
+		t.Fatal("combined command not found")
+	}
+
+	found := false
+	for _, sub := range compare.Commands() {
+		if sub.Name() == "three-way" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("compare three-way subcommand is not registered")
+	}
+}
+
+func TestParseThreeWayScope(t *testing.T) {
+	tests := []struct {
+		in      string
+		wantTyp threeWayScopeType
+		wantVal string
+		wantErr bool
+	}{
+		{in: "deploy/api", wantTyp: threeWayScopeResource, wantVal: "deploy/api"},
+		{in: "resource:statefulset/db", wantTyp: threeWayScopeResource, wantVal: "statefulset/db"},
+		{in: "namespace/prod", wantTyp: threeWayScopeNamespace, wantVal: "prod"},
+		{in: "cluster", wantTyp: threeWayScopeCluster, wantVal: "cluster"},
+		{in: "unit/payment-api", wantErr: true},
+		{in: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		got, err := parseThreeWayScope(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("parseThreeWayScope(%q) expected error", tt.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseThreeWayScope(%q) error = %v", tt.in, err)
+		}
+		if got.ScopeType != tt.wantTyp || got.ScopeValue != tt.wantVal {
+			t.Fatalf("parseThreeWayScope(%q) = %+v, want type=%v value=%q", tt.in, got, tt.wantTyp, tt.wantVal)
+		}
+	}
+}
+
+func TestBuildThreeWayReport_NamespaceScope(t *testing.T) {
+	prevDiscoverWorkloads := discoverThreeWayWorkloadsFn
+	discoverThreeWayWorkloadsFn = func(namespace string) ([]WorkloadInfo, error) {
+		return []WorkloadInfo{
+			{Kind: "Deployment", Namespace: "prod", Name: "api"},
+			{Kind: "Deployment", Namespace: "prod", Name: "worker"},
+		}, nil
+	}
+	defer func() { discoverThreeWayWorkloadsFn = prevDiscoverWorkloads }()
+
+	prevBuilder := buildThreeWayResourceResultFn
+	buildThreeWayResourceResultFn = func(ctx context.Context, resourceArg, namespace string) (compareResourceResult, error) {
+		switch resourceArg {
+		case "Deployment/api":
+			return compareResourceResult{
+				Resource:   "Deployment/api",
+				Namespace:  "prod",
+				Mode:       "dry-wet-live",
+				Connected:  true,
+				Mismatches: []compareFieldMismatch{{Field: "replicas", Dry: "3", Wet: "2", Live: "1"}},
+			}, nil
+		case "Deployment/worker":
+			return compareResourceResult{
+				Resource:  "Deployment/worker",
+				Namespace: "prod",
+				Mode:      "live-only",
+				Connected: false,
+				Notes:     []string{"Connect to ConfigHub to unlock DRY/WET/LIVE expected-state comparison."},
+			}, nil
+		default:
+			return compareResourceResult{}, nil
+		}
+	}
+	defer func() { buildThreeWayResourceResultFn = prevBuilder }()
+
+	report, err := buildThreeWayReport(context.Background(), threeWayScope{ScopeType: threeWayScopeNamespace, ScopeValue: "prod"})
+	if err != nil {
+		t.Fatalf("buildThreeWayReport() error = %v", err)
+	}
+	if report.Summary.TotalResources != 2 {
+		t.Fatalf("total resources = %d, want 2", report.Summary.TotalResources)
+	}
+	if report.Summary.MismatchedResources != 1 {
+		t.Fatalf("mismatched resources = %d, want 1", report.Summary.MismatchedResources)
+	}
+	if report.Summary.CauseBuckets["disconnected"] != 1 {
+		t.Fatalf("disconnected cause count = %d, want 1", report.Summary.CauseBuckets["disconnected"])
+	}
+}
+
+func TestRunCompareThreeWay_JSON(t *testing.T) {
+	restoreFlags := setThreeWayFlagState(threeWayFlagState{scope: "namespace/prod", format: "json"})
+	defer restoreFlags()
+
+	prevDiscoverWorkloads := discoverThreeWayWorkloadsFn
+	discoverThreeWayWorkloadsFn = func(namespace string) ([]WorkloadInfo, error) {
+		return []WorkloadInfo{{Kind: "Deployment", Namespace: "prod", Name: "api"}}, nil
+	}
+	defer func() { discoverThreeWayWorkloadsFn = prevDiscoverWorkloads }()
+
+	prevBuilder := buildThreeWayResourceResultFn
+	buildThreeWayResourceResultFn = func(ctx context.Context, resourceArg, namespace string) (compareResourceResult, error) {
+		return compareResourceResult{
+			Resource:  "Deployment/api",
+			Namespace: "prod",
+			Mode:      "dry-wet-live",
+			Connected: true,
+		}, nil
+	}
+	defer func() { buildThreeWayResourceResultFn = prevBuilder }()
+
+	out := captureStdout(t, func() {
+		if err := runCompareThreeWay(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runCompareThreeWay() error = %v", err)
+		}
+	})
+
+	var payload threeWayReport
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("invalid json output: %v\n%s", err, out)
+	}
+	if payload.Scope != "namespace/prod" {
+		t.Fatalf("scope = %q, want namespace/prod", payload.Scope)
+	}
+	if len(payload.Resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(payload.Resources))
+	}
+}
+
+func TestRunCompareThreeWay_UnsupportedScope(t *testing.T) {
+	restoreFlags := setThreeWayFlagState(threeWayFlagState{scope: "unit/payment-api", format: "ascii"})
+	defer restoreFlags()
+
+	err := runCompareThreeWay(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("expected unsupported scope error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "scope") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type threeWayFlagState struct {
+	scope  string
+	format string
+	json   bool
+}
+
+func setThreeWayFlagState(state threeWayFlagState) func() {
+	prevScope := compareThreeWayScopeRaw
+	prevFormat := compareThreeWayFormat
+	prevJSON := compareThreeWayJSON
+
+	compareThreeWayScopeRaw = state.scope
+	compareThreeWayFormat = state.format
+	compareThreeWayJSON = state.json
+
+	return func() {
+		compareThreeWayScopeRaw = prevScope
+		compareThreeWayFormat = prevFormat
+		compareThreeWayJSON = prevJSON
+	}
+}

--- a/cmd/cub-scout/smoke_test.go
+++ b/cmd/cub-scout/smoke_test.go
@@ -50,6 +50,12 @@ func TestSmoke_CLIHelp(t *testing.T) {
 			wantContains: []string{"list", "Usage:"},
 		},
 		{
+			name:         "compare three-way help",
+			args:         []string{"compare", "three-way", "--help"},
+			wantExitCode: 0,
+			wantContains: []string{"three-way", "--scope", "Usage:"},
+		},
+		{
 			name:         "scan help",
 			args:         []string{"scan", "--help"},
 			wantExitCode: 0,

--- a/docs/howto/import-to-confighub.md
+++ b/docs/howto/import-to-confighub.md
@@ -98,6 +98,9 @@ cub-scout import -n <namespace> --yes --connect
 cub unit list --space <suggested-space>
 cub-scout map workloads
 cub-scout tree ownership
+
+# Connected three-way check (intent vs render vs observed)
+cub-scout compare three-way --scope namespace/<namespace> --format ascii
 ```
 
 Success criteria:

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -281,6 +281,16 @@ Resource compare mode uses one positional argument:
 - Linked resources show DRY/WET/LIVE sections; unlinked resources degrade to LIVE-only with notes.
 - Linked resource output includes mismatch highlights across DRY/WET/LIVE when values diverge.
 
+Three-way compare subcommand:
+- `cub-scout compare three-way --scope <kind/name> -n <namespace>`
+- `cub-scout compare three-way --scope namespace/<ns> --format json`
+- `cub-scout compare three-way --scope cluster --format md`
+
+Supported `--scope` values:
+- `<kind/name>` or `resource:<kind/name>`
+- `namespace/<ns>`
+- `cluster`
+
 ---
 
 ## `app-space` Subcommands

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -33,6 +33,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `tree` | Hierarchical resource views | v0.5 |
 | `import` | Import workloads into ConfigHub | v1.0 |
 | `combined` (`compare`) | Compare Git and cluster/bundle structures, or show LIVE snapshot for one resource | v1.0 |
+| `compare three-way` | Connected intent/render/observed comparison for resource/namespace/cluster scopes | v1.6 |
 | `discover` | Scout-style workload discovery | v0.5 |
 | `health` | Scout-style health check | v0.5 |
 | `status` | Show connection status and cluster info | v1.0 |
@@ -837,6 +838,38 @@ Resource compare mode behavior:
 - If the live resource is linked to ConfigHub (`confighub.com/UnitSlug`), output includes DRY/WET/LIVE sections.
 - When DRY/WET/LIVE values differ, output includes a mismatch highlight section (`Diff Highlights` in ASCII, `Mismatches` table in Markdown/JSON).
 - If not linked (or not connected), output degrades to LIVE-only with explicit notes.
+
+### compare three-way
+
+Connected three-way comparison command for selected scopes.
+
+```bash
+cub-scout compare three-way --scope <scope> [flags]
+```
+
+Supported scopes:
+- `<kind/name>` or `resource:<kind/name>` (single resource)
+- `namespace/<ns>` (all workloads in namespace)
+- `cluster` (all discovered namespaces/workloads)
+
+Flags:
+- `--scope` (required)
+- `-n, --namespace` (resource scope namespace override)
+- `--format ascii|json|md`
+- `--json` (shorthand for `--format json`)
+
+Examples:
+
+```bash
+# Resource scope
+cub-scout compare three-way --scope deploy/payment-api -n prod
+
+# Namespace scope
+cub-scout compare three-way --scope namespace/prod --format json
+
+# Cluster scope
+cub-scout compare three-way --scope cluster --format md
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- add `cub-scout compare three-way` subcommand with `--scope` support for:
  - `resource` (`<kind/name>` or `resource:<kind/name>`)
  - `namespace/<ns>`
  - `cluster`
- aggregate per-resource DRY/WET/LIVE compare results into deterministic JSON plus ASCII/Markdown summaries
- include severity and likely-cause bucketing (`state-mismatch`, `disconnected`, `unlinked`, `missing-snapshots`, `lookup-failed`)
- keep graceful degradation behavior by reusing connected compare notes when resources are unlinked/disconnected
- add smoke coverage for `compare three-way --help`
- update command docs + import how-to with before/after three-way compare snippet

## Tests
- `go test ./cmd/cub-scout -run 'Test(CompareThreeWay|ParseThreeWayScope|BuildThreeWayReport|RunCompareThreeWay)' -count=3`
- `go test ./cmd/cub-scout -run 'Test(CompareThreeWay|ParseThreeWayScope|BuildThreeWayReport|RunCompareThreeWay|Smoke_)' -count=1`
- `go test ./cmd/cub-scout -count=1`
- `go test ./test/unit -count=1`
- `go test ./pkg/agent -count=1`
- `go build ./cmd/cub-scout`

Closes #213
