### PR TITLE
feat: add yaml-based custom ownership detectors

### DIFF
--- a/cmd/cub-scout/explain.go
+++ b/cmd/cub-scout/explain.go
@@ -240,7 +240,11 @@ func buildExplainSummary(result *agent.TraceResult) ExplainSummary {
 	}
 
 	if result.Error != "" {
-		summary.Owner = "Unknown - no recognized ownership labels found"
+		if customOwner := customOwnerFromTraceError(result.Error); customOwner != "" {
+			summary.Owner = customOwner
+		} else {
+			summary.Owner = "Unknown - no recognized ownership labels found"
+		}
 		if summary.Health == "Unknown" {
 			summary.Health = "Unavailable"
 		}
@@ -283,6 +287,19 @@ func explainOwner(tool string) string {
 	default:
 		return "Unknown"
 	}
+}
+
+func customOwnerFromTraceError(traceErr string) string {
+	const prefix = "custom owner detected:"
+	msg := strings.TrimSpace(traceErr)
+	if !strings.HasPrefix(strings.ToLower(msg), prefix) {
+		return ""
+	}
+	owner := strings.TrimSpace(msg[len(prefix):])
+	if idx := strings.Index(owner, "("); idx > 0 {
+		owner = strings.TrimSpace(owner[:idx])
+	}
+	return owner
 }
 
 func explainSource(chain []agent.ChainLink) string {

--- a/cmd/cub-scout/explain_test.go
+++ b/cmd/cub-scout/explain_test.go
@@ -167,3 +167,19 @@ func TestRenderExplainText_IncludesPartialTraceNotes(t *testing.T) {
 		t.Fatalf("expected partial-trace note in explain text:\\n%s", out)
 	}
 }
+
+func TestExplainOwner_Custom(t *testing.T) {
+	result := &agent.TraceResult{
+		Object: agent.ResourceRef{
+			Kind:      "Deployment",
+			Name:      "platform-api",
+			Namespace: "default",
+		},
+		Error: "custom owner detected: Internal Platform (trace chain unavailable for custom owners)",
+	}
+
+	summary := buildExplainSummary(result)
+	if summary.Owner != "Internal Platform" {
+		t.Fatalf("owner = %q, want %q", summary.Owner, "Internal Platform")
+	}
+}

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -63,6 +63,16 @@ func displayOwner(owner string) string {
 	return mapsvc.DisplayOwner(owner)
 }
 
+func displayOwnership(ownership agent.Ownership) string {
+	if ownership.Type == agent.OwnerCustom {
+		if name := strings.TrimSpace(ownership.Name); name != "" {
+			return name
+		}
+		return "Custom"
+	}
+	return displayOwner(ownership.Type)
+}
+
 var mapCmd = &cobra.Command{
 	Use:   "map",
 	Short: "Interactive map of resources and ownership",
@@ -1065,7 +1075,7 @@ func processResourceWithLookup(
 		Kind:        unstr.GetKind(),
 		Name:        unstr.GetName(),
 		APIVersion:  unstr.GetAPIVersion(),
-		Owner:       displayOwner(ownership.Type),
+		Owner:       displayOwnership(ownership),
 		Labels:      labels,
 		Status:      detectStatus(unstr),
 		CreatedAt:   unstr.GetCreationTimestamp().Time,
@@ -2896,43 +2906,15 @@ func resolveArgoOwnershipLineage(obj *unstructured.Unstructured, index *argoLine
 }
 
 func detectOwnership(obj *unstructured.Unstructured) (string, string) {
-	labels := obj.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
+	ownership := agent.DetectOwnership(obj)
+	owner := displayOwnership(ownership)
+
+	managedBy := strings.TrimSpace(ownership.Name)
+	if managedBy == "" {
+		managedBy = "-"
 	}
 
-	// ConfigHub
-	if slug, ok := labels["confighub.com/UnitSlug"]; ok {
-		return "ConfigHub", slug
-	}
-	// Flux Kustomize
-	if name, ok := labels["kustomize.toolkit.fluxcd.io/name"]; ok {
-		return "Flux", name
-	}
-	// Flux Helm
-	if name, ok := labels["helm.toolkit.fluxcd.io/name"]; ok {
-		return "Flux", name
-	}
-	// ArgoCD - check both label and tracking-id annotation
-	if instance, ok := labels["argocd.argoproj.io/instance"]; ok {
-		return "ArgoCD", instance
-	}
-	// ArgoCD tracking-id annotation (format: <app-name>:<group>/<kind>:<namespace>/<name>)
-	if tracking, ok := annotations["argocd.argoproj.io/tracking-id"]; ok {
-		if appName := parseArgoTrackingIDAppName(tracking); appName != "" {
-			return "ArgoCD", appName
-		}
-	}
-	// Helm
-	if labels["app.kubernetes.io/managed-by"] == "Helm" {
-		name := annotations["meta.helm.sh/release-name"]
-		return "Helm", name
-	}
-	return "Native", "-"
+	return owner, managedBy
 }
 
 func getContainerImage(obj *unstructured.Unstructured) string {

--- a/cmd/cub-scout/map_custom_owner_test.go
+++ b/cmd/cub-scout/map_custom_owner_test.go
@@ -1,0 +1,89 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestProcessResource_CustomOwnershipDisplay(t *testing.T) {
+	detectors := writeCustomDetectorsFile(t, `
+detectors:
+  - name: internal-platform
+    labels:
+      - key: platform.company.com/managed-by
+        value: "platform-controller"
+    owner_name: "Internal Platform"
+    owner_type: "custom"
+`)
+	t.Setenv("CUB_SCOUT_OWNERSHIP_DETECTORS", detectors)
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apps/v1")
+	obj.SetKind("Deployment")
+	obj.SetNamespace("default")
+	obj.SetName("payments-api")
+	obj.SetLabels(map[string]string{
+		"platform.company.com/managed-by": "platform-controller",
+	})
+
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	entries := processResourceWithLookup(obj, gvr, "local", nil, map[string]int{}, mapApplicationSetLookup{
+		byNamespacedName: map[string]int{},
+		byName:           map[string]int{},
+	})
+
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1", len(entries))
+	}
+	if entries[0].Owner != "Internal Platform" {
+		t.Fatalf("entry owner = %q, want %q", entries[0].Owner, "Internal Platform")
+	}
+	if got := entries[0].OwnerDetails["name"]; got != "Internal Platform" {
+		t.Fatalf("ownerDetails.name = %q, want %q", got, "Internal Platform")
+	}
+}
+
+func TestDetectOwnershipHelper_UsesAgentDetectors(t *testing.T) {
+	detectors := writeCustomDetectorsFile(t, `
+detectors:
+  - name: pulumi
+    annotations:
+      - key: pulumi.com/stack
+    owner_name: "Pulumi"
+    owner_type: "custom"
+`)
+	t.Setenv("CUB_SCOUT_OWNERSHIP_DETECTORS", detectors)
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apps/v1")
+	obj.SetKind("Deployment")
+	obj.SetNamespace("default")
+	obj.SetName("api")
+	obj.SetAnnotations(map[string]string{
+		"pulumi.com/stack": "platform/prod",
+	})
+
+	owner, managedBy := detectOwnership(obj)
+	if owner != "Pulumi" {
+		t.Fatalf("owner = %q, want %q", owner, "Pulumi")
+	}
+	if managedBy != "Pulumi" {
+		t.Fatalf("managedBy = %q, want %q", managedBy, "Pulumi")
+	}
+}
+
+func writeCustomDetectorsFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "detectors.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write detectors file: %v", err)
+	}
+	return path
+}

