### PR TITLE
[codex] Make fixture release gates offline-deterministic

### DIFF
--- a/examples/ai-integration/run-fixture-session.sh
+++ b/examples/ai-integration/run-fixture-session.sh
@@ -42,20 +42,24 @@ HISTORY_OUT="$OUTPUT_DIR/02-change-history.txt"
 SCAN_OUT="$OUTPUT_DIR/03-scan-safety.json"
 ORPHANS_OUT="$OUTPUT_DIR/04-unmanaged-resources.txt"
 
-CUB_SCOUT_TEST_TRACE_JSON="$TESTDATA_DIR/trace_argo_source_signals.json" \
+# Fixture replay must stay deterministic even when the caller happens to be
+# logged in to ConfigHub locally.
+FIXTURE_ENV=(CUB_SCOUT_OFFLINE=true)
+
+env "${FIXTURE_ENV[@]}" CUB_SCOUT_TEST_TRACE_JSON="$TESTDATA_DIR/trace_argo_source_signals.json" \
 "$BINARY" trace deployment/checkout -n checkout > "$TRACE_OUT"
 
 echo "Wrote $TRACE_OUT"
 
-CUB_SCOUT_TEST_HISTORY_JSON="$TESTDATA_DIR/history_changesets.json" \
+env "${FIXTURE_ENV[@]}" CUB_SCOUT_TEST_HISTORY_JSON="$TESTDATA_DIR/history_changesets.json" \
 "$BINARY" history deployment/checkout -n checkout --since 24h > "$HISTORY_OUT"
 
 echo "Wrote $HISTORY_OUT"
 
-"$BINARY" scan --file "$TESTDATA_DIR/misconfigured-deployment.yaml" --json > "$SCAN_OUT"
+env "${FIXTURE_ENV[@]}" "$BINARY" scan --file "$TESTDATA_DIR/misconfigured-deployment.yaml" --json > "$SCAN_OUT"
 echo "Wrote $SCAN_OUT (exit 0: scan succeeded, findings present but no --fail-on threshold)"
 
-CUB_SCOUT_TEST_MAP_ENTRIES_JSON="$TESTDATA_DIR/map_orphans.json" \
+env "${FIXTURE_ENV[@]}" CUB_SCOUT_TEST_MAP_ENTRIES_JSON="$TESTDATA_DIR/map_orphans.json" \
 "$BINARY" map orphans > "$ORPHANS_OUT"
 
 echo "Wrote $ORPHANS_OUT"

--- a/examples/connect-and-compare/demo.sh
+++ b/examples/connect-and-compare/demo.sh
@@ -69,10 +69,14 @@ GIT_FIXTURE="$REPO_ROOT/examples/combined-git-live/git-repo"
 BUNDLE_FIXTURE="$REPO_ROOT/examples/workflows/fleet-demo/bundles/dev"
 EXPECTED_DIR="$SCRIPT_DIR/expected-output"
 
+# This demo is fixture-first and should not change shape based on ambient
+# ConfigHub auth or connectivity on the machine running it.
+FIXTURE_ENV=(CUB_SCOUT_OFFLINE=true)
+
 mkdir -p "$OUTPUT_DIR"
 
 echo "[1/4] Standalone snapshot: doctor"
-NO_COLOR=1 CUB_SCOUT_TEST_DOCTOR_INPUT_JSON="$DOCTOR_FIXTURE" "$CUB" doctor --format ascii > "$OUTPUT_DIR/01-doctor.txt"
+env "${FIXTURE_ENV[@]}" NO_COLOR=1 CUB_SCOUT_TEST_DOCTOR_INPUT_JSON="$DOCTOR_FIXTURE" "$CUB" doctor --format ascii > "$OUTPUT_DIR/01-doctor.txt"
 
 echo "[2/4] Connect step (operator action)"
 cat > "$OUTPUT_DIR/02-connect.txt" <<'STEP2'
@@ -81,10 +85,10 @@ Connected mode established (fixture replay path for demo).
 STEP2
 
 echo "[3/4] Compare step: Git intent vs bundle snapshot"
-"$CUB" compare --git-path "$GIT_FIXTURE" --bundle "$BUNDLE_FIXTURE" --json > "$OUTPUT_DIR/03-compare.json"
+env "${FIXTURE_ENV[@]}" "$CUB" compare --git-path "$GIT_FIXTURE" --bundle "$BUNDLE_FIXTURE" --json > "$OUTPUT_DIR/03-compare.json"
 
 echo "[4/4] History step: ConfigHub ChangeSet timeline"
-CUB_SCOUT_TEST_HISTORY_JSON="$HISTORY_FIXTURE" "$CUB" history deploy/checkout -n prod --since 3650d --format ascii > "$OUTPUT_DIR/04-history.txt"
+env "${FIXTURE_ENV[@]}" CUB_SCOUT_TEST_HISTORY_JSON="$HISTORY_FIXTURE" "$CUB" history deploy/checkout -n prod --since 3650d --format ascii > "$OUTPUT_DIR/04-history.txt"
 
 if [[ "$VERIFY" == "true" ]]; then
     diff -u "$EXPECTED_DIR/01-doctor.txt" "$OUTPUT_DIR/01-doctor.txt"

--- a/examples/connect-and-compare/expected-output/01-doctor.txt
+++ b/examples/connect-and-compare/expected-output/01-doctor.txt
@@ -15,8 +15,6 @@ Health:
 Risks: 3 findings (1 CRITICAL, 1 WARNING, 1 INFO)
 Drift: 2 resources drifted from declared state
 
-Three-Way: ConfigHub connected - run cub-scout compare three-way --scope cluster for full comparison
-
 Top Issues:
   1. Deployment/checkout (ns: prod) - image tag drifted from approved release [CRITICAL]
   2. Deployment/worker (ns: prod) - resource limits are missing [WARNING]


### PR DESCRIPTION
## Summary
This fixes the release-gate fixture drift that caused the `v2.0.0-rc1` tag workflow to fail in `go test ./...` on GitHub Actions.

The root cause was that our fixture-first example scripts still inherited ambient ConfigHub auth/connectivity from the machine running them. That made the generated doctor snapshot differ between environments: locally it could show the connected `Three-Way` hint, while the GitHub runner produced the standalone/offline shape.

This change makes the fixture replays explicitly offline and refreshes the checked-in doctor snapshot to match that deterministic standalone output.

## Changes
- force `CUB_SCOUT_OFFLINE=true` in `examples/ai-integration/run-fixture-session.sh`
- force `CUB_SCOUT_OFFLINE=true` in `examples/connect-and-compare/demo.sh`
- update `examples/connect-and-compare/expected-output/01-doctor.txt` to the offline deterministic snapshot

## Why this is the right fix
These scripts are fixture-first release/test artifacts. They should not vary based on whether the caller happens to be logged in to ConfigHub.

## Validation
- `go test ./test/unit -run 'Test(AIIntegrationFixtureSessionScript|ConnectAndCompareDemoScript_VerifySnapshots)' -count=1`
- `go test ./...`
- manual replay of both scripts in a normal shell and in a clean no-auth shell

## Release note
`v2.0.0-rc1` is already published, but its release workflow failed before GoReleaser because of this test drift. After this merges, the safest follow-up is to cut a fresh RC tag from `main` rather than relying on the failed `v2.0.0-rc1` run.