### PR TITLE
docs: improve 1.x discoverability and add complete A-Z CLI reference

### DIFF
--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -2,6 +2,10 @@
 
 Complete reference for all commands, options, TUI keys, and expected outputs.
 
+Need a fast alphabetical index first?
+- [Complete CLI Reference (A-Z)](docs/reference/cli-reference.md)
+- [Start Here by user goal](docs/getting-started/start-here.md)
+
 ---
 
 ## Top-Level Commands

--- a/README.md
+++ b/README.md
@@ -8,19 +8,53 @@ Please send feedback by [opening an issue](https://github.com/confighub/cub-scou
 
 ---
 
-## Getting Value Fast
+## Fast Path (2 Minutes)
 
 ```bash
 brew install confighub/tap/cub-scout
 cub-scout quickstart             # Guided first-run tour of your current cluster
+cub-scout doctor                 # One-command health summary
+cub-scout explain deploy/app -n ns
 cub-scout map                    # Interactive TUI — explore your cluster
 cub-scout map list --json | jq   # JSON output — pipe to your tools
-cub-scout tree ownership         # See resources grouped by GitOps owner
-cub-scout trace deploy/app -n ns # Trace any resource to its Git source
-cub-scout scan                   # Find misconfigurations (46 patterns)
-cub-scout import --dry-run -n ns # Preview ConfigHub import (connected)
-kubectl cub-scout map status     # Same command surface via kubectl plugin
 ```
+
+### Pick Your Goal
+
+**Standalone value now**
+
+```bash
+cub-scout quickstart --yes
+cub-scout doctor
+cub-scout trace deploy/app -n ns
+cub-scout scan
+```
+
+**Connected value now**
+
+```bash
+cub auth login
+cub-scout compare three-way --scope namespace/prod
+cub-scout history deploy/app -n prod
+cub-scout impact shared-db-config
+```
+
+**AI and automation**
+
+```bash
+cub-scout mcp serve
+cub-scout context-pack --format json --max-bytes 16384
+cub-scout summary list --since 24h --json
+cub-scout watch --output-file /tmp/cub-scout-events.jsonl --once
+```
+
+### Find Commands Fast
+
+- [Start Here by user goal](docs/getting-started/start-here.md)
+- [Complete CLI Reference (A-Z)](docs/reference/cli-reference.md)
+- [Command Reference (examples + usage)](docs/reference/commands.md)
+- [CLI Contract Reference (stable schema/flags)](docs/reference/cli-contract.md)
+- [Examples Index](examples/README.md)
 
 ## Install Channels
 
@@ -111,7 +145,7 @@ Need contract docs for automation?
 
 cub-scout works fully offline. Connected mode is optional.
 
-> **Release scope:** v1.0 focuses on standalone use cases — cluster exploration, ownership detection, tracing, and scanning with no external dependencies. The 1.x series will progressively add connected use cases for [ConfigHub](https://confighub.com) (import, fleet queries, history, and policy context).
+> **Release scope:** v1.0 established the standalone contract surface. The v1.x line now also ships connected use cases for [ConfigHub](https://confighub.com) including import, history/audit, comparison, fleet insight, and summary workflows.
 
 | Feature | Standalone | Connected |
 |---------|:----------:|:---------:|

--- a/docs/getting-started/start-here.md
+++ b/docs/getting-started/start-here.md
@@ -1,0 +1,87 @@
+# Start Here
+
+Fast routing guide for new and returning `cub-scout` users.
+
+If you just want the command index, use:
+- [Complete CLI Reference (A-Z)](../reference/cli-reference.md)
+- [Command Reference](../reference/commands.md)
+
+---
+
+## 1) First-Time User (Standalone, no account required)
+
+Run:
+
+```bash
+brew install confighub/tap/cub-scout
+cub-scout quickstart --yes
+cub-scout doctor
+cub-scout explain deploy/<name> -n <namespace>
+cub-scout map
+```
+
+Then:
+- [First Map](first-map.md)
+- [Ownership Detection](../howto/ownership-detection.md)
+- [Trace Ownership](../howto/trace-ownership.md)
+- [New User Puzzle Quest](../../examples/new-user-puzzle-quest/)
+
+---
+
+## 2) Connected Value (ConfigHub context)
+
+Run:
+
+```bash
+cub auth login
+cub-scout compare three-way --scope namespace/<namespace>
+cub-scout history deploy/<name> -n <namespace>
+cub-scout impact <unit>
+cub-scout fleet outliers
+cub-scout audit list --since 7d
+```
+
+Then:
+- [Canonical Import Path](../howto/import-to-confighub.md)
+- [Migration Playbook](../howto/migration-playbook.md)
+- [Connect and Compare Demo](../../examples/connect-and-compare/)
+
+---
+
+## 3) AI Tooling Path (Read-only gateway)
+
+Run:
+
+```bash
+cub-scout mcp serve
+cub-scout context-pack --format json --max-bytes 16384
+./scripts/ask-mode-contract.sh --mode auto --command "./cub-scout import -n payments --dry-run"
+```
+
+Then:
+- [Using cub-scout from an AI Tool](../howto/using-cub-scout-from-ai-tool.md)
+- [Context-Pack v2](../howto/context-pack-v2.md)
+- [AI Ask-Mode Contract](../howto/ai-ask-mode-contract.md)
+- [MCP Gateway Example](../../examples/mcp-gateway/)
+- [AI Integration Examples](../../examples/ai-integration/)
+
+---
+
+## 4) Platform-Scale Features (v1.7 line)
+
+Run:
+
+```bash
+cub-scout tree composition
+cub-scout map meaning
+cub-scout summary list --since 24h
+cub-scout summary slack --dry-run --since 24h
+cub-scout watch --output-file /tmp/cub-scout-events.jsonl --once
+```
+
+Then:
+- [kro Composition Example](../../examples/kro-composition/)
+- [Connected Summary Storage Example](../../examples/connected-summary-storage/)
+- [Watch Webhook Example](../../examples/watch-webhook/)
+- [Extending cub-scout](../howto/extending.md)
+

--- a/docs/howto/extending.md
+++ b/docs/howto/extending.md
@@ -236,165 +236,105 @@ watcher.RegisterResource(watcher.ResourceConfig{
 
 ---
 
-## 4. Webhooks (Planned)
+## 4. Webhooks (Available)
 
-> **Not Yet Implemented:** This feature is planned for a future release.
+Receive read-only observation events from `cub-scout` using `watch`.
 
-Receive real-time events from the Agent.
+### Command Surface
 
-### Configuration
-
-```yaml
-# config/webhooks.yaml
-webhooks:
-  - name: slack-alerts
-    url: https://hooks.slack.com/services/xxx
-    events:
-      - finding.created
-      - finding.resolved
-    filter:
-      severity: [critical, warning]
-
-  - name: custom-system
-    url: https://my-system.internal/webhook
-    events:
-      - entry.created
-      - entry.updated
-      - entry.deleted
-      - drift.detected
-      - drift.resolved
-    headers:
-      Authorization: Bearer ${WEBHOOK_TOKEN}
-    retry:
-      maxAttempts: 3
-      backoffSeconds: [1, 5, 30]
+```bash
+cub-scout watch --webhook <url> [flags]
 ```
+
+At least one destination is required:
+- `--webhook <url>`
+- and/or `--output-file <path>`
 
 ### Event Types
 
-| Event | Payload |
-|-------|---------|
-| `entry.created` | GSFEntry |
-| `entry.updated` | GSFEntry (before/after) |
-| `entry.deleted` | GSFEntry |
-| `drift.detected` | GSFEntry with drift |
-| `drift.resolved` | GSFEntry |
-| `finding.created` | GSFFinding |
-| `finding.resolved` | GSFFinding |
-| `relation.created` | GSFRelation |
-| `relation.deleted` | GSFRelation |
+| Event Type | Description |
+|------------|-------------|
+| `resource.discovered` | New or changed resource discovered |
+| `ownership.changed` | Ownership classification changed |
+| `drift.detected` | Drift signal detected |
+| `scan.finding` | Risk/issue finding emitted |
 
-### Webhook Payload
+### Event Payload (JSON)
 
 ```json
 {
-  "event": "finding.created",
-  "timestamp": "2025-01-02T18:30:00Z",
-  "cluster": "prod-east",
-  "data": {
-    "id": "RISK-2025-0027",
-    "severity": "critical",
-    "resource": "prod-east/monitoring/ConfigMap/grafana-sidecar",
-    "message": "Namespace whitespace in sidecar config"
+  "type": "scan.finding",
+  "timestamp": "2026-03-07T17:00:00Z",
+  "resource": {
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod"
+  },
+  "owner": {
+    "type": "Flux",
+    "name": "frontend-app"
+  },
+  "severity": "warning",
+  "details": {
+    "category": "STATE",
+    "message": "out of sync"
   }
 }
 ```
 
-### Using Webhooks
+### Usage Examples
 
-When implemented, webhooks will be configured via a YAML file.
+```bash
+# One deterministic collection cycle
+cub-scout watch --webhook http://127.0.0.1:8787/events --once
+
+# Continuous stream with filters
+cub-scout watch --webhook https://hooks.example.com/cub-scout --interval 30s --namespace prod --severity warning,critical
+
+# File sink only (JSONL)
+cub-scout watch --output-file /tmp/cub-scout-events.jsonl --once
+```
+
+See `docs/reference/commands.md` (`watch`) and `examples/watch-webhook/`.
 
 ---
 
-## 5. Output Plugins (Planned)
+## 5. Output Destinations (Current + Future)
 
-> **Not Yet Implemented:** This feature is planned for a future release.
+Current output and sink options are command-specific and deterministic.
 
-Send GSF output to custom destinations.
+### Available Today
 
-### Built-in Outputs
+| Surface | Output/Sink | Command |
+|---------|-------------|---------|
+| Core command output | `ascii`, `json`, `md` | Most commands (`--format`) |
+| Watch stream to webhook | HTTP POST events | `cub-scout watch --webhook ...` |
+| Watch stream to file | JSONL file sink | `cub-scout watch --output-file ...` |
+| Connected summary digest | Slack webhook | `cub-scout summary slack --webhook-url ...` |
 
-| Output | Flag | Description |
-|--------|------|-------------|
-| stdout | `--output=json` | JSON to stdout |
-| stdout | `--output=jsonl` | JSON Lines to stdout |
-| ConfigHub | `--output=confighub` | Stream to ConfigHub API |
-| File | `--output=file:./out.json` | Write to file |
-| Prometheus | `--metrics` | Expose /metrics endpoint |
+### Notes
 
-### Custom Output Plugin
+- `cub-scout` remains read-only for cluster state.
+- Connected workflows may write summary records to configured local summary storage.
+- File sink and webhook routing are available now; broader pluggable sink architecture remains follow-up work.
 
-```go
-// pkg/output/plugin.go
-
-type OutputPlugin interface {
-    Name() string
-    Init(config map[string]interface{}) error
-    Write(snapshot *GSFSnapshot) error
-    WriteEvent(event *GSFEvent) error
-    Close() error
-}
-```
-
-### Example: Kafka Output
-
-```go
-type KafkaOutput struct {
-    producer *kafka.Producer
-    topic    string
-}
-
-func (k *KafkaOutput) Name() string {
-    return "kafka"
-}
-
-func (k *KafkaOutput) Init(config map[string]interface{}) error {
-    k.topic = config["topic"].(string)
-    // Initialize Kafka producer
-    return nil
-}
-
-func (k *KafkaOutput) Write(snapshot *GSFSnapshot) error {
-    data, _ := json.Marshal(snapshot)
-    return k.producer.Produce(&kafka.Message{
-        TopicPartition: kafka.TopicPartition{Topic: &k.topic},
-        Value:          data,
-    }, nil)
-}
-```
-
-### Using Custom Output
-
-When implemented, custom output plugins will be configured via command-line flags.
+See `docs/reference/commands.md` (`watch`, `summary list`, `summary slack`) and `examples/connected-summary-storage/`.
 
 ---
 
-## 6. GraphQL API (Planned)
+## 6. GraphQL API (Future)
 
-A GraphQL API for flexible queries is planned:
+`cub-scout` does not currently expose a GraphQL server.
 
-```graphql
-query {
-  entries(
-    cluster: "prod-east"
-    owner: { type: "flux" }
-    status: DEGRADED
-  ) {
-    id
-    name
-    owner { type ref }
-    drift { detected fields { path desired live } }
-    relations { to { id } type }
-  }
+For automation today, use deterministic JSON from existing command surfaces:
 
-  findings(severity: [CRITICAL, WARNING]) {
-    id
-    severity
-    resource { id name namespace }
-    remediation
-  }
-}
+```bash
+cub-scout map list --json
+cub-scout trace deploy/api -n prod --format json
+cub-scout scan --json
 ```
+
+Then filter/transform with your normal tooling (`jq`, scripts, pipelines).
 
 ---
 

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -9,6 +9,7 @@ breaking changes will be avoided within the same contract version.
 **Output model:** JSON is the canonical contract. ASCII/Markdown output is a rendering of the same fields.
 
 Human-friendly JSON contract index: [json-contracts.md](json-contracts.md)
+Alphabetical command index: [cli-reference.md](cli-reference.md)
 
 ---
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1,0 +1,91 @@
+# Complete CLI Reference (A-Z)
+
+Alphabetical command index for `cub-scout`.
+
+Source of truth:
+- command inventory: `cub-scout --help`
+- stable contracts/schemas: [CLI Contract Reference](cli-contract.md)
+- usage examples: [Command Reference](commands.md) and [CLI Guide](../../CLI-GUIDE.md)
+
+---
+
+## Top-Level Commands (Alphabetical)
+
+| Command | What It Does | Primary Docs | Demo / Workflow |
+|---------|---------------|--------------|-----------------|
+| `app-space` | Manage ConfigHub App structures | [CLI Guide](../../CLI-GUIDE.md) | [Import demos](../../examples/argo-import-confighub-demo/) |
+| `apply` | Apply a proposal JSON (GUI workflow) | [CLI Guide](../../CLI-GUIDE.md) | [Import from live](../../examples/import-from-live/) |
+| `audit` | Break-glass audit trail tools (`audit list`) | [Command Reference](commands.md#audit-list) | [Connect and compare](../../examples/connect-and-compare/) |
+| `bundle` | Inspect/replay/diff/timeline debug bundles | [Command Reference](commands.md) | [Artifact workflows](../../examples/workflows/) |
+| `catalog` | Manage bundle catalogs | [Command Reference](commands.md) | [Artifact workflows](../../examples/workflows/) |
+| `combined` | Git + cluster/bundle compare (alias: `compare`) | [Command Reference](commands.md#combined) | [Connect and compare](../../examples/connect-and-compare/) |
+| `completion` | Generate shell completion script | [Command Reference](commands.md) | - |
+| `connect` | Create/import kube context and optionally launch map | [Command Reference](commands.md#connect) | [New user puzzle quest](../../examples/new-user-puzzle-quest/) |
+| `context-pack` | Export deterministic AI context JSON | [How-to](../howto/context-pack-v2.md) | [AI integration](../../examples/ai-integration/) |
+| `debug` | Guided GitOps debugging wizard | [CLI Guide](../../CLI-GUIDE.md) | [Platform example](../../examples/platform-example/) |
+| `demo` | Run fixture demos | [CLI Guide](../../CLI-GUIDE.md) | [Demos index](../../examples/demos/) |
+| `discover` | Alias for workload discovery (`map workloads`) | [Command Reference](commands.md#discover) | [Running demos](../howto/running-demos.md) |
+| `doctor` | One-command cluster health summary | [Command Reference](commands.md#doctor) | [Connect and compare](../../examples/connect-and-compare/) |
+| `drift` | Detect desired vs live drift | [CLI Guide](../../CLI-GUIDE.md) | [Drift examples](../../examples/drift/) |
+| `explain` | Plain-English ownership + lineage for one resource | [Command Reference](commands.md#explain) | [New user puzzle quest](../../examples/new-user-puzzle-quest/) |
+| `fleet` | Fleet-level connected insights (`fleet outliers`) | [Command Reference](commands.md#fleet-outliers) | [Fleet import](../../examples/fleet-import/) |
+| `gitops` | GitOps diagnostics (`gitops status`) | [CLI Guide](../../CLI-GUIDE.md) | [Connected summary storage](../../examples/connected-summary-storage/) |
+| `graph` | Resource graph export/explain | [Command Reference](commands.md#graph-v06) | [Graph export](../../examples/graph-export/) |
+| `health` | Alias for health issues (`map issues`) | [Command Reference](commands.md#health) | [Running demos](../howto/running-demos.md) |
+| `help` | Command help and subcommand discovery | [CLI Guide](../../CLI-GUIDE.md) | - |
+| `history` | Connected ChangeSet timeline for a resource | [Command Reference](commands.md#history) | [Connect and compare](../../examples/connect-and-compare/) |
+| `impact` | Connected blast-radius preview for one unit | [Command Reference](commands.md#impact) | [Connect and compare](../../examples/connect-and-compare/) |
+| `import` | Import workloads into ConfigHub | [Command Reference](commands.md#import) | [Argo import demo](../../examples/argo-import-confighub-demo/) |
+| `import-argocd` | Import an ArgoCD Application | [CLI Guide](../../CLI-GUIDE.md) | [Argo import demo](../../examples/argo-import-confighub-demo/) |
+| `import-cluster-aggregator` | Aggregate multi-cluster imports (GUI path) | [CLI Guide](../../CLI-GUIDE.md) | [Fleet import](../../examples/fleet-import/) |
+| `map` | Interactive TUI and list/status/ownership views | [Command Reference](commands.md#map) | [New user puzzle quest](../../examples/new-user-puzzle-quest/) |
+| `mcp` | Read-only MCP gateway (`mcp serve`) | [Command Reference](commands.md#mcp) | [MCP gateway](../../examples/mcp-gateway/) |
+| `parse-repo` | Parse GitOps repository structure | [CLI Guide](../../CLI-GUIDE.md) | [Combined git+live](../../examples/combined-git-live/) |
+| `patterns` | Pattern detection engine | [Command Reference](commands.md) | [Patterns fixtures](../../test/fixtures/patterns/) |
+| `quickstart` | Guided first-run tour | [Command Reference](commands.md#quickstart) | [New user puzzle quest](../../examples/new-user-puzzle-quest/) |
+| `remedy` | Execute remediation for findings | [CLI Guide](../../CLI-GUIDE.md) | [Running demos](../howto/running-demos.md) |
+| `scan` | Risk/misconfiguration scanning | [Command Reference](commands.md#scan) | [Lifecycle hazards](../../examples/lifecycle-hazards/) |
+| `setup` | Install/configure shell setup helpers | [Command Reference](commands.md#setup) | - |
+| `snapshot` | Dump cluster state as GSF JSON | [CLI Guide](../../CLI-GUIDE.md) | [AI integration](../../examples/ai-integration/) |
+| `status` | Show connection mode + cluster info | [Command Reference](commands.md#status) | [Connect and compare](../../examples/connect-and-compare/) |
+| `summary` | Connected summary storage tools (`list`, `slack`) | [Command Reference](commands.md#summary-list) | [Connected summary storage](../../examples/connected-summary-storage/) |
+| `trace` | Trace ownership/source chain | [Command Reference](commands.md#trace) | [kro composition](../../examples/kro-composition/) |
+| `tree` | Runtime/ownership/git/composition hierarchy views | [Command Reference](commands.md#tree) | [kro composition](../../examples/kro-composition/) |
+| `version` | Print version/build info | [CLI Guide](../../CLI-GUIDE.md) | - |
+| `watch` | Stream events to webhook/file sinks | [Command Reference](commands.md#watch) | [Watch webhook](../../examples/watch-webhook/) |
+
+---
+
+## High-Value Subcommands (Alphabetical)
+
+| Subcommand | Purpose | Docs | Demo |
+|------------|---------|------|------|
+| `audit list` | Break-glass accept/reject audit trail | [Command Reference](commands.md#audit-list) | [Connect and compare](../../examples/connect-and-compare/) |
+| `bundle diff` | Compare two bundles | [Command Reference](commands.md) | [Workflows](../../examples/workflows/) |
+| `bundle inspect` | Inspect bundle metadata/files | [Command Reference](commands.md) | [Workflows](../../examples/workflows/) |
+| `bundle replay` | Re-render bundle sections | [Command Reference](commands.md) | [Workflows](../../examples/workflows/) |
+| `bundle summarize` | Summarize bundle evidence | [Command Reference](commands.md) | [Workflows](../../examples/workflows/) |
+| `bundle timeline` | Time-series view over catalogs | [Command Reference](commands.md) | [Workflows](../../examples/workflows/) |
+| `compare three-way` | DRY/WET/LIVE comparison (connected) | [Command Reference](commands.md#compare-three-way) | [Connect and compare](../../examples/connect-and-compare/) |
+| `fleet outliers` | Cluster divergence report | [Command Reference](commands.md#fleet-outliers) | [Fleet import](../../examples/fleet-import/) |
+| `gitops status` | GitOps pipeline health | [Command Reference](commands.md) | [Connected summary storage](../../examples/connected-summary-storage/) |
+| `map hooks` | Lifecycle hook inventory | [Command Reference](commands.md#map-hooks) | [Lifecycle hazards](../../examples/lifecycle-hazards/) |
+| `map list` | Resource ownership inventory | [Command Reference](commands.md#map-list) | [Running demos](../howto/running-demos.md) |
+| `map meaning` | Experimental meaning-first grouping | [Command Reference](commands.md#map-meaning) | [kro composition](../../examples/kro-composition/) |
+| `map orphans` | Unmanaged/orphan resources | [Command Reference](commands.md#map-orphans) | [Orphans](../../examples/orphans/) |
+| `mcp serve` | Read-only MCP server over stdio | [Command Reference](commands.md#mcp) | [MCP gateway](../../examples/mcp-gateway/) |
+| `patterns detect` | Run pattern detection | [Command Reference](commands.md) | [Patterns fixtures](../../test/fixtures/patterns/) |
+| `summary list` | Query persisted summary records | [Command Reference](commands.md#summary-list) | [Connected summary storage](../../examples/connected-summary-storage/) |
+| `summary slack` | Post summary digest to Slack | [Command Reference](commands.md#summary-slack) | [Connected summary storage](../../examples/connected-summary-storage/) |
+| `tree composition` | Crossplane/kro composition hierarchy | [README](../../README.md) | [kro composition](../../examples/kro-composition/) |
+
+---
+
+## Verification Tip
+
+For any command path, verify local runtime behavior directly:
+
+```bash
+cub-scout <command> --help
+```
+

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,7 +1,8 @@
 # Command Reference
 
-Curated reference for common cub-scout commands with usage examples.
+Curated reference for high-value cub-scout commands with usage examples.
 
+For the **complete alphabetical command index**, see [Complete CLI Reference (A-Z)](cli-reference.md).
 For the **exhaustive stable surface** (all contracted commands, flags, exit codes, and output schemas), see [CLI Contract Reference](cli-contract.md).
 
 ## Overview

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -328,9 +328,9 @@ See details:
 
 ---
 
-# What Is Left on the Roadmap
+# v1.x Roadmap Track
 
-Everything below is **new work**.
+Sections below include both shipped and future v1.x work.
 Nothing here represents unfinished 0.x promises.
 
 ---
@@ -522,7 +522,7 @@ Delivered:
 
 ## v1.4 — Discover & Connect
 
-**Status:** Planned
+**Status:** Released (delivered in v1.x line)
 **Theme:** *New user onboarding, immediate cluster value, and AI observation gateway*
 
 This milestone focuses on making cub-scout immediately useful to new users and positioning it as the read-only agentic observation layer for AI tools.
@@ -555,7 +555,7 @@ This milestone focuses on making cub-scout immediately useful to new users and p
 
 ## v1.5 — AI-Native Ops
 
-**Status:** Planned
+**Status:** Released (delivered in v1.x line)
 **Theme:** *AI tooling platform for Kubernetes and GitOps observation*
 
 ### MCP Architecture
@@ -584,7 +584,7 @@ while ConfigHub provides the durable backend and full MCP server capabilities.
 
 ## v1.6 — Connected Value
 
-**Status:** Planned
+**Status:** Released (delivered in v1.x line)
 **Theme:** *ConfigHub-powered insights that clusters cannot provide alone*
 
 This milestone delivers the "aha moment" for connected mode: what ConfigHub knows that your cluster API cannot tell you.

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,11 @@ All examples, demos, and integration code in one place.
 
 **Learning cub-scout hands-on?** Try the [Puzzle Quest](new-user-puzzle-quest/) — a guided walkthrough from zero to full cluster discovery.
 
+**Need quick command lookup?**
+- [Complete CLI Reference (A-Z)](../docs/reference/cli-reference.md)
+- [Command Reference](../docs/reference/commands.md)
+- [Start Here by user goal](../docs/getting-started/start-here.md)
+
 ## Quick Start
 
 ```bash
@@ -44,6 +49,15 @@ cub-scout map meaning
 # Or run a demo
 cub-scout demo quick
 ```
+
+## Most Valuable Demos First
+
+| Goal | Run This First | What It Proves |
+|------|----------------|----------------|
+| Learn core workflow quickly | [new-user-puzzle-quest/](new-user-puzzle-quest/) | `quickstart`, `doctor`, `map`, `trace`, `scan`, `import --dry-run` |
+| Show connected value in <60s | [connect-and-compare/](connect-and-compare/) | `doctor` + `compare three-way` + `history` narrative |
+| Enable AI tooling safely | [mcp-gateway/](mcp-gateway/) + [ai-integration/](ai-integration/) | `mcp serve`, fixture-driven AI session patterns |
+| Operate platform-scale slices | [kro-composition/](kro-composition/) + [connected-summary-storage/](connected-summary-storage/) + [watch-webhook/](watch-webhook/) | composition lineage, summary trend/digest, webhook event streaming |
 
 ---
 

--- a/examples/ai-agent-quest/README.md
+++ b/examples/ai-agent-quest/README.md
@@ -40,8 +40,8 @@ understand your cluster."
 | Cursor, Windsurf | Shell execution of `./cub-scout` commands |
 | Any CLI-capable agent | Shell execution of `./cub-scout` commands |
 
-> **Note:** MCP gateway (`cub-scout mcp serve`) is planned for v1.4.
-> Until then, all AI tools connect via direct CLI execution, which works great.
+> **Note:** MCP gateway is available now via `cub-scout mcp serve`.
+> Direct CLI execution still works and remains the simplest default path.
 
 ### Execution Modes
 

--- a/examples/ai-agent-quest/mcp-config.json
+++ b/examples/ai-agent-quest/mcp-config.json
@@ -1,9 +1,9 @@
 {
   "_comment": [
-    "MCP server configuration for cub-scout (PLANNED - NOT YET AVAILABLE).",
+    "MCP server configuration for cub-scout (AVAILABLE).",
     "",
-    "STATUS: The 'cub-scout mcp serve' command is planned for v1.4.",
-    "This config file is provided for future use.",
+    "STATUS: 'cub-scout mcp serve' is shipped.",
+    "Use this config directly with clients that support MCP stdio.",
     "",
     "CURRENT APPROACH: Use direct CLI execution instead:",
     "- Claude Code: runs ./cub-scout commands directly",
@@ -14,7 +14,7 @@
   ],
   "mcpServers": {
     "cub-scout": {
-      "_status": "PLANNED - requires cub-scout v1.4+",
+      "_status": "AVAILABLE",
       "command": "cub-scout",
       "args": ["mcp", "serve"],
       "env": {

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "Checking docs for known stale shipped-feature wording..."
+
+patterns=(
+  "planned for v1\\.4"
+  "PLANNED - requires cub-scout v1\\.4\\+"
+  "MCP gateway .* planned for v1\\.4"
+  "^## 4\\. Webhooks \\(Planned\\)$"
+)
+
+failed=0
+for pattern in "${patterns[@]}"; do
+  if rg -n --glob '!docs/archive/**' --glob '!examples/integrations/**' "$pattern" docs examples README.md CLI-GUIDE.md >/tmp/cub_scout_doc_freshness_hits.txt 2>/dev/null; then
+    echo ""
+    echo "Stale wording matched pattern: $pattern"
+    cat /tmp/cub_scout_doc_freshness_hits.txt
+    failed=1
+  fi
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  echo ""
+  echo "Doc freshness check failed."
+  exit 1
+fi
+
+echo "Doc freshness check passed."
+


### PR DESCRIPTION
## Summary
- fix shipped-status drift in roadmap by marking v1.4/v1.5/v1.6 as released in the v1.x line
- add a new user routing guide: `docs/getting-started/start-here.md`
- add a complete alphabetical CLI command index with doc + demo links: `docs/reference/cli-reference.md`
- front-load fast path and high-value flows in `README.md` and `examples/README.md`
- add cross-links from command/contract guides to the new CLI index
- update stale MCP/planned wording in AI quest docs
- rewrite `docs/howto/extending.md` sections to reflect shipped webhook/file-sink/summary-slack behavior and current future boundaries
- add `scripts/check-doc-freshness.sh` guard for known stale shipped-feature wording regressions

## Validation
- `./scripts/check-doc-freshness.sh`
- `git diff --check`
