### PR TITLE
Rename Hub/AppSpace to App/Deployment/Target model

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Ownership: Flux 60% │ ArgoCD 26% │ Helm 10% │ Native 4%
 cub-scout tree suggest
 ```
 
-**Suggested Organization** — Hub/AppSpace recommendation:
+**Suggested Organization** — App recommendation:
 
 ```
 HUB/APPSPACE SUGGESTION
@@ -460,7 +460,7 @@ HUB/APPSPACE SUGGESTION
 Detected pattern: D2 (Control Plane style)
   └── clusters/prod, clusters/staging structure
 
-Suggested Hub/AppSpace organization
+Suggested App organization
 (Space maps to App, Unit maps to App component in the new model;
 see docs/reference/glossary.md for the full mapping):
 
@@ -612,7 +612,7 @@ Scanned: 47 resources │ Patterns: 46 active (4,500+ reference)
 | `cub-scout connect ... --map` | Quick connect to a cluster API and launch the TUI |
 | `cub-scout discover` | Find workloads by owner (scout-style alias) |
 | `cub-scout tree` | Hierarchical views (runtime, git, config) |
-| `cub-scout tree suggest` | Suggested Hub/AppSpace organization |
+| `cub-scout tree suggest` | Suggested App organization |
 | `cub-scout trace deploy/x -n y` | Full ownership chain to Git source |
 | `cub-scout trace deploy/x -n y --history` | Deployment history (who deployed what, when) |
 | `cub-scout health` | Check for issues (scout-style alias) |
@@ -641,7 +641,7 @@ Scanned: 47 resources │ Patterns: 46 active (4,500+ reference)
 | `cub-scout tree git` | Git source structure (repos, paths) |
 | `cub-scout tree patterns` | Detected GitOps patterns (D2, Arnie, etc.) |
 | `cub-scout tree config --space X` | ConfigHub Unit relationships (wraps `cub unit tree`) |
-| `cub-scout tree suggest` | Recommended Hub/AppSpace structure |
+| `cub-scout tree suggest` | Recommended App structure |
 
 ---
 

