### PR TITLE
feat: publish connected summary Slack digests

### DIFF
--- a/cmd/cub-scout/smoke_test.go
+++ b/cmd/cub-scout/smoke_test.go
@@ -104,6 +104,12 @@ func TestSmoke_CLIHelp(t *testing.T) {
 			wantContains: []string{"summary list", "--since", "Usage:"},
 		},
 		{
+			name:         "summary slack help",
+			args:         []string{"summary", "slack", "--help"},
+			wantExitCode: 0,
+			wantContains: []string{"summary slack", "--webhook-url", "Usage:"},
+		},
+		{
 			name:         "debug help",
 			args:         []string{"debug", "--help"},
 			wantExitCode: 0,

--- a/cmd/cub-scout/summary_slack.go
+++ b/cmd/cub-scout/summary_slack.go
@@ -1,0 +1,494 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/internal/summarystore"
+	"github.com/spf13/cobra"
+)
+
+var (
+	summarySlackWebhookURL   string
+	summarySlackSince        string
+	summarySlackType         string
+	summarySlackCluster      string
+	summarySlackNamespace    string
+	summarySlackBatchSize    int
+	summarySlackDedupeWindow string
+	summarySlackForce        bool
+	summarySlackDryRun       bool
+
+	summarySlackHTTPClient = &http.Client{Timeout: 10 * time.Second}
+)
+
+type summarySlackDigestOptions struct {
+	Since     string
+	Type      string
+	Cluster   string
+	Namespace string
+	BatchSize int
+}
+
+type summarySlackRiskTotals struct {
+	Total    int `json:"total"`
+	Critical int `json:"critical"`
+	Warning  int `json:"warning"`
+	Info     int `json:"info"`
+}
+
+type summarySlackSyncTotals struct {
+	Total     int `json:"total"`
+	Failed    int `json:"failed"`
+	OutOfSync int `json:"outOfSync"`
+}
+
+type summarySlackDriftTotals struct {
+	Total int `json:"total"`
+}
+
+type summarySlackTopEntry struct {
+	When      string `json:"when"`
+	Type      string `json:"type"`
+	Cluster   string `json:"cluster"`
+	Namespace string `json:"namespace,omitempty"`
+	Summary   string `json:"summary"`
+}
+
+type summarySlackDigest struct {
+	GeneratedAt time.Time               `json:"generatedAt"`
+	Since       string                  `json:"since"`
+	Type        string                  `json:"type,omitempty"`
+	Cluster     string                  `json:"cluster,omitempty"`
+	Namespace   string                  `json:"namespace,omitempty"`
+	Count       int                     `json:"count"`
+	Risk        summarySlackRiskTotals  `json:"risk"`
+	Sync        summarySlackSyncTotals  `json:"sync"`
+	Drift       summarySlackDriftTotals `json:"drift"`
+	Clusters    []string                `json:"clusters"`
+	Scopes      []string                `json:"scopes"`
+	Top         []summarySlackTopEntry  `json:"top"`
+	NextAction  string                  `json:"nextAction"`
+	Signature   string                  `json:"signature"`
+}
+
+type slackTextObject struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type slackBlock struct {
+	Type   string            `json:"type"`
+	Text   *slackTextObject  `json:"text,omitempty"`
+	Fields []slackTextObject `json:"fields,omitempty"`
+}
+
+type slackWebhookPayload struct {
+	Text   string       `json:"text"`
+	Blocks []slackBlock `json:"blocks,omitempty"`
+}
+
+type summarySlackDedupeState struct {
+	LastSignature string    `json:"lastSignature"`
+	LastSentAt    time.Time `json:"lastSentAt"`
+}
+
+var summarySlackCmd = &cobra.Command{
+	Use:   "slack",
+	Short: "Publish connected summary digest to a Slack webhook",
+	Long: `Build a connected drift/sync/risk digest from persisted summary records
+and post it to a Slack Incoming Webhook.
+
+Examples:
+  cub-scout summary slack --webhook-url https://hooks.slack.com/services/...
+  cub-scout summary slack --since 7d --cluster kind-dev --batch-size 5
+  cub-scout summary slack --dry-run --since 24h`,
+	RunE: runSummarySlack,
+}
+
+func init() {
+	summaryCmd.AddCommand(summarySlackCmd)
+
+	summarySlackCmd.Flags().StringVar(&summarySlackWebhookURL, "webhook-url", "", "Slack incoming webhook URL (or CUB_SCOUT_SLACK_WEBHOOK_URL)")
+	summarySlackCmd.Flags().StringVar(&summarySlackSince, "since", "24h", "Digest lookback window (examples: 24h, 7d, 2w)")
+	summarySlackCmd.Flags().StringVar(&summarySlackType, "type", "", "Filter by summary type (scan, gitops-status)")
+	summarySlackCmd.Flags().StringVar(&summarySlackCluster, "cluster", "", "Filter by cluster/context")
+	summarySlackCmd.Flags().StringVarP(&summarySlackNamespace, "namespace", "n", "", "Filter by namespace")
+	summarySlackCmd.Flags().IntVar(&summarySlackBatchSize, "batch-size", 10, "Maximum entries to include in digest body")
+	summarySlackCmd.Flags().StringVar(&summarySlackDedupeWindow, "dedupe-window", "30m", "Skip duplicate digest signatures within this window")
+	summarySlackCmd.Flags().BoolVar(&summarySlackForce, "force", false, "Bypass dedupe and always post")
+	summarySlackCmd.Flags().BoolVar(&summarySlackDryRun, "dry-run", false, "Print payload JSON without posting")
+}
+
+func runSummarySlack(cmd *cobra.Command, args []string) error {
+	window, err := parseHistorySince(summarySlackSince)
+	if err != nil {
+		return err
+	}
+	if summarySlackBatchSize <= 0 {
+		return fmt.Errorf("--batch-size must be > 0")
+	}
+	dedupeWindow, err := parseHistorySince(summarySlackDedupeWindow)
+	if err != nil {
+		return fmt.Errorf("invalid --dedupe-window: %w", err)
+	}
+
+	store, err := newSummaryStore()
+	if err != nil {
+		return fmt.Errorf("open summary store: %w", err)
+	}
+
+	entries, err := store.List(summarystore.Query{
+		Since:     summaryNowFn().UTC().Add(-window),
+		Type:      strings.TrimSpace(summarySlackType),
+		Cluster:   strings.TrimSpace(summarySlackCluster),
+		Namespace: strings.TrimSpace(summarySlackNamespace),
+	})
+	if err != nil {
+		return fmt.Errorf("query summary store: %w", err)
+	}
+
+	digest := buildSlackDigest(entries, summarySlackDigestOptions{
+		Since:     strings.TrimSpace(summarySlackSince),
+		Type:      strings.TrimSpace(summarySlackType),
+		Cluster:   strings.TrimSpace(summarySlackCluster),
+		Namespace: strings.TrimSpace(summarySlackNamespace),
+		BatchSize: summarySlackBatchSize,
+	})
+	payload := buildSlackPayload(digest)
+
+	if summarySlackDryRun {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(payload)
+	}
+
+	if digest.Count == 0 {
+		fmt.Println("No connected summary records in selected window; skipping Slack post.")
+		return nil
+	}
+
+	statePath, err := summarySlackStatePath()
+	if err != nil {
+		return err
+	}
+	skip, err := shouldSkipSlackPost(statePath, digest.Signature, summaryNowFn().UTC(), dedupeWindow, summarySlackForce)
+	if err != nil {
+		return err
+	}
+	if skip {
+		fmt.Println("Skipping Slack post (duplicate digest within dedupe window).")
+		return nil
+	}
+
+	webhookURL := strings.TrimSpace(summarySlackWebhookURL)
+	if webhookURL == "" {
+		webhookURL = strings.TrimSpace(os.Getenv("CUB_SCOUT_SLACK_WEBHOOK_URL"))
+	}
+	if webhookURL == "" {
+		return fmt.Errorf("missing webhook URL (set --webhook-url or CUB_SCOUT_SLACK_WEBHOOK_URL)")
+	}
+
+	if err := postSlackPayload(cmd.Context(), webhookURL, payload); err != nil {
+		return err
+	}
+
+	if err := writeSlackDedupeState(statePath, summarySlackDedupeState{
+		LastSignature: digest.Signature,
+		LastSentAt:    summaryNowFn().UTC(),
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Posted Slack digest: %d record(s), risk C/W/I=%d/%d/%d, sync failed/out=%d/%d\n",
+		digest.Count, digest.Risk.Critical, digest.Risk.Warning, digest.Risk.Info, digest.Sync.Failed, digest.Sync.OutOfSync)
+	return nil
+}
+
+func buildSlackDigest(entries []summarystore.Record, opts summarySlackDigestOptions) summarySlackDigest {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.After(entries[j].Timestamp)
+	})
+
+	clusterSet := map[string]struct{}{}
+	scopeSet := map[string]struct{}{}
+	top := make([]summarySlackTopEntry, 0)
+
+	digest := summarySlackDigest{
+		GeneratedAt: summaryNowFn().UTC(),
+		Since:       strings.TrimSpace(opts.Since),
+		Type:        strings.TrimSpace(opts.Type),
+		Cluster:     strings.TrimSpace(opts.Cluster),
+		Namespace:   strings.TrimSpace(opts.Namespace),
+		Count:       len(entries),
+		NextAction:  buildSlackNextAction(opts),
+	}
+
+	for i, entry := range entries {
+		cluster := strings.TrimSpace(entry.Cluster)
+		if cluster != "" {
+			clusterSet[cluster] = struct{}{}
+		}
+		namespace := strings.TrimSpace(entry.Scope.Namespace)
+		if namespace != "" {
+			scopeSet[namespace] = struct{}{}
+		}
+
+		digest.Risk.Total += entry.Metrics.RiskTotal
+		digest.Risk.Critical += entry.Metrics.RiskCritical
+		digest.Risk.Warning += entry.Metrics.RiskWarning
+		digest.Risk.Info += entry.Metrics.RiskInfo
+		digest.Sync.Total += entry.Metrics.SyncTotal
+		digest.Sync.Failed += entry.Metrics.SyncFailed
+		digest.Sync.OutOfSync += entry.Metrics.SyncOutOfSync
+		digest.Drift.Total += entry.Metrics.DriftTotal
+
+		if i < opts.BatchSize {
+			top = append(top, summarySlackTopEntry{
+				When:      entry.Timestamp.UTC().Format(time.RFC3339),
+				Type:      entry.Type,
+				Cluster:   entry.Cluster,
+				Namespace: namespace,
+				Summary:   summarizeSlackEntry(entry),
+			})
+		}
+	}
+
+	digest.Clusters = sortedKeys(clusterSet)
+	digest.Scopes = sortedKeys(scopeSet)
+	digest.Top = top
+	digest.Signature = signSlackDigest(digest)
+
+	return digest
+}
+
+func summarizeSlackEntry(entry summarystore.Record) string {
+	parts := make([]string, 0, 3)
+	if entry.Metrics.RiskTotal > 0 {
+		parts = append(parts, fmt.Sprintf("risk C/W/I %d/%d/%d", entry.Metrics.RiskCritical, entry.Metrics.RiskWarning, entry.Metrics.RiskInfo))
+	}
+	if entry.Metrics.SyncTotal > 0 || entry.Metrics.SyncFailed > 0 || entry.Metrics.SyncOutOfSync > 0 {
+		parts = append(parts, fmt.Sprintf("sync failed/out %d/%d", entry.Metrics.SyncFailed, entry.Metrics.SyncOutOfSync))
+	}
+	if entry.Metrics.DriftTotal > 0 {
+		parts = append(parts, fmt.Sprintf("drift %d", entry.Metrics.DriftTotal))
+	}
+	if len(parts) == 0 {
+		return "no drift/sync/risk signals"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func buildSlackNextAction(opts summarySlackDigestOptions) string {
+	args := []string{"cub-scout", "summary", "list", "--since", strings.TrimSpace(opts.Since), "--format", "md"}
+	if value := strings.TrimSpace(opts.Type); value != "" {
+		args = append(args, "--type", value)
+	}
+	if value := strings.TrimSpace(opts.Cluster); value != "" {
+		args = append(args, "--cluster", value)
+	}
+	if value := strings.TrimSpace(opts.Namespace); value != "" {
+		args = append(args, "--namespace", value)
+	}
+	return strings.Join(args, " ")
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func signSlackDigest(digest summarySlackDigest) string {
+	payload := struct {
+		Count   int
+		Risk    summarySlackRiskTotals
+		Sync    summarySlackSyncTotals
+		Drift   summarySlackDriftTotals
+		Since   string
+		Type    string
+		Cluster string
+		Scope   string
+		Top     []summarySlackTopEntry
+	}{
+		Count:   digest.Count,
+		Risk:    digest.Risk,
+		Sync:    digest.Sync,
+		Drift:   digest.Drift,
+		Since:   digest.Since,
+		Type:    digest.Type,
+		Cluster: digest.Cluster,
+		Scope:   digest.Namespace,
+		Top:     digest.Top,
+	}
+	b, _ := json.Marshal(payload)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func buildSlackPayload(digest summarySlackDigest) slackWebhookPayload {
+	clusters := "-"
+	if len(digest.Clusters) > 0 {
+		clusters = strings.Join(digest.Clusters, ", ")
+	}
+	scopes := "-"
+	if len(digest.Scopes) > 0 {
+		scopes = strings.Join(digest.Scopes, ", ")
+	}
+
+	topLines := make([]string, 0, len(digest.Top))
+	for _, entry := range digest.Top {
+		namespace := entry.Namespace
+		if namespace == "" {
+			namespace = "-"
+		}
+		topLines = append(topLines, fmt.Sprintf("• `%s` `%s` `%s/%s` — %s", entry.When, entry.Type, entry.Cluster, namespace, entry.Summary))
+	}
+	if len(topLines) == 0 {
+		topLines = append(topLines, "• No records in selected window")
+	}
+
+	text := fmt.Sprintf("Connected digest (%s): %d record(s), risk C/W/I=%d/%d/%d, sync failed/out=%d/%d, drift=%d",
+		digest.Since,
+		digest.Count,
+		digest.Risk.Critical,
+		digest.Risk.Warning,
+		digest.Risk.Info,
+		digest.Sync.Failed,
+		digest.Sync.OutOfSync,
+		digest.Drift.Total,
+	)
+
+	return slackWebhookPayload{
+		Text: text,
+		Blocks: []slackBlock{
+			{
+				Type: "header",
+				Text: &slackTextObject{Type: "plain_text", Text: "cub-scout Connected Digest"},
+			},
+			{
+				Type: "section",
+				Text: &slackTextObject{Type: "mrkdwn", Text: fmt.Sprintf("*Window:* `%s`\n*Records:* `%d`\n*Clusters:* `%s`\n*Scopes:* `%s`", digest.Since, digest.Count, clusters, scopes)},
+			},
+			{
+				Type: "section",
+				Fields: []slackTextObject{
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Risk (C/W/I)*\n`%d / %d / %d`", digest.Risk.Critical, digest.Risk.Warning, digest.Risk.Info)},
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Sync (failed/out)*\n`%d / %d`", digest.Sync.Failed, digest.Sync.OutOfSync)},
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Drift*\n`%d`", digest.Drift.Total)},
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Next Action*\n`%s`", digest.NextAction)},
+				},
+			},
+			{
+				Type: "section",
+				Text: &slackTextObject{Type: "mrkdwn", Text: "*Top Signals*\n" + strings.Join(topLines, "\n")},
+			},
+		},
+	}
+}
+
+func postSlackPayload(ctx context.Context, webhookURL string, payload slackWebhookPayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal Slack payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := summarySlackHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("post Slack webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+		return fmt.Errorf("Slack webhook returned %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+func summarySlackStatePath() (string, error) {
+	dir, err := defaultSummaryStoreDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve summary store directory: %w", err)
+	}
+	return filepath.Join(dir, ".slack-dedupe-v1.json"), nil
+}
+
+func shouldSkipSlackPost(path, signature string, now time.Time, window time.Duration, force bool) (bool, error) {
+	if force {
+		return false, nil
+	}
+	state, err := readSlackDedupeState(path)
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(state.LastSignature) == "" {
+		return false, nil
+	}
+	if state.LastSignature != signature {
+		return false, nil
+	}
+	if state.LastSentAt.IsZero() {
+		return false, nil
+	}
+	if now.UTC().Sub(state.LastSentAt.UTC()) < window {
+		return true, nil
+	}
+	return false, nil
+}
+
+func readSlackDedupeState(path string) (summarySlackDedupeState, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return summarySlackDedupeState{}, nil
+		}
+		return summarySlackDedupeState{}, fmt.Errorf("read dedupe state: %w", err)
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return summarySlackDedupeState{}, nil
+	}
+	var state summarySlackDedupeState
+	if err := json.Unmarshal([]byte(trimmed), &state); err != nil {
+		return summarySlackDedupeState{}, fmt.Errorf("parse dedupe state: %w", err)
+	}
+	return state, nil
+}
+
+func writeSlackDedupeState(path string, state summarySlackDedupeState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create dedupe state directory: %w", err)
+	}
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal dedupe state: %w", err)
+	}
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		return fmt.Errorf("write dedupe state: %w", err)
+	}
+	return nil
+}