--- a/cmd/cub-scout/trace.go
+++ b/cmd/cub-scout/trace.go
@@ -302,6 +302,9 @@ func runTrace(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+	case agent.OwnerCustom:
+		result = buildCustomOwnerUnsupportedTraceResult(kind, name, traceNamespace, ownership)
+
 	default:
 		// Try Flux first, then Argo, then report not managed
 		fluxTracer := agent.NewFluxTracer()
@@ -1630,11 +1633,46 @@ func runTraceDiff(ctx context.Context, kind, name, namespace string) error {
 	case agent.OwnerHelm:
 		return runHelmDiff(ctx, name, namespace)
 	default:
-		fmt.Printf("%s⚠ Resource is not managed by GitOps (owner: %s)%s\n", colorYellow, ownership.Type, colorReset)
+		fmt.Printf("%s⚠ Resource is not managed by GitOps (owner: %s)%s\n", colorYellow, ownershipLabel(ownership), colorReset)
 		fmt.Printf("%s  Cannot show diff for unmanaged resources.%s\n", colorDim, colorReset)
 		fmt.Printf("%s  Consider importing to GitOps: cub-scout import%s\n", colorDim, colorReset)
 		fmt.Printf("\n")
 		return nil
+	}
+}
+
+func ownershipLabel(ownership *agent.Ownership) string {
+	if ownership == nil {
+		return "unknown"
+	}
+	if ownership.Type == agent.OwnerCustom {
+		if name := strings.TrimSpace(ownership.Name); name != "" {
+			return name
+		}
+		return "custom"
+	}
+	if ownership.Type == "" {
+		return "unknown"
+	}
+	return ownership.Type
+}
+
+func buildCustomOwnerUnsupportedTraceResult(kind, name, namespace string, ownership *agent.Ownership) *agent.TraceResult {
+	ownerName := ownershipLabel(ownership)
+	if ownerName == "" || ownerName == "unknown" {
+		ownerName = "Custom"
+	}
+
+	return &agent.TraceResult{
+		Object: agent.ResourceRef{
+			Kind:      kind,
+			Name:      name,
+			Namespace: namespace,
+		},
+		FullyManaged: false,
+		Tool:         "",
+		Error:        fmt.Sprintf("custom owner detected: %s (trace chain unavailable for custom owners)", ownerName),
+		TracedAt:     time.Now(),
 	}
 }
 