--- a/cmd/cub-scout/apply.go
+++ b/cmd/cub-scout/apply.go
@@ -59,7 +59,7 @@ func init() {
 // Can be a FullProposal directly or wrapped in CombinedResult/FleetResult
 type ApplyInput struct {
 	// Direct proposal
-	AppSpace       string               `json:"appSpace,omitempty"`
+	App            string               `json:"app,omitempty"`
 	Deployer       string               `json:"deployer,omitempty"`
 	Reconciliation []ReconciliationRule `json:"reconciliation,omitempty"`
 	Units          []UnitProposal       `json:"units,omitempty"`
@@ -125,17 +125,17 @@ func runApply(cmd *cobra.Command, args []string) error {
 	var proposal *FullProposal
 	if input.Proposal != nil {
 		proposal = input.Proposal
-	} else if input.AppSpace != "" {
+	} else if input.App != "" {
 		// Direct proposal format
 		proposal = &FullProposal{
-			AppSpace:       input.AppSpace,
+			App:       input.App,
 			Deployer:       input.Deployer,
 			Reconciliation: input.Reconciliation,
 			Units:          input.Units,
 			HubBases:       input.HubBases,
 		}
 	} else {
-		return fmt.Errorf("no proposal found in input (expected 'proposal' or 'appSpace' field)")
+		return fmt.Errorf("no proposal found in input (expected 'proposal' or 'app' field)")
 	}
 
 	if logger != nil {
@@ -162,12 +162,12 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 	}
 
 	// Step 1: Create App
-	fmt.Printf("  Creating App: %s\n", proposal.AppSpace)
+	fmt.Printf("  Creating App: %s\n", proposal.App)
 	if logger != nil {
-		logger.Log("Creating App: %s", proposal.AppSpace)
+		logger.Log("Creating App: %s", proposal.App)
 	}
 	if !dryRun {
-		if err := createAppSpaceForImport(proposal.AppSpace); err != nil {
+		if err := createAppForImport(proposal.App); err != nil {
 			if logger != nil {
 				logger.Log("FAILED: create space: %v", err)
 				logger.LogResult(0, 1, err)
@@ -246,7 +246,7 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 				manifest = []byte(fmt.Sprintf("# Placeholder for %s\n# Workloads: %v\n", unit.Slug, unit.Workloads))
 			}
 
-			if err := createUnitWithManifest(proposal.AppSpace, unit.Slug, labels, manifest); err != nil {
+			if err := createUnitWithManifest(proposal.App, unit.Slug, labels, manifest); err != nil {
 				fmt.Printf("      ⚠ failed to create: %v\n", err)
 				if logger != nil {
 					logger.Log("  FAILED: create deployment: %v", err)
@@ -280,4 +280,4 @@ func applyProposalFromJSONWithLogger(proposal *FullProposal, dryRun bool, logger
 
 // createUnitWithManifest is defined in combined.go
 // fetchWorkloadManifest is defined in combined.go
-// createAppSpaceForImport is defined in combined.go
+// createAppForImport is defined in combined.go

--- a/cmd/cub-scout/appspace.go
+++ b/cmd/cub-scout/appspace.go
@@ -12,13 +12,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var appSpaceCmd = &cobra.Command{
-	Use:   "app-space",
+var appCmd = &cobra.Command{
+	Use:   "app",
 	Short: "Manage Apps",
 	Long:  `Create, list, and manage Apps in ConfigHub.`,
 }
 
-var appSpaceCreateCmd = &cobra.Command{
+var appCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create an App",
 	Long: `Create a new App in ConfigHub.
@@ -37,44 +37,44 @@ Examples:
   cub-scout app-space create payments-team --label team=payments --label owner=platform
 `,
 	Args: cobra.ExactArgs(1),
-	RunE: runAppSpaceCreate,
+	RunE: runAppCreate,
 }
 
-var appSpaceListCmd = &cobra.Command{
+var appListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Apps",
 	Long:  `List all Apps in the current organization.`,
-	RunE:  runAppSpaceList,
+	RunE:  runAppList,
 }
 
 var (
-	appSpaceSetContext bool
-	appSpaceLabels     []string
-	appSpaceJSON       bool
+	appSetContext bool
+	appLabels     []string
+	appJSON       bool
 )
 
 func init() {
-	appSpaceCreateCmd.Flags().BoolVar(&appSpaceSetContext, "set-context", false, "Set as current context after creation")
-	appSpaceCreateCmd.Flags().StringArrayVar(&appSpaceLabels, "label", nil, "Labels in key=value format (can be repeated)")
+	appCreateCmd.Flags().BoolVar(&appSetContext, "set-context", false, "Set as current context after creation")
+	appCreateCmd.Flags().StringArrayVar(&appLabels, "label", nil, "Labels in key=value format (can be repeated)")
 
-	appSpaceListCmd.Flags().BoolVar(&appSpaceJSON, "json", false, "Output as JSON")
+	appListCmd.Flags().BoolVar(&appJSON, "json", false, "Output as JSON")
 
-	appSpaceCmd.AddCommand(appSpaceCreateCmd)
-	appSpaceCmd.AddCommand(appSpaceListCmd)
-	rootCmd.AddCommand(appSpaceCmd)
+	appCmd.AddCommand(appCreateCmd)
+	appCmd.AddCommand(appListCmd)
+	rootCmd.AddCommand(appCmd)
 }
 
-func runAppSpaceCreate(cmd *cobra.Command, args []string) error {
+func runAppCreate(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	// Build cub command
 	cubArgs := []string{"space", "create", name}
 
-	if appSpaceSetContext {
+	if appSetContext {
 		cubArgs = append(cubArgs, "--set-context")
 	}
 
-	for _, label := range appSpaceLabels {
+	for _, label := range appLabels {
 		cubArgs = append(cubArgs, "--label", label)
 	}
 
@@ -89,10 +89,10 @@ func runAppSpaceCreate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runAppSpaceList(cmd *cobra.Command, args []string) error {
+func runAppList(cmd *cobra.Command, args []string) error {
 	cubArgs := []string{"space", "list"}
 
-	if appSpaceJSON {
+	if appJSON {
 		cubArgs = append(cubArgs, "--json")
 	}
 
@@ -103,16 +103,16 @@ func runAppSpaceList(cmd *cobra.Command, args []string) error {
 	return cubCmd.Run()
 }
 
-// AppSpaceResult represents the result of creating an App
-type AppSpaceResult struct {
+// AppResult represents the result of creating an App
+type AppResult struct {
 	Name    string `json:"name"`
 	Created bool   `json:"created"`
 	Error   string `json:"error,omitempty"`
 }
 
-// CreateAppSpaceWithResult creates an App and returns structured result
-func CreateAppSpaceWithResult(name string, setContext bool, labels []string) (*AppSpaceResult, error) {
-	result := &AppSpaceResult{Name: name}
+// CreateAppWithResult creates an App and returns structured result
+func CreateAppWithResult(name string, setContext bool, labels []string) (*AppResult, error) {
+	result := &AppResult{Name: name}
 
 	cubArgs := []string{"space", "create", name, "--json"}
 

--- a/cmd/cub-scout/combined.go
+++ b/cmd/cub-scout/combined.go
@@ -158,12 +158,12 @@ func runCombined(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(workloads) > 0 || clusterNamespace != "" {
-		suggestion := SuggestHubAppSpaceStructure(workloads, "")
+		suggestion := SuggestAppStructure(workloads, "")
 		suggestionJSON := convertToSuggestionJSON(&suggestion)
 
 		result.Cluster = &ImportResult{
 			Namespace:  clusterNamespace,
-			Model:      "hub-appspace",
+			Model:      "app-deployment-target",
 			Workloads:  convertToWorkloadJSON(workloads),
 			Suggestion: suggestionJSON,
 		}
@@ -553,7 +553,7 @@ func convertToWorkloadJSON(workloads []WorkloadInfo) []WorkloadJSON {
 	return result
 }
 
-func convertToSuggestionJSON(s *HubAppSpaceSuggestion) *SuggestionJSON {
+func convertToSuggestionJSON(s *AppModelSuggestion) *SuggestionJSON {
 	if s == nil {
 		return nil
 	}
@@ -571,7 +571,7 @@ func convertToSuggestionJSON(s *HubAppSpaceSuggestion) *SuggestionJSON {
 		})
 	}
 	return &SuggestionJSON{
-		AppSpace: s.AppSpace,
+		App: s.App,
 		Units:    units,
 	}
 }
@@ -595,9 +595,9 @@ func applyProposal(proposal *FullProposal, workloads []WorkloadInfo, dryRun bool
 	}
 
 	// Step 1: Create App
-	fmt.Printf("  Creating App: %s\n", proposal.AppSpace)
+	fmt.Printf("  Creating App: %s\n", proposal.App)
 	if !dryRun {
-		if err := createAppSpaceForImport(proposal.AppSpace); err != nil {
+		if err := createAppForImport(proposal.App); err != nil {
 			return fmt.Errorf("create space: %w", err)
 		}
 		fmt.Printf("    ✓ Space created\n")
@@ -646,7 +646,7 @@ func applyProposal(proposal *FullProposal, workloads []WorkloadInfo, dryRun bool
 				}
 
 				// Create unit in ConfigHub
-				if err := createUnitWithManifest(proposal.AppSpace, unit.Slug, labels, manifest); err != nil {
+				if err := createUnitWithManifest(proposal.App, unit.Slug, labels, manifest); err != nil {
 					fmt.Printf("      ⚠ failed to create: %v\n", err)
 					skipped++
 					continue
@@ -665,9 +665,9 @@ func applyProposal(proposal *FullProposal, workloads []WorkloadInfo, dryRun bool
 	return nil
 }
 
-// createAppSpaceForImport creates an App for import using cub-scout app-space create
-func createAppSpaceForImport(name string) error {
-	result, err := CreateAppSpaceWithResult(name, true, nil)
+// createAppForImport creates an App for import using cub-scout app-space create
+func createAppForImport(name string) error {
+	result, err := CreateAppWithResult(name, true, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/cub-scout/fleet.go
+++ b/cmd/cub-scout/fleet.go
@@ -210,7 +210,7 @@ func runFleet(cmd *cobra.Command, args []string) error {
 // buildFleetProposal creates a unified proposal from fleet data
 func buildFleetProposal(fleet *FleetResult) *FullProposal {
 	proposal := &FullProposal{
-		AppSpace: "fleet-team",
+		App: "fleet-team",
 		Units:    []UnitProposal{},
 	}
 

--- a/cmd/cub-scout/hierarchy.go
+++ b/cmd/cub-scout/hierarchy.go
@@ -221,7 +221,7 @@ func loadSuggestDataCmd() tea.Cmd {
 		}
 
 		// Generate suggestion using existing logic
-		suggestion := SuggestHubAppSpaceStructure(workloads, "")
+		suggestion := SuggestAppStructure(workloads, "")
 
 		return suggestDataLoadedMsg{
 			proposal: &suggestion,
@@ -1679,7 +1679,7 @@ func initialModelWithContext(appContext string) Model {
 		m.searchQuery = appContext // Pre-fill search with app name
 	} else {
 		// Restore from snapshot if available (only when no explicit context)
-		if snap := loadHubSnapshot(); snap != nil {
+		if snap := loadAppSnapshot(); snap != nil {
 			m.cursor = snap.Cursor
 			m.mapsMode = snap.MapsMode
 			m.pendingSnapshot = snap // Save for expanded paths restoration after data loads
@@ -1816,7 +1816,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.detailsPane.GotoBottom()
 				return m, nil
 			case "q":
-				saveHubSnapshot(&m)
+				saveAppSnapshot(&m)
 				return m, tea.Quit
 			case "tab":
 				m.detailsFocused = false
@@ -1933,7 +1933,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, m.keymap.Quit):
-			saveHubSnapshot(&m)
+			saveAppSnapshot(&m)
 			return m, tea.Quit
 
 		case key.Matches(msg, m.keymap.Up):
@@ -2137,11 +2137,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.suggestLoading = true
 			return m, loadSuggestDataCmd()
 
-		case key.Matches(msg, m.keymap.HubView):
+		case key.Matches(msg, m.keymap.AppView):
 			// Toggle App model view mode
-			m.hubViewMode = !m.hubViewMode
+			m.appViewMode = !m.appViewMode
 			m.rebuildFlatList()
-			if m.hubViewMode {
+			if m.appViewMode {
 				m.statusMsg = "App model view enabled"
 			} else {
 				m.statusMsg = "Standard view"
@@ -2151,13 +2151,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keymap.LocalCluster):
 			// Switch to local cluster TUI
 			m.launchLocalCluster = true
-			saveHubSnapshot(&m)
+			saveAppSnapshot(&m)
 			return m, tea.Quit
 
 		case key.Matches(msg, m.keymap.Import):
 			// Launch the new import wizard (exits hierarchy, runs wizard, returns)
 			m.launchImportWizard = true
-			saveHubSnapshot(&m)
+			saveAppSnapshot(&m)
 			return m, tea.Quit
 
 		case key.Matches(msg, m.keymap.Create):
@@ -3871,7 +3871,7 @@ func (m Model) renderHelpOverlay() string {
 	b.WriteString("\n")
 	b.WriteString("  " + cmdStyle.Render("KubeCon") + "     " + descStyle.Render("Platform team + App teams"))
 	b.WriteString("\n")
-	b.WriteString("  " + descStyle.Render("See: docs/map/reference/hub-appspace-examples.md"))
+	b.WriteString("  " + descStyle.Render("See: docs/map/reference/app-model-examples.md"))
 	b.WriteString("\n\n")
 
 	b.WriteString(sectionStyle.Render("QUERY EXAMPLES") + " " + descStyle.Render("(type after :)"))
@@ -4174,7 +4174,7 @@ func (m Model) renderMapsView() string {
 		}
 	}
 
-	b.WriteString(fmt.Sprintf("  ├── %s\n", purpleStyle.Render("Hub (Platform)")))
+	b.WriteString(fmt.Sprintf("  ├── %s\n", purpleStyle.Render("Platform")))
 	if len(platformSpaces) > 0 {
 		for _, s := range platformSpaces {
 			b.WriteString(fmt.Sprintf("  │   └── %s\n", s))
@@ -4450,7 +4450,7 @@ func (m Model) renderSuggestView() string {
 	// Show suggestion
 	proposal := m.suggestProposal
 
-	b.WriteString(sectionStyle.Render("Suggested App: ") + nameStyle.Render(proposal.AppSpace))
+	b.WriteString(sectionStyle.Render("Suggested App: ") + nameStyle.Render(proposal.App))
 	b.WriteString("\n\n")
 
 	b.WriteString(sectionStyle.Render("Suggested Units:"))
@@ -5516,9 +5516,9 @@ func (m *Model) rebuildFlatList() {
 		}
 		m.flatList = append(m.flatList, node)
 		if node.Expanded {
-			if m.hubViewMode && node.Type == "org" {
+			if m.appViewMode && node.Type == "org" {
 				// App model view: group spaces
-				m.addHubAppSpaceView(node)
+				m.addAppView(node)
 			} else {
 				m.addChildrenToFlatList(node, 1)
 			}
@@ -5587,8 +5587,8 @@ func (m *Model) unitMatchesCurrentCluster(node *TreeNode) bool {
 	return matchesCluster(targetSlug, m.currentCluster)
 }
 
-// addHubAppSpaceView adds spaces grouped into Hub (platform) and Apps (apps)
-func (m *Model) addHubAppSpaceView(orgNode *TreeNode) {
+// addAppView adds spaces grouped into Platform and Apps
+func (m *Model) addAppView(orgNode *TreeNode) {
 	// Categorize spaces into Hub (platform) vs Apps
 	var hubSpaces, appSpaces []*TreeNode
 	for _, child := range orgNode.Children {
@@ -5611,7 +5611,7 @@ func (m *Model) addHubAppSpaceView(orgNode *TreeNode) {
 	if len(hubSpaces) > 0 {
 		hubGroup := &TreeNode{
 			ID:       orgNode.ID + "/hub",
-			Name:     "🏢 Hub (Platform)",
+			Name:     "🏢 Platform",
 			Type:     "hub_group",
 			Info:     fmt.Sprintf("(%d spaces)", len(hubSpaces)),
 			Parent:   orgNode,
@@ -6172,7 +6172,7 @@ func formatGroupPatternContext(node *TreeNode) string {
 	b.WriteString("\n")
 	b.WriteString("─────────────────────────────────────\n")
 	b.WriteString("Press B to toggle App model view\n")
-	b.WriteString("See: docs/map/reference/hub-appspace-examples.md\n")
+	b.WriteString("See: docs/map/reference/app-model-examples.md\n")
 
 	return b.String()
 }

--- a/cmd/cub-scout/hierarchy_test.go
+++ b/cmd/cub-scout/hierarchy_test.go
@@ -894,8 +894,8 @@ func TestHierarchyDelete(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
 }
 
-// TestHubSnapshotSaveLoad tests that Hub TUI state is saved and restored.
-func TestHubSnapshotSaveLoad(t *testing.T) {
+// TestAppSnapshotSaveLoad tests that Hub TUI state is saved and restored.
+func TestAppSnapshotSaveLoad(t *testing.T) {
 	// Use a temp directory for testing
 	tmpDir := t.TempDir()
 	originalHome := os.Getenv("HOME")
@@ -917,7 +917,7 @@ func TestHubSnapshotSaveLoad(t *testing.T) {
 	m.nodes[0].Expanded = true
 
 	// Save snapshot
-	saveHubSnapshot(&m)
+	saveAppSnapshot(&m)
 
 	// Verify file was created
 	snapPath := filepath.Join(sessionsDir, "hub-snapshot.json")
@@ -926,7 +926,7 @@ func TestHubSnapshotSaveLoad(t *testing.T) {
 	}
 
 	// Load snapshot
-	snap := loadHubSnapshot()
+	snap := loadAppSnapshot()
 	if snap == nil {
 		t.Fatal("snapshot was not loaded")
 	}
@@ -946,8 +946,8 @@ func TestHubSnapshotSaveLoad(t *testing.T) {
 	}
 }
 
-// TestHubSnapshotExpiry tests that old snapshots are not loaded.
-func TestHubSnapshotExpiry(t *testing.T) {
+// TestAppSnapshotExpiry tests that old snapshots are not loaded.
+func TestAppSnapshotExpiry(t *testing.T) {
 	// Use a temp directory for testing
 	tmpDir := t.TempDir()
 	originalHome := os.Getenv("HOME")
@@ -961,7 +961,7 @@ func TestHubSnapshotExpiry(t *testing.T) {
 	}
 
 	// Create an old snapshot (> 24 hours old)
-	oldSnap := HubSnapshot{
+	oldSnap := AppSnapshot{
 		Version:    hubSnapshotVersion,
 		UpdatedAt:  time.Now().Add(-25 * time.Hour), // 25 hours ago
 		Cursor:     5,
@@ -976,7 +976,7 @@ func TestHubSnapshotExpiry(t *testing.T) {
 	}
 
 	// Load should return nil for expired snapshot
-	snap := loadHubSnapshot()
+	snap := loadAppSnapshot()
 	if snap != nil {
 		t.Error("expected nil for expired snapshot, but got a snapshot")
 	}

--- a/cmd/cub-scout/hierarchy_types.go
+++ b/cmd/cub-scout/hierarchy_types.go
@@ -489,14 +489,14 @@ type Model struct {
 	suggestMode     bool                   // Suggest view active
 	suggestLoading  bool                   // Loading cluster data
 	suggestError    error                  // Error fetching data
-	suggestProposal *HubAppSpaceSuggestion // Generated suggestion
+	suggestProposal *AppModelSuggestion // Generated suggestion
 	suggestCursor   int                    // Cursor for navigation
 
 	// Launch local cluster TUI flag (L to switch)
 	launchLocalCluster bool // Switch to local cluster TUI on exit
 
-	// Hub/AppSpace view mode (B to toggle)
-	hubViewMode bool // Group spaces into Hub (platform) vs AppSpaces (apps)
+	// App view mode (B to toggle)
+	appViewMode bool // Group spaces into Platform vs Apps
 
 	// Cluster filter mode (a to toggle)
 	showAllUnits   bool   // false = filter to current cluster, true = show all units
@@ -504,7 +504,7 @@ type Model struct {
 	contextName    string // Raw kubectl context name
 
 	// Pending snapshot for restoring expanded paths after data loads
-	pendingSnapshot *HubSnapshot
+	pendingSnapshot *AppSnapshot
 
 	// Optimistic UI state - tracks pending CRUD operations for immediate feedback
 	pendingActions []PendingAction
@@ -556,7 +556,7 @@ type keyMap struct {
 	Maps         key.Binding
 	Panel        key.Binding
 	Suggest      key.Binding
-	HubView      key.Binding
+	AppView      key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -657,9 +657,9 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("g"),
 			key.WithHelp("g", "suggest units"),
 		),
-		HubView: key.NewBinding(
+		AppView: key.NewBinding(
 			key.WithKeys("B"),
-			key.WithHelp("B", "hub/appspace view"),
+			key.WithHelp("B", "app view"),
 		),
 	}
 }
@@ -698,7 +698,7 @@ type panelDataLoadedMsg struct {
 }
 
 type suggestDataLoadedMsg struct {
-	proposal *HubAppSpaceSuggestion // Generated suggestion
+	proposal *AppModelSuggestion // Generated suggestion
 	err      error
 }
 
@@ -934,8 +934,8 @@ func (n TreeNode) Description() string {
 	return n.Info
 }
 
-// HubSnapshot represents saved Hub TUI state for resumption
-type HubSnapshot struct {
+// AppSnapshot represents saved App TUI state for resumption
+type AppSnapshot struct {
 	Version       string    `json:"version"`
 	UpdatedAt     time.Time `json:"updated_at"`
 	Cursor        int       `json:"cursor"`
@@ -947,18 +947,18 @@ type HubSnapshot struct {
 
 const hubSnapshotVersion = "1.0"
 
-func getHubSnapshotPath() string {
+func getAppSnapshotPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".confighub", "sessions", "hub-snapshot.json")
 }
 
-func loadHubSnapshot() *HubSnapshot {
-	path := getHubSnapshotPath()
+func loadAppSnapshot() *AppSnapshot {
+	path := getAppSnapshotPath()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
 	}
-	var snap HubSnapshot
+	var snap AppSnapshot
 	if err := json.Unmarshal(data, &snap); err != nil {
 		return nil
 	}
@@ -969,7 +969,7 @@ func loadHubSnapshot() *HubSnapshot {
 	return &snap
 }
 
-func saveHubSnapshot(m *Model) {
+func saveAppSnapshot(m *Model) {
 	// Collect expanded node paths
 	var expandedPaths []string
 	var collectExpanded func(nodes []*TreeNode, path string)
@@ -984,7 +984,7 @@ func saveHubSnapshot(m *Model) {
 	}
 	collectExpanded(m.nodes, "")
 
-	snap := HubSnapshot{
+	snap := AppSnapshot{
 		Version:       hubSnapshotVersion,
 		UpdatedAt:     time.Now(),
 		Cursor:        m.cursor,
@@ -994,7 +994,7 @@ func saveHubSnapshot(m *Model) {
 		ExpandedPaths: expandedPaths,
 	}
 
-	path := getHubSnapshotPath()
+	path := getAppSnapshotPath()
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return

--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -120,7 +120,7 @@ type WorkloadJSON struct {
 
 // SuggestionJSON is the JSON representation of the import suggestion
 type SuggestionJSON struct {
-	AppSpace string     `json:"appSpace"`
+	App string     `json:"app"`
 	Units    []UnitJSON `json:"units"`
 }
 
@@ -366,11 +366,11 @@ func runImport(cmd *cobra.Command, args []string) error {
 	// Step 5: Apply
 	if logger != nil {
 		logger.Section("APPLYING")
-		logger.Log("Creating App: %s", proposal.AppSpace)
+		logger.Log("Creating App: %s", proposal.App)
 	}
 
 	// Try delegating Argo/Flux workloads to cub gitops import first.
-	delegation, err := attemptGitOpsDelegation(proposal.AppSpace, allWorkloads, logger)
+	delegation, err := attemptGitOpsDelegation(proposal.App, allWorkloads, logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: GitOps delegation failed, falling back to scout import: %v\n", err)
 		if logger != nil {
@@ -387,13 +387,13 @@ func runImport(cmd *cobra.Command, args []string) error {
 	if len(scoutWorkloads) == 0 && delegation.AnyDelegated() {
 		fmt.Println()
 		fmt.Println("No Helm/Native leftovers to snapshot-import.")
-		fmt.Printf("GitOps-managed workloads imported via cub gitops import into App '%s'.\n", proposal.AppSpace)
-		return printSpaceSummary(proposal.AppSpace)
+		fmt.Printf("GitOps-managed workloads imported via cub gitops import into App '%s'.\n", proposal.App)
+		return printSpaceSummary(proposal.App)
 	}
 
 	proposalToApply := proposal
 	if len(scoutWorkloads) != len(allWorkloads) {
-		proposalToApply = SuggestFullProposal(nil, scoutWorkloads, proposal.AppSpace)
+		proposalToApply = SuggestFullProposal(nil, scoutWorkloads, proposal.App)
 	}
 
 	return applyImportWithLogger(proposalToApply, scoutWorkloads, logger, shouldConnect, importAuditReason)
@@ -472,7 +472,7 @@ func normalizeImportAuditReason(raw string) (string, error) {
 }
 
 func createImportAuditContext(proposal *FullProposal, workloads []WorkloadInfo, reason string, logger *ImportLogger) (*importAuditContext, error) {
-	if proposal == nil || strings.TrimSpace(proposal.AppSpace) == "" {
+	if proposal == nil || strings.TrimSpace(proposal.App) == "" {
 		return nil, fmt.Errorf("cannot create break-glass audit context without app space")
 	}
 
@@ -481,7 +481,7 @@ func createImportAuditContext(proposal *FullProposal, workloads []WorkloadInfo, 
 
 	args := []string{
 		"changeset", "create",
-		"--space", proposal.AppSpace,
+		"--space", proposal.App,
 		changeSetSlug,
 		"--description", description,
 		"--label", "break-glass=true",
@@ -1120,7 +1120,7 @@ func printDiscovery(namespaces []string, workloads []WorkloadInfo, proposal *Ful
 	fmt.Println("┌─────────────────────────────────────────────────────────────┐")
 	fmt.Println("│ WILL CREATE                                                 │")
 	fmt.Println("└─────────────────────────────────────────────────────────────┘")
-	fmt.Printf("  App: %s\n\n", proposal.AppSpace)
+	fmt.Printf("  App: %s\n\n", proposal.App)
 
 	for _, unit := range proposal.Units {
 		labels := []string{}
@@ -1195,7 +1195,7 @@ func attemptGitOpsDelegation(space string, workloads []WorkloadInfo, logger *Imp
 	}
 
 	// Ensure space exists so target lookups and gitops commands can run.
-	if _, err := CreateAppSpaceWithResult(space, true, nil); err != nil {
+	if _, err := CreateAppWithResult(space, true, nil); err != nil {
 		msg := fmt.Sprintf("cannot ensure app space: %v", err)
 		if needArgo {
 			result.ArgoReason = msg
@@ -1394,8 +1394,8 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 	fmt.Println()
 
 	// Create App
-	fmt.Printf("Creating App: %s... ", proposal.AppSpace)
-	result, err := CreateAppSpaceWithResult(proposal.AppSpace, true, nil)
+	fmt.Printf("Creating App: %s... ", proposal.App)
+	result, err := CreateAppWithResult(proposal.App, true, nil)
 	if err != nil {
 		fmt.Println(SymError)
 		if logger != nil {
@@ -1407,12 +1407,12 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 	if result.Created {
 		fmt.Println(SymOK)
 		if logger != nil {
-			logger.Log("Created App: %s", proposal.AppSpace)
+			logger.Log("Created App: %s", proposal.App)
 		}
 	} else {
 		fmt.Println("(exists)")
 		if logger != nil {
-			logger.Log("App already exists: %s", proposal.AppSpace)
+			logger.Log("App already exists: %s", proposal.App)
 		}
 	}
 
@@ -1464,7 +1464,7 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
 		}
 
-		if err := createUnitWithManifestSimple(proposal.AppSpace, unit, labels, manifest, auditCtx); err != nil {
+		if err := createUnitWithManifestSimple(proposal.App, unit, labels, manifest, auditCtx); err != nil {
 			fmt.Printf("✗ (%v)\n", err)
 			if logger != nil {
 				logger.Log("  FAILED: create deployment: %v", err)
@@ -1513,7 +1513,7 @@ func applyImportWithLogger(proposal *FullProposal, workloads []WorkloadInfo, log
 		return nil
 	}
 
-	return printSpaceSummary(proposal.AppSpace)
+	return printSpaceSummary(proposal.App)
 }
 
 func fetchManifest(kind, namespace, name string) ([]byte, error) {
@@ -1651,7 +1651,7 @@ func confirm() bool {
 func startWorkerAndSetTargets(proposal *FullProposal, logger *ImportLogger) error {
 	if logger != nil {
 		logger.Section("STARTING WORKER")
-		logger.Log("Space: %s", proposal.AppSpace)
+		logger.Log("Space: %s", proposal.App)
 	}
 
 	// Get current kubectl context for target matching
@@ -1662,11 +1662,11 @@ func startWorkerAndSetTargets(proposal *FullProposal, logger *ImportLogger) erro
 	}
 	kubeContext := strings.TrimSpace(string(ctxOut))
 
-	fmt.Printf("Starting worker for App '%s'...\n", proposal.AppSpace)
+	fmt.Printf("Starting worker for App '%s'...\n", proposal.App)
 
 	// Start worker in background with output to devnull.
 	// Command exits while worker keeps running.
-	workerCmd := exec.Command("cub", "worker", "run", "dev", "--space", proposal.AppSpace)
+	workerCmd := exec.Command("cub", "worker", "run", "dev", "--space", proposal.App)
 	devNull, _ := os.Open(os.DevNull)
 	workerCmd.Stdout = devNull
 	workerCmd.Stderr = devNull
@@ -1691,7 +1691,7 @@ func startWorkerAndSetTargets(proposal *FullProposal, logger *ImportLogger) erro
 		fmt.Print(".")
 
 		// Check if target exists
-		checkCmd := exec.Command("cub", "target", "list", "--space", proposal.AppSpace, "-o", "json")
+		checkCmd := exec.Command("cub", "target", "list", "--space", proposal.App, "-o", "json")
 		out, err := checkCmd.Output()
 		if err != nil {
 			continue
@@ -1707,7 +1707,7 @@ func startWorkerAndSetTargets(proposal *FullProposal, logger *ImportLogger) erro
 
 	if targetSlug == "" {
 		fmt.Println("⚠ Targets not ready yet. Set target manually:")
-		fmt.Printf("  cub unit set-target <unit> <target> --space %s\n", proposal.AppSpace)
+		fmt.Printf("  cub unit set-target <unit> <target> --space %s\n", proposal.App)
 	} else {
 		// Set target on all units
 		fmt.Printf("Setting target '%s' on deployments...\n", targetSlug)
@@ -1716,7 +1716,7 @@ func startWorkerAndSetTargets(proposal *FullProposal, logger *ImportLogger) erro
 		}
 
 		for _, unit := range proposal.Units {
-			setCmd := exec.Command("cub", "unit", "set-target", unit.Slug, targetSlug, "--space", proposal.AppSpace)
+			setCmd := exec.Command("cub", "unit", "set-target", unit.Slug, targetSlug, "--space", proposal.App)
 			if err := setCmd.Run(); err != nil {
 				fmt.Printf("  ⚠ %s: failed to set target\n", unit.Slug)
 				if logger != nil {
@@ -1731,7 +1731,7 @@ func startWorkerAndSetTargets(proposal *FullProposal, logger *ImportLogger) erro
 		}
 	}
 
-	if err := printSpaceSummary(proposal.AppSpace); err != nil {
+	if err := printSpaceSummary(proposal.App); err != nil {
 		return err
 	}
 
@@ -1874,7 +1874,7 @@ func outputProposalJSON(proposal *FullProposal, workloads []WorkloadInfo, namesp
 }
 
 func resolveConnectedWorkloadsFromProposal(proposal *FullProposal, workloads []WorkloadInfo) []WorkloadInfo {
-	if proposal == nil || strings.TrimSpace(proposal.AppSpace) == "" || len(proposal.Units) == 0 || len(workloads) == 0 {
+	if proposal == nil || strings.TrimSpace(proposal.App) == "" || len(proposal.Units) == 0 || len(workloads) == 0 {
 		return workloads
 	}
 
@@ -1889,7 +1889,7 @@ func resolveConnectedWorkloadsFromProposal(proposal *FullProposal, workloads []W
 		return workloads
 	}
 
-	existingUnitSlugs, err := listUnitSlugsForSpace(proposal.AppSpace)
+	existingUnitSlugs, err := listUnitSlugsForSpace(proposal.App)
 	if err != nil || len(existingUnitSlugs) == 0 {
 		return workloads
 	}

--- a/cmd/cub-scout/import_bundle_test.go
+++ b/cmd/cub-scout/import_bundle_test.go
@@ -67,7 +67,7 @@ func TestBuildImportFromBundlePreview_BasicContract(t *testing.T) {
 	if proposal == nil {
 		t.Fatal("proposal is nil")
 	}
-	if proposal.AppSpace == "" {
+	if proposal.App == "" {
 		t.Error("proposal.appSpace is empty")
 	}
 	if len(proposal.Units) == 0 {
@@ -221,7 +221,7 @@ func TestRunImport_FromBundleJSONContract(t *testing.T) {
 	if result.Workloads[0].Owner != "Flux" {
 		t.Fatalf("owner = %q, want Flux", result.Workloads[0].Owner)
 	}
-	if result.Proposal == nil || result.Proposal.AppSpace == "" {
+	if result.Proposal == nil || result.Proposal.App == "" {
 		t.Fatalf("proposal missing or empty: %+v", result.Proposal)
 	}
 	if result.Evidence.Source != "bundle" {
@@ -310,7 +310,7 @@ func TestOutputProposalJSON_ClusterEvidenceSource(t *testing.T) {
 	defer restore()
 
 	proposal := &FullProposal{
-		AppSpace: "test-space",
+		App: "test-space",
 		Units: []UnitProposal{
 			{
 				Slug:    "test-unit",
@@ -360,7 +360,7 @@ func TestOutputProposalJSON_ConnectedFallbackFromExistingUnits(t *testing.T) {
 	}()
 
 	proposal := &FullProposal{
-		AppSpace: "orders-team",
+		App: "orders-team",
 		Units: []UnitProposal{
 			{
 				Slug:      "orders-api",

--- a/cmd/cub-scout/import_suggest_golden_test.go
+++ b/cmd/cub-scout/import_suggest_golden_test.go
@@ -284,7 +284,7 @@ func runImportSuggestGolden(t *testing.T, name string, workloads []WorkloadInfo)
 	t.Helper()
 
 	// Run the suggestion engine
-	suggestion := SuggestHubAppSpaceStructure(workloads, "")
+	suggestion := SuggestAppStructure(workloads, "")
 
 	// Build input summary for context
 	nsSet := make(map[string]bool)
@@ -323,7 +323,7 @@ func runImportSuggestGolden(t *testing.T, name string, workloads []WorkloadInfo)
 			Owners:        ownerCounts,
 		},
 		Suggestion: suggestGoldenSuggestion{
-			AppSpace: suggestion.AppSpace,
+			AppSpace: suggestion.App,
 			Units:    units,
 		},
 	}

--- a/cmd/cub-scout/import_wizard.go
+++ b/cmd/cub-scout/import_wizard.go
@@ -1255,7 +1255,7 @@ func (m *ImportWizardModel) selectEditMenuItem() (tea.Model, tea.Cmd) {
 		}
 	case 1: // Rename app space
 		m.editMode = editModeRenameSpace
-		m.editInput = m.proposal.AppSpace
+		m.editInput = m.proposal.App
 	case 2: // Merge with another unit
 		if len(m.proposal.Units) > 1 {
 			m.editMode = editModeMergeSelect
@@ -1294,7 +1294,7 @@ func (m *ImportWizardModel) confirmTextEdit() (tea.Model, tea.Cmd) {
 		}
 	case editModeRenameSpace:
 		if m.editInput != "" {
-			m.proposal.AppSpace = sanitizeSlug(m.editInput)
+			m.proposal.App = sanitizeSlug(m.editInput)
 		}
 	case editModeAddLabel:
 		// Format: key=value
@@ -1542,7 +1542,7 @@ func (m ImportWizardModel) generateProposal() tea.Msg {
 // - Native workloads are grouped by app label
 func (m ImportWizardModel) generateSmartProposal(workloads []WorkloadInfo) *FullProposal {
 	proposal := &FullProposal{
-		AppSpace: inferAppSpace(workloads, ""),
+		App: inferApp(workloads, ""),
 	}
 
 	// Group workloads by their "unit key":
@@ -1620,7 +1620,7 @@ func (m ImportWizardModel) generateSmartProposal(workloads []WorkloadInfo) *Full
 				unit.Tier = tier
 				unit.Labels["tier"] = tier
 			}
-			if team := extractTeam(w, proposal.AppSpace); team != "" {
+			if team := extractTeam(w, proposal.App); team != "" {
 				if _, exists := unit.Labels["team"]; !exists {
 					unit.Labels["team"] = team
 				}
@@ -1657,7 +1657,7 @@ func (m ImportWizardModel) startApplyCmd() tea.Cmd {
 		}
 
 		// Create App first
-		_, err := CreateAppSpaceWithResult(m.proposal.AppSpace, true, nil)
+		_, err := CreateAppWithResult(m.proposal.App, true, nil)
 		if err != nil {
 			return wizardErrMsg{err: fmt.Errorf("create space: %w", err)}
 		}
@@ -1706,7 +1706,7 @@ func (m ImportWizardModel) applyNextUnitCmd(unitIndex int) tea.Cmd {
 			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
 		}
 
-		if err := createUnitWithManifestSimple(m.proposal.AppSpace, unit, labels, manifest, nil); err != nil {
+		if err := createUnitWithManifestSimple(m.proposal.App, unit, labels, manifest, nil); err != nil {
 			return wizardApplyProgressMsg{unitSlug: unit.Slug, success: false, err: err.Error()}
 		}
 
@@ -1722,8 +1722,8 @@ func (m ImportWizardModel) startWorkerCmd() tea.Cmd {
 		}
 
 		// Use app space name as worker name
-		workerName := m.proposal.AppSpace + "-worker"
-		space := m.proposal.AppSpace
+		workerName := m.proposal.App + "-worker"
+		space := m.proposal.App
 
 		// Start worker in background
 		cmd := exec.Command("cub", "worker", "run", workerName, "--space", space)
@@ -1810,7 +1810,7 @@ func (m ImportWizardModel) runTestAddAnnotation() tea.Msg {
 	os.RemoveAll(testDebugDir)
 	os.MkdirAll(testDebugDir, 0755)
 	appendTestDebug("=== TEST STARTED ===")
-	appendTestDebug(fmt.Sprintf("Space: %s, Unit: %s, Annotation: %s", m.proposal.AppSpace, m.testUnitSlug, m.testAnnotation))
+	appendTestDebug(fmt.Sprintf("Space: %s, Unit: %s, Annotation: %s", m.proposal.App, m.testUnitSlug, m.testAnnotation))
 
 	if m.proposal == nil || m.testUnitSlug == "" {
 		appendTestDebug("ERROR: no unit to test")
@@ -1826,7 +1826,7 @@ func (m ImportWizardModel) runTestAddAnnotation() tea.Msg {
 
 	// Step 1: Get unit JSON
 	appendTestDebug("Step 1: Getting unit JSON...")
-	getCmd := exec.Command("cub", "unit", "get", "--space", m.proposal.AppSpace, m.testUnitSlug, "--json")
+	getCmd := exec.Command("cub", "unit", "get", "--space", m.proposal.App, m.testUnitSlug, "--json")
 	unitJSON, err := getCmd.CombinedOutput()
 	writeTestDebug("01-unit-get.json", unitJSON)
 	appendTestDebug(fmt.Sprintf("Unit get result: %d bytes, err=%v", len(unitJSON), err))
@@ -1916,7 +1916,7 @@ func (m ImportWizardModel) runTestAddAnnotation() tea.Msg {
 
 	// Step 5: Update unit
 	appendTestDebug("Step 5: Updating unit with modified YAML...")
-	updateCmd := exec.Command("cub", "unit", "update", "--space", m.proposal.AppSpace, m.testUnitSlug, "-", "--change-desc", "Import wizard test")
+	updateCmd := exec.Command("cub", "unit", "update", "--space", m.proposal.App, m.testUnitSlug, "-", "--change-desc", "Import wizard test")
 	updateCmd.Stdin = strings.NewReader(string(modifiedYAML))
 	updateOutput, err := updateCmd.CombinedOutput()
 	writeTestDebug("05-update-result.txt", updateOutput)
@@ -1957,7 +1957,7 @@ func (m ImportWizardModel) runTestApply() tea.Msg {
 	// First, check if the unit has a target. If not, find one and set it.
 	appendTestDebug("Checking if unit has target...")
 	checkCmd := exec.Command("cub", "unit", "get",
-		"--space", m.proposal.AppSpace,
+		"--space", m.proposal.App,
 		"--json",
 		m.testUnitSlug)
 	checkOutput, _ := checkCmd.CombinedOutput()
@@ -1977,7 +1977,7 @@ func (m ImportWizardModel) runTestApply() tea.Msg {
 		appendTestDebug("Unit has no target, finding one...")
 		// Find a Kubernetes target
 		targetCmd := exec.Command("cub", "target", "list",
-			"--space", m.proposal.AppSpace,
+			"--space", m.proposal.App,
 			"--json")
 		targetOutput, err := targetCmd.CombinedOutput()
 		writeTestDebug("07-target-list.json", targetOutput)
@@ -1995,7 +1995,7 @@ func (m ImportWizardModel) runTestApply() tea.Msg {
 		// Use jq to find Kubernetes target
 		jqCmd := exec.Command("sh", "-c",
 			fmt.Sprintf(`cub target list --space %s --json | jq -r '[.[] | select(.Target.ProviderType == "Kubernetes")] | .[0].Target.Slug // empty'`,
-				m.proposal.AppSpace))
+				m.proposal.App))
 		jqOutput, _ := jqCmd.CombinedOutput()
 		targetSlug := strings.TrimSpace(string(jqOutput))
 		appendTestDebug(fmt.Sprintf("Found target slug via jq: '%s'", targetSlug))
@@ -2013,7 +2013,7 @@ func (m ImportWizardModel) runTestApply() tea.Msg {
 		// Set the target on the unit
 		appendTestDebug(fmt.Sprintf("Setting target to: %s", targetSlug))
 		setTargetCmd := exec.Command("cub", "unit", "set-target",
-			"--space", m.proposal.AppSpace,
+			"--space", m.proposal.App,
 			m.testUnitSlug,
 			targetSlug)
 		setOutput, err := setTargetCmd.CombinedOutput()
@@ -2033,7 +2033,7 @@ func (m ImportWizardModel) runTestApply() tea.Msg {
 	// Apply the unit
 	appendTestDebug("Applying unit...")
 	cmd := exec.Command("cub", "unit", "apply",
-		"--space", m.proposal.AppSpace,
+		"--space", m.proposal.App,
 		"--wait",
 		m.testUnitSlug)
 
@@ -2075,7 +2075,7 @@ func (m ImportWizardModel) runTestWaitSync() tea.Msg {
 	// This indicates the worker has synced
 	appendTestDebug("Getting unit status...")
 	cmd := exec.Command("cub", "unit", "get",
-		"--space", m.proposal.AppSpace,
+		"--space", m.proposal.App,
 		"--json",
 		m.testUnitSlug)
 
@@ -2252,7 +2252,7 @@ func (m ImportWizardModel) runTestVerify() tea.Msg {
 			// Verify the annotation is still in the Unit (ConfigHub side worked)
 			appendTestDebug("Checking if annotation is in Unit data...")
 			unitCmd := exec.Command("cub", "unit", "get",
-				"--space", m.proposal.AppSpace,
+				"--space", m.proposal.App,
 				"--json",
 				m.testUnitSlug)
 			unitOutput, err := unitCmd.CombinedOutput()
@@ -2313,7 +2313,7 @@ func (m ImportWizardModel) checkSyncStatusCmd() tea.Cmd {
 	return func() tea.Msg {
 		// Check unit status
 		cmd := exec.Command("cub", "unit", "get",
-			"--space", m.proposal.AppSpace,
+			"--space", m.proposal.App,
 			"--json",
 			m.testUnitSlug)
 
@@ -2572,9 +2572,9 @@ func (m ImportWizardModel) renderProposalTree() string {
 	b.WriteString("\n\n")
 
 	// Tree root: App
-	appSpaceIcon := "📁"
-	appSpaceName := wizardSelectedStyle.Render(m.proposal.AppSpace)
-	b.WriteString(fmt.Sprintf("%s %s\n", appSpaceIcon, appSpaceName))
+	appIcon := "📁"
+	appName := wizardSelectedStyle.Render(m.proposal.App)
+	b.WriteString(fmt.Sprintf("%s %s\n", appIcon, appName))
 
 	numUnits := len(m.proposal.Units)
 	for i, unit := range m.proposal.Units {
@@ -2740,7 +2740,7 @@ func (m ImportWizardModel) renderEditOverlay() string {
 		b.WriteString(headerStyle.Render("Rename App"))
 		b.WriteString("\n\n")
 		b.WriteString("Current: ")
-		b.WriteString(m.proposal.AppSpace)
+		b.WriteString(m.proposal.App)
 		b.WriteString("\n\n")
 		b.WriteString("New name: ")
 		b.WriteString(wizardSelectedStyle.Render(m.editInput))
@@ -2827,7 +2827,7 @@ func (m ImportWizardModel) renderArchitectureDiagram() string {
 	b.WriteString(boxColor.Render("│") + "                           " + boxColor.Render("│") + "\n")
 
 	// App
-	spaceName := wizardTruncate(m.proposal.AppSpace, 18)
+	spaceName := wizardTruncate(m.proposal.App, 18)
 	b.WriteString(boxColor.Render("│") + "  " + spaceStyle.Render(spaceName) + strings.Repeat(" ", 25-len(spaceName)) + boxColor.Render("│") + "\n")
 
 	// Units (show up to 4)
@@ -2865,7 +2865,7 @@ func (m ImportWizardModel) renderArchitectureDiagram() string {
 	b.WriteString(boxColor.Render("              ▼") + "\n")
 
 	// Worker box
-	workerName := m.proposal.AppSpace + "-worker"
+	workerName := m.proposal.App + "-worker"
 	if len(workerName) > 17 {
 		workerName = workerName[:14] + "..."
 	}
@@ -2917,7 +2917,7 @@ func (m ImportWizardModel) renderApplyProgress() string {
 		b.WriteString(dimStyle.Render("This registers your workloads for management."))
 		b.WriteString("\n\n")
 
-		b.WriteString(fmt.Sprintf("Creating App: %s\n", m.proposal.AppSpace))
+		b.WriteString(fmt.Sprintf("Creating App: %s\n", m.proposal.App))
 		if m.applyProgress > 0 {
 			b.WriteString(wizardSuccessStyle.Render("  ✓ Created") + "\n")
 		}
@@ -2953,7 +2953,7 @@ func (m ImportWizardModel) renderApplyProgress() string {
 			}
 		}
 		b.WriteString(fmt.Sprintf("Created %d units in ", successCount))
-		b.WriteString(wizardSelectedStyle.Render(m.proposal.AppSpace) + "\n\n")
+		b.WriteString(wizardSelectedStyle.Render(m.proposal.App) + "\n\n")
 
 		// Next steps
 		b.WriteString(headerStyle.Render("Next Steps") + "\n\n")
@@ -2961,7 +2961,7 @@ func (m ImportWizardModel) renderApplyProgress() string {
 		if m.workerStarted {
 			b.WriteString(wizardSuccessStyle.Render("✓ Worker started") + "\n")
 			b.WriteString(fmt.Sprintf("  Name: %s\n", m.workerName))
-			b.WriteString(fmt.Sprintf("  Space: %s\n", m.proposal.AppSpace))
+			b.WriteString(fmt.Sprintf("  Space: %s\n", m.proposal.App))
 			b.WriteString("\n")
 
 			// Offer test option
@@ -2973,7 +2973,7 @@ func (m ImportWizardModel) renderApplyProgress() string {
 		} else {
 			b.WriteString("Start a worker to connect this cluster:\n\n")
 			b.WriteString(dimStyle.Render("  Press ") + wizardSelectedStyle.Render("w") + dimStyle.Render(" to start now, or run:") + "\n\n")
-			b.WriteString(fmt.Sprintf("  cub worker run %s-worker --space %s\n", m.proposal.AppSpace, m.proposal.AppSpace))
+			b.WriteString(fmt.Sprintf("  cub worker run %s-worker --space %s\n", m.proposal.App, m.proposal.App))
 			b.WriteString("\n")
 			b.WriteString(dimStyle.Render("The worker will:") + "\n")
 			b.WriteString("  • Connect to ConfigHub\n")
@@ -3004,7 +3004,7 @@ func (m ImportWizardModel) renderArgoCleanupList() string {
 			}
 		}
 		b.WriteString(fmt.Sprintf("Created %d units in ", successCount))
-		b.WriteString(wizardSelectedStyle.Render(m.proposal.AppSpace) + "\n")
+		b.WriteString(wizardSelectedStyle.Render(m.proposal.App) + "\n")
 		b.WriteString("ArgoCD Applications have been handled.\n\n")
 
 		// Next steps
@@ -3013,7 +3013,7 @@ func (m ImportWizardModel) renderArgoCleanupList() string {
 		if m.workerStarted {
 			b.WriteString(wizardSuccessStyle.Render("✓ Worker started") + "\n")
 			b.WriteString(fmt.Sprintf("  Name: %s\n", m.workerName))
-			b.WriteString(fmt.Sprintf("  Space: %s\n", m.proposal.AppSpace))
+			b.WriteString(fmt.Sprintf("  Space: %s\n", m.proposal.App))
 			b.WriteString("\n")
 
 			// Offer test option
@@ -3025,7 +3025,7 @@ func (m ImportWizardModel) renderArgoCleanupList() string {
 		} else {
 			b.WriteString("Start a worker to connect this cluster:\n\n")
 			b.WriteString(dimStyle.Render("  Press ") + wizardSelectedStyle.Render("w") + dimStyle.Render(" to start now, or run:") + "\n\n")
-			b.WriteString(fmt.Sprintf("  cub worker run %s-worker --space %s\n", m.proposal.AppSpace, m.proposal.AppSpace))
+			b.WriteString(fmt.Sprintf("  cub worker run %s-worker --space %s\n", m.proposal.App, m.proposal.App))
 			b.WriteString("\n")
 			b.WriteString(dimStyle.Render("The worker will:") + "\n")
 			b.WriteString("  • Connect to ConfigHub\n")
@@ -3292,7 +3292,7 @@ func (m ImportWizardModel) renderTestDetails() string {
 	b.WriteString(fmt.Sprintf("Unit:       %s\n", wizardSelectedStyle.Render(m.testUnitSlug)))
 	b.WriteString(fmt.Sprintf("Annotation: %s\n", dimStyle.Render("confighub.com/import-test")))
 	b.WriteString(fmt.Sprintf("Value:      %s\n", dimStyle.Render(m.testAnnotation)))
-	b.WriteString(fmt.Sprintf("Space:      %s\n", dimStyle.Render(m.proposal.AppSpace)))
+	b.WriteString(fmt.Sprintf("Space:      %s\n", dimStyle.Render(m.proposal.App)))
 	b.WriteString("\n")
 
 	// Phase details

--- a/cmd/cub-scout/import_wizard_test.go
+++ b/cmd/cub-scout/import_wizard_test.go
@@ -103,7 +103,7 @@ func testWorkloads() []WorkloadItem {
 // testProposal returns a mock FullProposal
 func testProposal() *FullProposal {
 	return &FullProposal{
-		AppSpace: "my-team",
+		App: "my-team",
 		Deployer: "ArgoCD",
 		Units: []UnitProposal{
 			{

--- a/cmd/cub-scout/logger.go
+++ b/cmd/cub-scout/logger.go
@@ -90,7 +90,7 @@ func (l *ImportLogger) LogProposal(proposal *FullProposal) {
 		return
 	}
 	l.Section("PROPOSAL")
-	l.Log("App: %s", proposal.AppSpace)
+	l.Log("App: %s", proposal.App)
 	l.Log("Units: %d", len(proposal.Units))
 	for _, u := range proposal.Units {
 		l.Log("  %s (app=%s, variant=%s)", u.Slug, u.App, u.Variant)

--- a/cmd/cub-scout/logger_test.go
+++ b/cmd/cub-scout/logger_test.go
@@ -115,7 +115,7 @@ func TestLogProposal(t *testing.T) {
 	}
 
 	proposal := &FullProposal{
-		AppSpace: "my-team",
+		App: "my-team",
 		Units: []UnitProposal{
 			{
 				Slug:      "nginx-prod",

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -1274,7 +1274,7 @@ var mapFleetCmd = &cobra.Command{
 	Short: "Show fleet view grouped by app and variant (App model)",
 	Long: `Display units across spaces grouped by app and variant labels.
 
-This view requires units imported with --model hub-appspace, which adds:
+This view requires units imported with --model app-deployment-target, which adds:
   - Labels.app: The application name
   - Labels.variant: The environment variant (dev, staging, prod)
 

--- a/cmd/cub-scout/patterns.go
+++ b/cmd/cub-scout/patterns.go
@@ -56,7 +56,7 @@ type SuggestedOrg struct {
 
 type SuggestedHub struct {
 	Name      string           `json:"name"`
-	AppSpaces []SuggestedSpace `json:"appSpaces"`
+	Apps []SuggestedSpace `json:"apps"`
 }
 
 type SuggestedSpace struct {
@@ -576,7 +576,7 @@ func suggestOrganization(result *PatternsResult) SuggestedOrg {
 				hubMap["platform"] = &SuggestedHub{Name: "platform"}
 			}
 			for _, app := range r.Apps {
-				hubMap["platform"].AppSpaces = append(hubMap["platform"].AppSpaces, SuggestedSpace{
+				hubMap["platform"].Apps = append(hubMap["platform"].Apps, SuggestedSpace{
 					Name:      app,
 					Workloads: []string{app},
 					Env:       "shared",
@@ -592,7 +592,7 @@ func suggestOrganization(result *PatternsResult) SuggestedOrg {
 			hubMap[hubName] = &SuggestedHub{Name: hubName}
 		}
 		for _, ns := range team.Namespaces {
-			hubMap[hubName].AppSpaces = append(hubMap[hubName].AppSpaces, SuggestedSpace{
+			hubMap[hubName].Apps = append(hubMap[hubName].Apps, SuggestedSpace{
 				Name:      ns,
 				Workloads: []string{fmt.Sprintf("%d workloads", team.Workloads/len(team.Namespaces))},
 				Env:       inferEnv(ns),
@@ -606,7 +606,7 @@ func suggestOrganization(result *PatternsResult) SuggestedOrg {
 		if hubMap[hubName] == nil && len(chain.Environments) > 2 {
 			hubMap[hubName] = &SuggestedHub{Name: hubName}
 			for ns := range chain.Environments {
-				hubMap[hubName].AppSpaces = append(hubMap[hubName].AppSpaces, SuggestedSpace{
+				hubMap[hubName].Apps = append(hubMap[hubName].Apps, SuggestedSpace{
 					Name:      fmt.Sprintf("%s-%s", chain.AppName, inferEnv(ns)),
 					Workloads: []string{fmt.Sprintf("%s/%s", ns, chain.AppName)},
 					Env:       inferEnv(ns),
@@ -788,7 +788,7 @@ func printPatterns(r *PatternsResult) {
 
 	for _, hub := range r.Suggested.Hubs {
 		fmt.Printf("\n├── Hub: %s\n", hub.Name)
-		for _, space := range hub.AppSpaces {
+		for _, space := range hub.Apps {
 			fmt.Printf("│   └── App: %s [%s]\n", space.Name, space.Env)
 		}
 	}

--- a/cmd/cub-scout/suggest.go
+++ b/cmd/cub-scout/suggest.go
@@ -18,15 +18,15 @@ type ImportSuggestion struct {
 	Apps  []AppSuggestion
 }
 
-// HubAppSpaceSuggestion represents a suggested import structure (hub-appspace model)
-// In this model, one Space acts as the "App Space" containing all variants via labels
-type HubAppSpaceSuggestion struct {
-	AppSpace string            // The team's App Space (one per team, not per env)
-	Units    []HubAppSpaceUnit // Units with app/variant labels
+// AppModelSuggestion represents a suggested import structure (app-deployment-target model)
+// In this model, one App contains all variants/deployments via labels
+type AppModelSuggestion struct {
+	App   string         // The app name (one per team, not per env)
+	Units    []AppModelUnit // Units with app/variant labels
 }
 
-// HubAppSpaceUnit represents a unit in the Hub/App Space model
-type HubAppSpaceUnit struct {
+// AppModelUnit represents a unit in the App model
+type AppModelUnit struct {
 	Slug      string         // e.g., "payment-api-prod"
 	App       string         // app label value
 	Variant   string         // variant label value
@@ -418,9 +418,9 @@ func (s *ImportSuggestion) TotalWorkloads() int {
 	return count
 }
 
-// SuggestHubAppSpaceStructure analyzes workloads and suggests an App model structure
-// Key difference: One App contains ALL variants via labels (not one space per env)
-func SuggestHubAppSpaceStructure(workloads []WorkloadInfo, defaultSpace string) HubAppSpaceSuggestion {
+// SuggestAppStructure analyzes workloads and suggests an App/Deployment/Target structure
+// One App contains all variants via labels (not one space per env)
+func SuggestAppStructure(workloads []WorkloadInfo, defaultSpace string) AppModelSuggestion {
 	// Group workloads by inferred app and variant
 	type unitKey struct {
 		app, variant string
@@ -441,8 +441,8 @@ func SuggestHubAppSpaceStructure(workloads []WorkloadInfo, defaultSpace string) 
 	}
 
 	// Build suggestion
-	suggestion := HubAppSpaceSuggestion{
-		AppSpace: inferAppSpace(workloads, defaultSpace),
+	suggestion := AppModelSuggestion{
+		App: inferApp(workloads, defaultSpace),
 	}
 
 	// Sort keys for consistent output
@@ -466,7 +466,7 @@ func SuggestHubAppSpaceStructure(workloads []WorkloadInfo, defaultSpace string) 
 			slug = fmt.Sprintf("%s-%s", key.app, key.variant)
 		}
 
-		suggestion.Units = append(suggestion.Units, HubAppSpaceUnit{
+		suggestion.Units = append(suggestion.Units, AppModelUnit{
 			Slug:      sanitizeSlug(slug),
 			App:       key.app,
 			Variant:   key.variant,
@@ -477,9 +477,9 @@ func SuggestHubAppSpaceStructure(workloads []WorkloadInfo, defaultSpace string) 
 	return suggestion
 }
 
-// inferAppSpace suggests an App name (team workspace)
+// inferApp suggests an App name (team workspace)
 // In the App model, this is the team's workspace containing all their variants
-func inferAppSpace(workloads []WorkloadInfo, defaultSpace string) string {
+func inferApp(workloads []WorkloadInfo, defaultSpace string) string {
 	if defaultSpace != "" {
 		return defaultSpace
 	}
@@ -517,14 +517,14 @@ func inferAppSpace(workloads []WorkloadInfo, defaultSpace string) string {
 	return "imported-team"
 }
 
-// Print displays the Hub/App Space suggestion
-func (s *HubAppSpaceSuggestion) Print() {
+// Print displays the App/Deployment/Target suggestion
+func (s *AppModelSuggestion) Print() {
 	fmt.Printf("Suggested structure (App model):\n")
-	fmt.Printf("  App: %s\n", s.AppSpace)
+	fmt.Printf("  App: %s\n", s.App)
 	fmt.Println()
 
 	// Group by app for display
-	appUnits := make(map[string][]HubAppSpaceUnit)
+	appUnits := make(map[string][]AppModelUnit)
 	for _, u := range s.Units {
 		appUnits[u.App] = append(appUnits[u.App], u)
 	}
@@ -558,14 +558,14 @@ func (s *HubAppSpaceSuggestion) Print() {
 	}
 }
 
-// FullProposal represents the complete Hub/App Space mapping proposal
+// FullProposal represents the complete App/Deployment/Target mapping proposal
 // combining Git repo structure with cluster workloads
 type FullProposal struct {
 	// Hub-level items
 	HubBases []HubBaseProposal `json:"hubBases,omitempty"` // Templates from Git base/
 
-	// App Space level
-	AppSpace       string               `json:"appSpace"`
+	// App level
+	App            string               `json:"app"`
 	Deployer       string               `json:"deployer,omitempty"`       // Detected deployer (Flux, Argo, etc.)
 	Reconciliation []ReconciliationRule `json:"reconciliation,omitempty"` // Suggested rules by variant
 	Units          []UnitProposal       `json:"units"`
@@ -617,10 +617,10 @@ type ClusterOnlyApp struct {
 	Owner     string   `json:"owner"` // Native = orphan
 }
 
-// SuggestFullProposal combines Git facts + Cluster facts into a full Hub/App Space proposal
+// SuggestFullProposal combines Git facts + Cluster facts into a full App/Deployment/Target proposal
 func SuggestFullProposal(gitApps []gitops.AppDefinition, workloads []WorkloadInfo, defaultSpace string) *FullProposal {
 	proposal := &FullProposal{
-		AppSpace: inferAppSpace(workloads, defaultSpace),
+		App: inferApp(workloads, defaultSpace),
 	}
 
 	// Detect dominant deployer from workloads
@@ -714,8 +714,8 @@ func SuggestFullProposal(gitApps []gitops.AppDefinition, workloads []WorkloadInf
 						unit.Labels["tier"] = tier
 					}
 
-					// Extract team from labels or app space
-					if team := extractTeam(w, proposal.AppSpace); team != "" {
+					// Extract team from labels or app name
+					if team := extractTeam(w, proposal.App); team != "" {
 						unit.Labels["team"] = team
 					}
 				}
@@ -784,7 +784,7 @@ func SuggestFullProposal(gitApps []gitops.AppDefinition, workloads []WorkloadInf
 					unit.Tier = tier
 					unit.Labels["tier"] = tier
 				}
-				if team := extractTeam(w, proposal.AppSpace); team != "" {
+				if team := extractTeam(w, proposal.App); team != "" {
 					if _, exists := unit.Labels["team"]; !exists {
 						unit.Labels["team"] = team
 					}
@@ -845,7 +845,7 @@ func extractTier(w WorkloadInfo) string {
 }
 
 // extractTeam infers team from labels or namespace
-func extractTeam(w WorkloadInfo, appSpace string) string {
+func extractTeam(w WorkloadInfo, app string) string {
 	// Check labels
 	if team, ok := w.Labels["team"]; ok {
 		return team
@@ -853,9 +853,9 @@ func extractTeam(w WorkloadInfo, appSpace string) string {
 	if team, ok := w.Labels["app.kubernetes.io/part-of"]; ok {
 		return team
 	}
-	// Derive from App Space name (strip -team suffix)
-	if appSpace != "" {
-		return strings.TrimSuffix(appSpace, "-team")
+	// Derive from app name (strip -team suffix)
+	if app != "" {
+		return strings.TrimSuffix(app, "-team")
 	}
 	return ""
 }
@@ -905,8 +905,8 @@ func (p *FullProposal) Print() {
 		}
 	}
 
-	// App Space
-	fmt.Printf("\n  APP: %s\n", p.AppSpace)
+	// App
+	fmt.Printf("\n  APP: %s\n", p.App)
 
 	// Deployer
 	if p.Deployer != "" {

--- a/cmd/cub-scout/tree.go
+++ b/cmd/cub-scout/tree.go
@@ -1275,7 +1275,7 @@ func runTreeSuggest(ctx context.Context) error {
 	}
 
 	if treeJSON {
-		suggestion := SuggestHubAppSpaceStructure(workloads, treeSpace)
+		suggestion := SuggestAppStructure(workloads, treeSpace)
 		return json.NewEncoder(os.Stdout).Encode(suggestion)
 	}
 
@@ -1286,7 +1286,7 @@ func runTreeSuggest(ctx context.Context) error {
 	fmt.Println("Based on cluster workloads, here's a suggested ConfigHub structure:")
 	fmt.Println()
 
-	suggestion := SuggestHubAppSpaceStructure(workloads, treeSpace)
+	suggestion := SuggestAppStructure(workloads, treeSpace)
 	suggestion.Print()
 
 	fmt.Println()

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@ New to cub-scout? Start here:
 |-------|-----------|
 | Import docs crosswalk | [reference/import-docs-crosswalk.md](reference/import-docs-crosswalk.md) |
 | Connected tiers + views guide | [reference/connected-tiers-and-views-product-guide.md](reference/connected-tiers-and-views-product-guide.md) |
-| App model examples | [reference/hub-appspace-examples.md](reference/hub-appspace-examples.md) |
+| App model examples | [reference/app-model-examples.md](reference/app-model-examples.md) |
 | Rendered Manifest + Argo guide | [reference/rendered-manifest-and-argo-product-guide.md](reference/rendered-manifest-and-argo-product-guide.md) |
 | Stored in Git vs ConfigHub | [reference/stored-in-git-vs-confighub.md](reference/stored-in-git-vs-confighub.md) |
 | Resolver pattern | [reference/resolver-pattern.md](reference/resolver-pattern.md) |

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -265,7 +265,7 @@ The Agent supports multiple output modes via 14 top-level commands and 17 map su
 | `snapshot` | Dump cluster state as GSF JSON | Standalone |
 | `import` | Import workloads into ConfigHub | Connected |
 | `import-argocd` | Import ArgoCD Application | Connected |
-| `app-space` | Manage App Spaces | Connected |
+| `app` | Manage Apps | Connected |
 | `remedy` | Execute risk remediation | Standalone |
 | `combined` | Git repo + cluster alignment | Standalone/Connected |
 | `parse-repo` | Parse GitOps repo structure | Standalone |

--- a/docs/howto/tree-hierarchies.md
+++ b/docs/howto/tree-hierarchies.md
@@ -11,7 +11,7 @@ cub-scout tree
 # Resources grouped by owner
 cub-scout tree ownership
 
-# Suggested Hub/AppSpace organization
+# Suggested App organization
 cub-scout tree suggest
 ```
 
@@ -378,7 +378,7 @@ Use --edge clone to see inheritance instead.
 
 ### Suggested Organization
 
-Analyzes cluster workloads and suggests Hub/AppSpace organization.
+Analyzes cluster workloads and suggests App organization.
 
 ```bash
 cub-scout tree suggest

--- a/docs/outcomes/README.md
+++ b/docs/outcomes/README.md
@@ -98,7 +98,7 @@ Map shows the complete picture of how apps flow from source to production:
 │  3. UPGRADE (Paid)                                                     │
 │     → "Make a change" operations (import, apply, destroy)              │
 │     → AI-powered trace and actions                                     │
-│     → Platform team collaboration (Hub/AppSpace model)                 │
+│     → Platform team collaboration (App/Deployment/Target model)                 │
 │     → Enterprise features (audit, RBAC, compliance)                    │
 │     → VALUE: "I can operate at scale"                                  │
 └────────────────────────────────────────────────────────────────────────┘

--- a/docs/outcomes/confighub-integration.md
+++ b/docs/outcomes/confighub-integration.md
@@ -99,7 +99,7 @@ cub unit get payment-api --all-spaces
 cub unit apply payment-api
 ```
 
-## The Hub/AppSpace Model
+## The App/Deployment/Target Model
 
 ConfigHub enables platform + app team collaboration:
 
@@ -277,7 +277,7 @@ cub-scout import
 
 ConfigHub integration provides:
 - **DRY → WET → Live visibility** across your entire fleet
-- **Hub/AppSpace model** for platform + app team collaboration
+- **App/Deployment/Target model** for platform + app team collaboration
 - **RM Pattern support** for better config transport
 - **Fleet-wide queries** to answer "what's running where"
 - **Complete audit trail** from source to deployment

--- a/docs/outcomes/enterprise-case-studies.md
+++ b/docs/outcomes/enterprise-case-studies.md
@@ -134,7 +134,7 @@ Common enterprise challenges and solutions:
 | Multi-tool chaos | Check each dashboard | Single view across all deployers |
 | Can't query fleet | Manual per-cluster scripts | `cub-scout map list -q "..."` |
 | Hotfix → Git hell | Drift accumulates | `cub drift accept` reconciles |
-| No ownership boundaries | Tribal knowledge | Hub = platform, AppSpace = team |
+| No ownership boundaries | Tribal knowledge | Hub = platform, App = team |
 
 ---
 

--- a/docs/reference/app-model-examples.md
+++ b/docs/reference/app-model-examples.md
@@ -1,6 +1,6 @@
-# Hub/AppSpace View Examples
+# App View Examples
 
-Visual examples of the `B` key Hub/AppSpace grouping for common reference architectures.
+Visual examples of the `B` key App grouping for common reference architectures.
 
 ---
 
@@ -8,11 +8,11 @@ Visual examples of the `B` key Hub/AppSpace grouping for common reference archit
 
 Press `B` in Hub mode (`cub-scout map --hub`) to toggle between:
 - **Flat view**: Org → Spaces (alphabetical)
-- **Hub/AppSpace view**: Org → Hub (platform) → AppSpaces (teams)
+- **App view**: Org → Hub (platform) → Apps (teams)
 
 **Categorization rules:**
 - **Hub (Platform)**: `platform-*`, `infra-*`, `hub-*`, `shared-*`, `*-base`, `*-infra`
-- **AppSpaces**: Everything else (team workspaces)
+- **Apps**: Everything else (team workspaces)
 
 ---
 
@@ -34,7 +34,7 @@ confighub ▾
 └─ platform-prod                  7 targets
 ```
 
-### Hub/AppSpace View (press B)
+### App View (press B)
 
 ```
 confighub ▾
@@ -45,7 +45,7 @@ confighub ▾
 │  └─ platform-prod                       7 targets
 │     └─ Workers: prod-worker (Ready)
 │
-└─ AppSpaces                              6 spaces
+└─ Apps                              6 spaces
    ├─ appchat-dev                         4 units
    │  └─ chat-frontend, chat-backend, redis, postgres
    ├─ appchat-prod                        4 units
@@ -79,7 +79,7 @@ confighub ▾
 └─ fluffy-cub-traderx-prod-us
 ```
 
-### Hub/AppSpace View (press B)
+### App View (press B)
 
 ```
 confighub ▾
@@ -90,7 +90,7 @@ confighub ▾
 │  └─ fluffy-cub-traderx-infra           Shared infra
 │     └─ Units: ingress-controller, cert-manager, monitoring
 │
-└─ AppSpaces                              3 spaces
+└─ Apps                              3 spaces
    ├─ fluffy-cub-traderx-prod-asia       Asia production
    │  └─ Units: traderx (variant=prod, region=asia)
    ├─ fluffy-cub-traderx-prod-eu         EU production
@@ -101,7 +101,7 @@ confighub ▾
 
 **What this shows:**
 - Base and infra spaces are Hub (platform governance)
-- Regional prod spaces are AppSpaces (team deployments)
+- Regional prod spaces are Apps (team deployments)
 - Each region clones from `traderx-base`
 
 ---
@@ -122,7 +122,7 @@ confighub ▾
 └─ curious-cub-staging
 ```
 
-### Hub/AppSpace View (press B)
+### App View (press B)
 
 ```
 confighub ▾
@@ -133,7 +133,7 @@ confighub ▾
 │  └─ curious-cub-infra                  Shared infrastructure
 │     └─ Units: external-secrets, cert-manager, ingress-nginx
 │
-└─ AppSpaces                              4 spaces
+└─ Apps                              4 spaces
    ├─ curious-cub                        Default workspace
    ├─ curious-cub-dev                    Development
    │  └─ Units: curious-app (variant=dev)
@@ -145,7 +145,7 @@ confighub ▾
 
 **What this shows:**
 - `*-base` and `*-infra` → Hub (shared/governed)
-- `*-dev`, `*-staging`, `*-prod` → AppSpaces (environments as team workspaces)
+- `*-dev`, `*-staging`, `*-prod` → Apps (environments as team workspaces)
 - Units have `variant` labels for environment
 
 ---
@@ -163,7 +163,7 @@ confighub ▾
 └─ jesper-fluxcd
 ```
 
-### Hub/AppSpace View (press B)
+### App View (press B)
 
 ```
 confighub ▾
@@ -171,7 +171,7 @@ confighub ▾
 ├─ Hub (Platform)                         0 spaces
 │  └─ (none detected)
 │
-└─ AppSpaces                              3 spaces
+└─ Apps                              3 spaces
    ├─ example-jesper-argocd-team         ArgoCD example
    │  └─ Deployer: ArgoCD
    │  └─ Units: podinfo, nginx, redis
@@ -194,7 +194,7 @@ confighub ▾
 
 Real spaces: `acorn-bear-infra`, `acorn-bear-asia-prod`, `acorn-bear-eu-prod`, `acorn-bear-eu-staging`, `acorn-bear-us-staging`
 
-### Hub/AppSpace View (press B)
+### App View (press B)
 
 ```
 confighub ▾
@@ -203,7 +203,7 @@ confighub ▾
 │  └─ acorn-bear-infra                   Shared infrastructure
 │     └─ Units: cluster-autoscaler, external-dns, vault
 │
-└─ AppSpaces                              4 spaces
+└─ Apps                              4 spaces
    ├─ acorn-bear-asia-prod               Asia production
    │  └─ Units: (variant=prod, region=asia)
    ├─ acorn-bear-eu-prod                 EU production
@@ -216,7 +216,7 @@ confighub ▾
 
 **What this shows:**
 - `*-infra` → Hub (shared across all regions)
-- Regional spaces → AppSpaces (team workspaces per region/env)
+- Regional spaces → Apps (team workspaces per region/env)
 - Labels encode both variant AND region
 
 ---
@@ -301,7 +301,7 @@ cub unit list --where "Labels.app='curious-app'"
     └── app-2/v2.0.0/
 ```
 
-### Hub/AppSpace View (press B)
+### App View (press B)
 
 ```
 confighub ▾
@@ -312,7 +312,7 @@ confighub ▾
 │     ├─ Units: grafana (version=v2.1.0)
 │     └─ Units: ingress (version=v3.0.0)
 │
-└─ AppSpaces                              4 spaces
+└─ Apps                              4 spaces
    ├─ banko-apps                         Internal applications
    │  ├─ Units: app-1 (version=v1.0.0)
    │  └─ Units: app-2 (version=v2.0.0)
@@ -326,8 +326,8 @@ confighub ▾
 
 **What this shows:**
 - `platform/` directory → Hub (versioned shared components)
-- `apps/` directory → AppSpace (team-owned internal apps)
-- Each `clusters/{name}` → AppSpace (per-cluster deployments)
+- `apps/` directory → App (team-owned internal apps)
+- Each `clusters/{name}` → App (per-cluster deployments)
 - Version info preserved in labels: `version=v1.0.0`
 
 **Key patterns:**
@@ -364,7 +364,7 @@ confighub ▾
     └── us/
 ```
 
-### Hub/AppSpace View (press B)
+### App View (press B)
 
 ```
 confighub ▾
@@ -379,7 +379,7 @@ confighub ▾
 │     ├─ Units: variant-prod
 │     └─ Units: variant-non-prod
 │
-└─ AppSpaces                             11 spaces
+└─ Apps                             11 spaces
    ├─ integration-gpu                    Integration (GPU)
    │  └─ Units: app (variant=integration, gpu=true)
    ├─ integration-non-gpu                Integration (non-GPU)
@@ -405,7 +405,7 @@ confighub ▾
 **What this shows:**
 - `base/` → Hub (template for all envs)
 - `variants/` → Hub (shared mixins referenced by envs)
-- Each `envs/{name}` → AppSpace (one per environment)
+- Each `envs/{name}` → App (one per environment)
 - Labels encode: `variant`, `region`, `gpu` dimensions
 
 **Key patterns:**
@@ -436,11 +436,11 @@ confighub ▾
 
 ---
 
-## Summary: Pattern → Hub/AppSpace Mapping
+## Summary: Pattern → App Mapping
 
 These mappings are working defaults, not immutable doctrine. Domain-to-platform projection is an active collaboration area, and examples should evolve as real fleet patterns are validated.
 
-| Pattern | Hub Contains | AppSpaces Contain |
+| Pattern | Hub Contains | Apps Contain |
 |---------|--------------|-------------------|
 | **KubeCon Demo** | `platform-*` (workers, targets) | `app*-dev`, `app*-prod` (units) |
 | **TraderX** | `*-base`, `*-infra` | `*-prod-{region}` |
@@ -463,7 +463,7 @@ These examples show cub-scout's import discovery in action, with static fixtures
 
 ## See Also
 
-- [Hub/AppSpace Model](#hub-appspace-model) - Conceptual model
+- [App Model](#app-model-model) - Conceptual model
 - [Adoption Patterns](#adoption-patterns) - Banko/Arnie source details
 - [Import to ConfigHub](../howto/import-to-confighub.md) - Full migration path
 - [Import from Live](../howto/import-from-live.md) - Cluster-only import guide

--- a/docs/reference/connected-tiers-and-views-product-guide.md
+++ b/docs/reference/connected-tiers-and-views-product-guide.md
@@ -25,7 +25,7 @@ Connected mode adds context and lifecycle correlation; standalone remains fully 
 
 ### Connected
 
-- Hierarchy context (Org -> Hub -> AppSpace -> Unit + labels)
+- Hierarchy context (Org -> App -> Deployment -> Unit + labels)
 - WET <-> LIVE panel semantics
 - Import/adoption and break-glass accept/reject workflows
 - Causality surfaces for "what should be" vs "what is"
@@ -41,7 +41,7 @@ Connected mode adds context and lifecycle correlation; standalone remains fully 
 
 Hierarchy path:
 
-`Org -> Hub -> AppSpace -> Unit -> Labels`
+`Org -> App -> Deployment -> Unit -> Labels`
 
 Rules:
 

--- a/docs/roadmap-1x-connected-upsell.md
+++ b/docs/roadmap-1x-connected-upsell.md
@@ -126,7 +126,7 @@ Exit criteria:
   - upsell: “Upgrade to fleet-wide risk posture and trend tracking.”
 - `map` / `tree`:
   - trigger: local view is useful but context is fragmented
-  - upsell: “Connect to see org/hub/app-space hierarchy and cluster scoping.”
+  - upsell: “Connect to see org/hub/app hierarchy and cluster scoping.”
 
 ## Upsell quality bar
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -399,7 +399,7 @@ Current canonical behavior and scope are defined by:
 
 * `docs/reference/connected-tiers-and-views-product-guide.md`
 * `docs/reference/gitops-repo-structures.md`
-* `docs/reference/hub-appspace-examples.md`
+* `docs/reference/app-model-examples.md`
 * `docs/reference/import-docs-crosswalk.md`
 
 Coverage currently represented in this roadmap:

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -65,7 +65,7 @@ When using AI to write code, 100% test coverage is non-negotiable.
 | **Integration** | 20% | `go test -tags=integration ./test/integration/...` | CLI commands work, JSON output valid |
 | **GitOps E2E** | 20% | `./test/prove-it-works.sh --level=gitops` | Flux + ArgoCD ownership, trace, deep-dive |
 | **Attribution Contract** | 20% | `go test ./pkg/agent/... -run Attribution` | Determinism, scoring, bundle replay (v0.16+) |
-| **Connected** | 20% | `./test/prove-it-works.sh --level=connected` | ConfigHub worker, import, app-space list |
+| **Connected** | 20% | `./test/prove-it-works.sh --level=connected` | ConfigHub worker, import, app list |
 
 **Target: >90% score across all groups = FULLY PROVEN**
 
@@ -155,7 +155,7 @@ The `prove-it-works.sh` script supports 7 levels:
 | **gitops** | 5m | Yes | No | Flux + ArgoCD ownership, trace |
 | **demos** | 10m | Yes | No | Demo scripts run |
 | **examples** | 15m | Yes | No | Example apps deploy |
-| **connected** | 20m | Yes | Yes | Worker, import, app-space |
+| **connected** | 20m | Yes | Yes | Worker, import, app |
 | **full** | 30m | Yes | Yes | EVERYTHING |
 
 ```bash
@@ -339,7 +339,7 @@ cub worker list
 |------|------------------|
 | `cub auth` | User is logged in |
 | `cub worker run` | Worker starts and shows "Ready" |
-| `app-space list` | Can list spaces |
+| `app list` | Can list spaces |
 | `import --dry-run` | Discovers workloads |
 | `import` | Creates unit in ConfigHub |
 | `map fleet` | Fleet view works |

--- a/examples/combined-git-live/expected-output/alignment.json
+++ b/examples/combined-git-live/expected-output/alignment.json
@@ -157,7 +157,7 @@
       { "name": "payment-worker", "gitPath": "apps/payment-worker/base", "source": "git" },
       { "name": "notifications-service", "gitPath": "apps/notifications-service/base", "source": "git" }
     ],
-    "appSpace": "banko-team",
+    "app": "banko-team",
     "deployer": "Flux",
     "reconciliation": [
       { "match": { "variant": "prod" }, "drift": "revert", "approval": "required" },

--- a/examples/connect-and-compare/expected-output/03-compare.json
+++ b/examples/connect-and-compare/expected-output/03-compare.json
@@ -4,7 +4,7 @@
   },
   "cluster": {
     "namespace": "api",
-    "model": "hub-appspace",
+    "model": "app-deployment-target",
     "workloads": [
       {
         "kind": "Deployment",
@@ -17,7 +17,7 @@
       }
     ],
     "suggestion": {
-      "appSpace": "api-team",
+      "app": "api-team",
       "units": [
         {
           "slug": "api",

--- a/examples/fleet-import/cluster-dev.json
+++ b/examples/fleet-import/cluster-dev.json
@@ -52,7 +52,7 @@
     }
   ],
   "suggestion": {
-    "appSpace": "banko-team",
+    "app": "banko-team",
     "units": [
       {
         "slug": "payment-api-dev",

--- a/examples/fleet-import/cluster-prod.json
+++ b/examples/fleet-import/cluster-prod.json
@@ -64,7 +64,7 @@
     }
   ],
   "suggestion": {
-    "appSpace": "banko-team",
+    "app": "banko-team",
     "units": [
       {
         "slug": "payment-api-prod",

--- a/examples/fleet-import/expected-output/fleet-summary.json
+++ b/examples/fleet-import/expected-output/fleet-summary.json
@@ -56,7 +56,7 @@
           }
         ],
         "suggestion": {
-          "appSpace": "banko-team",
+          "app": "banko-team",
           "units": [
             { "slug": "payment-api-dev", "app": "payment-api", "variant": "dev", "workloads": ["payment-dev/payment-api"] },
             { "slug": "payment-worker-dev", "app": "payment-worker", "variant": "dev", "workloads": ["payment-dev/payment-worker"] },
@@ -133,7 +133,7 @@
           }
         ],
         "suggestion": {
-          "appSpace": "banko-team",
+          "app": "banko-team",
           "units": [
             { "slug": "payment-api-prod", "app": "payment-api", "variant": "prod", "workloads": ["payment-prod/payment-api"] },
             { "slug": "payment-worker-prod", "app": "payment-worker", "variant": "prod", "workloads": ["payment-prod/payment-worker"] },
@@ -160,7 +160,7 @@
     }
   },
   "proposal": {
-    "appSpace": "fleet-team",
+    "app": "fleet-team",
     "deployer": "Flux",
     "reconciliation": [
       { "match": { "variant": "prod" }, "drift": "revert", "approval": "required" },

--- a/examples/import-from-bundle/expected-output/suggestion.json
+++ b/examples/import-from-bundle/expected-output/suggestion.json
@@ -7,7 +7,7 @@
     "api"
   ],
   "proposal": {
-    "appSpace": "api-team",
+    "app": "api-team",
     "units": [
       {
         "slug": "api",

--- a/examples/import-from-live/expected-output/suggestion.json
+++ b/examples/import-from-live/expected-output/suggestion.json
@@ -1,5 +1,5 @@
 {
-  "appSpace": "myapp-team",
+  "app": "myapp-team",
   "units": [
     {
       "slug": "api-dev",

--- a/examples/scripts/verify-connected-demo.sh
+++ b/examples/scripts/verify-connected-demo.sh
@@ -365,7 +365,7 @@ if [[ "$kubernetes_targets" -lt 0 || "$renderer_targets" -lt 0 || "$ready_kubern
 fi
 
 connected_workloads=0
-proposal_app_space=""
+proposal_app_name=""
 if [[ "$import_preview_status" == "ok" ]]; then
     import_parse="$(python3 - "$IMPORT_JSON_FILE" <<'PY'
 import json, sys
@@ -398,11 +398,11 @@ for w in workloads:
     if isinstance(value, str) and value.strip().lower() in {"true", "1", "yes"}:
         count += 1
 proposal = data.get("proposal") if isinstance(data.get("proposal"), dict) else {}
-app_space = str(proposal.get("AppSpace") or proposal.get("appSpace") or "").strip()
-print(f"{count}\t{app_space}")
+app_name = str(proposal.get("App") or proposal.get("app") or "").strip()
+print(f"{count}\t{app_name}")
 PY
 )"
-    IFS=$'\t' read -r connected_workloads proposal_app_space <<<"$import_parse"
+    IFS=$'\t' read -r connected_workloads proposal_app_name <<<"$import_parse"
 
     if [[ "$connected_workloads" -lt 0 ]]; then
         echo "FAIL connected demo readiness"
@@ -490,7 +490,7 @@ connected_gate="enforced"
 if [[ "$MIN_CONNECTED" -gt 0 ]]; then
     if [[ "$import_preview_status" == "timeout" ]]; then
         connected_gate="skipped-timeout"
-    elif [[ -n "$proposal_app_space" && "$proposal_app_space" != "$SPACE" ]]; then
+    elif [[ -n "$proposal_app_name" && "$proposal_app_name" != "$SPACE" ]]; then
         connected_gate="skipped"
     elif [[ "$connected_workloads" -lt "$MIN_CONNECTED" ]]; then
         failures+=("connected workloads below threshold ($connected_workloads < $MIN_CONNECTED)")
@@ -504,9 +504,9 @@ if [[ ${#failures[@]} -gt 0 ]]; then
     for msg in "${failures[@]}"; do
         echo "- $msg"
     done
-    echo "workers_ready=$ready_workers targets_kubernetes=$kubernetes_targets ready_targets_kubernetes=$ready_kubernetes_targets targets_renderer=$renderer_targets ready_targets_renderer=$ready_renderer_targets units_dry=$dry_units units_wet=$wet_units units_managed=$managed_units connected_workloads=$connected_workloads connected_gate=$connected_gate proposal_app_space=${proposal_app_space:-none} connected_preview=$import_preview_status"
+    echo "workers_ready=$ready_workers targets_kubernetes=$kubernetes_targets ready_targets_kubernetes=$ready_kubernetes_targets targets_renderer=$renderer_targets ready_targets_renderer=$ready_renderer_targets units_dry=$dry_units units_wet=$wet_units units_managed=$managed_units connected_workloads=$connected_workloads connected_gate=$connected_gate proposal_app_name=${proposal_app_name:-none} connected_preview=$import_preview_status"
     exit 1
 fi
 
 echo "PASS connected demo readiness"
-echo "workers_ready=$ready_workers targets_kubernetes=$kubernetes_targets ready_targets_kubernetes=$ready_kubernetes_targets targets_renderer=$renderer_targets ready_targets_renderer=$ready_renderer_targets units_dry=$dry_units units_wet=$wet_units units_managed=$managed_units connected_workloads=$connected_workloads connected_gate=$connected_gate proposal_app_space=${proposal_app_space:-none} connected_preview=$import_preview_status"
+echo "workers_ready=$ready_workers targets_kubernetes=$kubernetes_targets ready_targets_kubernetes=$ready_kubernetes_targets targets_renderer=$renderer_targets ready_targets_renderer=$ready_renderer_targets units_dry=$dry_units units_wet=$wet_units units_managed=$managed_units connected_workloads=$connected_workloads connected_gate=$connected_gate proposal_app_name=${proposal_app_name:-none} connected_preview=$import_preview_status"

--- a/test/README.md
+++ b/test/README.md
@@ -32,7 +32,7 @@ go build ./cmd/cub-scout && go test ./...
 | **Integration** | 20% | `go test -tags=integration ./test/integration/...` | CLI commands work, JSON output valid |
 | **GitOps E2E** | 20% | `./test/prove-it-works.sh --level=gitops` | Flux + ArgoCD ownership, trace, deep-dive |
 | **Attribution Contract** | 20% | `go test ./pkg/agent/... -run Attribution` | Determinism, scoring, bundle replay (v0.16+) |
-| **Connected** | 20% | `./test/prove-it-works.sh --level=connected` | ConfigHub worker, import, app-space list |
+| **Connected** | 20% | `./test/prove-it-works.sh --level=connected` | ConfigHub worker, import, app list |
 
 **Target: >90% score across all groups = FULLY PROVEN**
 
@@ -279,7 +279,7 @@ examples/                          # Phase 3: All examples
 | `snapshot` | - | - | - | - |
 | `import` | - | ✓ | - | ✓ |
 | `import-argocd` | - | - | - | - |
-| `app-space` | - | - | ✓ | - |
+| `app` | - | - | ✓ | - |
 | `remedy` | ✓ | - | - | - |
 | `combined` | - | - | - | - |
 | `parse-repo` | - | - | - | - |
@@ -458,7 +458,7 @@ The test suite is organized into 7 levels, from quick smoke tests to full connec
 | **gitops** | 5m | Yes | No | Flux + ArgoCD ownership, trace |
 | **demos** | 10m | Yes | No | Demo scripts run |
 | **examples** | 15m | Yes | No | Example apps deploy |
-| **connected** | 20m | Yes | Yes | Worker, import, app-space |
+| **connected** | 20m | Yes | Yes | Worker, import, app |
 | **full** | 30m | Yes | Yes | EVERYTHING |
 
 **Run with:** `./test/prove-it-works.sh --level=<level>`
@@ -535,7 +535,7 @@ GitOps E2E tests verify BOTH Flux and ArgoCD work correctly:
 
 # Must include:
 # - Units tree with workload expansion
-# - Namespace → AppSpace inference
+# - Namespace → App inference
 # - Ownership graph (which owner type manages each unit)
 # - Label analysis (app.kubernetes.io/* labels)
 # - ConfigHub mapping suggestions
@@ -563,7 +563,7 @@ cub worker list
 |------|------------------|
 | `cub auth` | User is logged in |
 | `cub worker run` | Worker starts and shows "Ready" |
-| `app-space list` | Can list spaces (should show 150+) |
+| `app list` | Can list spaces (should show 150+) |
 | `import --dry-run boutique` | Discovers workloads |
 | `import --dry-run online-boutique` | Discovers 12 microservices |
 | `import boutique` | Creates unit in ConfigHub |

--- a/test/expected-outputs/README.md
+++ b/test/expected-outputs/README.md
@@ -22,7 +22,7 @@ These expected outputs serve three functions:
 | `snapshot` | No | standalone |
 | `import` | No | connected |
 | `import-argocd` | No | connected |
-| `app-space` | No | connected |
+| `app` | No | connected |
 | `remedy` | No | standalone |
 | `combined` | No | standalone/connected |
 | `parse-repo` | No | standalone |

--- a/test/fixtures/expected-output/examples/README.md
+++ b/test/fixtures/expected-output/examples/README.md
@@ -48,7 +48,7 @@ When connected to ConfigHub, you see additional context:
 ┌─ CONFIGHUB ────────────────────────────────────────────────────────────┐
 │  Org: ConfigHub                                                        │
 │  └─ Hub: user@example.com                                          │
-│     └─ AppSpace: example-jesper-argocd-team                            │
+│     └─ App: example-jesper-argocd-team                            │
 │        └─ Unit: example-jesper-argocd ✓                                │
 │           ├─ Status: Ready                                             │
 │           └─ Target: dev-kubernetes-yaml-kind-atk                      │

--- a/test/integration/import_e2e_test.go
+++ b/test/integration/import_e2e_test.go
@@ -146,7 +146,7 @@ func spaceExistsInList(t *testing.T, slug string) bool {
 //
 //	{
 //	  "namespaces": ["ns1"],
-//	  "proposal": { "appSpace": "...", "deployer": "...", "units": [...], ... },
+//	  "proposal": { "app": "...", "deployer": "...", "units": [...], ... },
 //	  "workloads": [{ "kind": "...", "name": "...", "owner": "...", ... }]
 //	}
 // =============================================================================
@@ -161,7 +161,7 @@ type importDryRunResult struct {
 
 // importProposal matches the "proposal" object in the JSON output.
 type importProposal struct {
-	AppSpace    string             `json:"appSpace"`
+	App         string             `json:"app"`
 	Deployer    string             `json:"deployer,omitempty"`
 	Units       []importUnit       `json:"units"`
 	ClusterOnly []importClusterApp `json:"clusterOnly,omitempty"`
@@ -259,9 +259,9 @@ func TestImportDryRunJSON(t *testing.T) {
 		t.Fatal("Expected 'proposal' to be present, got nil")
 	}
 
-	// Proposal must have appSpace
-	if result.Proposal.AppSpace == "" {
-		t.Error("Expected proposal.appSpace to be non-empty")
+	// Proposal must have app
+	if result.Proposal.App == "" {
+		t.Error("Expected proposal.app to be non-empty")
 	}
 
 	// Proposal must have units
@@ -269,8 +269,8 @@ func TestImportDryRunJSON(t *testing.T) {
 		t.Error("Expected at least one unit in proposal")
 	}
 
-	t.Logf("Dry-run result: %d workloads, appSpace=%s, %d units",
-		len(result.Workloads), result.Proposal.AppSpace, len(result.Proposal.Units))
+	t.Logf("Dry-run result: %d workloads, app=%s, %d units",
+		len(result.Workloads), result.Proposal.App, len(result.Proposal.Units))
 }
 
 // TestImportDryRunSuggestionContract verifies the JSON contract shape of the
@@ -324,12 +324,12 @@ func TestImportDryRunSuggestionContract(t *testing.T) {
 		}
 	}
 
-	// Contract: proposal has non-empty appSpace
+	// Contract: proposal has non-empty app
 	if result.Proposal == nil {
 		t.Fatal("proposal is nil")
 	}
-	if result.Proposal.AppSpace == "" {
-		t.Error("proposal.appSpace is empty")
+	if result.Proposal.App == "" {
+		t.Error("proposal.app is empty")
 	}
 
 	// Contract: each unit has slug and workloads
@@ -368,8 +368,8 @@ func TestImportFromBundleDryRunJSONConnectedContract(t *testing.T) {
 	if result.Evidence.BundlePath != bundlePath {
 		t.Fatalf("evidence.bundlePath = %q, want %q", result.Evidence.BundlePath, bundlePath)
 	}
-	if result.Proposal == nil || result.Proposal.AppSpace == "" {
-		t.Fatal("Expected non-empty proposal.appSpace for bundle import dry-run")
+	if result.Proposal == nil || result.Proposal.App == "" {
+		t.Fatal("Expected non-empty proposal.app for bundle import dry-run")
 	}
 	if len(result.Workloads) == 0 {
 		t.Fatal("Expected at least one workload from bundle import dry-run")
@@ -401,9 +401,9 @@ func TestImportFullRoundTrip(t *testing.T) {
 		t.Fatal("Dry-run returned nil proposal")
 	}
 
-	spaceName := dryResult.Proposal.AppSpace
+	spaceName := dryResult.Proposal.App
 	if spaceName == "" {
-		t.Fatal("Dry-run returned empty appSpace — cannot proceed with import")
+		t.Fatal("Dry-run returned empty app — cannot proceed with import")
 	}
 	t.Logf("Will create space: %s with %d units", spaceName, len(dryResult.Proposal.Units))
 
@@ -481,7 +481,7 @@ func TestImportIdempotent(t *testing.T) {
 	if dryResult.Proposal == nil {
 		t.Fatal("Dry-run returned nil proposal")
 	}
-	spaceName := dryResult.Proposal.AppSpace
+	spaceName := dryResult.Proposal.App
 
 	t.Cleanup(func() {
 		deleteTestSpace(t, spaceName)
@@ -550,7 +550,7 @@ func TestImportCleanup(t *testing.T) {
 	if dryResult.Proposal == nil {
 		t.Fatal("Dry-run returned nil proposal")
 	}
-	spaceName := dryResult.Proposal.AppSpace
+	spaceName := dryResult.Proposal.App
 
 	// Import (no deferred cleanup — we're testing manual cleanup)
 	importOutput := runCubAgentAllowFailures(t, "import", "-n", ns, "-y", "--no-log")

--- a/test/prove-it-works.sh
+++ b/test/prove-it-works.sh
@@ -387,7 +387,7 @@ if [[ $CURRENT_IDX -ge 6 ]]; then
         skip_test "Connected mode" "ConfigHub not authenticated (run: cub auth login)"
     else
         subsection "ConfigHub Connection"
-        run_test "app-space list" "./cub-scout app-space list | head -10"
+        run_test "app list" "./cub-scout app list | head -10"
 
         subsection "Import Preview"
         run_test "import dry-run" "./cub-scout import -n boutique --dry-run"
@@ -409,7 +409,7 @@ if [[ $CURRENT_IDX -ge 6 ]]; then
             # Verify space was created
             run_test "verify space" "cub space list --json | python3 -c 'import sys,json; spaces=[s[\"Slug\"] for s in json.load(sys.stdin)]; print(\"Spaces:\", spaces[:5])'"
             # Cleanup the space (find it from the dry-run output)
-            CREATED_SPACE=$(./cub-scout import -n "$E2E_NS" --dry-run --json 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["suggestion"]["appSpace"])' 2>/dev/null)
+            CREATED_SPACE=$(./cub-scout import -n "$E2E_NS" --dry-run --json 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["suggestion"]["app"])' 2>/dev/null)
             if [[ -n "$CREATED_SPACE" ]]; then
                 run_test "cleanup space" "cub space delete $CREATED_SPACE --recursive"
             fi

--- a/test/test-levels.yaml
+++ b/test/test-levels.yaml
@@ -127,7 +127,7 @@ levels:
 
   # Level 6: Connected (< 20 minutes, needs ConfigHub)
   connected:
-    description: "ConfigHub connected mode - workers, targets, app-space"
+    description: "ConfigHub connected mode - workers, targets, app"
     requirements:
       cluster: true
       flux: true
@@ -137,11 +137,11 @@ levels:
       - cub auth test-login || cub auth login
       - ./test/preflight/worker-health
     tests:
-      - ./cub-scout app-space list
+      - ./cub-scout app list
       - ./cub-scout map --hub (TTY check)
       - ./cub-scout import -n boutique --dry-run
     assertions:
-      - "app-space list shows spaces"
+      - "app list shows spaces"
       - "No null values in output"
 
   # Level 7: Full proof (complete verification)

--- a/test/unit/demo_readiness_script_test.go
+++ b/test/unit/demo_readiness_script_test.go
@@ -175,7 +175,7 @@ func TestVerifyConnectedDemoScript_SkipsConnectedGateWhenProposalSpaceDiffers(t 
 	  {"Unit":{"Slug":"demo-app-wet"}}
 	]`)
 	mustWrite(t, importJSON, `{
-	  "proposal":{"appSpace":"other-space"},
+	  "proposal":{"app":"other-space"},
 	  "workloads":[{"name":"api","connected":false}]
 	}`)
 
@@ -223,8 +223,8 @@ exit 2
 	if !strings.Contains(string(out), "connected_gate=skipped") {
 		t.Fatalf("expected connected gate skip note, got:\n%s", string(out))
 	}
-	if !strings.Contains(string(out), "proposal_app_space=other-space") {
-		t.Fatalf("expected proposal app space note, got:\n%s", string(out))
+	if !strings.Contains(string(out), "proposal_app_name=other-space") {
+		t.Fatalf("expected proposal app name note, got:\n%s", string(out))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Propagates the canonical App/Deployment/Target mapping (confirmed in #323) across all code, tests, docs, and examples
- Renames Go types (`HubAppSpaceSuggestion` → `AppModelSuggestion`, etc.), JSON fields (`"appSpace"` → `"app"`), CLI command (`app-space` → `app`), and model ID (`hub-appspace` → `app-deployment-target`)
- Renames `docs/reference/hub-appspace-examples.md` → `app-model-examples.md`
- 45 files changed, 290 insertions(+), 290 deletions(-)

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Golden files regenerated
- [x] Build succeeds

Closes #322, #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)