--- a/cmd/cub-scout/summary_slack_test.go
+++ b/cmd/cub-scout/summary_slack_test.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/internal/summarystore"
+	"github.com/spf13/cobra"
+)
+
+func TestBuildSlackDigest(t *testing.T) {
+	now := time.Date(2026, 3, 7, 11, 0, 0, 0, time.UTC)
+	entries := []summarystore.Record{
+		{
+			Timestamp: now.Add(-20 * time.Minute),
+			Type:      "scan",
+			Cluster:   "kind-dev",
+			Scope:     summarystore.Scope{Namespace: "prod"},
+			Metrics: summarystore.Metrics{
+				RiskTotal:    4,
+				RiskCritical: 1,
+				RiskWarning:  2,
+				RiskInfo:     1,
+			},
+		},
+		{
+			Timestamp: now.Add(-15 * time.Minute),
+			Type:      "gitops-status",
+			Cluster:   "kind-dev",
+			Scope:     summarystore.Scope{Namespace: "prod"},
+			Metrics: summarystore.Metrics{
+				SyncFailed:    2,
+				SyncOutOfSync: 1,
+				DriftTotal:    1,
+			},
+		},
+	}
+
+	digest := buildSlackDigest(entries, summarySlackDigestOptions{
+		Since:     "24h",
+		Cluster:   "kind-dev",
+		Namespace: "prod",
+		BatchSize: 10,
+	})
+
+	if digest.Count != 2 {
+		t.Fatalf("count = %d, want 2", digest.Count)
+	}
+	if digest.Risk.Critical != 1 || digest.Risk.Warning != 2 || digest.Risk.Info != 1 {
+		t.Fatalf("unexpected risk totals: %+v", digest.Risk)
+	}
+	if digest.Sync.Failed != 2 || digest.Sync.OutOfSync != 1 {
+		t.Fatalf("unexpected sync totals: %+v", digest.Sync)
+	}
+	if digest.Drift.Total != 1 {
+		t.Fatalf("drift total = %d, want 1", digest.Drift.Total)
+	}
+	if !strings.Contains(digest.NextAction, "cub-scout summary list") {
+		t.Fatalf("next action missing summary command: %q", digest.NextAction)
+	}
+}
+
+func TestRenderSlackPayload(t *testing.T) {
+	digest := summarySlackDigest{
+		Since: "24h",
+		Count: 3,
+		Risk: summarySlackRiskTotals{
+			Critical: 1,
+			Warning:  1,
+			Info:     1,
+		},
+		Sync: summarySlackSyncTotals{
+			Failed:    2,
+			OutOfSync: 1,
+		},
+		Drift:    summarySlackDriftTotals{Total: 1},
+		Clusters: []string{"kind-dev"},
+		Scopes:   []string{"prod"},
+		Top: []summarySlackTopEntry{
+			{When: "2026-03-07T10:40:00Z", Type: "scan", Cluster: "kind-dev", Namespace: "prod", Summary: "risk C/W/I 1/1/1"},
+		},
+		NextAction: "cub-scout summary list --since 24h",
+	}
+
+	payload := buildSlackPayload(digest)
+	if !strings.Contains(payload.Text, "Connected digest") {
+		t.Fatalf("payload text missing heading: %q", payload.Text)
+	}
+	if len(payload.Blocks) == 0 {
+		t.Fatal("expected Slack blocks")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if !strings.Contains(string(body), "cub-scout summary list --since 24h") {
+		t.Fatalf("payload missing next action command: %s", body)
+	}
+}
+
+func TestRunSummarySlack_PostsToWebhook(t *testing.T) {
+	restoreFlags := withSummarySlackFlagsForTest()
+	defer restoreFlags()
+
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	prevNow := summaryNowFn
+	summaryNowFn = func() time.Time { return now }
+	defer func() { summaryNowFn = prevNow }()
+
+	dir := t.TempDir()
+	t.Setenv("CUB_SCOUT_SUMMARY_DIR", dir)
+	store, err := summarystore.New(summarystore.Options{RootDir: dir, RetentionDays: 30, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("summarystore.New() error = %v", err)
+	}
+	if err := store.Write(summarystore.Record{
+		Timestamp: now.Add(-30 * time.Minute),
+		Type:      "scan",
+		Cluster:   "kind-dev",
+		Scope:     summarystore.Scope{Namespace: "prod"},
+		Metrics:   summarystore.Metrics{RiskTotal: 2, RiskCritical: 1, RiskWarning: 1},
+	}); err != nil {
+		t.Fatalf("store.Write() error = %v", err)
+	}
+
+	var (
+		mu       sync.Mutex
+		requests [][]byte
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode webhook payload: %v", err)
+		}
+		raw, _ := json.Marshal(payload)
+		mu.Lock()
+		requests = append(requests, raw)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	summarySlackWebhookURL = server.URL
+	summarySlackSince = "24h"
+	summarySlackBatchSize = 5
+	summarySlackForce = true
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	if err := runSummarySlack(cmd, nil); err != nil {
+		t.Fatalf("runSummarySlack() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) != 1 {
+		t.Fatalf("webhook request count = %d, want 1", len(requests))
+	}
+	if !strings.Contains(string(requests[0]), "risk") {
+		t.Fatalf("payload missing risk fields: %s", requests[0])
+	}
+}
+
+func TestRunSummarySlack_DedupeSkipsWithinWindow(t *testing.T) {
+	restoreFlags := withSummarySlackFlagsForTest()
+	defer restoreFlags()
+
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	prevNow := summaryNowFn
+	summaryNowFn = func() time.Time { return now }
+	defer func() { summaryNowFn = prevNow }()
+
+	dir := t.TempDir()
+	t.Setenv("CUB_SCOUT_SUMMARY_DIR", dir)
+	store, err := summarystore.New(summarystore.Options{RootDir: dir, RetentionDays: 30, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("summarystore.New() error = %v", err)
+	}
+	if err := store.Write(summarystore.Record{
+		Timestamp: now.Add(-10 * time.Minute),
+		Type:      "scan",
+		Cluster:   "kind-dev",
+		Scope:     summarystore.Scope{Namespace: "prod"},
+		Metrics:   summarystore.Metrics{RiskTotal: 1, RiskWarning: 1},
+	}); err != nil {
+		t.Fatalf("store.Write() error = %v", err)
+	}
+
+	var (
+		mu    sync.Mutex
+		count int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	summarySlackWebhookURL = server.URL
+	summarySlackSince = "24h"
+	summarySlackBatchSize = 5
+	summarySlackDedupeWindow = "2h"
+	summarySlackForce = false
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	if err := runSummarySlack(cmd, nil); err != nil {
+		t.Fatalf("first runSummarySlack() error = %v", err)
+	}
+	if err := runSummarySlack(cmd, nil); err != nil {
+		t.Fatalf("second runSummarySlack() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count != 1 {
+		t.Fatalf("webhook post count = %d, want 1 (dedupe skip)", count)
+	}
+}
+
+func TestRunSummarySlack_BatchSizeLimitsEntries(t *testing.T) {
+	now := time.Date(2026, 3, 7, 11, 0, 0, 0, time.UTC)
+	entries := []summarystore.Record{
+		{Timestamp: now.Add(-1 * time.Minute), Type: "scan", Cluster: "a", Scope: summarystore.Scope{Namespace: "prod"}, Metrics: summarystore.Metrics{RiskTotal: 1}},
+		{Timestamp: now.Add(-2 * time.Minute), Type: "scan", Cluster: "a", Scope: summarystore.Scope{Namespace: "prod"}, Metrics: summarystore.Metrics{RiskTotal: 1}},
+		{Timestamp: now.Add(-3 * time.Minute), Type: "scan", Cluster: "a", Scope: summarystore.Scope{Namespace: "prod"}, Metrics: summarystore.Metrics{RiskTotal: 1}},
+	}
+
+	digest := buildSlackDigest(entries, summarySlackDigestOptions{Since: "24h", BatchSize: 2})
+	if len(digest.Top) != 2 {
+		t.Fatalf("top entries len = %d, want 2", len(digest.Top))
+	}
+}
+
+func TestSummarySlackCommandRegistered(t *testing.T) {
+	summary := findRootCommand(t, "summary")
+	if summary == nil {
+		t.Fatal("summary command not found")
+	}
+	for _, sub := range summary.Commands() {
+		if sub.Name() == "slack" {
+			return
+		}
+	}
+	t.Fatal("summary slack subcommand not found")
+}
+
+func withSummarySlackFlagsForTest() func() {
+	prevWebhook := summarySlackWebhookURL
+	prevSince := summarySlackSince
+	prevType := summarySlackType
+	prevCluster := summarySlackCluster
+	prevNamespace := summarySlackNamespace
+	prevBatch := summarySlackBatchSize
+	prevDedupe := summarySlackDedupeWindow
+	prevForce := summarySlackForce
+	prevDryRun := summarySlackDryRun
+
+	summarySlackWebhookURL = ""
+	summarySlackSince = "24h"
+	summarySlackType = ""
+	summarySlackCluster = ""
+	summarySlackNamespace = ""
+	summarySlackBatchSize = 10
+	summarySlackDedupeWindow = "30m"
+	summarySlackForce = false
+	summarySlackDryRun = false
+
+	return func() {
+		summarySlackWebhookURL = prevWebhook
+		summarySlackSince = prevSince
+		summarySlackType = prevType
+		summarySlackCluster = prevCluster
+		summarySlackNamespace = prevNamespace
+		summarySlackBatchSize = prevBatch
+		summarySlackDedupeWindow = prevDedupe
+		summarySlackForce = prevForce
+		summarySlackDryRun = prevDryRun
+	}
+}
+
+func findRootCommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == name {
+			return cmd
+		}
+	}
+	return nil
+}

--- a/docs/howto/scan-for-risks.md
+++ b/docs/howto/scan-for-risks.md
@@ -114,6 +114,7 @@ Connected trend query example:
 
 ```bash
 ./cub-scout summary list --since 7d --type scan --format md
+./cub-scout summary slack --since 24h --webhook-url https://hooks.slack.com/services/...
 ```
 
 ## Next Steps

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -244,6 +244,28 @@ Connected storage defaults:
 
 ---
 
+## `summary slack` Options
+
+| Option | Description |
+|--------|-------------|
+| `--webhook-url` | Slack incoming webhook URL (`CUB_SCOUT_SLACK_WEBHOOK_URL` fallback) |
+| `--since` | Digest lookback window (`24h`, `7d`, `2w`) |
+| `--type` | Summary type filter (`scan`, `gitops-status`) |
+| `--cluster` | Cluster/context filter |
+| `-n, --namespace` | Namespace filter |
+| `--batch-size` | Max entries included in digest body |
+| `--dedupe-window` | Skip duplicate digest signatures within this window |
+| `--force` | Bypass dedupe and always post |
+| `--dry-run` | Print payload JSON without posting |
+
+Digest content contract:
+- Severity breakdown (`risk critical/warning/info`)
+- Affected scope (`clusters`, `namespaces`)
+- Sync/drift totals (`sync failed/out-of-sync`, `drift total`)
+- Next action command (`cub-scout summary list ... --format md`)
+
+---
+
 ## `import-argocd` Options
 
 | Option | Description |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -40,6 +40,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `history` | Show connected change history from ConfigHub ChangeSets | v1.4 |
 | `audit list` | Show connected break-glass accept/reject audit trail | v1.6 |
 | `summary list` | Query persisted connected drift/sync/risk snapshots | v1.7 |
+| `summary slack` | Publish connected summary digest to Slack webhook | v1.7 |
 | `connect` | Quickly configure kube context from server URL or kubeconfig | v1.0 |
 | `setup` | Set up shell completions | v0.19 |
 | `mcp serve` | Serve read-only MCP tools over stdio | v1.4 |
@@ -998,6 +999,56 @@ cub-scout summary list --since 48h --namespace prod --json
 - Optional overrides:
   - `CUB_SCOUT_SUMMARY_DIR` (storage path)
   - `CUB_SCOUT_SUMMARY_RETENTION_DAYS` (retention window)
+
+---
+
+## summary slack
+
+Build a connected digest from persisted summary records and post to Slack Incoming Webhook.
+
+```bash
+cub-scout summary slack [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--webhook-url` | Slack incoming webhook URL (or `CUB_SCOUT_SLACK_WEBHOOK_URL`) |
+| `--since` | Digest lookback window (examples: `24h`, `7d`, `2w`) |
+| `--type` | Filter by type (`scan`, `gitops-status`) |
+| `--cluster` | Filter by cluster/context name |
+| `-n, --namespace` | Filter by namespace |
+| `--batch-size` | Max entries included in digest body |
+| `--dedupe-window` | Skip duplicate digest signatures within this window |
+| `--force` | Bypass dedupe and always post |
+| `--dry-run` | Print webhook payload JSON without posting |
+
+### Examples
+
+```bash
+# Post the last 24h digest to Slack
+cub-scout summary slack --webhook-url https://hooks.slack.com/services/...
+
+# Scope to one cluster and namespace
+cub-scout summary slack --since 7d --cluster kind-dev --namespace prod
+
+# Render payload only (no webhook post)
+cub-scout summary slack --dry-run --since 24h
+```
+
+### Digest Contract
+
+Each digest includes:
+- Severity breakdown (risk critical/warning/info)
+- Affected scope (clusters + namespaces)
+- Sync/drift summary (`sync failed/out-of-sync`, `drift total`)
+- Next-action command (`cub-scout summary list ... --format md`)
+
+Noise controls:
+- Windowing: `--since`
+- Batching: `--batch-size`
+- Deduping: signature state file + `--dedupe-window` (`--force` bypass)
 
 ---
 

--- a/examples/connected-summary-storage/README.md
+++ b/examples/connected-summary-storage/README.md
@@ -23,6 +23,12 @@ cub-scout summary list --since 24h
 
 # JSON for automation
 cub-scout summary list --since 24h --json
+
+# Build/post Slack digest (webhook required)
+cub-scout summary slack --webhook-url https://hooks.slack.com/services/... --since 24h
+
+# Preview Slack payload only
+cub-scout summary slack --dry-run --since 24h
 ```
 
 ## Storage Contract
@@ -31,3 +37,12 @@ cub-scout summary list --since 24h --json
 - Index dimensions: `cluster`, `scope.namespace`, `timestamp`, `type`
 - Default retention: 30 days
 - Retention override: `CUB_SCOUT_SUMMARY_RETENTION_DAYS`
+
+## End-to-End Demo Script
+
+```bash
+./examples/connected-summary-storage/slack-demo.sh
+```
+
+The script posts only when `CUB_SCOUT_SLACK_WEBHOOK_URL` is set, and always prints
+the generated payload in dry-run mode first.

--- a/examples/connected-summary-storage/slack-demo.sh
+++ b/examples/connected-summary-storage/slack-demo.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -x "./cub-scout" ]]; then
+  echo "Building ./cub-scout ..."
+  go build ./cmd/cub-scout
+fi
+
+echo "== Connected summary window =="
+./cub-scout summary list --since 24h || true
+
+echo
+echo "== Slack payload preview (dry-run) =="
+./cub-scout summary slack --since 24h --dry-run || true
+
+if [[ -n "${CUB_SCOUT_SLACK_WEBHOOK_URL:-}" ]]; then
+  echo
+  echo "== Posting digest to Slack =="
+  ./cub-scout summary slack --since 24h --webhook-url "$CUB_SCOUT_SLACK_WEBHOOK_URL"
+else
+  echo
+  echo "Skipping post: set CUB_SCOUT_SLACK_WEBHOOK_URL to enable webhook delivery."
+fi


### PR DESCRIPTION
## Summary
- add `cub-scout summary slack` to publish connected drift/sync/risk digests to Slack Incoming Webhook
- aggregate persisted `connected.summary.v1` records into digest totals and top entries
- include required digest content: severity breakdown, affected scope, and next-action command
- add noise controls: window (`--since`), batching (`--batch-size`), dedupe (`--dedupe-window`), bypass (`--force`)
- add dry-run mode (`--dry-run`) and env webhook fallback (`CUB_SCOUT_SLACK_WEBHOOK_URL`)
- add end-to-end demo script: `examples/connected-summary-storage/slack-demo.sh`
- update command docs/matrix/howto and smoke help coverage

## Verification
- integration test with webhook mock: `TestRunSummarySlack_PostsToWebhook`
- dedupe/batch tests: `TestRunSummarySlack_DedupeSkipsWithinWindow`, `TestRunSummarySlack_BatchSizeLimitsEntries`
- digest/payload contract tests: `TestBuildSlackDigest`, `TestRenderSlackPayload`
- registration/help: `TestSummarySlackCommandRegistered`, `TestSmoke_*`

## Proof-First Logs
- red phase: `/tmp/cub-scout-regression/v1.7/210/verify1-red-*.log`
- iterative scoped reruns: `/tmp/cub-scout-regression/v1.7/210/verify1-*.log`, `verify2-*.log`, `verify3-*.log`
- close gates: `/tmp/cub-scout-regression/v1.7/210/close-build.log`, `close-cmd.log`, `close-all.log`

## Commands Run
- `go test ./cmd/cub-scout -run 'Test(BuildSlackDigest|RenderSlackPayload)' -count=1`
- `go test ./cmd/cub-scout -run 'TestRunSummarySlack_PostsToWebhook' -count=1`
- `go test ./cmd/cub-scout -run 'TestRunSummarySlack_(DedupeSkipsWithinWindow|BatchSizeLimitsEntries)' -count=1`
- `go test ./cmd/cub-scout -run 'Test(SummarySlackCommandRegistered|Smoke_)' -count=1`
- reran the same scoped set for verify #2 and verify #3
- `go build ./cmd/cub-scout`
- `go test ./cmd/cub-scout -count=1`
- `go test ./... -count=1`

Closes #210