--- a/cmd/cub-scout/trace_custom_owner_test.go
+++ b/cmd/cub-scout/trace_custom_owner_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func TestBuildCustomOwnerUnsupportedTraceResult(t *testing.T) {
+	result := buildCustomOwnerUnsupportedTraceResult(
+		"Deployment",
+		"platform-api",
+		"default",
+		&agent.Ownership{
+			Type: agent.OwnerCustom,
+			Name: "Internal Platform",
+		},
+	)
+
+	if result.Object.Kind != "Deployment" || result.Object.Name != "platform-api" || result.Object.Namespace != "default" {
+		t.Fatalf("unexpected object ref: %#v", result.Object)
+	}
+	if !strings.Contains(result.Error, "custom owner detected: Internal Platform") {
+		t.Fatalf("expected custom owner in error, got: %q", result.Error)
+	}
+}
+
+func TestOwnershipLabel_CustomUsesName(t *testing.T) {
+	got := ownershipLabel(&agent.Ownership{Type: agent.OwnerCustom, Name: "Pulumi"})
+	if got != "Pulumi" {
+		t.Fatalf("ownershipLabel(custom) = %q, want %q", got, "Pulumi")
+	}
+}

--- a/docs/howto/extending.md
+++ b/docs/howto/extending.md
@@ -115,92 +115,52 @@ cub-scout scan --risk-dir ./my-risks
 
 Add detection for custom deployment tools.
 
-### Ownership Detector Interface
+### Configuration File
 
-```go
-// pkg/ownership/detector.go
+Create one of these files:
 
-type Detector interface {
-    // Name returns the owner type name (e.g., "mydeployer")
-    Name() string
+- `~/.cub-scout/detectors.yaml` (default)
+- or set `CUB_SCOUT_OWNERSHIP_DETECTORS=/path/to/detectors.yaml`
 
-    // Priority returns detection priority (lower = higher priority)
-    Priority() int
-
-    // Detect checks if this detector owns the resource
-    // Returns (owner, confidence) where confidence is 0.0-1.0
-    Detect(obj *unstructured.Unstructured) (*Owner, float64)
-}
-
-type Owner struct {
-    Type   string            // e.g., "mydeployer"
-    Ref    string            // e.g., "pipeline/prod-deploy"
-    Labels map[string]string // Additional ownership metadata
-}
-```
-
-### Example: Custom Detector
-
-```go
-// pkg/ownership/mydeployer.go
-
-type MyDeployerDetector struct{}
-
-func (d *MyDeployerDetector) Name() string {
-    return "mydeployer"
-}
-
-func (d *MyDeployerDetector) Priority() int {
-    return 50  // Between Flux (20) and Unknown (100)
-}
-
-func (d *MyDeployerDetector) Detect(obj *unstructured.Unstructured) (*Owner, float64) {
-    labels := obj.GetLabels()
-
-    // Check for our custom label
-    if pipeline, ok := labels["mycompany.io/deployed-by"]; ok {
-        return &Owner{
-            Type: "mydeployer",
-            Ref:  pipeline,
-            Labels: map[string]string{
-                "pipeline": pipeline,
-            },
-        }, 1.0  // High confidence
-    }
-
-    return nil, 0
-}
-```
-
-### Registering Custom Detectors
-
-```go
-// In your main.go or init
-
-import "github.com/confighub/agent/pkg/ownership"
-
-func init() {
-    ownership.Register(&MyDeployerDetector{})
-}
-```
-
-### Configuration-Based Detectors
-
-For simple label/annotation detection, use config:
+Example:
 
 ```yaml
-# config/ownership.yaml
 detectors:
-  - name: mydeployer
-    priority: 50
+  - name: internal-platform
     labels:
-      - key: mycompany.io/deployed-by
-        ref_field: true  # Use this label's value as the owner ref
+      - key: platform.company.com/managed-by
+        value: "platform-controller"
+    owner_name: "Internal Platform"
+    owner_type: "custom"
+
+  - name: pulumi
     annotations:
-      - key: mycompany.io/pipeline-id
+      - key: pulumi.com/stack
+    owner_name: "Pulumi"
+    owner_type: "custom"
 ```
 
-**Note:** Configuration-based detectors are not yet implemented. Currently, custom detectors must be added in Go code.
+### Matching Rules
+
+1. Built-in detectors run first (Flux, ArgoCD, Helm, Terraform, ConfigHub, Crossplane).
+2. Custom detectors run after built-ins, in YAML order.
+3. A detector matches when all listed label/annotation rules match.
+4. `value` is optional: when omitted, key existence is enough.
+5. First matching custom detector wins.
+
+### Behavior on Errors
+
+- Missing config file: silently ignored (default behavior only).
+- Invalid config file: warning is printed once to stderr, then built-ins continue.
+- Invalid detector entry (missing `name`, no usable rules): that entry is skipped.
+
+### Where It Appears
+
+Custom owners appear in:
+
+- `cub-scout map list` owner column
+- `cub-scout explain` owner field
+- `cub-scout trace` warning text for unsupported non-GitOps trace chains
 
 ---
 

--- a/docs/howto/ownership-detection.md
+++ b/docs/howto/ownership-detection.md
@@ -40,7 +40,10 @@ Map checks labels on each resource to determine ownership:
 | **Flux** | Toolkit labels | `kustomize.toolkit.fluxcd.io/*` or `helm.toolkit.fluxcd.io/*` |
 | **ArgoCD** | Argo label or tracking-id | `argocd.argoproj.io/instance` label OR `argocd.argoproj.io/tracking-id` annotation |
 | **Helm** | Managed-by label | `app.kubernetes.io/managed-by: Helm` |
