### PR TITLE
fix: stabilize full-test attribution replay + debug bundle e2e

### DIFF
--- a/cmd/cub-scout/debug.go
+++ b/cmd/cub-scout/debug.go
@@ -77,7 +77,7 @@ func runDebug(cmd *cobra.Command, args []string) error {
 
 	// TEST HOOK: Load debug session from JSON file for testing
 	if debugJSON := os.Getenv("CUB_SCOUT_TEST_DEBUG_JSON"); debugJSON != "" {
-		return loadAndRenderDebugFromJSON(debugJSON)
+		return loadAndRenderDebugFromJSON(ctx, debugJSON)
 	}
 
 	// If resource provided, run non-interactive analysis
@@ -213,8 +213,10 @@ func normalizeDebugKind(kind string) string {
 	}
 }
 
-// loadAndRenderDebugFromJSON loads a debug session from JSON for testing
-func loadAndRenderDebugFromJSON(path string) error {
+// loadAndRenderDebugFromJSON loads a debug session from JSON for testing.
+// It still applies --save-bundle behavior so fixture-driven execution matches
+// non-test code paths.
+func loadAndRenderDebugFromJSON(ctx context.Context, path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read debug JSON: %w", err)
@@ -223,6 +225,13 @@ func loadAndRenderDebugFromJSON(path string) error {
 	var session DebugSession
 	if err := json.Unmarshal(data, &session); err != nil {
 		return fmt.Errorf("failed to parse debug JSON: %w", err)
+	}
+
+	// Preserve --save-bundle behavior in test-hook mode.
+	if debugSaveBundleDir != "" {
+		if err := saveDebugBundle(ctx, nil, &session, debugSaveBundleDir); err != nil {
+			return fmt.Errorf("failed to save bundle: %w", err)
+		}
 	}
 
 	// Render based on format

--- a/cmd/cub-scout/debug_test.go
+++ b/cmd/cub-scout/debug_test.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -300,5 +302,59 @@ func TestSaveDebugBundle_WithAttribution(t *testing.T) {
 	}
 	if len(graph.Edges) != 1 {
 		t.Errorf("Edges count = %d, want 1", len(graph.Edges))
+	}
+}
+
+func TestLoadAndRenderDebugFromJSON_SaveBundle(t *testing.T) {
+	tmpDir := t.TempDir()
+	fixturePath := filepath.Join(tmpDir, "debug.json")
+	session := DebugSession{
+		Target: ResourceRef{
+			Kind:      "Deployment",
+			Name:      "api-server",
+			Namespace: "production",
+		},
+		StartedAt:   time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+		CompletedAt: time.Date(2026, 3, 7, 12, 1, 0, 0, time.UTC),
+	}
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, data, 0644); err != nil {
+		t.Fatalf("Write fixture failed: %v", err)
+	}
+
+	oldFormat := debugFormat
+	oldSaveDir := debugSaveBundleDir
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe failed: %v", err)
+	}
+	defer func() {
+		debugFormat = oldFormat
+		debugSaveBundleDir = oldSaveDir
+		os.Stdout = oldStdout
+		_ = r.Close()
+	}()
+
+	debugFormat = "json"
+	debugSaveBundleDir = filepath.Join(tmpDir, "bundles")
+	os.Stdout = w
+
+	err = loadAndRenderDebugFromJSON(context.Background(), fixturePath)
+	_ = w.Close()
+	_, _ = io.Copy(io.Discard, r)
+	if err != nil {
+		t.Fatalf("loadAndRenderDebugFromJSON failed: %v", err)
+	}
+
+	bundleDir := filepath.Join(debugSaveBundleDir, generateBundleDirName(session.Target))
+	if _, err := os.Stat(filepath.Join(bundleDir, "metadata.json")); err != nil {
+		t.Fatalf("expected metadata.json in saved bundle: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(bundleDir, "session.json")); err != nil {
+		t.Fatalf("expected session.json in saved bundle: %v", err)
 	}
 }

--- a/docs/releases/v1.7.0.md
+++ b/docs/releases/v1.7.0.md
@@ -73,9 +73,7 @@ Release verification in this cut:
 - targeted kro + meaning + map/tree/trace tests
 - shell syntax validation across `examples/**/*.sh`
 - import delegation validation script
-
-Note:
-- `scripts/full-test.sh` currently fails in its determinism step due to a pre-existing fixture path mismatch in the script (`bundle replay` expects a bundle directory but receives a fixture JSON path).
+- `./scripts/full-test.sh` (unit, race, determinism, fixture E2E)
 
 ---
 

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -52,7 +52,8 @@ pass "Build succeeded"
 
 # 2) Unit tests
 info "Running unit tests..."
-go test ./... || fail "Unit tests failed"
+GO_TEST_PARALLELISM="${GO_TEST_PARALLELISM:-4}"
+go test -p "$GO_TEST_PARALLELISM" ./... || fail "Unit tests failed"
 pass "Unit tests passed"
 
 # 3) Race detection
@@ -65,13 +66,13 @@ info "Running determinism tests..."
 TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" EXIT
 
-# Create a test bundle using fixtures
-export CUB_SCOUT_TEST_TARGET_OBJECT="$ROOT_DIR/test/fixtures/crossplane/managed_with_composite_label.json"
+# Use a fixture bundle that includes attribution.json
+ATTR_BUNDLE_FIXTURE="$ROOT_DIR/test/fixtures/attribution/bundle-with-attribution"
 
 # Test attribution graph determinism
 info "  Testing attribution graph determinism..."
 for i in 1 2 3; do
-  ./cub-scout bundle replay "$ROOT_DIR/test/fixtures/crossplane/managed_with_composite_label.json" \
+  ./cub-scout bundle replay "$ATTR_BUNDLE_FIXTURE" \
     --section attribution --format json > "$TMPDIR/attr-$i.json" || fail "Attribution replay failed (run $i)"
 done
 

--- a/test/fixtures/attribution/bundle-with-attribution/attribution.json
+++ b/test/fixtures/attribution/bundle-with-attribution/attribution.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "attribution-graph.v1",
+  "generated_from": {
+    "bundle_id": "fixture-attribution-bundle",
+    "created_at": "2026-03-07T00:00:00Z",
+    "tool_version": "v1.7.0-test"
+  },
+  "nodes": [
+    {
+      "id": "mr:uid:11111111-1111-1111-1111-111111111111",
+      "type": "mr",
+      "ref": {
+        "apiVersion": "s3.aws.upbound.io/v1beta1",
+        "kind": "Bucket",
+        "name": "db-storage",
+        "uid": "11111111-1111-1111-1111-111111111111"
+      },
+      "present": true
+    },
+    {
+      "id": "xr:uid:22222222-2222-2222-2222-222222222222",
+      "type": "xr",
+      "ref": {
+        "apiVersion": "storage.example.io/v1alpha1",
+        "kind": "XBucket",
+        "name": "xbucket-prod",
+        "uid": "22222222-2222-2222-2222-222222222222"
+      },
+      "present": true
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge:fixture00000001",
+      "type": "owns",
+      "from": "xr:uid:22222222-2222-2222-2222-222222222222",
+      "to": "mr:uid:11111111-1111-1111-1111-111111111111",
+      "evidence": "owner_reference"
+    }
+  ],
+  "summary": {
+    "nodes_by_type": {
+      "mr": 1,
+      "xr": 1
+    },
+    "edges_by_type": {
+      "owns": 1
+    },
+    "unattributed_count": 0,
+    "ambiguous_count": 0
+  }
+}

