### PR TITLE
docs(roadmap): sync output sink milestone status

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,7 +65,7 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 ### Extension & Integration Ideas (`howto/extending.md`)
 
 - [x] Webhook event streaming (entry/drift/finding events) — graduated to #234
-- [ ] Output plugin architecture (Kafka, custom destinations)
+- [x] Output plugin architecture (file sink foundation; Kafka/custom destinations follow-up) — graduated to #308
 - [x] Config-based custom ownership detectors (YAML, no Go required) — graduated to #233
 - [ ] Config-based CRD watching (YAML status extraction)
 


### PR DESCRIPTION
## Summary
Updates the roadmap checklist to reflect that output plugin architecture has now shipped its file-sink foundation in #309.

## Changes
- Mark `Output plugin architecture` item complete in `docs/roadmap.md` with follow-up note for Kafka/custom sinks.

## Why
Roadmap status should match shipped behavior to avoid stale planning state.

## Review-by-Evidence

### What changed (1-3 bullets)
- One checklist line updated in roadmap.

### Why (1 bullet)
- Keeps milestone/progress reporting accurate after #309 merge.

### Tests added/updated
- None (docs-only)

### Golden diffs?
- [x] No golden file changes
- [ ] Yes - golden files changed (see below)

### Cluster proof required?
- [x] Not required (docs-only change)
- [ ] Yes - cluster proof provided (see below)

### Risk assessment
**Could this create false certainty (false ownership claims, misleading health status)?**
- [x] No - change does not affect ownership or health logic
- [ ] No - covered by existing tests
- [ ] Potential risk - mitigated by: [explain]

## Checklist
- [x] CI passes
- [x] No false ownership/health claims introduced
- [x] Documentation updated if needed
- [x] Review-by-evidence section complete