+| **Terraform** | Terraform metadata | `app.terraform.io/run-id` annotation OR `app.terraform.io/managed` label |
+| **Crossplane** | Crossplane labels/ownerRefs | `crossplane.io/*` labels or Crossplane owner references |
 | **ConfigHub** | Unit slug | `confighub.com/UnitSlug` |
+| **Custom** | Configured detector rules | `~/.cub-scout/detectors.yaml` / `$CUB_SCOUT_OWNERSHIP_DETECTORS` |
 | **Native** | Nothing detected | No GitOps ownership labels |
 
 ### Flux Detection
@@ -97,6 +100,30 @@ If no GitOps labels are found, the resource is marked as **Native**. This usuall
 - Someone ran `kubectl apply` directly
 - A controller created the resource
 - Labels were removed
+
+### Custom Detector Configuration
+
+You can extend ownership detection without writing Go code.
+
+Create `~/.cub-scout/detectors.yaml`:
+
+```yaml
+detectors:
+  - name: internal-platform
+    labels:
+      - key: platform.company.com/managed-by
+        value: platform-controller
+    owner_name: Internal Platform
+    owner_type: custom
+```
+
+Rules:
+
+1. Built-in detectors run first.
+2. Custom detectors run in file order.
+3. First matching custom detector wins.
+
+If config is invalid, cub-scout warns and falls back to built-ins.
 
 ## Filter by Owner
 

--- a/docs/howto/trace-ownership.md
+++ b/docs/howto/trace-ownership.md
@@ -26,6 +26,7 @@ In mixed environments with multiple GitOps tools:
 | Flux | Flux source + Kustomization/HelmRelease chain |
 | ArgoCD | Argo Application/ApplicationSet/App-of-Apps chain |
 | Helm (standalone) | Helm release metadata from cluster secrets |
+| Custom detector owner | Emits custom owner name with an unsupported-chain warning |
 | Native/Unknown | Kubernetes ownerRef chain + orphan metadata |
 
 This means Argo traces are resolved from Argo resources directly (not by reusing Flux semantics).

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -165,6 +165,9 @@ cub-scout map list -n production
 # Filter by owner
 cub-scout map list -q "owner=Flux"
 
+# Filter by custom owner name from detectors.yaml
+cub-scout map list -q "owner=Internal Platform"
+
 # Filter by multiple criteria
 cub-scout map list -q "owner!=Native AND kind=Deployment"
 
@@ -554,6 +557,7 @@ Show the full GitOps ownership chain for a resource. Works with **Flux, ArgoCD, 
 
 Owner detection for `trace` uses the same deterministic precedence as `map list`.
 After owner detection, `trace` resolves with an owner-specific chain resolver (Flux, ArgoCD, or Helm).
