### PR TITLE
docs: enforce CLI-GUIDE parity with runtime command inventory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Check read-only policy
         run: ./scripts/check-readonly.sh
 
+      - name: Check CLI guide parity
+        run: ./scripts/check-cli-guide-parity.sh
+
       - name: Run unit tests
         run: go test ./... -v -covermode=atomic -coverprofile=coverage.out
 

--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -16,23 +16,31 @@ The table below reflects the current `cub-scout --help` output.
 |---------|-------------|
 | `app-space` | Manage App Spaces |
 | `apply` | Apply a proposal from JSON (GUI) |
+| `audit` | Break-glass audit trail tools |
 | `bundle` | Work with debug bundles |
 | `catalog` | Manage bundle catalogs |
 | `combined` | Show Git repo structure + cluster workloads aligned |
 | `completion` | Generate shell completion script |
 | `connect` | Quickly configure kube context from server URL or kubeconfig |
+| `context-pack` | Export deterministic AI context JSON bundle |
 | `debug` | Guided GitOps debugging wizard |
 | `demo` | Run interactive demos |
 | `discover` | Discover resources (alias for `map workloads`) |
+| `doctor` | One-command actionable health summary |
 | `drift` | Detect drift between desired and live state |
+| `explain` | Plain-English ownership and lineage for one resource |
+| `fleet` | Fleet-level connected insights |
 | `gitops` | GitOps status and diagnostics |
 | `graph` | Resource graph operations |
 | `health` | Check issues (alias for `map issues`) |
+| `help` | Help for any command path |
 | `history` | Show connected change history from ConfigHub ChangeSets |
+| `impact` | Preview connected blast radius for one unit |
 | `import` | Import workloads into ConfigHub |
 | `import-argocd` | Import an ArgoCD Application into ConfigHub |
 | `import-cluster-aggregator` | Aggregate imports from multiple clusters (GUI) |
 | `map` | Interactive map of resources and ownership |
+| `mcp` | Model Context Protocol gateway (`mcp serve`) |
 | `parse-repo` | Parse a GitOps repository structure |
 | `patterns` | Pattern detection engine |
 | `quickstart` | Guided first-run tour across doctor, explain, ownership, and scan |
@@ -41,9 +49,11 @@ The table below reflects the current `cub-scout --help` output.
 | `setup` | Set up shell completions and configuration |
 | `snapshot` | Dump cluster state as GSF JSON |
 | `status` | Show connection status and cluster info |
+| `summary` | Query/publish connected summary digests |
 | `trace` | Trace any resource to its Git source |
 | `tree` | Show hierarchical views of resources |
 | `version` | Print version information |
+| `watch` | Stream observation events to webhook/file sinks |
 
 ---
 
@@ -91,6 +101,43 @@ The table below reflects the current `cub-scout --help` output.
 - No cluster connectivity: wizard prints fallback guidance for example bundle mode.
 - Empty cluster: doctor/ownership steps still run and explain no representative workload.
 - No connected context: connected-mode preview step is skipped.
+
+---
+
+## `doctor` — One-Command Health Summary
+
+**What it does:** Produces a compact actionable summary of ownership, health, risk, and drift in one report.
+
+```bash
+./cub-scout doctor
+./cub-scout doctor --namespace production
+./cub-scout doctor --format json
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--format` | Output format: `ascii`, `json` |
+| `-n, --namespace` | Namespace scope |
+| `--top` | Number of top issues to include (default: 3) |
+
+---
+
+## `explain` — Plain-English Ownership and Lineage
+
+**What it does:** Explains ownership and source lineage for one resource in text, JSON, or Markdown.
+
+```bash
+./cub-scout explain deploy/my-app -n prod
+./cub-scout explain deployment/my-app -n prod --format json
+./cub-scout explain deployment/my-app -n prod --format md
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--format` | Output format: `text`, `json`, `md` |
+| `-n, --namespace` | Namespace of target resource |
 
 ---
 
@@ -347,6 +394,77 @@ Connected │ Cluster: prod-east │ Context: eks-prod-east │ Worker: ● brid
 **Graceful behavior:**
 - Not connected: `history requires ConfigHub connection. Run: cub auth login`
 - No matching history: clear message that the resource may not be imported yet
+
+---
+
+## `impact` — Connected Blast Radius Preview
+
+**What it does:** Shows dependency impact for a ConfigHub unit before proposed changes.
+
+```bash
+./cub-scout impact unit/shared-db-config
+./cub-scout impact shared-db-config --format md
+./cub-scout impact shared-db-config --json
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--format` | Output format: `ascii`, `json`, `md` |
+| `--json` | Shorthand for `--format json` |
+
+---
+
+## `fleet` — Connected Fleet Insights
+
+Use `fleet outliers` to identify clusters that diverge from fleet norms.
+
+```bash
+./cub-scout fleet outliers
+./cub-scout fleet outliers --format md
+./cub-scout fleet outliers --json
+```
+
+---
+
+## `audit` — Break-Glass Audit Trail
+
+Use `audit list` to review connected accept/reject decisions from ChangeSets.
+
+```bash
+./cub-scout audit list
+./cub-scout audit list -n prod --since 7d
+./cub-scout audit list --format md
+./cub-scout audit list --json
+```
+
+**Options (`audit list`):**
+| Option | Description |
+|--------|-------------|
+| `--format` | Output format: `ascii`, `json`, `md` |
+| `--json` | Shorthand for `--format json` |
+| `-n, --namespace` | Optional namespace scope |
+| `--since` | Lookback window (default: `7d`) |
+| `--include-synthetic` | Include demo-seeded synthetic ChangeSets |
+
+---
+
+## `summary` — Connected Summary Storage
+
+Summary storage keeps connected scan/sync/risk snapshots for trend and digest workflows.
+
+```bash
+./cub-scout summary list --since 24h
+./cub-scout summary list --cluster kind-dev --namespace prod --json
+./cub-scout summary slack --dry-run --since 24h
+./cub-scout summary slack --webhook-url https://hooks.slack.com/services/... --since 7d
+```
+
+**Subcommands:**
+| Command | Description |
+|---------|-------------|
+| `list` | Query persisted summary records |
+| `slack` | Build and post Slack digest from stored records |
 
 ---
 
