### PR TITLE
feat(extensibility): add YAML CRD watching for map/watch

### DIFF
--- a/cmd/cub-scout/custom_resources.go
+++ b/cmd/cub-scout/custom_resources.go
@@ -1,0 +1,220 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+)
+
+const customResourceConfigEnvVar = "CUB_SCOUT_RESOURCE_CONFIG"
+
+var defaultMapWatchResources = []schema.GroupVersionResource{
+	{Group: "apps", Version: "v1", Resource: "deployments"},
+	{Group: "apps", Version: "v1", Resource: "statefulsets"},
+	{Group: "apps", Version: "v1", Resource: "daemonsets"},
+	{Group: "", Version: "v1", Resource: "services"},
+	{Group: "", Version: "v1", Resource: "configmaps"},
+	{Group: "", Version: "v1", Resource: "secrets"},
+	{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+	{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+	{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
+	{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
+	{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"},
+}
+
+type customResourcesFile struct {
+	Resources []customResourceSpec `json:"resources" yaml:"resources"`
+}
+
+type customResourceSpec struct {
+	Group    string                    `json:"group" yaml:"group"`
+	Version  string                    `json:"version" yaml:"version"`
+	Resource string                    `json:"resource" yaml:"resource"`
+	Status   *customResourceStatusSpec `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+type customResourceStatusSpec struct {
+	HealthPath        string   `json:"healthPath,omitempty" yaml:"healthPath,omitempty"`
+	HealthyValues     []string `json:"healthyValues,omitempty" yaml:"healthyValues,omitempty"`
+	DegradedValues    []string `json:"degradedValues,omitempty" yaml:"degradedValues,omitempty"`
+	ProgressingValues []string `json:"progressingValues,omitempty" yaml:"progressingValues,omitempty"`
+}
+
+type customResourceConfig struct {
+	GVR schema.GroupVersionResource
+}
+
+type customResourceConfigCache struct {
+	mu          sync.RWMutex
+	path        string
+	modTime     time.Time
+	size        int64
+	configs     []customResourceConfig
+	warnedToken string
+}
+
+var mapWatchCustomResourceCache = customResourceConfigCache{}
+var mapWatchLoadCustomResourceConfigs = loadCustomResourceConfigs
+
+func collectMapResourceList() []schema.GroupVersionResource {
+	return buildMapWatchResourceList()
+}
+
+func collectWatchResourceList() []schema.GroupVersionResource {
+	return buildMapWatchResourceList()
+}
+
+func buildMapWatchResourceList() []schema.GroupVersionResource {
+	configs := mapWatchLoadCustomResourceConfigs()
+	out := append([]schema.GroupVersionResource(nil), defaultMapWatchResources...)
+
+	seen := map[string]struct{}{}
+	for _, gvr := range out {
+		seen[resourceKey(gvr)] = struct{}{}
+	}
+	for _, config := range configs {
+		key := resourceKey(config.GVR)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, config.GVR)
+	}
+
+	return out
+}
+
+func loadCustomResourceConfigs() []customResourceConfig {
+	path := resolveCustomResourceConfigPath()
+	if path == "" {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			mapWatchCustomResourceCache.mu.Lock()
+			mapWatchCustomResourceCache.path = path
+			mapWatchCustomResourceCache.modTime = time.Time{}
+			mapWatchCustomResourceCache.size = 0
+			mapWatchCustomResourceCache.configs = nil
+			mapWatchCustomResourceCache.warnedToken = ""
+			mapWatchCustomResourceCache.mu.Unlock()
+			return nil
+		}
+		warnCustomResourceConfig(path, time.Time{}, 0, fmt.Sprintf("failed to stat config: %v", err))
+		return nil
+	}
+
+	mapWatchCustomResourceCache.mu.RLock()
+	if mapWatchCustomResourceCache.path == path &&
+		mapWatchCustomResourceCache.modTime.Equal(info.ModTime()) &&
+		mapWatchCustomResourceCache.size == info.Size() {
+		configs := append([]customResourceConfig(nil), mapWatchCustomResourceCache.configs...)
+		mapWatchCustomResourceCache.mu.RUnlock()
+		return configs
+	}
+	mapWatchCustomResourceCache.mu.RUnlock()
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		warnCustomResourceConfig(path, info.ModTime(), info.Size(), fmt.Sprintf("failed to read config: %v", readErr))
+		return nil
+	}
+
+	var parsed customResourcesFile
+	if unmarshalErr := yaml.Unmarshal(data, &parsed); unmarshalErr != nil {
+		warnCustomResourceConfig(path, info.ModTime(), info.Size(), fmt.Sprintf("invalid YAML: %v", unmarshalErr))
+		return nil
+	}
+
+	configs := compileCustomResourceConfigs(parsed.Resources)
+
+	mapWatchCustomResourceCache.mu.Lock()
+	mapWatchCustomResourceCache.path = path
+	mapWatchCustomResourceCache.modTime = info.ModTime()
+	mapWatchCustomResourceCache.size = info.Size()
+	mapWatchCustomResourceCache.configs = configs
+	mapWatchCustomResourceCache.warnedToken = ""
+	mapWatchCustomResourceCache.mu.Unlock()
+
+	return append([]customResourceConfig(nil), configs...)
+}
+
+func compileCustomResourceConfigs(specs []customResourceSpec) []customResourceConfig {
+	if len(specs) == 0 {
+		return nil
+	}
+
+	out := make([]customResourceConfig, 0, len(specs))
+	for _, spec := range specs {
+		group := strings.TrimSpace(spec.Group)
+		version := strings.TrimSpace(spec.Version)
+		resource := strings.TrimSpace(spec.Resource)
+		if group == "" || version == "" || resource == "" {
+			continue
+		}
+
+		out = append(out, customResourceConfig{
+			GVR: schema.GroupVersionResource{
+				Group:    group,
+				Version:  version,
+				Resource: resource,
+			},
+		})
+	}
+	return out
+}
+
+func resolveCustomResourceConfigPath() string {
+	if override := strings.TrimSpace(os.Getenv(customResourceConfigEnvVar)); override != "" {
+		return override
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".cub-scout", "resources.yaml")
+}
+
+func warnCustomResourceConfig(path string, modTime time.Time, size int64, reason string) {
+	token := fmt.Sprintf("%s|%d|%d|%s", path, modTime.UnixNano(), size, reason)
+
+	mapWatchCustomResourceCache.mu.Lock()
+	defer mapWatchCustomResourceCache.mu.Unlock()
+
+	if mapWatchCustomResourceCache.warnedToken == token {
+		return
+	}
+
+	mapWatchCustomResourceCache.warnedToken = token
+	mapWatchCustomResourceCache.configs = nil
+	mapWatchCustomResourceCache.path = path
+	mapWatchCustomResourceCache.modTime = modTime
+	mapWatchCustomResourceCache.size = size
+
+	fmt.Fprintf(os.Stderr, "Warning: custom resource config ignored (%s): %s\n", path, reason)
+}
+
+func resourceKey(gvr schema.GroupVersionResource) string {
+	return strings.TrimSpace(gvr.Group) + "|" + strings.TrimSpace(gvr.Version) + "|" + strings.TrimSpace(gvr.Resource)
+}
+
+func resetCustomResourceConfigCacheForTest() {
+	mapWatchCustomResourceCache.mu.Lock()
+	defer mapWatchCustomResourceCache.mu.Unlock()
+	mapWatchCustomResourceCache.path = ""
+	mapWatchCustomResourceCache.modTime = time.Time{}
+	mapWatchCustomResourceCache.size = 0
+	mapWatchCustomResourceCache.configs = nil
+	mapWatchCustomResourceCache.warnedToken = ""
+}

--- a/cmd/cub-scout/custom_resources_test.go
+++ b/cmd/cub-scout/custom_resources_test.go
@@ -1,0 +1,173 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestCompileCustomResourceConfigs(t *testing.T) {
+	specs := []customResourceSpec{
+		{Group: "example.io", Version: "v1", Resource: "widgets"},
+		{Group: "", Version: "v1", Resource: "invalid-missing-group"},
+		{Group: "example.io", Version: "", Resource: "invalid-missing-version"},
+		{Group: "example.io", Version: "v1", Resource: ""},
+		{Group: "  another.io  ", Version: "  v1beta1  ", Resource: "  pipelines  "},
+	}
+
+	got := compileCustomResourceConfigs(specs)
+	if len(got) != 2 {
+		t.Fatalf("compile count = %d, want 2", len(got))
+	}
+
+	if got[0].GVR.Group != "example.io" || got[0].GVR.Version != "v1" || got[0].GVR.Resource != "widgets" {
+		t.Fatalf("first gvr = %#v", got[0].GVR)
+	}
+	if got[1].GVR.Group != "another.io" || got[1].GVR.Version != "v1beta1" || got[1].GVR.Resource != "pipelines" {
+		t.Fatalf("second gvr = %#v", got[1].GVR)
+	}
+}
+
+func TestBuildMapWatchResourceList_DeduplicatesAndAppends(t *testing.T) {
+	oldLoader := mapWatchLoadCustomResourceConfigs
+	mapWatchLoadCustomResourceConfigs = func() []customResourceConfig {
+		return []customResourceConfig{
+			{GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}}, // duplicate default
+			{GVR: schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}},
+		}
+	}
+	defer func() { mapWatchLoadCustomResourceConfigs = oldLoader }()
+
+	got := buildMapWatchResourceList()
+	if len(got) < len(defaultMapWatchResources)+1 {
+		t.Fatalf("resource list len = %d, want at least %d", len(got), len(defaultMapWatchResources)+1)
+	}
+
+	dupCount := 0
+	customCount := 0
+	for _, gvr := range got {
+		if gvr.Group == "apps" && gvr.Version == "v1" && gvr.Resource == "deployments" {
+			dupCount++
+		}
+		if gvr.Group == "example.io" && gvr.Version == "v1" && gvr.Resource == "widgets" {
+			customCount++
+		}
+	}
+	if dupCount != 1 {
+		t.Fatalf("deployments count = %d, want 1", dupCount)
+	}
+	if customCount != 1 {
+		t.Fatalf("custom widgets count = %d, want 1", customCount)
+	}
+
+	last := got[len(got)-1]
+	if last.Group != "example.io" || last.Version != "v1" || last.Resource != "widgets" {
+		t.Fatalf("last resource = %#v, want custom widgets", last)
+	}
+}
+
+func TestLoadCustomResourceConfigs_InvalidYAMLWarns(t *testing.T) {
+	t.Setenv(customResourceConfigEnvVar, filepath.Join(t.TempDir(), "resources.yaml"))
+	resetCustomResourceConfigCacheForTest()
+
+	if err := os.WriteFile(os.Getenv(customResourceConfigEnvVar), []byte("resources: [\n"), 0644); err != nil {
+		t.Fatalf("write invalid yaml: %v", err)
+	}
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	first := loadCustomResourceConfigs()
+	second := loadCustomResourceConfigs()
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+	out, _ := io.ReadAll(r)
+	_ = r.Close()
+
+	if len(first) != 0 || len(second) != 0 {
+		t.Fatalf("expected no configs on invalid yaml, got first=%d second=%d", len(first), len(second))
+	}
+	if !strings.Contains(string(out), "custom resource config ignored") {
+		t.Fatalf("expected warning message, got: %q", string(out))
+	}
+}
+
+func TestLoadCustomResourceConfigs_EnvOverrideParses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resources.yaml")
+	t.Setenv(customResourceConfigEnvVar, path)
+	resetCustomResourceConfigCacheForTest()
+
+	content := `
+resources:
+  - group: example.io
+    version: v1
+    resource: widgets
+  - group: platform.example.io
+    version: v1beta1
+    resource: pipelines
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got := loadCustomResourceConfigs()
+	if len(got) != 2 {
+		t.Fatalf("config count = %d, want 2", len(got))
+	}
+	if got[0].GVR.Group != "example.io" || got[0].GVR.Resource != "widgets" {
+		t.Fatalf("first config gvr = %#v", got[0].GVR)
+	}
+	if got[1].GVR.Group != "platform.example.io" || got[1].GVR.Version != "v1beta1" || got[1].GVR.Resource != "pipelines" {
+		t.Fatalf("second config gvr = %#v", got[1].GVR)
+	}
+}
+
+func TestCollectWatchResourceList_IncludesConfiguredCustomResources(t *testing.T) {
+	oldLoader := mapWatchLoadCustomResourceConfigs
+	mapWatchLoadCustomResourceConfigs = func() []customResourceConfig {
+		return []customResourceConfig{
+			{GVR: schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}},
+		}
+	}
+	defer func() { mapWatchLoadCustomResourceConfigs = oldLoader }()
+
+	got := collectWatchResourceList()
+	if len(got) == 0 {
+		t.Fatal("collectWatchResourceList() returned empty list")
+	}
+	last := got[len(got)-1]
+	if last.Group != "example.io" || last.Version != "v1" || last.Resource != "widgets" {
+		t.Fatalf("last resource = %#v, want custom widgets", last)
+	}
+}
+
+func TestMapResourceList_IncludesConfiguredCustomResources(t *testing.T) {
+	oldLoader := mapWatchLoadCustomResourceConfigs
+	mapWatchLoadCustomResourceConfigs = func() []customResourceConfig {
+		return []customResourceConfig{
+			{GVR: schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}},
+		}
+	}
+	defer func() { mapWatchLoadCustomResourceConfigs = oldLoader }()
+
+	got := collectMapResourceList()
+	if len(got) == 0 {
+		t.Fatal("collectMapResourceList() returned empty list")
+	}
+	last := got[len(got)-1]
+	if last.Group != "example.io" || last.Version != "v1" || last.Resource != "widgets" {
+		t.Fatalf("last resource = %#v, want custom widgets", last)
+	}
+}

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -737,22 +737,8 @@ func runMapListFromCluster(ctx context.Context) error {
 	byOwner := map[string]int{} // populated during collection; recomputed after filtering for summary correctness
 	appSetLookup := loadMapApplicationSetLookup(ctx, dynClient, mapNamespace)
 
-	// Resource types to scan
-	resources := []schema.GroupVersionResource{
-		{Group: "apps", Version: "v1", Resource: "deployments"},
-		{Group: "apps", Version: "v1", Resource: "statefulsets"},
-		{Group: "apps", Version: "v1", Resource: "daemonsets"},
-		{Group: "", Version: "v1", Resource: "services"},
-		{Group: "", Version: "v1", Resource: "configmaps"},
-		{Group: "", Version: "v1", Resource: "secrets"},
-		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
-		// Flux resources
-		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
-		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
-		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
-		// Argo resources
-		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"},
-	}
+	// Resource types to scan (defaults + optional custom CRD config)
+	resources := collectMapResourceList()
 
 	var startList time.Time
 	if debug {

--- a/cmd/cub-scout/watch.go
+++ b/cmd/cub-scout/watch.go
@@ -21,7 +21,6 @@ import (
 	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -255,19 +254,7 @@ func collectWatchEntries(ctx context.Context, dynClient dynamic.Interface, names
 		clusterName = "default"
 	}
 
-	resources := []schema.GroupVersionResource{
-		{Group: "apps", Version: "v1", Resource: "deployments"},
-		{Group: "apps", Version: "v1", Resource: "statefulsets"},
-		{Group: "apps", Version: "v1", Resource: "daemonsets"},
-		{Group: "", Version: "v1", Resource: "services"},
-		{Group: "", Version: "v1", Resource: "configmaps"},
-		{Group: "", Version: "v1", Resource: "secrets"},
-		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
-		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
-		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
-		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
-		{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"},
-	}
+	resources := collectWatchResourceList()
 
 	appSetLookup := loadMapApplicationSetLookup(ctx, dynClient, namespace)
 

--- a/docs/howto/extending.md
+++ b/docs/howto/extending.md
@@ -170,8 +170,13 @@ Watch additional CRDs beyond the defaults.
 
 ### Configuration
 
+Create one of these files:
+
+- `~/.cub-scout/resources.yaml` (default)
+- or set `CUB_SCOUT_RESOURCE_CONFIG=/path/to/resources.yaml`
+
 ```yaml
-# config/resources.yaml
+# ~/.cub-scout/resources.yaml
 resources:
   # Standard format
   - group: mycompany.io
@@ -189,7 +194,29 @@ resources:
       progressingValues: ["Pending", "Building"]
 ```
 
-**Note:** Configuration-based resource watching is not yet implemented. Currently, custom resources must be registered in Go code.
+### Where It Applies
+
+Configured resources are appended to built-in defaults for:
+
+- `cub-scout map list`
+- `cub-scout watch`
+
+### Matching Rules
+
+1. Built-in resources are always included first.
+2. Configured resources are appended in YAML order.
+3. Duplicate Group/Version/Resource entries are deduplicated.
+4. Invalid entries (missing group/version/resource) are skipped.
+
+### Behavior on Errors
+
+- Missing config file: silently ignored.
+- Invalid config file: warning printed once to stderr, then defaults continue.
+
+### Status Extraction Fields
+
+`status.*` keys are accepted for forward compatibility, but this slice does not
+override status rendering with those fields yet.
 
 ### Programmatic Registration
 

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -262,6 +262,9 @@ At least one destination is required: `--webhook` and/or `--output-file`.
 
 Event types: `resource.discovered`, `ownership.changed`, `drift.detected`, `scan.finding`.
 
+Custom CRDs for watch/map can be configured in `~/.cub-scout/resources.yaml`
+or via `CUB_SCOUT_RESOURCE_CONFIG`.
+
 ## `summary slack` Options
 
 | Option | Description |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -185,6 +185,9 @@ In default ASCII mode, `map list` includes a `TRY NEXT` section with contextual 
 
 Machine-readable formats (`--format json` and `--format md`) do not include these hints.
 
+Custom CRDs can be appended to this inventory using `~/.cub-scout/resources.yaml`
+or `CUB_SCOUT_RESOURCE_CONFIG` (see `docs/howto/extending.md`).
+
 ---
 
 ## quickstart
@@ -689,6 +692,8 @@ cub-scout watch --output-file /tmp/cub-scout-events.jsonl --once
 ```
 
 See [`examples/watch-webhook/`](../../examples/watch-webhook/) for a local receiver and end-to-end walkthrough.
+Custom CRDs in `~/.cub-scout/resources.yaml` (or `CUB_SCOUT_RESOURCE_CONFIG`)
+are included in watch resource discovery.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,7 +67,7 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 - [x] Webhook event streaming (entry/drift/finding events) — graduated to #234
 - [x] Output plugin architecture (file sink foundation; Kafka/custom destinations follow-up) — graduated to #308
 - [x] Config-based custom ownership detectors (YAML, no Go required) — graduated to #233
-- [ ] Config-based CRD watching (YAML status extraction)
+- [x] Config-based CRD watching (YAML resource registration for map/watch; status extraction fields reserved) — graduated to #311
 
 ### Scale and Testing
 


### PR DESCRIPTION
## Summary
Implements config-based custom CRD watching for `map list` and `watch` using YAML config, with safe fallback behavior.

## Changes
- Added custom resource config loader in `cmd/cub-scout/custom_resources.go`:
  - Default path: `~/.cub-scout/resources.yaml`
  - Env override: `CUB_SCOUT_RESOURCE_CONFIG`
  - Config schema: `resources[]` with `group`, `version`, `resource`
  - Dedupe by GVR while preserving deterministic order
  - Graceful fallback on missing/invalid config
- Integrated merged resource list into:
  - `runMapListFromCluster` (`cmd/cub-scout/map.go`)
  - `collectWatchEntries` (`cmd/cub-scout/watch.go`)
- Added deterministic tests in `cmd/cub-scout/custom_resources_test.go` for parse/merge/fallback/map+watch integration.
- Updated docs:
  - `docs/howto/extending.md`
  - `docs/reference/commands.md`
  - `docs/reference/command-matrix.md`
  - `docs/roadmap.md`

## Why
Roadmap item “Config-based CRD watching” was still open. This ships YAML-driven custom resource registration for map/watch without requiring code changes.

## Review-by-Evidence

### What changed (1-3 bullets)
- Added YAML-based custom resource registration for map/watch.
- Added deterministic merge/dedupe and warning-based fallback semantics.
- Synced docs and roadmap status to shipped behavior.

### Why (1 bullet)
- Enables operators to extend watch/map coverage to organization CRDs safely and deterministically.

### Tests added/updated
- `cmd/cub-scout/custom_resources_test.go`

### Golden diffs?
- [x] No golden file changes
- [ ] Yes - golden files changed (see below)

### Cluster proof required?
- [x] Not required (discovery-surface extension covered by deterministic unit + baseline suite)
- [ ] Yes - cluster proof provided (see below)

### Risk assessment
**Could this create false certainty (false ownership claims, misleading health status)?**
- [x] No - change does not alter ownership/health inference logic
- [x] No - covered by tests and fallback behavior
- [ ] Potential risk - mitigated by: [explain]

## Checklist
- [x] CI passes
- [x] No false ownership/health claims introduced
- [x] Documentation updated if needed
- [x] Review-by-evidence section complete

Proof artifacts: `/tmp/cub-scout-regression/v1.7/311/`

Closes #311