+When a resource matches a custom ownership detector, `trace` prints the configured owner name and explains that chain resolution is currently limited to Flux/ArgoCD/Helm.
 For detailed rules, see `docs/reference/ownership-precedence.md` and `docs/howto/trace-ownership.md`.
 
 ```bash

--- a/docs/reference/ownership-precedence.md
+++ b/docs/reference/ownership-precedence.md
@@ -23,8 +23,9 @@ cub-scout checks for ownership signals in the following order. The **first match
 | 5 | **ConfigHub** | Label or annotation: `confighub.com/UnitSlug` |
 | 6 | **Crossplane (system)** | API group: `pkg.crossplane.io` or `apiextensions.crossplane.io` |
 | 7 | **Crossplane (managed)** | Labels: `crossplane.io/claim-name`, `crossplane.io/composite`, or ownerRef to Crossplane resource |
-| 8 | **Kubernetes (native)** | OwnerReferences present (controller preferred) |
-| 9 | **Unknown** | No ownership signals detected |
+| 8 | **Custom (config file)** | `~/.cub-scout/detectors.yaml` (or `$CUB_SCOUT_OWNERSHIP_DETECTORS`) detectors, first matching detector wins |
+| 9 | **Kubernetes (native)** | OwnerReferences present (controller preferred) |
+| 10 | **Unknown** | No ownership signals detected |
 
 ---
 
@@ -170,6 +171,36 @@ determine ownership from available signals.
 
 ---
 
+### Custom (Config File)
+
+**Confidence: High** (explicit configured match rules)
+
+Custom detectors are loaded from:
+
+- `~/.cub-scout/detectors.yaml`
+- or `$CUB_SCOUT_OWNERSHIP_DETECTORS` (path override)
+
+Format:
+
+```yaml
+detectors:
+  - name: internal-platform
+    labels:
+      - key: platform.company.com/managed-by
+        value: platform-controller
+    owner_name: Internal Platform
+    owner_type: custom
+```
+
+Rules:
+
+1. Built-in detectors run first (priorities 1-7 above).
+2. Custom detectors run next, in file order (first match wins).
+3. If the config file is missing, behavior is unchanged.
+4. If the config file is invalid, cub-scout prints a warning and continues with built-ins only.
+
+---
+
 ## Precedence: Multiple Signals Present
 
 When a resource has multiple ownership signals, cub-scout uses **first-match wins**
@@ -181,8 +212,10 @@ based on the priority order above.
 |-----------------|--------|--------|
 | Flux + Helm labels | **Flux** | Flux checked before Helm (priority 1 vs 3) |
 | ArgoCD + Helm labels | **ArgoCD** | ArgoCD checked before Helm (priority 2 vs 3) |
-| Helm + OwnerRef | **Helm** | Helm checked before K8s native (priority 3 vs 8) |
-| Crossplane claim + OwnerRef | **Crossplane** | Crossplane checked before K8s native (priority 7 vs 8) |
+| Helm + OwnerRef | **Helm** | Helm checked before K8s native (priority 3 vs 9) |
+| Crossplane claim + OwnerRef | **Crossplane** | Crossplane checked before K8s native (priority 7 vs 9) |
+| Flux + matching custom detector | **Flux** | Built-ins run before custom detectors |
+| Two matching custom detectors | **First custom detector** | Custom detectors are evaluated in file order |
 | Only OwnerRef | **Kubernetes** | Only signal present |
 
 ### Flux HelmRelease Special Case
@@ -273,3 +306,4 @@ This enables debugging when ownership appears incorrect.
 - [How To: Understand Ownership Detection](../howto/ownership-detection.md) - User guide
 - [Reference: Commands](commands.md) - CLI usage
 - Source: `pkg/agent/ownership.go`
+- Custom detector loader: `pkg/agent/ownership_custom.go`

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,7 @@ Worked examples showing how cub-scout discovers workloads and proposes ConfigHub
 | [combined-git-live/](combined-git-live/) | **Flux** (Banko) | Git repo + cluster alignment |
 | [fleet-import/](fleet-import/) | **Multi-cluster** | Aggregating imports from 2 clusters into a unified proposal |
 | [demo-data-adt/](demo-data-adt/) | **App-Deployment-Target** | Multi-app × multi-env with version skew detection |
+| [custom-ownership-detectors/](custom-ownership-detectors/) | **Extensibility** | YAML ownership detectors (`~/.cub-scout/detectors.yaml`) with map/trace/explain parity |
 | [ai-agent-quest/](ai-agent-quest/) | **AI + K8s** | Give your AI agent cluster vision — standalone observation + ConfigHub intelligence |
 | [new-user-puzzle-quest/](new-user-puzzle-quest/) | **Hands-on learning** | Step-by-step quest for first-time operators |
 
@@ -163,6 +164,7 @@ Expected output for each example is in `test/fixtures/expected-output/examples/`
 | [combined-git-live/](combined-git-live/) | **Working** | Git + cluster alignment (Flux/Banko pattern) | Learning combined discovery, Git drift detection |
 | [fleet-import/](fleet-import/) | **Working** | Multi-cluster fleet aggregation | Learning fleet import, cross-cluster proposals |
 | [demo-data-adt/](demo-data-adt/) | **Working** | App-Deployment-Target model (multi-app × multi-env) | Learning ADT model, version skew, scan |
+| [custom-ownership-detectors/](custom-ownership-detectors/) | **Working** | Config-driven custom ownership detection | Extending ownership classification with YAML |
 | [new-user-puzzle-quest/](new-user-puzzle-quest/) | **Working** | Quest-style new-user walkthrough (AI-assisted) | Guided capability/discovery/import validation |
 | [connect-and-compare/](connect-and-compare/) | **Working** | 60-second connected-mode fixture flow | Standalone->connected value narrative for demos/recordings |
 | [connected-summary-storage/](connected-summary-storage/) | **Working** | Connected summary persistence + query workflow | Trend/history snapshots for scan + gitops status |

--- a/examples/custom-ownership-detectors/README.md
+++ b/examples/custom-ownership-detectors/README.md
@@ -1,0 +1,44 @@
+# Custom Ownership Detectors (YAML)
+
+Configure custom ownership detection without Go code.
+
+## 1) Install detector config
+
+```bash
+mkdir -p ~/.cub-scout
+cp examples/custom-ownership-detectors/detectors.yaml ~/.cub-scout/detectors.yaml
+```
+
+Optional override path:
+
+```bash
+export CUB_SCOUT_OWNERSHIP_DETECTORS="$(pwd)/examples/custom-ownership-detectors/detectors.yaml"
+```
+
+## 2) Label or annotate a resource
+
+```bash
+kubectl annotate deploy/my-app -n default pulumi.com/stack=platform/prod --overwrite
+# or
+kubectl label deploy/my-app -n default platform.company.com/managed-by=platform-controller --overwrite
+```
+
+## 3) Verify output
+
+```bash
+# Map shows configured owner name
+./cub-scout map list -n default -q "name=my-app"
+
+# Explain shows configured owner name in summary
+./cub-scout explain deploy/my-app -n default
+
+# Trace reports custom owner with unsupported-chain warning
+./cub-scout trace deploy/my-app -n default
+```
+
+## Matching semantics
+
+- Built-in detectors run first.
+- Custom detectors run next, in file order.
+- First matching custom detector wins.
+- Invalid config prints one warning and falls back to built-ins.

--- a/examples/custom-ownership-detectors/detectors.yaml
+++ b/examples/custom-ownership-detectors/detectors.yaml
@@ -1,0 +1,13 @@
+detectors:
+  - name: internal-platform
+    labels:
+      - key: platform.company.com/managed-by
+        value: platform-controller
+    owner_name: Internal Platform
+    owner_type: custom
+
+  - name: pulumi
+    annotations:
+      - key: pulumi.com/stack
+    owner_name: Pulumi
+    owner_type: custom

--- a/pkg/agent/ownership.go
+++ b/pkg/agent/ownership.go
@@ -17,6 +17,7 @@ const (
 	OwnerTerraform  = "terraform"
 	OwnerConfigHub  = "confighub"
 	OwnerCrossplane = "crossplane"
+	OwnerCustom     = "custom"
 	OwnerKubernetes = "k8s"
 	OwnerUnknown    = "unknown"
 )
@@ -58,6 +59,12 @@ func DetectOwnership(resource *unstructured.Unstructured) Ownership {
 
 	// Check for Crossplane ownership
 	if ownership := detectCrossplaneOwnership(labels, annotations, resource); ownership.Type != "" {
+		return ownership
+	}
+
+	// Check for custom configured ownership detectors.
+	// Built-ins intentionally run first to preserve contract precedence.
+	if ownership := detectCustomOwnership(labels, annotations); ownership.Type != "" {
 		return ownership
 	}
 

--- a/pkg/agent/ownership_custom.go
+++ b/pkg/agent/ownership_custom.go
@@ -1,0 +1,244 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+const customDetectorsEnvVar = "CUB_SCOUT_OWNERSHIP_DETECTORS"
+
+type customMatcher struct {
+	Key   string
+	Value *string
+}
+
+type customOwnershipDetector struct {
+	Name        string
+	OwnerName   string
+	OwnerType   string
+	Labels      []customMatcher
+	Annotations []customMatcher
+}
+
+type customDetectorCache struct {
+	mu          sync.RWMutex
+	path        string
+	modTime     time.Time
+	size        int64
+	detectors   []customOwnershipDetector
+	warnedToken string
+}
+
+var ownershipCustomCache = customDetectorCache{}
+
+type customDetectorsFile struct {
+	Detectors []customDetectorSpec `json:"detectors" yaml:"detectors"`
+}
+
+type customDetectorSpec struct {
+	Name        string            `json:"name" yaml:"name"`
+	Labels      []customMatchSpec `json:"labels" yaml:"labels"`
+	Annotations []customMatchSpec `json:"annotations" yaml:"annotations"`
+	OwnerName   string            `json:"owner_name" yaml:"owner_name"`
+	OwnerType   string            `json:"owner_type" yaml:"owner_type"`
+}
+
+type customMatchSpec struct {
+	Key   string  `json:"key" yaml:"key"`
+	Value *string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+func detectCustomOwnership(labels, annotations map[string]string) Ownership {
+	detectors := loadCustomOwnershipDetectors()
+	for _, detector := range detectors {
+		if matchesCustomDetector(detector, labels, annotations) {
+			return Ownership{
+				Type:       detector.OwnerType,
+				SubType:    "custom-detector",
+				Name:       detector.OwnerName,
+				Source:     "custom:" + detector.Name,
+				Confidence: "high",
+			}
+		}
+	}
+	return Ownership{}
+}
+
+func loadCustomOwnershipDetectors() []customOwnershipDetector {
+	path := resolveCustomDetectorsPath()
+	if path == "" {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			ownershipCustomCache.mu.Lock()
+			ownershipCustomCache.path = path
+			ownershipCustomCache.modTime = time.Time{}
+			ownershipCustomCache.size = 0
+			ownershipCustomCache.detectors = nil
+			ownershipCustomCache.warnedToken = ""
+			ownershipCustomCache.mu.Unlock()
+			return nil
+		}
+		warnCustomOwnershipConfig(path, time.Time{}, 0, fmt.Sprintf("failed to stat config: %v", err))
+		return nil
+	}
+
+	ownershipCustomCache.mu.RLock()
+	if ownershipCustomCache.path == path &&
+		ownershipCustomCache.modTime.Equal(info.ModTime()) &&
+		ownershipCustomCache.size == info.Size() {
+		detectors := append([]customOwnershipDetector(nil), ownershipCustomCache.detectors...)
+		ownershipCustomCache.mu.RUnlock()
+		return detectors
+	}
+	ownershipCustomCache.mu.RUnlock()
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		warnCustomOwnershipConfig(path, info.ModTime(), info.Size(), fmt.Sprintf("failed to read config: %v", readErr))
+		return nil
+	}
+
+	var parsed customDetectorsFile
+	if unmarshalErr := yaml.Unmarshal(data, &parsed); unmarshalErr != nil {
+		warnCustomOwnershipConfig(path, info.ModTime(), info.Size(), fmt.Sprintf("invalid YAML: %v", unmarshalErr))
+		return nil
+	}
+
+	detectors := compileCustomDetectors(parsed.Detectors)
+
+	ownershipCustomCache.mu.Lock()
+	ownershipCustomCache.path = path
+	ownershipCustomCache.modTime = info.ModTime()
+	ownershipCustomCache.size = info.Size()
+	ownershipCustomCache.detectors = detectors
+	ownershipCustomCache.warnedToken = ""
+	ownershipCustomCache.mu.Unlock()
+
+	return append([]customOwnershipDetector(nil), detectors...)
+}
+
+func resolveCustomDetectorsPath() string {
+	if override := strings.TrimSpace(os.Getenv(customDetectorsEnvVar)); override != "" {
+		return override
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".cub-scout", "detectors.yaml")
+}
+
+func compileCustomDetectors(specs []customDetectorSpec) []customOwnershipDetector {
+	if len(specs) == 0 {
+		return nil
+	}
+
+	detectors := make([]customOwnershipDetector, 0, len(specs))
+	for _, spec := range specs {
+		name := strings.TrimSpace(spec.Name)
+		if name == "" {
+			continue
+		}
+
+		ownerName := strings.TrimSpace(spec.OwnerName)
+		if ownerName == "" {
+			ownerName = name
+		}
+
+		ownerType := strings.ToLower(strings.TrimSpace(spec.OwnerType))
+		if ownerType == "" {
+			ownerType = OwnerCustom
+		}
+
+		labels := compileCustomMatchers(spec.Labels)
+		annotations := compileCustomMatchers(spec.Annotations)
+		if len(labels) == 0 && len(annotations) == 0 {
+			continue
+		}
+
+		detectors = append(detectors, customOwnershipDetector{
+			Name:        name,
+			OwnerName:   ownerName,
+			OwnerType:   ownerType,
+			Labels:      labels,
+			Annotations: annotations,
+		})
+	}
+
+	return detectors
+}
+
+func compileCustomMatchers(specs []customMatchSpec) []customMatcher {
+	matchers := make([]customMatcher, 0, len(specs))
+	for _, spec := range specs {
+		key := strings.TrimSpace(spec.Key)
+		if key == "" {
+			continue
+		}
+		matchers = append(matchers, customMatcher{
+			Key:   key,
+			Value: normalizeCustomMatchValue(spec.Value),
+		})
+	}
+	return matchers
+}
+
+func normalizeCustomMatchValue(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	v := strings.TrimSpace(*value)
+	return &v
+}
+
+func matchesCustomDetector(detector customOwnershipDetector, labels, annotations map[string]string) bool {
+	return matchesAllCustomMatchers(detector.Labels, labels) &&
+		matchesAllCustomMatchers(detector.Annotations, annotations)
+}
+
+func matchesAllCustomMatchers(matchers []customMatcher, values map[string]string) bool {
+	if len(matchers) == 0 {
+		return true
+	}
+	for _, matcher := range matchers {
+		got, ok := values[matcher.Key]
+		if !ok {
+			return false
+		}
+		if matcher.Value != nil && got != *matcher.Value {
+			return false
+		}
+	}
+	return true
+}
+
+func warnCustomOwnershipConfig(path string, modTime time.Time, size int64, reason string) {
+	token := fmt.Sprintf("%s|%d|%d|%s", path, modTime.UnixNano(), size, reason)
+
+	ownershipCustomCache.mu.Lock()
+	defer ownershipCustomCache.mu.Unlock()
+
+	if ownershipCustomCache.warnedToken == token {
+		return
+	}
+	ownershipCustomCache.warnedToken = token
+	ownershipCustomCache.detectors = nil
+	ownershipCustomCache.path = path
+	ownershipCustomCache.modTime = modTime
+	ownershipCustomCache.size = size
+
+	fmt.Fprintf(os.Stderr, "Warning: custom ownership detector config ignored (%s): %s\n", path, reason)
+}

--- a/pkg/agent/ownership_custom_test.go
+++ b/pkg/agent/ownership_custom_test.go
@@ -1,0 +1,137 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDetectOwnership_CustomDetectors(t *testing.T) {
+	tmpDir := t.TempDir()
+	detectors := filepath.Join(tmpDir, "detectors.yaml")
+	if err := os.WriteFile(detectors, []byte(`
+detectors:
+  - name: internal-platform
+    labels:
+      - key: platform.company.com/managed-by
+        value: "platform-controller"
+    owner_name: "Internal Platform"
+    owner_type: "custom"
+`), 0o600); err != nil {
+		t.Fatalf("write detectors file: %v", err)
+	}
+
+	t.Setenv("CUB_SCOUT_OWNERSHIP_DETECTORS", detectors)
+
+	resource := newTestResource("default", "payments-api", map[string]string{
+		"platform.company.com/managed-by": "platform-controller",
+	}, nil)
+
+	ownership := DetectOwnership(resource)
+	if ownership.Type != "custom" {
+		t.Fatalf("Type = %q, want %q", ownership.Type, "custom")
+	}
+	if ownership.Name != "Internal Platform" {
+		t.Fatalf("Name = %q, want %q", ownership.Name, "Internal Platform")
+	}
+	if ownership.Source != "custom:internal-platform" {
+		t.Fatalf("Source = %q, want %q", ownership.Source, "custom:internal-platform")
+	}
+}
+
+func TestDetectOwnership_CustomDetectorPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	detectors := filepath.Join(tmpDir, "detectors.yaml")
+	if err := os.WriteFile(detectors, []byte(`
+detectors:
+  - name: first
+    labels:
+      - key: platform.company.com/managed-by
+    owner_name: "First Controller"
+    owner_type: "custom"
+  - name: second
+    labels:
+      - key: platform.company.com/managed-by
+    owner_name: "Second Controller"
+    owner_type: "custom"
+`), 0o600); err != nil {
+		t.Fatalf("write detectors file: %v", err)
+	}
+
+	t.Setenv("CUB_SCOUT_OWNERSHIP_DETECTORS", detectors)
+
+	resource := newTestResource("default", "edge", map[string]string{
+		"platform.company.com/managed-by": "anything",
+	}, nil)
+
+	ownership := DetectOwnership(resource)
+	if ownership.Type != "custom" {
+		t.Fatalf("Type = %q, want %q", ownership.Type, "custom")
+	}
+	if ownership.Name != "First Controller" {
+		t.Fatalf("Name = %q, want %q", ownership.Name, "First Controller")
+	}
+	if ownership.Source != "custom:first" {
+		t.Fatalf("Source = %q, want %q", ownership.Source, "custom:first")
+	}
+}
+
+func TestDetectOwnership_CustomDetectorInvalidConfigFallsBack(t *testing.T) {
+	tmpDir := t.TempDir()
+	detectors := filepath.Join(tmpDir, "detectors.yaml")
+	if err := os.WriteFile(detectors, []byte("detectors: ["), 0o600); err != nil {
+		t.Fatalf("write detectors file: %v", err)
+	}
+
+	t.Setenv("CUB_SCOUT_OWNERSHIP_DETECTORS", detectors)
+
+	resource := newTestResourceWithOwners("default", "payments-api", []metav1.OwnerReference{
+		{
+			Kind: "Deployment",
+			Name: "payments-api",
+			UID:  "abc-123",
+		},
+	})
+
+	warnOut := captureStderr(t, func() {
+		ownership := DetectOwnership(resource)
+		if ownership.Type != OwnerKubernetes {
+			t.Fatalf("Type = %q, want %q", ownership.Type, OwnerKubernetes)
+		}
+	})
+
+	if !strings.Contains(strings.ToLower(warnOut), "custom ownership detector") {
+		t.Fatalf("expected warning for invalid custom detector config, got %q", warnOut)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+
+	return <-done
+}


### PR DESCRIPTION
Closes #233

## Scope
Implements #233: config-based custom ownership detectors (YAML, no Go required).

## What changed
- Added YAML-driven custom detector loading in `pkg/agent`:
  - default path: `~/.cub-scout/detectors.yaml`
  - override: `CUB_SCOUT_OWNERSHIP_DETECTORS`
  - detector order: first matching custom detector wins
  - precedence: built-ins run first, custom detectors run before k8s ownerRef fallback
- Added new owner type constant: `custom`
- Updated map ownership plumbing:
  - `map list` owner column shows configured `owner_name`
  - legacy map helper now delegates to canonical `agent.DetectOwnership`
- Updated trace behavior for custom owners:
  - emits explicit custom-owner warning text when chain resolution is unsupported
- Updated explain behavior:
  - custom owner name is surfaced in owner summary when trace path is unsupported

## Graceful degradation
- No detector config file: unchanged behavior.
- Invalid detector config file: warning to stderr, built-ins continue.
- Invalid detector entries (missing required fields/match rules): skipped.

## Tests added
- `pkg/agent/ownership_custom_test.go`
  - `TestDetectOwnership_CustomDetectors`
  - `TestDetectOwnership_CustomDetectorPrecedence`
  - `TestDetectOwnership_CustomDetectorInvalidConfigFallsBack`
- `cmd/cub-scout/map_custom_owner_test.go`
  - `TestProcessResource_CustomOwnershipDisplay`
  - `TestDetectOwnershipHelper_UsesAgentDetectors`
- `cmd/cub-scout/explain_test.go`
  - `TestExplainOwner_Custom`
- `cmd/cub-scout/trace_custom_owner_test.go`
  - `TestBuildCustomOwnerUnsupportedTraceResult`
  - `TestOwnershipLabel_CustomUsesName`

## Docs/examples
- Updated:
  - `docs/reference/ownership-precedence.md`
  - `docs/howto/ownership-detection.md`
  - `docs/howto/trace-ownership.md`
  - `docs/howto/extending.md`
  - `docs/reference/commands.md`
  - `examples/README.md`
- Added:
  - `examples/custom-ownership-detectors/README.md`
  - `examples/custom-ownership-detectors/detectors.yaml`

## Proof-first evidence
- Proof matrix + logs: `/tmp/cub-scout-regression/v1.7/233/`
- Red phase captured, then verify #1/#2/#3, post-doc verify, scoped regression, full baseline.

## Commands run
- `go test ./pkg/agent -run 'TestDetectOwnership_CustomDetectors|TestDetectOwnership_CustomDetectorPrecedence|TestDetectOwnership_CustomDetectorInvalidConfigFallsBack' -count=1`
- `go test ./cmd/cub-scout -run 'TestProcessResource_CustomOwnershipDisplay|TestDetectOwnershipHelper_UsesAgentDetectors|TestExplainOwner_Custom|TestBuildCustomOwnerUnsupportedTraceResult|TestOwnershipLabel_CustomUsesName' -count=1`
- `go test ./pkg/agent ./cmd/cub-scout -count=1`
- `go build ./cmd/cub-scout`
- `go test ./... -count=1`
