### PR TITLE
feat(cli): add watch webhook stream command

### DIFF
--- a/cmd/cub-scout/main.go
+++ b/cmd/cub-scout/main.go
@@ -36,6 +36,7 @@ POPULAR COMMANDS
   map list         List resources with ownership (scriptable, supports --json)
   tree             Hierarchical views: runtime, ownership, git, composition
   trace            Trace any resource to its Git source
+  watch            Stream observation events to webhook
   scan             Find misconfigurations (46 patterns)
   import           Preview/import workloads to ConfigHub (connected mode)
   gitops status    GitOps pipeline health check

--- a/cmd/cub-scout/smoke_test.go
+++ b/cmd/cub-scout/smoke_test.go
@@ -62,6 +62,12 @@ func TestSmoke_CLIHelp(t *testing.T) {
 			wantContains: []string{"scan", "Usage:"},
 		},
 		{
+			name:         "watch help",
+			args:         []string{"watch", "--help"},
+			wantExitCode: 0,
+			wantContains: []string{"watch", "--webhook", "Usage:"},
+		},
+		{
 			name:         "quickstart help",
 			args:         []string{"quickstart", "--help"},
 			wantExitCode: 0,
@@ -173,7 +179,7 @@ func TestSmoke_RootCommand(t *testing.T) {
 	}
 
 	// Verify key subcommands exist
-	expectedCmds := []string{"version", "completion", "map", "quickstart", "scan", "trace", "status", "history", "audit", "summary"}
+	expectedCmds := []string{"version", "completion", "map", "quickstart", "scan", "watch", "trace", "status", "history", "audit", "summary"}
 	for _, name := range expectedCmds {
 		found := false
 		for _, cmd := range rootCmd.Commands() {

--- a/cmd/cub-scout/watch.go
+++ b/cmd/cub-scout/watch.go
@@ -1,0 +1,530 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var (
+	watchWebhookURL      string
+	watchInterval        time.Duration
+	watchNamespace       string
+	watchOwner           string
+	watchSeverity        string
+	watchOnce            bool
+	watchMaxQueuedEvents int
+)
+
+type watchEvent struct {
+	Type      string                 `json:"type"`
+	Timestamp time.Time              `json:"timestamp"`
+	Resource  watchEventResource     `json:"resource"`
+	Owner     *watchEventOwner       `json:"owner,omitempty"`
+	Severity  string                 `json:"severity,omitempty"`
+	Details   map[string]interface{} `json:"details,omitempty"`
+}
+
+type watchEventResource struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+type watchEventOwner struct {
+	Type string `json:"type,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type watchFinding struct {
+	Key       string
+	Category  string
+	Severity  string
+	Kind      string
+	Name      string
+	Namespace string
+	Message   string
+}
+
+type watchState struct {
+	entriesByID map[string]MapEntry
+	findings    map[string]watchFinding
+}
+
+var (
+	watchBuildConfig   = buildConfig
+	watchCollectState  = collectWatchState
+	watchPostEvent     = postWatchEvent
+	watchEventNow      = time.Now
+	watchSleepWithCtx  = sleepWithContext
+	watchDefaultClient = &http.Client{Timeout: 10 * time.Second}
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Stream observation events to a webhook",
+	Long: `Watch cluster observation changes and stream JSON events to a webhook.
+
+Event types:
+  - resource.discovered
+  - ownership.changed
+  - drift.detected
+  - scan.finding
+`,
+	RunE: runWatch,
+}
+
+func init() {
+	rootCmd.AddCommand(watchCmd)
+	watchCmd.Flags().StringVar(&watchWebhookURL, "webhook", "", "Webhook URL to receive events")
+	watchCmd.Flags().DurationVar(&watchInterval, "interval", 20*time.Second, "Polling interval (for example 20s, 1m)")
+	watchCmd.Flags().StringVarP(&watchNamespace, "namespace", "n", "", "Filter events to a namespace")
+	watchCmd.Flags().StringVar(&watchOwner, "owner", "", "Filter events by owner display name (for example Flux, ArgoCD, Internal Platform)")
+	watchCmd.Flags().StringVar(&watchSeverity, "severity", "", "Filter finding/drift events by severity (comma-separated: critical,warning,info)")
+	watchCmd.Flags().BoolVar(&watchOnce, "once", false, "Run one collection cycle and exit")
+	watchCmd.Flags().IntVar(&watchMaxQueuedEvents, "max-queued-events", 1000, "Maximum buffered events when webhook is unavailable")
+}
+
+func runWatch(cmd *cobra.Command, args []string) error {
+	webhookURL := strings.TrimSpace(watchWebhookURL)
+	if webhookURL == "" {
+		return fmt.Errorf("missing --webhook URL")
+	}
+	if watchInterval <= 0 {
+		return fmt.Errorf("--interval must be > 0")
+	}
+	if watchMaxQueuedEvents <= 0 {
+		return fmt.Errorf("--max-queued-events must be > 0")
+	}
+
+	severityFilter := parseWatchSeverityFilter(watchSeverity)
+	ownerFilter := strings.TrimSpace(watchOwner)
+
+	cfg, err := watchBuildConfig()
+	if err != nil {
+		return withKubeRecoveryHint(fmt.Errorf("build kubernetes config: %w", err), "cub-scout watch")
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return withKubeRecoveryHint(fmt.Errorf("create dynamic client: %w", err), "cub-scout watch")
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var (
+		prevState watchState
+		queue     []watchEvent
+	)
+
+	if watchOnce {
+		curr, err := watchCollectState(ctx, dynClient, watchNamespace)
+		if err != nil {
+			return err
+		}
+		events := buildWatchEvents(prevState, curr, severityFilter, ownerFilter, watchEventNow)
+		queue = appendWatchQueue(queue, events, watchMaxQueuedEvents)
+		_, err = flushWatchQueue(ctx, webhookURL, queue)
+		return err
+	}
+
+	// Prime baseline to avoid spamming initial full-state events in long-running mode.
+	initial, err := watchCollectState(ctx, dynClient, watchNamespace)
+	if err != nil {
+		return err
+	}
+	prevState = initial
+
+	ticker := time.NewTicker(watchInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			curr, err := watchCollectState(ctx, dynClient, watchNamespace)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: watch collection failed: %v\n", err)
+				continue
+			}
+			events := buildWatchEvents(prevState, curr, severityFilter, ownerFilter, watchEventNow)
+			queue = appendWatchQueue(queue, events, watchMaxQueuedEvents)
+			remaining, err := flushWatchQueue(ctx, webhookURL, queue)
+			queue = remaining
+			prevState = curr
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: webhook delivery failed (buffered %d events): %v\n", len(queue), err)
+				continue
+			}
+		}
+	}
+}
+
+func collectWatchState(ctx context.Context, dynClient dynamic.Interface, namespace string) (watchState, error) {
+	entries, err := collectWatchEntries(ctx, dynClient, namespace)
+	if err != nil {
+		return watchState{}, err
+	}
+	findings, err := collectWatchFindings(ctx, dynClient, namespace)
+	if err != nil {
+		return watchState{}, err
+	}
+
+	state := watchState{
+		entriesByID: make(map[string]MapEntry, len(entries)),
+		findings:    make(map[string]watchFinding, len(findings)),
+	}
+	for _, entry := range entries {
+		state.entriesByID[entry.ID] = entry
+	}
+	for _, finding := range findings {
+		state.findings[finding.Key] = finding
+	}
+	return state, nil
+}
+
+func collectWatchEntries(ctx context.Context, dynClient dynamic.Interface, namespace string) ([]MapEntry, error) {
+	clusterName := os.Getenv("CLUSTER_NAME")
+	if clusterName == "" {
+		clusterName = "default"
+	}
+
+	resources := []schema.GroupVersionResource{
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "apps", Version: "v1", Resource: "statefulsets"},
+		{Group: "apps", Version: "v1", Resource: "daemonsets"},
+		{Group: "", Version: "v1", Resource: "services"},
+		{Group: "", Version: "v1", Resource: "configmaps"},
+		{Group: "", Version: "v1", Resource: "secrets"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
+		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"},
+	}
+
+	appSetLookup := loadMapApplicationSetLookup(ctx, dynClient, namespace)
+
+	entries := make([]MapEntry, 0, 256)
+	byOwner := map[string]int{}
+	for _, gvr := range resources {
+		if namespace != "" {
+			l, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, v1.ListOptions{})
+			if err != nil {
+				continue
+			}
+			for _, item := range l.Items {
+				entries = processResourceWithLookup(&item, gvr, clusterName, entries, byOwner, appSetLookup)
+			}
+			continue
+		}
+
+		l, err := dynClient.Resource(gvr).List(ctx, v1.ListOptions{})
+		if err != nil {
+			continue
+		}
+		for _, item := range l.Items {
+			entries = processResourceWithLookup(&item, gvr, clusterName, entries, byOwner, appSetLookup)
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Namespace != entries[j].Namespace {
+			return entries[i].Namespace < entries[j].Namespace
+		}
+		if entries[i].Kind != entries[j].Kind {
+			return entries[i].Kind < entries[j].Kind
+		}
+		return entries[i].Name < entries[j].Name
+	})
+	return entries, nil
+}
+
+func collectWatchFindings(ctx context.Context, dynClient dynamic.Interface, namespace string) ([]watchFinding, error) {
+	scanner := agent.NewStateScannerWithClient(dynClient)
+
+	var (
+		res *agent.StateScanResult
+		err error
+	)
+	if namespace != "" {
+		res, err = scanner.ScanNamespace(ctx, namespace)
+	} else {
+		res, err = scanner.Scan(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]watchFinding, 0, len(res.Findings)+len(res.RuntimeFindings))
+	for _, finding := range res.Findings {
+		key := fmt.Sprintf("%s|%s|%s|%s|%s", finding.CCVEID, finding.Kind, finding.Namespace, finding.Name, finding.Reason)
+		out = append(out, watchFinding{
+			Key:       key,
+			Category:  finding.Category,
+			Severity:  normalizeFindingSeverity(finding.Severity),
+			Kind:      finding.Kind,
+			Name:      finding.Name,
+			Namespace: finding.Namespace,
+			Message:   finding.Message,
+		})
+	}
+	for _, finding := range res.RuntimeFindings {
+		key := fmt.Sprintf("%s|%s|%s|%s|%s", finding.CCVEID, finding.Kind, finding.Namespace, finding.Name, finding.FailureType)
+		out = append(out, watchFinding{
+			Key:       key,
+			Category:  finding.Category,
+			Severity:  normalizeFindingSeverity(finding.Severity),
+			Kind:      finding.Kind,
+			Name:      finding.Name,
+			Namespace: finding.Namespace,
+			Message:   finding.Message,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out, nil
+}
+
+func buildWatchEvents(prev, curr watchState, severityFilter map[string]struct{}, ownerFilter string, nowFn func() time.Time) []watchEvent {
+	ts := nowFn().UTC()
+	events := make([]watchEvent, 0)
+
+	for id, entry := range curr.entriesByID {
+		prevEntry, existed := prev.entriesByID[id]
+		if !existed {
+			event := watchEvent{
+				Type:      "resource.discovered",
+				Timestamp: ts,
+				Resource: watchEventResource{
+					Kind:      entry.Kind,
+					Name:      entry.Name,
+					Namespace: entry.Namespace,
+				},
+				Owner: watchOwnerFromEntry(entry),
+				Details: map[string]interface{}{
+					"status": entry.Status,
+				},
+			}
+			if shouldEmitWatchEvent(event, severityFilter, ownerFilter) {
+				events = append(events, event)
+			}
+			continue
+		}
+
+		if prevEntry.Owner != entry.Owner {
+			event := watchEvent{
+				Type:      "ownership.changed",
+				Timestamp: ts,
+				Resource: watchEventResource{
+					Kind:      entry.Kind,
+					Name:      entry.Name,
+					Namespace: entry.Namespace,
+				},
+				Owner: watchOwnerFromEntry(entry),
+				Details: map[string]interface{}{
+					"before": prevEntry.Owner,
+					"after":  entry.Owner,
+				},
+			}
+			if shouldEmitWatchEvent(event, severityFilter, ownerFilter) {
+				events = append(events, event)
+			}
+		}
+	}
+
+	for key, finding := range curr.findings {
+		if _, alreadySeen := prev.findings[key]; alreadySeen {
+			continue
+		}
+		entry := findWatchEntryForResource(curr.entriesByID, finding.Namespace, finding.Kind, finding.Name)
+		owner := watchOwnerFromEntry(entry)
+
+		scanEvent := watchEvent{
+			Type:      "scan.finding",
+			Timestamp: ts,
+			Resource:  watchEventResource{Kind: finding.Kind, Name: finding.Name, Namespace: finding.Namespace},
+			Owner:     owner,
+			Severity:  finding.Severity,
+			Details: map[string]interface{}{
+				"category": finding.Category,
+				"message":  finding.Message,
+			},
+		}
+		if shouldEmitWatchEvent(scanEvent, severityFilter, ownerFilter) {
+			events = append(events, scanEvent)
+		}
+
+		if strings.EqualFold(finding.Category, "STATE") || strings.EqualFold(finding.Category, "DRIFT") {
+			driftEvent := watchEvent{
+				Type:      "drift.detected",
+				Timestamp: ts,
+				Resource:  watchEventResource{Kind: finding.Kind, Name: finding.Name, Namespace: finding.Namespace},
+				Owner:     owner,
+				Severity:  finding.Severity,
+				Details: map[string]interface{}{
+					"category": finding.Category,
+					"message":  finding.Message,
+				},
+			}
+			if shouldEmitWatchEvent(driftEvent, severityFilter, ownerFilter) {
+				events = append(events, driftEvent)
+			}
+		}
+	}
+
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].Type != events[j].Type {
+			return events[i].Type < events[j].Type
+		}
+		if events[i].Resource.Namespace != events[j].Resource.Namespace {
+			return events[i].Resource.Namespace < events[j].Resource.Namespace
+		}
+		if events[i].Resource.Kind != events[j].Resource.Kind {
+			return events[i].Resource.Kind < events[j].Resource.Kind
+		}
+		return events[i].Resource.Name < events[j].Resource.Name
+	})
+
+	return events
+}
+
+func watchOwnerFromEntry(entry MapEntry) *watchEventOwner {
+	if entry.Owner == "" {
+		return nil
+	}
+	owner := &watchEventOwner{Type: entry.Owner}
+	if entry.OwnerDetails != nil {
+		owner.Name = strings.TrimSpace(entry.OwnerDetails["name"])
+	}
+	return owner
+}
+
+func findWatchEntryForResource(entriesByID map[string]MapEntry, namespace, kind, name string) MapEntry {
+	for _, entry := range entriesByID {
+		if entry.Namespace == namespace && entry.Kind == kind && entry.Name == name {
+			return entry
+		}
+	}
+	return MapEntry{}
+}
+
+func normalizeFindingSeverity(severity string) string {
+	s := strings.ToLower(strings.TrimSpace(severity))
+	if s == "" {
+		return "warning"
+	}
+	return s
+}
+
+func parseWatchSeverityFilter(raw string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, token := range strings.Split(raw, ",") {
+		v := strings.ToLower(strings.TrimSpace(token))
+		if v == "" {
+			continue
+		}
+		out[v] = struct{}{}
+	}
+	return out
+}
+
+func shouldEmitWatchEvent(event watchEvent, severityFilter map[string]struct{}, ownerFilter string) bool {
+	if ownerFilter != "" {
+		if event.Owner == nil || !strings.EqualFold(strings.TrimSpace(event.Owner.Type), ownerFilter) {
+			return false
+		}
+	}
+	if len(severityFilter) == 0 || event.Severity == "" {
+		return true
+	}
+	_, ok := severityFilter[strings.ToLower(event.Severity)]
+	return ok
+}
+
+func appendWatchQueue(queue, events []watchEvent, maxQueued int) []watchEvent {
+	if len(events) == 0 {
+		return queue
+	}
+	queue = append(queue, events...)
+	if len(queue) <= maxQueued {
+		return queue
+	}
+	return append([]watchEvent(nil), queue[len(queue)-maxQueued:]...)
+}
+
+func flushWatchQueue(ctx context.Context, webhookURL string, queue []watchEvent) ([]watchEvent, error) {
+	for i, event := range queue {
+		if err := watchPostEvent(ctx, webhookURL, event); err != nil {
+			return append([]watchEvent(nil), queue[i:]...), err
+		}
+	}
+	return queue[:0], nil
+}
+
+func postWatchEvent(ctx context.Context, webhookURL string, event watchEvent) error {
+	body, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+
+	var lastErr error
+	backoff := 500 * time.Millisecond
+	for attempt := 0; attempt < 4; attempt++ {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+		if reqErr != nil {
+			return fmt.Errorf("build webhook request: %w", reqErr)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, doErr := watchDefaultClient.Do(req)
+		if doErr == nil {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("webhook returned %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+		} else {
+			lastErr = doErr
+		}
+
+		if attempt == 3 {
+			break
+		}
+		if err := watchSleepWithCtx(ctx, backoff); err != nil {
+			return err
+		}
+		backoff *= 2
+	}
+	return fmt.Errorf("post webhook event failed after retries: %w", lastErr)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/cmd/cub-scout/watch_test.go
+++ b/cmd/cub-scout/watch_test.go
@@ -1,0 +1,271 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+func TestBuildWatchEvents_DiscoveredAndOwnershipChanged(t *testing.T) {
+	prev := watchState{
+		entriesByID: map[string]MapEntry{
+			"id-1": {
+				ID:        "id-1",
+				Namespace: "prod",
+				Kind:      "Deployment",
+				Name:      "api",
+				Owner:     "Flux",
+			},
+		},
+		findings: map[string]watchFinding{},
+	}
+	curr := watchState{
+		entriesByID: map[string]MapEntry{
+			"id-1": {
+				ID:        "id-1",
+				Namespace: "prod",
+				Kind:      "Deployment",
+				Name:      "api",
+				Owner:     "ArgoCD",
+			},
+			"id-2": {
+				ID:        "id-2",
+				Namespace: "prod",
+				Kind:      "Service",
+				Name:      "api",
+				Owner:     "Internal Platform",
+			},
+		},
+		findings: map[string]watchFinding{},
+	}
+
+	events := buildWatchEvents(prev, curr, nil, "", func() time.Time {
+		return time.Date(2026, 3, 7, 11, 0, 0, 0, time.UTC)
+	})
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+
+	types := map[string]bool{}
+	for _, e := range events {
+		types[e.Type] = true
+	}
+	if !types["resource.discovered"] {
+		t.Fatalf("missing resource.discovered event: %#v", events)
+	}
+	if !types["ownership.changed"] {
+		t.Fatalf("missing ownership.changed event: %#v", events)
+	}
+}
+
+func TestBuildWatchEvents_FindingFilters(t *testing.T) {
+	prev := watchState{
+		entriesByID: map[string]MapEntry{
+			"id-1": {
+				ID:        "id-1",
+				Namespace: "prod",
+				Kind:      "Deployment",
+				Name:      "api",
+				Owner:     "Flux",
+			},
+		},
+		findings: map[string]watchFinding{},
+	}
+	curr := watchState{
+		entriesByID: prev.entriesByID,
+		findings: map[string]watchFinding{
+			"f1": {
+				Key:       "f1",
+				Category:  "STATE",
+				Severity:  "warning",
+				Kind:      "Deployment",
+				Name:      "api",
+				Namespace: "prod",
+				Message:   "out of sync",
+			},
+			"f2": {
+				Key:       "f2",
+				Category:  "SILENT",
+				Severity:  "info",
+				Kind:      "Deployment",
+				Name:      "api",
+				Namespace: "prod",
+				Message:   "minor",
+			},
+		},
+	}
+
+	events := buildWatchEvents(prev, curr, map[string]struct{}{"warning": {}}, "Flux", func() time.Time {
+		return time.Date(2026, 3, 7, 11, 1, 0, 0, time.UTC)
+	})
+
+	// warning STATE finding should emit both scan.finding and drift.detected
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+	for _, e := range events {
+		if e.Severity != "warning" {
+			t.Fatalf("unexpected severity in filtered events: %#v", events)
+		}
+		if e.Type != "scan.finding" && e.Type != "drift.detected" {
+			t.Fatalf("unexpected event type %q", e.Type)
+		}
+	}
+}
+
+func TestAppendWatchQueue_DropsOldest(t *testing.T) {
+	queue := []watchEvent{{Type: "e1"}, {Type: "e2"}}
+	queue = appendWatchQueue(queue, []watchEvent{{Type: "e3"}, {Type: "e4"}}, 3)
+
+	if len(queue) != 3 {
+		t.Fatalf("queue len = %d, want 3", len(queue))
+	}
+	if queue[0].Type != "e2" || queue[2].Type != "e4" {
+		t.Fatalf("unexpected queue contents: %#v", queue)
+	}
+}
+
+func TestFlushWatchQueue_PartialFailureKeepsRemaining(t *testing.T) {
+	restore := overrideWatchDeps(t)
+	defer restore()
+
+	calls := 0
+	watchPostEvent = func(ctx context.Context, webhookURL string, event watchEvent) error {
+		calls++
+		if calls == 2 {
+			return errors.New("boom")
+		}
+		return nil
+	}
+
+	queue := []watchEvent{{Type: "e1"}, {Type: "e2"}, {Type: "e3"}}
+	remaining, err := flushWatchQueue(context.Background(), "https://hooks.example.com/cub-scout", queue)
+	if err == nil {
+		t.Fatal("expected flush error, got nil")
+	}
+	if calls != 2 {
+		t.Fatalf("post call count = %d, want 2", calls)
+	}
+	if len(remaining) != 2 || remaining[0].Type != "e2" || remaining[1].Type != "e3" {
+		t.Fatalf("unexpected remaining queue: %#v", remaining)
+	}
+}
+
+func TestPostWatchEvent_Retries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("retry"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	oldClient := watchDefaultClient
+	oldSleep := watchSleepWithCtx
+	watchDefaultClient = srv.Client()
+	watchSleepWithCtx = func(ctx context.Context, d time.Duration) error { return nil }
+	defer func() {
+		watchDefaultClient = oldClient
+		watchSleepWithCtx = oldSleep
+	}()
+
+	err := postWatchEvent(context.Background(), srv.URL, watchEvent{
+		Type:      "scan.finding",
+		Timestamp: time.Now().UTC(),
+		Resource:  watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"},
+	})
+	if err != nil {
+		t.Fatalf("postWatchEvent() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("webhook call count = %d, want 3", got)
+	}
+}
+
+func TestRunWatch_OncePostsEvents(t *testing.T) {
+	restore := overrideWatchDeps(t)
+	defer restore()
+
+	posted := []watchEvent{}
+	watchBuildConfig = func() (*rest.Config, error) {
+		return &rest.Config{Host: "https://example.invalid"}, nil
+	}
+	watchCollectState = func(ctx context.Context, dynClient dynamic.Interface, namespace string) (watchState, error) {
+		return watchState{
+			entriesByID: map[string]MapEntry{
+				"id-1": {
+					ID:        "id-1",
+					Namespace: "prod",
+					Kind:      "Deployment",
+					Name:      "api",
+					Owner:     "Flux",
+				},
+			},
+			findings: map[string]watchFinding{
+				"f1": {
+					Key:       "f1",
+					Category:  "STATE",
+					Severity:  "warning",
+					Kind:      "Deployment",
+					Name:      "api",
+					Namespace: "prod",
+					Message:   "out of sync",
+				},
+			},
+		}, nil
+	}
+	watchPostEvent = func(ctx context.Context, webhookURL string, event watchEvent) error {
+		posted = append(posted, event)
+		return nil
+	}
+
+	watchWebhookURL = "https://hooks.example.com/cub-scout"
+	watchInterval = 1 * time.Second
+	watchNamespace = "prod"
+	watchOwner = ""
+	watchSeverity = ""
+	watchOnce = true
+	watchMaxQueuedEvents = 100
+
+	watchCmd.SetContext(context.Background())
+
+	if err := runWatch(watchCmd, nil); err != nil {
+		t.Fatalf("runWatch() error = %v", err)
+	}
+	if len(posted) == 0 {
+		t.Fatal("expected posted events, got none")
+	}
+}
+
+func overrideWatchDeps(t *testing.T) func() {
+	t.Helper()
+	oldBuildConfig := watchBuildConfig
+	oldCollectState := watchCollectState
+	oldPostEvent := watchPostEvent
+	oldNow := watchEventNow
+	oldSleep := watchSleepWithCtx
+	oldClient := watchDefaultClient
+
+	return func() {
+		watchBuildConfig = oldBuildConfig
+		watchCollectState = oldCollectState
+		watchPostEvent = oldPostEvent
+		watchEventNow = oldNow
+		watchSleepWithCtx = oldSleep
+		watchDefaultClient = oldClient
+	}
+}

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -41,6 +41,7 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `status` | Show connection status and cluster info |
 | `summary` | Query persisted connected summary snapshots |
 | `trace` | Trace any resource to its Git source |
+| `watch` | Stream observation events to webhook |
 | `tree` | Show hierarchical views of resources |
 | `version` | Print version information |
 
@@ -243,6 +244,20 @@ Connected storage defaults:
 - Overrides: `CUB_SCOUT_SUMMARY_DIR`, `CUB_SCOUT_SUMMARY_RETENTION_DAYS`
 
 ---
+
+## `watch` Options
+
+| Option | Description |
+|--------|-------------|
+| `--webhook` | Webhook URL for event delivery (required) |
+| `--interval` | Polling interval (`20s` default) |
+| `-n, --namespace` | Namespace filter |
+| `--owner` | Owner display-name filter |
+| `--severity` | Finding severity filter (`critical,warning,info`) |
+| `--once` | Run one collection cycle and exit |
+| `--max-queued-events` | Buffer size while webhook is unavailable |
+
+Event types: `resource.discovered`, `ownership.changed`, `drift.detected`, `scan.finding`.
 
 ## `summary slack` Options
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -28,6 +28,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `impact` | Connected blast-radius preview for one unit | v1.6 |
 | `fleet outliers` | Connected cluster-drift outlier report | v1.6 |
 | `trace` | Show GitOps ownership chain | v0.5 |
+| `watch --webhook <url>` | Stream observation events to a webhook | v1.7 |
 | `scan` | Scan for misconfigurations | v0.5 |
 | `scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD | v0.19 |
 | `tree` | Hierarchical resource views | v0.5 |
@@ -627,6 +628,54 @@ See `docs/howto/trace-context-troubleshooting.md` for the full flow.
 | Bucket | Flux |
 | Repository (Git/Helm) | ArgoCD |
 | Helm secrets | Standalone Helm |
+
+---
+
+## watch
+
+Stream observation events to a webhook.
+
+```bash
+cub-scout watch --webhook <url> [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--webhook` | Webhook URL to receive events |
+| `--interval` | Polling interval (default: `20s`) |
+| `-n, --namespace` | Namespace filter |
+| `--owner` | Owner display-name filter |
+| `--severity` | Finding severity filter (`critical,warning,info`) |
+| `--once` | Run one collection cycle and exit |
+| `--max-queued-events` | Max buffered events while webhook is unreachable |
+
+### Event Types
+
+- `resource.discovered`
+- `ownership.changed`
+- `drift.detected`
+- `scan.finding`
+
+### Event Payload
+
+```json
+{
+  "type": "drift.detected",
+  "timestamp": "2026-03-07T11:00:00Z",
+  "resource": {"kind": "Deployment", "name": "api", "namespace": "prod"},
+  "owner": {"type": "ArgoCD", "name": "api-app"},
+  "severity": "warning",
+  "details": {"category": "STATE", "message": "out of sync"}
+}
+```
+
+### Example
+
+```bash
+cub-scout watch --webhook https://hooks.example.com/cub-scout --interval 30s
+```
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -677,6 +677,8 @@ cub-scout watch --webhook <url> [flags]
 cub-scout watch --webhook https://hooks.example.com/cub-scout --interval 30s
 ```
 
+See [`examples/watch-webhook/`](../../examples/watch-webhook/) for a local receiver and end-to-end walkthrough.
+
 ---
 
 ## scan

--- a/examples/README.md
+++ b/examples/README.md
@@ -79,6 +79,7 @@ The `argo-import-confighub-demo` and `flux-import-confighub-demo` run against re
 | [ai-integration/](ai-integration/) | **Per-tool AI integrations** | Reproducible Claude/Cursor/Copilot MCP + CLI examples (offline fixtures) |
 | [connect-and-compare/](connect-and-compare/) | **Connected value story** | 60-second fixture demo: doctor -> connect -> compare -> history |
 | [connected-summary-storage/](connected-summary-storage/) | **Connected trend snapshots** | Persist/query scan + gitops summary history (`summary list`) |
+| [watch-webhook/](watch-webhook/) | **Webhook stream receiver** | Local receiver + walkthrough for `cub-scout watch --webhook` |
 
 **Using AI tools?** Start with [Giving Your AI Eyes](ai-agent-quest/) — watch your AI reason about cluster state and hit the wall that ConfigHub removes.
 
@@ -166,6 +167,7 @@ Expected output for each example is in `test/fixtures/expected-output/examples/`
 | [new-user-puzzle-quest/](new-user-puzzle-quest/) | **Working** | Quest-style new-user walkthrough (AI-assisted) | Guided capability/discovery/import validation |
 | [connect-and-compare/](connect-and-compare/) | **Working** | 60-second connected-mode fixture flow | Standalone->connected value narrative for demos/recordings |
 | [connected-summary-storage/](connected-summary-storage/) | **Working** | Connected summary persistence + query workflow | Trend/history snapshots for scan + gitops status |
+| [watch-webhook/](watch-webhook/) | **Working** | Local webhook receiver and watch walkthrough | Validating event stream integrations and filters |
 | [workflows/](workflows/) | **Working** | Artifact + fleet demos (CI → local, env comparison) | CI/CD integration, sharing bundles, comparing environments |
 | [apptique-examples/](apptique-examples/) | **Working** | Real GitOps patterns (Flux, Argo) | Learning GitOps ownership |
 | [platform-example/](platform-example/) | **Working** | Full Flux learning environment (~35 resources) | Learning GitOps + orphan detection |

--- a/examples/watch-webhook/README.md
+++ b/examples/watch-webhook/README.md
@@ -1,0 +1,83 @@
+# Watch Webhook Example
+
+Demonstrates `cub-scout watch --webhook` by streaming one-shot or continuous events
+into a local receiver.
+
+## What This Covers
+
+- `cub-scout watch --webhook <url>` basic usage
+- Event delivery for:
+  - `resource.discovered`
+  - `ownership.changed`
+  - `drift.detected`
+  - `scan.finding`
+- Local webhook receiver for demos and validation
+
+## Prerequisites
+
+- `kubectl` context configured
+- `cub-scout` binary available from this repo (`./cub-scout`)
+- Python 3 for local receiver script
+
+## Quick Run (One Shot)
+
+1. Start the local receiver:
+
+```bash
+cd examples/watch-webhook
+python3 mock_webhook.py --port 8787 --output /tmp/cub-scout-watch-events.jsonl
+```
+
+2. In another terminal, run one cycle:
+
+```bash
+cd /path/to/cub-scout
+./cub-scout watch --webhook http://127.0.0.1:8787/events --once
+```
+
+3. Inspect captured events:
+
+```bash
+cat /tmp/cub-scout-watch-events.jsonl
+```
+
+## Continuous Run
+
+```bash
+./cub-scout watch \
+  --webhook http://127.0.0.1:8787/events \
+  --interval 20s \
+  --namespace default \
+  --severity warning,critical
+```
+
+Stop with `Ctrl+C`.
+
+## Sample Event
+
+```json
+{
+  "type": "scan.finding",
+  "timestamp": "2026-03-07T17:00:00Z",
+  "resource": {
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod"
+  },
+  "owner": {
+    "type": "Flux",
+    "name": "frontend-app"
+  },
+  "severity": "warning",
+  "details": {
+    "category": "STATE",
+    "message": "out of sync"
+  }
+}
+```
+
+## Notes
+
+- This example is read-only and does not mutate cluster state.
+- Use `--once` for deterministic smoke checks in local validation scripts.
+- For remote endpoints, ensure the webhook URL is reachable from the machine running `cub-scout`.

--- a/examples/watch-webhook/mock_webhook.py
+++ b/examples/watch-webhook/mock_webhook.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Minimal webhook receiver for cub-scout watch examples."""
+
+import argparse
+import datetime
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Local webhook receiver for cub-scout watch events")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8787, help="Bind port (default: 8787)")
+    parser.add_argument(
+        "--output",
+        default="/tmp/cub-scout-watch-events.jsonl",
+        help="Output JSONL file path (default: /tmp/cub-scout-watch-events.jsonl)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            content_length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(content_length)
+
+            try:
+                event = json.loads(raw_body.decode("utf-8"))
+            except json.JSONDecodeError:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"invalid json")
+                return
+
+            envelope = {
+                "receivedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "path": self.path,
+                "event": event,
+            }
+
+            with output_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(envelope, separators=(",", ":")) + "\n")
+
+            event_type = event.get("type", "unknown")
+            print(f"[{datetime.datetime.now().isoformat(timespec='seconds')}] event={event_type} path={self.path}")
+
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, format: str, *args) -> None:  # noqa: A003
+            # Keep output focused on event summaries above.
+            return
+
+    server = HTTPServer((args.host, args.port), Handler)
+    print(f"Listening on http://{args.host}:{args.port} -> {output_path}")
+    print("Press Ctrl+C to stop")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/golden/harness.go
+++ b/test/golden/harness.go
@@ -171,8 +171,8 @@ func Normalize(s string) string {
 	elapsedRegex := regexp.MustCompile(`\d+[dhms]\s*\d*[dhms]?`)
 	s = elapsedRegex.ReplaceAllString(s, "<ELAPSED>")
 
-	// Normalize temp paths
-	tempPathRegex := regexp.MustCompile(`(/tmp|/var/folders)/[^\s"']+`)
+	// Normalize temp paths, including macOS /private symlink prefixes.
+	tempPathRegex := regexp.MustCompile(`(/private)?(/tmp|/var/folders)/[^\s"']+`)
 	s = tempPathRegex.ReplaceAllString(s, "<TEMP_PATH>")
 
 	// Normalize UUIDs

--- a/test/golden/harness_test.go
+++ b/test/golden/harness_test.go
@@ -1,0 +1,18 @@
+package golden
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalize_TempPathsWithPrivatePrefix(t *testing.T) {
+	input := "A: /private/tmp/work/file.yaml\nB: /tmp/work/file.yaml\nC: /var/folders/zz/file.yaml\n"
+	out := Normalize(input)
+
+	if strings.Count(out, "<TEMP_PATH>") != 3 {
+		t.Fatalf("expected 3 normalized temp paths, got %q", out)
+	}
+	if strings.Contains(out, "/private/tmp") || strings.Contains(out, "/tmp/") || strings.Contains(out, "/var/folders/") {
+		t.Fatalf("expected temp paths to be normalized, got %q", out)
+	}
+}

--- a/test/golden/scan-file/scan_file_test.go
+++ b/test/golden/scan-file/scan_file_test.go
@@ -264,6 +264,11 @@ func normalizeScanForGolden(s string, fixturePath string) string {
 
 	s = normalizeScanOutput(s)
 
+	// If generic temp-path normalization happened first, keep scan-file contract
+	// stable by forcing the file field placeholder.
+	s = strings.ReplaceAll(s, "File: <TEMP_PATH>", "File: <FILE>")
+	s = strings.ReplaceAll(s, "File: /private<TEMP_PATH>", "File: <FILE>")
+
 	// After normalization, the path might have $HOME prefix - replace that too
 	// Pattern: $HOME/anything/testdata/inputs/filename -> <FILE>
 	filePathRegex := regexp.MustCompile(`\$HOME[^\s]+/testdata/inputs/[^\s]+`)


### PR DESCRIPTION
## Summary
Adds a new `cub-scout watch --webhook <url>` command that streams observation events to a webhook, with retry/buffer behavior and deterministic filters. Also hardens golden normalization for macOS `/private/tmp` path variants so full local regression runs stay deterministic, and adds a runnable watch webhook example.

## Changes
- Added `watch` command and wiring in [`cmd/cub-scout/watch.go`].
- Added event types: `resource.discovered`, `ownership.changed`, `drift.detected`, `scan.finding`.
- Added flags: `--webhook` (required), `--interval`, `--namespace`, `--owner`, `--severity`, `--once`, `--max-queued-events`.
- Added exponential-backoff webhook posting and queue buffering.
- Ensured long-running mode advances state even on partial webhook failure and preserves only unsent queue tail.
- Added tests in [`cmd/cub-scout/watch_test.go`] and smoke coverage in [`cmd/cub-scout/smoke_test.go`].
- Updated command docs in [`docs/reference/commands.md`] and [`docs/reference/command-matrix.md`], plus root help text in [`cmd/cub-scout/main.go`].
- Added runnable example docs + local receiver script:
  - `examples/watch-webhook/README.md`
  - `examples/watch-webhook/mock_webhook.py`
  - indexed from `examples/README.md`
- Updated golden normalization to handle `/private/tmp` path forms in [`test/golden/harness.go`] + test [`test/golden/harness_test.go`], and kept scan-file placeholder contract stable in [`test/golden/scan-file/scan_file_test.go`].

## Why
Issue #234 needs webhook event streaming for external automation hooks, and local proof gates require deterministic output across macOS temp-path forms.

## Review-by-Evidence

### What changed (1-3 bullets)
- New `watch` command and event pipeline added, including filters and retry/buffer semantics.
- Queue flushing now preserves only unsent events on partial failures and avoids duplicate replay in long-running mode.
- Golden normalization now treats `/private/tmp` deterministically; scan-file golden placeholder remains `<FILE>`.

### Why (1 bullet)
- Enables event-stream integrations while keeping output/testing deterministic across environments.

### Tests added/updated
- `cmd/cub-scout/watch_test.go`
- `cmd/cub-scout/smoke_test.go`
- `test/golden/harness_test.go`
- `test/golden/scan-file/scan_file_test.go`

### Golden diffs?
- [x] No golden file changes
- [ ] Yes - golden files changed (see below)

### Cluster proof required?
- [x] Not required (change does not affect risky areas)
- [ ] Yes - cluster proof provided (see below)

### Risk assessment
**Could this create false certainty (false ownership claims, misleading health status)?**
- [x] No - change does not affect ownership or health logic
- [x] No - covered by existing tests
- [ ] Potential risk - mitigated by: [explain]

## Checklist
- [x] CI passes
- [x] No false ownership/health claims introduced
- [x] Documentation updated if needed
- [x] Review-by-evidence section complete

Closes #234