@@ -1357,6 +1475,36 @@ Helm Hook Ambiguity (1)
 
 ---
 
+## `watch` — Event Streaming
+
+Streams observation events to webhook and/or local JSONL sink.
+
+```bash
+./cub-scout watch --once
+./cub-scout watch --output-file /tmp/cub-scout-events.jsonl --once
+./cub-scout watch --webhook https://hooks.example.com/cub-scout --interval 30s
+```
+
+**Event types:**
+- `resource.discovered`
+- `ownership.changed`
+- `drift.detected`
+- `scan.finding`
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--interval` | Polling interval (default: `20s`) |
+| `--max-queued-events` | Buffer limit when webhook is unavailable (default: `1000`) |
+| `-n, --namespace` | Filter by namespace |
+| `--once` | Run one collection cycle and exit |
+| `--output-file` | Append JSONL events to local file |
+| `--owner` | Filter by owner display name |
+| `--severity` | Filter finding/drift severity (`critical,warning,info`) |
+| `--webhook` | Webhook URL sink |
+
+---
+
 ## `snapshot` — Export State as JSON (GSF)
 
 Exports cluster state in GitOps State Format (GSF) — a JSON format for third-party tool integration.
@@ -1732,6 +1880,27 @@ Read-only MCP gateway that exposes cub-scout observation tools over stdio.
 
 ---
 
+## `context-pack` — AI Handoff Evidence Bundle
+
+Exports a compact, model-agnostic JSON evidence pack for AI handoffs.
+
+```bash
+./cub-scout context-pack --format json
+./cub-scout context-pack --namespace prod --top-risks 8 --trace-seeds 8
+./cub-scout context-pack --max-bytes 32768
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--format` | Output format (`json`) |
+| `--max-bytes` | Maximum payload size (default: 16384) |
+| `-n, --namespace` | Namespace scope |
+| `--top-risks` | Number of risk issues included (default: 5) |
+| `--trace-seeds` | Number of trace seed resources included (default: 5) |
+
+---
+
 ## `patterns` — Pattern Detection (v0.7)
 
 Pattern detection engine for analyzing resource graphs.
@@ -1873,10 +2042,11 @@ done
 
 ---
 
-## `version` / `completion` / `setup`
+## `version` / `completion` / `setup` / `help`
 
 ```bash
 ./cub-scout version
+./cub-scout help map
 ./cub-scout completion bash > /etc/bash_completion.d/cub-scout
 ./cub-scout completion zsh > "${fpath[1]}/_cub-scout"
 ./cub-scout setup

--- a/scripts/check-cli-guide-parity.sh
+++ b/scripts/check-cli-guide-parity.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "Checking CLI-GUIDE top-level command parity..."
+
+help_cmds="$(
+  go run ./cmd/cub-scout --help \
+    | awk 'f && NF { if ($1 == "Flags:") exit; print $1 } /Available Commands:/ { f = 1 }' \
+    | sort -u
+)"
+
+guide_cmds="$(
+  awk '
+    BEGIN { inside = 0 }
+    /^## Top-Level Commands/ { inside = 1; next }
+    inside && /^---/ { inside = 0 }
+    inside && /^\| `/ {
+      cmd = $0
+      sub(/^\| `/, "", cmd)
+      sub(/`.*/, "", cmd)
+      print cmd
+    }
+  ' CLI-GUIDE.md | sort -u
+)"
+
+missing_from_guide="$(comm -23 <(printf "%s\n" "$help_cmds") <(printf "%s\n" "$guide_cmds") || true)"
+extra_in_guide="$(comm -13 <(printf "%s\n" "$help_cmds") <(printf "%s\n" "$guide_cmds") || true)"
+
+failed=0
+
+if [[ -n "$missing_from_guide" ]]; then
+  echo ""
+  echo "Commands in 'cub-scout --help' but missing from CLI-GUIDE top-level table:"
+  printf "%s\n" "$missing_from_guide"
+  failed=1
+fi
+
+if [[ -n "$extra_in_guide" ]]; then
+  echo ""
+  echo "Commands in CLI-GUIDE top-level table but not in 'cub-scout --help':"
+  printf "%s\n" "$extra_in_guide"
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo ""
+  echo "CLI-GUIDE parity check failed."
+  exit 1
+fi
+
+echo "CLI-GUIDE parity check passed."


### PR DESCRIPTION
## Summary
- add missing top-level commands to `CLI-GUIDE.md` so the command table matches `cub-scout --help`
- add focused sections for previously missing high-value commands: `doctor`, `explain`, `impact`, `fleet`, `audit`, `summary`, `watch`, `context-pack`
- include `help` explicitly in utility command section
- add CI gate `scripts/check-cli-guide-parity.sh` and run it in Unit Tests job

## Why
`CLI-GUIDE.md` claimed complete command coverage but had drifted from the actual command surface. This PR restores parity and prevents future drift.

## Verification
- `./scripts/check-cli-guide-parity.sh`
- `./scripts/check-doc-freshness.sh`
- `git diff --check`
