### PR TITLE
feat(watch): add output-file sink and sink pipeline

### DIFF
--- a/cmd/cub-scout/smoke_test.go
+++ b/cmd/cub-scout/smoke_test.go
@@ -65,7 +65,7 @@ func TestSmoke_CLIHelp(t *testing.T) {
 			name:         "watch help",
 			args:         []string{"watch", "--help"},
 			wantExitCode: 0,
-			wantContains: []string{"watch", "--webhook", "Usage:"},
+			wantContains: []string{"watch", "--webhook", "--output-file", "Usage:"},
 		},
 		{
 			name:         "quickstart help",

--- a/cmd/cub-scout/watch.go
+++ b/cmd/cub-scout/watch.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -26,6 +27,7 @@ import (
 
 var (
 	watchWebhookURL      string
+	watchOutputFile      string
 	watchInterval        time.Duration
 	watchNamespace       string
 	watchOwner           string
@@ -69,6 +71,44 @@ type watchState struct {
 	findings    map[string]watchFinding
 }
 
+type watchEventSink interface {
+	Name() string
+	Retryable() bool
+	Write(ctx context.Context, event watchEvent) error
+}
+
+type watchWebhookSink struct {
+	url string
+}
+
+func (s *watchWebhookSink) Name() string    { return "webhook" }
+func (s *watchWebhookSink) Retryable() bool { return true }
+func (s *watchWebhookSink) Write(ctx context.Context, event watchEvent) error {
+	return watchPostEvent(ctx, s.url, event)
+}
+
+type watchFileSink struct {
+	path string
+	file *os.File
+}
+
+func (s *watchFileSink) Name() string    { return "file" }
+func (s *watchFileSink) Retryable() bool { return false }
+
+func (s *watchFileSink) Write(ctx context.Context, event watchEvent) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	body, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+	if _, err := s.file.Write(append(body, '\n')); err != nil {
+		return fmt.Errorf("write %q: %w", s.path, err)
+	}
+	return nil
+}
+
 var (
 	watchBuildConfig   = buildConfig
 	watchCollectState  = collectWatchState
@@ -80,8 +120,8 @@ var (
 
 var watchCmd = &cobra.Command{
 	Use:   "watch",
-	Short: "Stream observation events to a webhook",
-	Long: `Watch cluster observation changes and stream JSON events to a webhook.
+	Short: "Stream observation events to webhook/file sinks",
+	Long: `Watch cluster observation changes and stream JSON events to configured sinks.
 
 Event types:
   - resource.discovered
@@ -95,6 +135,7 @@ Event types:
 func init() {
 	rootCmd.AddCommand(watchCmd)
 	watchCmd.Flags().StringVar(&watchWebhookURL, "webhook", "", "Webhook URL to receive events")
+	watchCmd.Flags().StringVar(&watchOutputFile, "output-file", "", "Append JSONL events to a local file path")
 	watchCmd.Flags().DurationVar(&watchInterval, "interval", 20*time.Second, "Polling interval (for example 20s, 1m)")
 	watchCmd.Flags().StringVarP(&watchNamespace, "namespace", "n", "", "Filter events to a namespace")
 	watchCmd.Flags().StringVar(&watchOwner, "owner", "", "Filter events by owner display name (for example Flux, ArgoCD, Internal Platform)")
@@ -105,8 +146,9 @@ func init() {
 
 func runWatch(cmd *cobra.Command, args []string) error {
 	webhookURL := strings.TrimSpace(watchWebhookURL)
-	if webhookURL == "" {
-		return fmt.Errorf("missing --webhook URL")
+	outputFile := strings.TrimSpace(watchOutputFile)
+	if webhookURL == "" && outputFile == "" {
+		return fmt.Errorf("missing destination: provide either --webhook or --output-file")
 	}
 	if watchInterval <= 0 {
 		return fmt.Errorf("--interval must be > 0")
@@ -114,6 +156,11 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	if watchMaxQueuedEvents <= 0 {
 		return fmt.Errorf("--max-queued-events must be > 0")
 	}
+	sinks, cleanup, err := buildWatchSinks(webhookURL, outputFile)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
 	severityFilter := parseWatchSeverityFilter(watchSeverity)
 	ownerFilter := strings.TrimSpace(watchOwner)
@@ -142,7 +189,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		}
 		events := buildWatchEvents(prevState, curr, severityFilter, ownerFilter, watchEventNow)
 		queue = appendWatchQueue(queue, events, watchMaxQueuedEvents)
-		_, err = flushWatchQueue(ctx, webhookURL, queue)
+		_, err = flushWatchQueue(ctx, sinks, queue)
 		return err
 	}
 
@@ -168,11 +215,11 @@ func runWatch(cmd *cobra.Command, args []string) error {
 			}
 			events := buildWatchEvents(prevState, curr, severityFilter, ownerFilter, watchEventNow)
 			queue = appendWatchQueue(queue, events, watchMaxQueuedEvents)
-			remaining, err := flushWatchQueue(ctx, webhookURL, queue)
+			remaining, err := flushWatchQueue(ctx, sinks, queue)
 			queue = remaining
 			prevState = curr
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: webhook delivery failed (buffered %d events): %v\n", len(queue), err)
+				fmt.Fprintf(os.Stderr, "Warning: event delivery failed (buffered %d events): %v\n", len(queue), err)
 				continue
 			}
 		}
@@ -471,10 +518,56 @@ func appendWatchQueue(queue, events []watchEvent, maxQueued int) []watchEvent {
 	return append([]watchEvent(nil), queue[len(queue)-maxQueued:]...)
 }
 
-func flushWatchQueue(ctx context.Context, webhookURL string, queue []watchEvent) ([]watchEvent, error) {
+func buildWatchSinks(webhookURL, outputFile string) ([]watchEventSink, func(), error) {
+	sinks := make([]watchEventSink, 0, 2)
+	cleanup := func() {}
+
+	if webhookURL != "" {
+		sinks = append(sinks, &watchWebhookSink{url: webhookURL})
+	}
+	if outputFile != "" {
+		sink, err := newWatchFileSink(outputFile)
+		if err != nil {
+			return nil, cleanup, err
+		}
+		sinks = append(sinks, sink)
+		cleanup = func() {
+			_ = sink.file.Close()
+		}
+	}
+	if len(sinks) == 0 {
+		return nil, cleanup, fmt.Errorf("missing destination: provide either --webhook or --output-file")
+	}
+	return sinks, cleanup, nil
+}
+
+func newWatchFileSink(outputFile string) (*watchFileSink, error) {
+	path := strings.TrimSpace(outputFile)
+	if path == "" {
+		return nil, fmt.Errorf("invalid --output-file: empty path")
+	}
+	dir := filepath.Dir(path)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("create output directory %q: %w", dir, err)
+		}
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open output file %q: %w", path, err)
+	}
+	return &watchFileSink{path: path, file: file}, nil
+}
+
+func flushWatchQueue(ctx context.Context, sinks []watchEventSink, queue []watchEvent) ([]watchEvent, error) {
 	for i, event := range queue {
-		if err := watchPostEvent(ctx, webhookURL, event); err != nil {
-			return append([]watchEvent(nil), queue[i:]...), err
+		for _, sink := range sinks {
+			if err := sink.Write(ctx, event); err != nil {
+				if sink.Retryable() {
+					return append([]watchEvent(nil), queue[i:]...), fmt.Errorf("%s sink: %w", sink.Name(), err)
+				}
+				return queue[:0], fmt.Errorf("%s sink: %w", sink.Name(), err)
+			}
 		}
 	}
 	return queue[:0], nil

--- a/cmd/cub-scout/watch_test.go
+++ b/cmd/cub-scout/watch_test.go
@@ -5,9 +5,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -135,29 +139,198 @@ func TestAppendWatchQueue_DropsOldest(t *testing.T) {
 	}
 }
 
-func TestFlushWatchQueue_PartialFailureKeepsRemaining(t *testing.T) {
+func TestRunWatch_RequiresDestination(t *testing.T) {
 	restore := overrideWatchDeps(t)
 	defer restore()
 
-	calls := 0
-	watchPostEvent = func(ctx context.Context, webhookURL string, event watchEvent) error {
-		calls++
-		if calls == 2 {
-			return errors.New("boom")
-		}
-		return nil
+	watchWebhookURL = ""
+	watchOutputFile = ""
+	watchInterval = 1 * time.Second
+	watchMaxQueuedEvents = 100
+	watchCmd.SetContext(context.Background())
+
+	err := runWatch(watchCmd, nil)
+	if err == nil {
+		t.Fatal("expected destination validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "either --webhook or --output-file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildWatchSinks_FileOnly(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "events.jsonl")
+	sinks, cleanup, err := buildWatchSinks("", outputPath)
+	if err != nil {
+		t.Fatalf("buildWatchSinks() error = %v", err)
+	}
+	defer cleanup()
+
+	if len(sinks) != 1 {
+		t.Fatalf("sink count = %d, want 1", len(sinks))
 	}
 
+	event := watchEvent{
+		Type:      "scan.finding",
+		Timestamp: time.Date(2026, 3, 7, 18, 0, 0, 0, time.UTC),
+		Resource:  watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"},
+	}
+
+	if err := sinks[0].Write(context.Background(), event); err != nil {
+		t.Fatalf("sink write failed: %v", err)
+	}
+
+	raw, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("line count = %d, want 1", len(lines))
+	}
+
+	var decoded watchEvent
+	if err := json.Unmarshal([]byte(lines[0]), &decoded); err != nil {
+		t.Fatalf("decode event json: %v", err)
+	}
+	if decoded.Type != "scan.finding" {
+		t.Fatalf("decoded type = %q, want scan.finding", decoded.Type)
+	}
+}
+
+func TestBuildWatchSinks_WebhookAndFile(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	oldClient := watchDefaultClient
+	watchDefaultClient = srv.Client()
+	defer func() { watchDefaultClient = oldClient }()
+
+	outputPath := filepath.Join(t.TempDir(), "events.jsonl")
+	sinks, cleanup, err := buildWatchSinks(srv.URL, outputPath)
+	if err != nil {
+		t.Fatalf("buildWatchSinks() error = %v", err)
+	}
+	defer cleanup()
+
+	if len(sinks) != 2 {
+		t.Fatalf("sink count = %d, want 2", len(sinks))
+	}
+
+	queue := []watchEvent{
+		{
+			Type:      "resource.discovered",
+			Timestamp: time.Date(2026, 3, 7, 18, 5, 0, 0, time.UTC),
+			Resource:  watchEventResource{Kind: "Service", Name: "api", Namespace: "prod"},
+		},
+	}
+	remaining, err := flushWatchQueue(context.Background(), sinks, queue)
+	if err != nil {
+		t.Fatalf("flushWatchQueue() error = %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining len = %d, want 0", len(remaining))
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("webhook calls = %d, want 1", got)
+	}
+
+	raw, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if !strings.Contains(string(raw), "\"resource.discovered\"") {
+		t.Fatalf("expected event JSON in output file, got %q", string(raw))
+	}
+}
+
+func TestFlushWatchQueue_WithFileSink(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "events.jsonl")
+	sinks, cleanup, err := buildWatchSinks("", outputPath)
+	if err != nil {
+		t.Fatalf("buildWatchSinks() error = %v", err)
+	}
+	defer cleanup()
+
+	queue := []watchEvent{
+		{
+			Type:      "resource.discovered",
+			Timestamp: time.Date(2026, 3, 7, 18, 10, 0, 0, time.UTC),
+			Resource:  watchEventResource{Kind: "Service", Name: "api", Namespace: "prod"},
+		},
+		{
+			Type:      "scan.finding",
+			Timestamp: time.Date(2026, 3, 7, 18, 10, 30, 0, time.UTC),
+			Resource:  watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		},
+	}
+
+	remaining, err := flushWatchQueue(context.Background(), sinks, queue)
+	if err != nil {
+		t.Fatalf("flushWatchQueue() error = %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining len = %d, want 0", len(remaining))
+	}
+
+	raw, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("line count = %d, want 2", len(lines))
+	}
+}
+
+type testWatchSink struct {
+	calls     int
+	failAt    int
+	retryable bool
+}
+
+func (s *testWatchSink) Name() string { return "test" }
+func (s *testWatchSink) Retryable() bool {
+	return s.retryable
+}
+
+func (s *testWatchSink) Write(ctx context.Context, event watchEvent) error {
+	s.calls++
+	if s.failAt > 0 && s.calls == s.failAt {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func TestFlushWatchQueue_PartialFailureKeepsRemaining(t *testing.T) {
+	sink := &testWatchSink{failAt: 2, retryable: true}
 	queue := []watchEvent{{Type: "e1"}, {Type: "e2"}, {Type: "e3"}}
-	remaining, err := flushWatchQueue(context.Background(), "https://hooks.example.com/cub-scout", queue)
+	remaining, err := flushWatchQueue(context.Background(), []watchEventSink{sink}, queue)
 	if err == nil {
 		t.Fatal("expected flush error, got nil")
 	}
-	if calls != 2 {
-		t.Fatalf("post call count = %d, want 2", calls)
+	if sink.calls != 2 {
+		t.Fatalf("sink call count = %d, want 2", sink.calls)
 	}
 	if len(remaining) != 2 || remaining[0].Type != "e2" || remaining[1].Type != "e3" {
 		t.Fatalf("unexpected remaining queue: %#v", remaining)
+	}
+}
+
+func TestFlushWatchQueue_NonRetryableFailureDropsQueue(t *testing.T) {
+	sink := &testWatchSink{failAt: 1, retryable: false}
+	queue := []watchEvent{{Type: "e1"}, {Type: "e2"}}
+
+	remaining, err := flushWatchQueue(context.Background(), []watchEventSink{sink}, queue)
+	if err == nil {
+		t.Fatal("expected flush error, got nil")
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining len = %d, want 0", len(remaining))
 	}
 }
 
@@ -234,6 +407,7 @@ func TestRunWatch_OncePostsEvents(t *testing.T) {
 	}
 
 	watchWebhookURL = "https://hooks.example.com/cub-scout"
+	watchOutputFile = ""
 	watchInterval = 1 * time.Second
 	watchNamespace = "prod"
 	watchOwner = ""

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -41,7 +41,7 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `status` | Show connection status and cluster info |
 | `summary` | Query persisted connected summary snapshots |
 | `trace` | Trace any resource to its Git source |
-| `watch` | Stream observation events to webhook |
+| `watch` | Stream observation events to webhook/file sinks |
 | `tree` | Show hierarchical views of resources |
 | `version` | Print version information |
 
@@ -249,13 +249,16 @@ Connected storage defaults:
 
 | Option | Description |
 |--------|-------------|
-| `--webhook` | Webhook URL for event delivery (required) |
+| `--webhook` | Webhook URL for event delivery |
+| `--output-file` | Append JSONL events to local file |
 | `--interval` | Polling interval (`20s` default) |
 | `-n, --namespace` | Namespace filter |
 | `--owner` | Owner display-name filter |
 | `--severity` | Finding severity filter (`critical,warning,info`) |
 | `--once` | Run one collection cycle and exit |
 | `--max-queued-events` | Buffer size while webhook is unavailable |
+
+At least one destination is required: `--webhook` and/or `--output-file`.
 
 Event types: `resource.discovered`, `ownership.changed`, `drift.detected`, `scan.finding`.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -28,7 +28,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `impact` | Connected blast-radius preview for one unit | v1.6 |
 | `fleet outliers` | Connected cluster-drift outlier report | v1.6 |
 | `trace` | Show GitOps ownership chain | v0.5 |
-| `watch --webhook <url>` | Stream observation events to a webhook | v1.7 |
+| `watch --webhook <url>` | Stream observation events to webhook/file sinks | v1.7 |
 | `scan` | Scan for misconfigurations | v0.5 |
 | `scan --lifecycle-hazards` | Detect Helm hook risks under ArgoCD | v0.19 |
 | `tree` | Hierarchical resource views | v0.5 |
@@ -637,17 +637,20 @@ See `docs/howto/trace-context-troubleshooting.md` for the full flow.
 
 ## watch
 
-Stream observation events to a webhook.
+Stream observation events to webhook/file sinks.
 
 ```bash
-cub-scout watch --webhook <url> [flags]
+cub-scout watch [--webhook <url>] [--output-file <path>] [flags]
 ```
+
+At least one destination is required: `--webhook` and/or `--output-file`.
 
 ### Flags
 
 | Flag | Description |
 |------|-------------|
 | `--webhook` | Webhook URL to receive events |
+| `--output-file` | Append JSONL events to a local file |
 | `--interval` | Polling interval (default: `20s`) |
 | `-n, --namespace` | Namespace filter |
 | `--owner` | Owner display-name filter |
@@ -679,6 +682,10 @@ cub-scout watch --webhook <url> [flags]
 
 ```bash
 cub-scout watch --webhook https://hooks.example.com/cub-scout --interval 30s
+```
+
+```bash
+cub-scout watch --output-file /tmp/cub-scout-events.jsonl --once
 ```
 
 See [`examples/watch-webhook/`](../../examples/watch-webhook/) for a local receiver and end-to-end walkthrough.

--- a/examples/watch-webhook/README.md
+++ b/examples/watch-webhook/README.md
@@ -53,6 +53,14 @@ cat /tmp/cub-scout-watch-events.jsonl
 
 Stop with `Ctrl+C`.
 
+## File Sink (No Webhook)
+
+Write events directly to local JSONL:
+
+```bash
+./cub-scout watch --output-file /tmp/cub-scout-watch-events.jsonl --once
+```
+
 ## Sample Event
 
 ```json


### PR DESCRIPTION
## Summary
Adds pluggable watch output sinks and introduces `--output-file` as the first non-webhook sink for `cub-scout watch`. Existing webhook retry/buffer semantics are preserved.

## Changes
- Added sink abstraction in `cmd/cub-scout/watch.go`:
  - `watchEventSink` interface (`Name`, `Retryable`, `Write`)
  - `watchWebhookSink` (retryable)
  - `watchFileSink` (non-retryable, JSONL append)
- Added `--output-file` flag and destination validation (`--webhook` and/or `--output-file` required).
- Refactored queue flush path to operate on sink list and preserve retry queue only for retryable sink failures.
- Added deterministic tests in `cmd/cub-scout/watch_test.go` for:
  - destination validation
  - file-only sink writes
  - webhook+file sink composition
  - flush behavior for retryable vs non-retryable failures
- Updated smoke/help coverage in `cmd/cub-scout/smoke_test.go`.
- Updated docs:
  - `docs/reference/commands.md`
  - `docs/reference/command-matrix.md`
  - `examples/watch-webhook/README.md`

## Why
Roadmap follow-up for output plugin architecture: this establishes a sink pipeline and ships a deterministic file sink foundation without regressing existing webhook behavior.

## Review-by-Evidence

### What changed (1-3 bullets)
- `watch` now supports sink composition and local JSONL output via `--output-file`.
- Queue retry semantics now explicitly depend on sink retryability.
- Docs/examples now cover both webhook and file sink destinations.

### Why (1 bullet)
- Enables reliable local integrations and unblocks future destinations (Kafka/custom plugins) on top of a stable sink contract.

### Tests added/updated
- `cmd/cub-scout/watch_test.go`
- `cmd/cub-scout/smoke_test.go`

### Golden diffs?
- [x] No golden file changes
- [ ] Yes - golden files changed (see below)

### Cluster proof required?
- [x] Not required (change does not affect risky ownership/health inference paths)
- [ ] Yes - cluster proof provided (see below)

### Risk assessment
**Could this create false certainty (false ownership claims, misleading health status)?**
- [x] No - change does not affect ownership or health logic
- [x] No - covered by existing tests
- [ ] Potential risk - mitigated by: [explain]

## Checklist
- [x] CI passes
- [x] No false ownership/health claims introduced
- [x] Documentation updated if needed
- [x] Review-by-evidence section complete

Proof artifacts: `/tmp/cub-scout-regression/v1.7/308/`

Closes #308
