### PR TITLE
[codex] Refine remaining cub-scout MCP routing edges

### DIFF
--- a/cmd/cub-scout/mcp.go
+++ b/cmd/cub-scout/mcp.go
@@ -214,7 +214,7 @@ func newMCPGatewayWithMode(runner mcpToolRunner, connectedRunner mcpToolRunner, 
 		"scan": {
 			Descriptor: mcpToolDescriptor{
 				Name:        "scan",
-				Description: "Standalone configuration and runtime findings (scan --json). Use AFTER doctor when the user wants detailed risk or misconfiguration findings, not a broad health summary. DO NOT load first for bare 'what's wrong?' if doctor has not run yet.",
+				Description: "Standalone live-cluster configuration and runtime findings (scan --json). Use AFTER doctor when the user wants detailed risk or misconfiguration findings in the cluster or namespace right now, or an awareness scan of live state, not a broad health summary. DO NOT load first for bare 'what's wrong?' if doctor has not run yet. DO NOT use this as a governed promotion or revision-safety gate.",
 				InputSchema: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -237,7 +237,7 @@ func newMCPGatewayWithMode(runner mcpToolRunner, connectedRunner mcpToolRunner, 
 		"trace": {
 			Descriptor: mcpToolDescriptor{
 				Name:        "trace",
-				Description: "Exact ownership and source chain for one resource (trace --format json). Use AFTER explain when the user asks where a resource came from, which source or deployer owns it end-to-end, or what GitOps chain produced it. DO NOT load for broad cluster status or first-pass troubleshooting; use doctor or explain first.",
+				Description: "Exact ownership and source chain for one resource (trace --format json). Use AFTER doctor or explain once the user has narrowed to one resource and wants to know where it came from, which source or deployer owns it end-to-end, or what GitOps chain produced it. DO NOT load for broad cluster status or first-pass troubleshooting; use doctor first, then explain if the resource is still unclear.",
 				InputSchema: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -337,7 +337,7 @@ func newMCPGatewayWithMode(runner mcpToolRunner, connectedRunner mcpToolRunner, 
 		tools["confighub_changesets"] = mcpTool{
 			Descriptor: mcpToolDescriptor{
 				Name:        "confighub_changesets",
-				Description: "Connected-only governed ChangeSet history from ConfigHub (cub changeset list --json). Use when the user asks what changed, who changed it, or what receipt proves a governed write. DO NOT load for current cluster health or ownership; use doctor, explain, or trace first.",
+				Description: "Connected-only governed ChangeSet history and receipts from ConfigHub (cub changeset list --json). Use when the user asks what governed write changed a known unit or space, who changed it, or what receipt proves a governed write. Load after trace or confighub_units has identified the governed object or scope you care about. DO NOT load for current cluster health or ownership, or when the governed object is still unknown; use doctor, explain, trace, or confighub_units first.",
 				InputSchema: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -368,7 +368,7 @@ func newMCPGatewayWithMode(runner mcpToolRunner, connectedRunner mcpToolRunner, 
 		tools["confighub_units"] = mcpTool{
 			Descriptor: mcpToolDescriptor{
 				Name:        "confighub_units",
-				Description: "Connected-only ConfigHub unit and fleet inventory (cub unit list --json). Use when the user asks about governed units, intended state, or which ConfigHub unit corresponds to something already identified. Load after doctor, map, explain, or trace has established the cluster-side object you care about. DO NOT load for raw cluster inventory or bare 'what's running?'; use map or doctor first.",
+				Description: "Connected-only ConfigHub unit and fleet inventory / cluster-to-ConfigHub lookup (cub unit list --json). Use when the user asks which ConfigHub unit corresponds to something already identified, or wants governed unit inventory before drilling into one unit. Load after doctor, map, explain, or trace has established the cluster-side object you care about. DO NOT load for raw cluster inventory or exact unit facts; use map or doctor first, then confighub_unit_get once the unit is known.",
 				InputSchema: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -406,7 +406,7 @@ func newMCPGatewayWithMode(runner mcpToolRunner, connectedRunner mcpToolRunner, 
 		tools["confighub_unit_get"] = mcpTool{
 			Descriptor: mcpToolDescriptor{
 				Name:        "confighub_unit_get",
-				Description: "Connected-only exact ConfigHub unit details (cub unit get --json). Load ONLY after the user already has a unit slug or ID, or after confighub_units identified it. If you do not have a unit yet, use confighub_units first. DO NOT load for bare cluster troubleshooting or governed-vs-live comparison; use explain, trace, or CLI compare flows first.",
+				Description: "Connected-only exact ConfigHub unit details and applied/live revision facts (cub unit get --json). Load ONLY after the user already has a unit slug or ID, or after confighub_units identified it. Use this for 'show me the intended state, last applied revision, or live revision for unit X.' If you do not have a unit yet, use confighub_units first. DO NOT load for bare cluster troubleshooting or governed-vs-live comparison; use explain, trace, or compare_three_way first.",
 				InputSchema: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{

--- a/cmd/cub-scout/mcp_test.go
+++ b/cmd/cub-scout/mcp_test.go
@@ -88,12 +88,12 @@ func TestNewMCPGateway_ToolDescriptionsExpressChainBoundaries(t *testing.T) {
 		{name: "compare_three_way", contains: []string{"governed state agrees with live state", "Load after doctor, explain, or trace", "use doctor first"}},
 		{name: "doctor", contains: []string{"FIRST standalone tool", "whether cub-scout is the right first read-only step", "Use before explain, trace, or scan"}},
 		{name: "map", contains: []string{"what's running in this cluster", "raw `kubectl get` output", "use doctor first"}},
-		{name: "scan", contains: []string{"Use AFTER doctor", "DO NOT load first"}},
+		{name: "scan", contains: []string{"Use AFTER doctor", "awareness scan of live state", "DO NOT use this as a governed promotion or revision-safety gate"}},
 		{name: "explain", contains: []string{"Use AFTER doctor or map", "raw `kubectl describe`", "DO NOT load for broad cluster inventory or health"}},
-		{name: "trace", contains: []string{"Use AFTER explain", "DO NOT load for broad cluster status"}},
-		{name: "confighub_changesets", contains: []string{"Connected-only", "DO NOT load for current cluster health or ownership"}},
-		{name: "confighub_units", contains: []string{"Connected-only", "Load after doctor, map, explain, or trace", "use map or doctor first"}},
-		{name: "confighub_unit_get", contains: []string{"Load ONLY after", "use confighub_units first", "DO NOT load for bare cluster troubleshooting or governed-vs-live comparison"}},
+		{name: "trace", contains: []string{"Use AFTER doctor or explain", "then explain if the resource is still unclear", "DO NOT load for broad cluster status"}},
+		{name: "confighub_changesets", contains: []string{"Connected-only", "what governed write changed a known unit or space", "Load after trace or confighub_units"}},
+		{name: "confighub_units", contains: []string{"Connected-only", "cluster-to-ConfigHub lookup", "Load after doctor, map, explain, or trace", "then confighub_unit_get once the unit is known"}},
+		{name: "confighub_unit_get", contains: []string{"Load ONLY after", "last applied revision, or live revision", "use confighub_units first", "compare_three_way first"}},
 	}
 
 	for _, tc := range cases {
@@ -105,6 +105,51 @@ func TestNewMCPGateway_ToolDescriptionsExpressChainBoundaries(t *testing.T) {
 		for _, want := range tc.contains {
 			if !strings.Contains(desc, want) {
 				t.Errorf("%s description missing %q\nfull description: %s", tc.name, want, desc)
+			}
+		}
+	}
+}
+
+func TestNewMCPGateway_ToolDescriptionsCoverRepresentativeIntentEdges(t *testing.T) {
+	gateway := newMCPGatewayWithMode(nil, nil, true)
+	tools := gateway.tools
+
+	cases := []struct {
+		tool     string
+		intent   string
+		contains []string
+	}{
+		{
+			tool:     "scan",
+			intent:   "Is this revision safe to promote?",
+			contains: []string{"awareness scan of live state", "DO NOT use this as a governed promotion or revision-safety gate"},
+		},
+		{
+			tool:     "confighub_changesets",
+			intent:   "What governed write changed this known unit?",
+			contains: []string{"what governed write changed a known unit or space", "Load after trace or confighub_units"},
+		},
+		{
+			tool:     "confighub_units",
+			intent:   "Which ConfigHub unit corresponds to deployment/api?",
+			contains: []string{"cluster-to-ConfigHub lookup", "corresponds to something already identified"},
+		},
+		{
+			tool:     "confighub_unit_get",
+			intent:   "Show me the last applied revision for unit payments-api.",
+			contains: []string{"last applied revision, or live revision for unit X", "compare_three_way first"},
+		},
+	}
+
+	for _, tc := range cases {
+		tool, ok := tools[tc.tool]
+		if !ok {
+			t.Fatalf("tool %q not found", tc.tool)
+		}
+		desc := tool.Descriptor.Description
+		for _, want := range tc.contains {
+			if !strings.Contains(desc, want) {
+				t.Errorf("%s representative intent %q missing %q\nfull description: %s", tc.tool, tc.intent, want, desc)
 			}
 		}
 	}

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -175,6 +175,13 @@ cub-scout mcp serve
 - Connected mode adds read-only connected comparison plus ConfigHub query tools.
 - MCP tool responses are backed by the existing CLI JSON surfaces rather than a separate hand-built fact model.
 
+### Tool Routing Notes
+
+- `doctor` is the first standalone troubleshooting tool.
+- `scan` is an awareness scan of live cluster state, not a governed promotion or revision-safety gate.
+- `confighub_units` is the discovery/lookup step for "which ConfigHub unit is this?", while `confighub_unit_get` is the exact detail step once a unit is already known.
+- `compare_three_way` is the connected convergence proof tool after scope discovery, not the first troubleshooting move.
+
 ### Stable `doctor` MCP Surface
 
 - Tool name: `doctor`


### PR DESCRIPTION
## Summary
This narrows the remaining M2 cleanup/refinement work on `cub-scout mcp serve`.

It sharpens the MCP tool descriptions that still had the highest confusion risk after `#376` and `#377`, especially around:
- awareness vs authority (`scan` is live-state awareness, not a promotion gate)
- discovery vs exact detail (`confighub_units` vs `confighub_unit_get`)
- scope preconditions for governed receipts (`confighub_changesets`)
- when to go to `trace` directly vs through `explain`

It also records the durable routing notes in the CLI contract doc and adds representative-intent tests so the cold-test lessons stay enforced.

## Why
`cub-scout` is already the family MCP reference point. These description edges are small, but they are the exact kind of wording drift that later servers can copy forward.

This PR keeps the work scoped to M2 cleanup rather than widening into new product surface.

## Validation
- `go test ./cmd/cub-scout -run 'TestNewMCPGateway|TestMCPGatewayHandleRequest_ToolsList|TestMCPGatewayHandleRequest_ToolsCallCompareThreeWay|TestMCPGatewayHandleRequest_ToolsCallConnectedChangesets'`
- `go test ./cmd/cub-scout -run 'TestMCP'`

## Notes
- The duplicate `SKILL.md` ambiguity is already resolved in current repo state: `skills/cub-scout/SKILL.md` is the only remaining `SKILL.md` path.
- This does not claim full M2 completion mechanically; there is still no full MCP cold-test scorer proving the `>=94%` bar in CI.
- Real authority-side promotion/revision safety remains later `confighub-scan` / product work, not M2 copy work.