--- a/test/fixtures/attribution/bundle-with-attribution/metadata.json
+++ b/test/fixtures/attribution/bundle-with-attribution/metadata.json
@@ -1,0 +1,16 @@
+{
+  "formatVersion": "v1",
+  "cubScoutVersion": "v1.7.0-test",
+  "createdAt": "2026-03-07T00:00:00Z",
+  "target": {
+    "kind": "Bucket",
+    "name": "db-storage"
+  },
+  "contents": {
+    "hasSession": false,
+    "hasDrift": false,
+    "hasEvents": false,
+    "hasLogs": false,
+    "hasAttribution": true
+  }
+}


### PR DESCRIPTION
## Summary
- fix determinism stage in scripts/full-test.sh to replay from a real bundle fixture containing attribution
- add a committed attribution fixture bundle under test/fixtures/attribution/bundle-with-attribution
- preserve --save-bundle behavior when using CUB_SCOUT_TEST_DEBUG_JSON test hook
- add regression test for test-hook + save-bundle path
- harden full-test.sh unit phase with bounded package parallelism to avoid runner-kill flakes
- update v1.7.0 release notes verification block to reflect current behavior

## Verification
- go test ./cmd/cub-scout -run "TestLoadAndRenderDebugFromJSON_SaveBundle|TestSaveDebugBundle_Integration|TestSaveDebugBundle_WithAttribution" -count=1
- ./scripts/full-test.sh
