### PR TITLE
feat(history): default-exclude synthetic demo changesets

### DIFF
--- a/cmd/cub-scout/audit.go
+++ b/cmd/cub-scout/audit.go
@@ -19,9 +19,10 @@ import (
 )
 
 var (
-	auditListNamespace string
-	auditListFormat    string
-	auditListSince     string
+	auditListNamespace        string
+	auditListFormat           string
+	auditListSince            string
+	auditListIncludeSynthetic bool
 )
 
 var auditCmd = &cobra.Command{
@@ -49,16 +50,18 @@ func init() {
 	auditListCmd.Flags().StringVarP(&auditListNamespace, "namespace", "n", "", "Namespace scope (optional)")
 	auditListCmd.Flags().StringVar(&auditListFormat, "format", "ascii", "Output format: ascii, json, md")
 	auditListCmd.Flags().StringVar(&auditListSince, "since", "7d", "Lookback window (examples: 24h, 7d, 2w)")
+	auditListCmd.Flags().BoolVar(&auditListIncludeSynthetic, "include-synthetic", false, "Include synthetic/demo seeded ChangeSets")
 	auditListCmd.Flags().Bool("json", false, "Output as JSON (shorthand for --format json)")
 }
 
 var errAuditDisconnected = errors.New("audit requires ConfigHub connection. Run: cub auth login")
 
 type auditListQuery struct {
-	Namespace string
-	Since     string
-	Window    time.Duration
-	Now       time.Time
+	Namespace        string
+	Since            string
+	Window           time.Duration
+	Now              time.Time
+	IncludeSynthetic bool
 }
 
 type auditEntry struct {
@@ -102,10 +105,11 @@ func runAuditList(cmd *cobra.Command, args []string) error {
 	}
 
 	query := auditListQuery{
-		Namespace: strings.TrimSpace(auditListNamespace),
-		Since:     strings.TrimSpace(auditListSince),
-		Window:    window,
-		Now:       auditNowFn().UTC(),
+		Namespace:        strings.TrimSpace(auditListNamespace),
+		Since:            strings.TrimSpace(auditListSince),
+		Window:           window,
+		Now:              auditNowFn().UTC(),
+		IncludeSynthetic: auditListIncludeSynthetic,
 	}
 
 	entries, err := resolveAuditEntries(cmd.Context(), query)
@@ -139,7 +143,7 @@ func resolveAuditEntries(ctx context.Context, q auditListQuery) ([]auditEntry, e
 		if err != nil {
 			return nil, fmt.Errorf("read audit fixture %q: %w", fixture, err)
 		}
-		entries, err := buildAuditEntriesFromChangeSets(string(raw), q.Namespace, q.Now.Add(-q.Window))
+		entries, err := buildAuditEntriesFromChangeSetsWithOptions(string(raw), q.Namespace, q.Now.Add(-q.Window), q.IncludeSynthetic)
 		if err != nil {
 			return nil, fmt.Errorf("parse audit fixture %q: %w", fixture, err)
 		}
@@ -174,10 +178,14 @@ func fetchAuditEntries(ctx context.Context, q auditListQuery) ([]auditEntry, err
 		return nil, fmt.Errorf("fetch break-glass audit history: %w", err)
 	}
 
-	return buildAuditEntriesFromChangeSets(raw, q.Namespace, q.Now.Add(-q.Window))
+	return buildAuditEntriesFromChangeSetsWithOptions(raw, q.Namespace, q.Now.Add(-q.Window), q.IncludeSynthetic)
 }
 
 func buildAuditEntriesFromChangeSets(raw, namespace string, cutoff time.Time) ([]auditEntry, error) {
+	return buildAuditEntriesFromChangeSetsWithOptions(raw, namespace, cutoff, false)
+}
+
+func buildAuditEntriesFromChangeSetsWithOptions(raw, namespace string, cutoff time.Time, includeSynthetic bool) ([]auditEntry, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" || raw == "null" {
 		return nil, nil
@@ -192,6 +200,9 @@ func buildAuditEntriesFromChangeSets(raw, namespace string, cutoff time.Time) ([
 	items := historyExtractItems(payload)
 	entries := make([]auditEntry, 0, len(items))
 	for _, item := range items {
+		if !includeSynthetic && isSyntheticChangeSet(item) {
+			continue
+		}
 		ts, ok := historyExtractTime(item, "CreatedAt", "createdAt", "Timestamp", "timestamp", "UpdatedAt", "updatedAt")
 		if !ok {
 			continue

--- a/cmd/cub-scout/audit_test.go
+++ b/cmd/cub-scout/audit_test.go
@@ -77,6 +77,65 @@ func TestBuildAuditEntriesFromChangeSets_FiltersAndSorts(t *testing.T) {
 	}
 }
 
+func TestBuildAuditEntriesFromChangeSets_ExcludesSyntheticByDefault(t *testing.T) {
+	cutoff := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	raw := `[
+	  {
+	    "Slug": "CS-REAL-1",
+	    "CreatedAt": "2026-03-06T10:00:00Z",
+	    "Description": "break-glass accept: real",
+	    "CreatedBy": "sre",
+	    "Labels": {"break-glass":"true"}
+	  },
+	  {
+	    "Slug": "CS-DEMO-1",
+	    "CreatedAt": "2026-03-06T11:00:00Z",
+	    "Description": "break-glass accept: demo seed",
+	    "CreatedBy": "demo-bot",
+	    "Labels": {"break-glass":"true", "synthetic":"true"}
+	  }
+	]`
+
+	got, err := buildAuditEntriesFromChangeSets(raw, "", cutoff)
+	if err != nil {
+		t.Fatalf("buildAuditEntriesFromChangeSets() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(got))
+	}
+	if got[0].ChangeSet != "CS-REAL-1" {
+		t.Fatalf("changeset = %q, want CS-REAL-1", got[0].ChangeSet)
+	}
+}
+
+func TestBuildAuditEntriesFromChangeSetsWithOptions_IncludesSynthetic(t *testing.T) {
+	cutoff := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	raw := `[
+	  {
+	    "Slug": "CS-REAL-1",
+	    "CreatedAt": "2026-03-06T10:00:00Z",
+	    "Description": "break-glass accept: real",
+	    "CreatedBy": "sre",
+	    "Labels": {"break-glass":"true"}
+	  },
+	  {
+	    "Slug": "CS-DEMO-1",
+	    "CreatedAt": "2026-03-06T11:00:00Z",
+	    "Description": "break-glass accept: demo seed",
+	    "CreatedBy": "demo-bot",
+	    "Labels": {"break-glass":"true", "source":"cub-scout-demo-seed"}
+	  }
+	]`
+
+	got, err := buildAuditEntriesFromChangeSetsWithOptions(raw, "", cutoff, true)
+	if err != nil {
+		t.Fatalf("buildAuditEntriesFromChangeSetsWithOptions() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(got))
+	}
+}
+
 func TestRenderAuditASCII_Empty(t *testing.T) {
 	out := renderAuditASCII(auditListResult{Since: "7d", Namespace: "prod"})
 	if !strings.Contains(out, "No break-glass decisions") {
@@ -154,12 +213,15 @@ func withAuditListFlagsForTest() func() {
 	prevFormat := auditListFormat
 	prevNamespace := auditListNamespace
 	prevSince := auditListSince
+	prevIncludeSynthetic := auditListIncludeSynthetic
 	auditListFormat = "ascii"
 	auditListNamespace = ""
 	auditListSince = "7d"
+	auditListIncludeSynthetic = false
 	return func() {
 		auditListFormat = prevFormat
 		auditListNamespace = prevNamespace
 		auditListSince = prevSince
+		auditListIncludeSynthetic = prevIncludeSynthetic
 	}
 }

--- a/cmd/cub-scout/history.go
+++ b/cmd/cub-scout/history.go
@@ -21,9 +21,10 @@ import (
 )
 
 var (
-	historyNamespace string
-	historyFormat    string
-	historySince     string
+	historyNamespace        string
+	historyFormat           string
+	historySince            string
+	historyIncludeSynthetic bool
 )
 
 var historyCmd = &cobra.Command{
@@ -45,16 +46,18 @@ func init() {
 	historyCmd.Flags().StringVarP(&historyNamespace, "namespace", "n", "", "Namespace scope (optional)")
 	historyCmd.Flags().StringVar(&historyFormat, "format", "ascii", "Output format: ascii, json, md")
 	historyCmd.Flags().StringVar(&historySince, "since", "7d", "Lookback window (examples: 24h, 7d, 2w)")
+	historyCmd.Flags().BoolVar(&historyIncludeSynthetic, "include-synthetic", false, "Include synthetic/demo seeded ChangeSets")
 }
 
 var errHistoryDisconnected = errors.New("history requires ConfigHub connection. Run: cub auth login")
 
 type historyQuery struct {
-	Resource  string
-	Namespace string
-	Since     string
-	Window    time.Duration
-	Now       time.Time
+	Resource         string
+	Namespace        string
+	Since            string
+	Window           time.Duration
+	Now              time.Time
+	IncludeSynthetic bool
 }
 
 type historyEntry struct {
@@ -90,11 +93,12 @@ func runHistory(cmd *cobra.Command, args []string) error {
 	}
 
 	query := historyQuery{
-		Resource:  strings.TrimSpace(args[0]),
-		Namespace: strings.TrimSpace(historyNamespace),
-		Since:     strings.TrimSpace(historySince),
-		Window:    window,
-		Now:       historyNowFn().UTC(),
+		Resource:         strings.TrimSpace(args[0]),
+		Namespace:        strings.TrimSpace(historyNamespace),
+		Since:            strings.TrimSpace(historySince),
+		Window:           window,
+		Now:              historyNowFn().UTC(),
+		IncludeSynthetic: historyIncludeSynthetic,
 	}
 
 	entries, err := resolveHistoryEntries(cmd.Context(), query)
@@ -129,7 +133,7 @@ func resolveHistoryEntries(ctx context.Context, q historyQuery) ([]historyEntry,
 		if err != nil {
 			return nil, fmt.Errorf("read history fixture %q: %w", fixture, err)
 		}
-		entries, err := buildHistoryEntriesFromChangeSets(string(raw), q.Now.Add(-q.Window))
+		entries, err := buildHistoryEntriesFromChangeSetsWithOptions(string(raw), q.Now.Add(-q.Window), q.IncludeSynthetic)
 		if err != nil {
 			return nil, fmt.Errorf("parse history fixture %q: %w", fixture, err)
 		}
@@ -201,7 +205,7 @@ func fetchHistoryEntries(ctx context.Context, q historyQuery) ([]historyEntry, e
 	}
 
 	cutoff := q.Now.Add(-q.Window)
-	entries, err := buildHistoryEntriesFromChangeSets(raw, cutoff)
+	entries, err := buildHistoryEntriesFromChangeSetsWithOptions(raw, cutoff, q.IncludeSynthetic)
 	if err != nil {
 		return nil, err
 	}
@@ -235,6 +239,10 @@ func runHistoryCubCommandImpl(ctx context.Context, args []string) (string, error
 }
 
 func buildHistoryEntriesFromChangeSets(raw string, cutoff time.Time) ([]historyEntry, error) {
+	return buildHistoryEntriesFromChangeSetsWithOptions(raw, cutoff, false)
+}
+
+func buildHistoryEntriesFromChangeSetsWithOptions(raw string, cutoff time.Time, includeSynthetic bool) ([]historyEntry, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" || raw == "null" {
 		return nil, nil
@@ -248,6 +256,9 @@ func buildHistoryEntriesFromChangeSets(raw string, cutoff time.Time) ([]historyE
 	items := historyExtractItems(payload)
 	entries := make([]historyEntry, 0, len(items))
 	for _, item := range items {
+		if !includeSynthetic && isSyntheticChangeSet(item) {
+			continue
+		}
 		ts, ok := historyExtractTime(item, "CreatedAt", "createdAt", "Timestamp", "timestamp", "UpdatedAt", "updatedAt")
 		if !ok {
 			continue

--- a/cmd/cub-scout/history_test.go
+++ b/cmd/cub-scout/history_test.go
@@ -98,6 +98,63 @@ func TestBuildHistoryEntriesFromChangeSets_FiltersAndSorts(t *testing.T) {
 	}
 }
 
+func TestBuildHistoryEntriesFromChangeSets_ExcludesSyntheticByDefault(t *testing.T) {
+	cutoff := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	raw := `[
+	  {
+	    "Slug": "CS-REAL-1",
+	    "CreatedAt": "2026-03-06T10:00:00Z",
+	    "Description": "real rollout",
+	    "CreatedBy": "release-bot"
+	  },
+	  {
+	    "Slug": "CS-DEMO-1",
+	    "CreatedAt": "2026-03-06T11:00:00Z",
+	    "Description": "demo seed",
+	    "CreatedBy": "demo-bot",
+	    "Labels": {"synthetic":"true", "source":"cub-scout-demo-seed"}
+	  }
+	]`
+
+	got, err := buildHistoryEntriesFromChangeSets(raw, cutoff)
+	if err != nil {
+		t.Fatalf("buildHistoryEntriesFromChangeSets() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(got))
+	}
+	if got[0].ChangeSet != "CS-REAL-1" {
+		t.Fatalf("changeset = %q, want CS-REAL-1", got[0].ChangeSet)
+	}
+}
+
+func TestBuildHistoryEntriesFromChangeSetsWithOptions_IncludesSynthetic(t *testing.T) {
+	cutoff := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	raw := `[
+	  {
+	    "Slug": "CS-REAL-1",
+	    "CreatedAt": "2026-03-06T10:00:00Z",
+	    "Description": "real rollout",
+	    "CreatedBy": "release-bot"
+	  },
+	  {
+	    "Slug": "CS-DEMO-1",
+	    "CreatedAt": "2026-03-06T11:00:00Z",
+	    "Description": "demo seed",
+	    "CreatedBy": "demo-bot",
+	    "Labels": {"demo":"true"}
+	  }
+	]`
+
+	got, err := buildHistoryEntriesFromChangeSetsWithOptions(raw, cutoff, true)
+	if err != nil {
+		t.Fatalf("buildHistoryEntriesFromChangeSetsWithOptions() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(got))
+	}
+}
+
 func TestRenderHistoryASCII_Empty(t *testing.T) {
 	out := renderHistoryASCII(historyResult{
 		Resource:  "deploy/my-app",
@@ -184,13 +241,16 @@ func withHistoryFlagsForTest() func() {
 	prevFormat := historyFormat
 	prevNamespace := historyNamespace
 	prevSince := historySince
+	prevIncludeSynthetic := historyIncludeSynthetic
 	historyFormat = "ascii"
 	historyNamespace = ""
 	historySince = "7d"
+	historyIncludeSynthetic = false
 	return func() {
 		historyFormat = prevFormat
 		historyNamespace = prevNamespace
 		historySince = prevSince
+		historyIncludeSynthetic = prevIncludeSynthetic
 	}
 }
 

--- a/cmd/cub-scout/synthetic_changesets.go
+++ b/cmd/cub-scout/synthetic_changesets.go
@@ -1,0 +1,61 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func isSyntheticChangeSet(item map[string]interface{}) bool {
+	for _, kv := range syntheticMetadataMaps(item) {
+		for rawKey, rawVal := range kv {
+			key := strings.ToLower(strings.TrimSpace(rawKey))
+			val := strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", rawVal)))
+
+			switch key {
+			case "synthetic", "demo":
+				if isTruthyValue(val) {
+					return true
+				}
+			case "source":
+				if val == "cub-scout-demo-seed" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func syntheticMetadataMaps(item map[string]interface{}) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, 8)
+
+	appendMaps := func(container map[string]interface{}) {
+		for _, key := range []string{"Labels", "labels", "Annotations", "annotations"} {
+			if m, ok := container[key].(map[string]interface{}); ok && m != nil {
+				out = append(out, m)
+			}
+		}
+	}
+
+	appendMaps(item)
+	if meta, ok := item["Metadata"].(map[string]interface{}); ok && meta != nil {
+		appendMaps(meta)
+	}
+	if meta, ok := item["metadata"].(map[string]interface{}); ok && meta != nil {
+		appendMaps(meta)
+	}
+
+	return out
+}
+
+func isTruthyValue(val string) bool {
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "true", "1", "yes", "y":
+		return true
+	default:
+		return false
+	}
+}

--- a/docs/reference/command-matrix.md
+++ b/docs/reference/command-matrix.md
@@ -223,6 +223,7 @@ Complete reference of all commands, options, TUI keys, and availability.
 | `-n, --namespace` | Namespace scope (optional) |
 | `--since` | Lookback window (`24h`, `7d`, `2w`) |
 | `--format` | Output format (`ascii`, `json`, `md`) |
+| `--include-synthetic` | Include synthetic/demo seeded ChangeSets |
 | `--json` | Output as JSON |
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1129,6 +1129,7 @@ cub-scout history <resource> [flags]
 | `-n, --namespace` | Optional namespace scope |
 | `--since` | Lookback window (examples: `24h`, `7d`, `2w`) |
 | `--format` | Output format: `ascii`, `json`, `md` |
+| `--include-synthetic` | Include synthetic/demo seeded ChangeSets |
 
 ### Examples
 
@@ -1141,12 +1142,16 @@ cub-scout history deploy/my-app -n prod --since 24h --format json
 
 # Markdown timeline for tickets/PRs
 cub-scout history deploy/my-app --since 2w --format md
+
+# Include synthetic/demo seeded records when needed
+cub-scout history deploy/my-app -n prod --include-synthetic
 ```
 
 ### Connected Mode Notes
 
 - Requires ConfigHub authentication (`cub auth login`).
 - Uses read-only ChangeSet queries under the hood.
+- Synthetic/demo seeded ChangeSets are excluded by default; use `--include-synthetic` to include them.
 - If no history is found, output clearly notes the resource may not be imported yet.
 
 ---
@@ -1166,6 +1171,7 @@ cub-scout audit list [flags]
 | `-n, --namespace` | Optional namespace scope |
 | `--since` | Lookback window (examples: `24h`, `7d`, `2w`) |
 | `--format` | Output format: `ascii`, `json`, `md` |
+| `--include-synthetic` | Include synthetic/demo seeded ChangeSets |
 | `--json` | Output as JSON (shorthand for `--format json`) |
 
 ### Examples
@@ -1179,12 +1185,16 @@ cub-scout audit list -n prod --since 7d
 
 # Export machine-readable output
 cub-scout audit list --format json
+
+# Include synthetic/demo seeded break-glass entries
+cub-scout audit list --include-synthetic
 ```
 
 ### Connected Mode Notes
 
 - Requires ConfigHub authentication (`cub auth login`).
 - Uses read-only ChangeSet queries filtered to break-glass records.
+- Synthetic/demo seeded ChangeSets are excluded by default; use `--include-synthetic` to include them.
 - If no records are found, output reports: `No break-glass decisions recorded for this scope`.
 
 ---

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -52,6 +52,7 @@ Safety contract:
   - `demo=true`
   - `synthetic=true`
   - `source=cub-scout-demo-seed`
+- `cub-scout history` / `cub-scout audit list` exclude these by default; use `--include-synthetic` to view them.
 - Never run against production spaces.
 
 ## k9s Plugin


### PR DESCRIPTION
## Summary
Makes history/audit operational views real-data-first by default: synthetic/demo seeded ChangeSets are excluded unless explicitly requested.

## Changes
- Added synthetic marker detection helper (`cmd/cub-scout/synthetic_changesets.go`):
  - `synthetic=true`
  - `demo=true`
  - `source=cub-scout-demo-seed`
- Updated `history` command:
  - New flag: `--include-synthetic`
  - Default excludes synthetic/demo seeded entries
  - Option path supports explicit inclusion
- Updated `audit list` command:
  - New flag: `--include-synthetic`
  - Same default exclusion / optional inclusion behavior
- Added deterministic tests in:
  - `cmd/cub-scout/history_test.go`
  - `cmd/cub-scout/audit_test.go`
- Updated docs:
  - `docs/reference/commands.md`
  - `docs/reference/command-matrix.md`
  - `examples/scripts/README.md`

## Why
Synthetic demo history is useful for storytelling but can confuse operational tooling. Defaulting to real-data-first avoids ambiguity while preserving explicit demo workflows.

## Review-by-Evidence

### What changed (1-3 bullets)
- Default history/audit output now excludes synthetic/demo seeded records.
- New `--include-synthetic` flag restores inclusive behavior when needed.
- Marker detection is deterministic and tolerant of payload key casing/shape.

### Why (1 bullet)
- Prevents fake/demo data from polluting operational history/audit interpretation.

### Tests added/updated
- `cmd/cub-scout/history_test.go`
- `cmd/cub-scout/audit_test.go`

### Golden diffs?
- [x] No golden file changes
- [ ] Yes - golden files changed (see below)

### Cluster proof required?
- [x] Not required (parser/output contract change fully covered by deterministic unit + baseline)
- [ ] Yes - cluster proof provided (see below)

### Risk assessment
**Could this create false certainty (false ownership claims, misleading health status)?**
- [x] No - reduces ambiguity in audit/history outputs
- [x] No - covered by tests and explicit opt-in flag behavior
- [ ] Potential risk - mitigated by: [explain]

## Checklist
- [x] CI passes
- [x] No false ownership/health claims introduced
- [x] Documentation updated if needed
- [x] Review-by-evidence section complete

Proof artifacts: `/tmp/cub-scout-regression/v1.7/313/`

Closes #313
