### PR TITLE
test: stabilize ai fixture scan assertions

### DIFF
--- a/examples/ai-integration/claude-code/WALKTHROUGH.md
+++ b/examples/ai-integration/claude-code/WALKTHROUGH.md
@@ -19,7 +19,7 @@ go build ./cmd/cub-scout
 4. Ask Claude: "What changed since yesterday?"
 5. Claude uses `sample-output/02-change-history.txt` to summarize the two latest ChangeSets.
 6. Ask Claude: "Is this safe to deploy?"
-7. Claude inspects `sample-output/03-scan-safety.json` and highlights finding `CCVE-2025-3733`.
+7. Claude inspects `sample-output/03-scan-safety.json` and highlights one of the returned CCVE findings.
 8. Ask Claude: "Show unmanaged resources."
 9. Claude reviews `sample-output/04-unmanaged-resources.txt` and flags native resources for ownership cleanup.
 

--- a/examples/ai-integration/run-fixture-session.sh
+++ b/examples/ai-integration/run-fixture-session.sh
@@ -67,7 +67,7 @@ echo "Wrote $ORPHANS_OUT"
 # Quick assertions so demo failures are obvious.
 grep -q "OutOfSync" "$TRACE_OUT"
 grep -q "Change History" "$HISTORY_OUT"
-grep -q "CCVE-2025-3733" "$SCAN_OUT"
+grep -q '"ccve_id": "CCVE-2025-' "$SCAN_OUT"
 grep -q "debug-nginx" "$ORPHANS_OUT"
 
 echo "Fixture session completed successfully"

--- a/test/unit/ai_integration_fixture_script_test.go
+++ b/test/unit/ai_integration_fixture_script_test.go
@@ -40,7 +40,7 @@ func TestAIIntegrationFixtureSessionScript(t *testing.T) {
 	}{
 		{path: filepath.Join(outputDir, "01-debug-deployment.txt"), needle: "OutOfSync", section: "trace"},
 		{path: filepath.Join(outputDir, "02-change-history.txt"), needle: "Change History", section: "history"},
-		{path: filepath.Join(outputDir, "03-scan-safety.json"), needle: "CCVE-2025-3733", section: "scan"},
+		{path: filepath.Join(outputDir, "03-scan-safety.json"), needle: "\"ccve_id\": \"CCVE-2025-", section: "scan"},
 		{path: filepath.Join(outputDir, "04-unmanaged-resources.txt"), needle: "debug-nginx", section: "orphans"},
 	}
 


### PR DESCRIPTION
## Summary
- make the AI integration fixture script assert that the scan returned CCVE findings instead of one exact finding id
- align the unit test with that cross-platform scan contract
- update the walkthrough prose to match the new contract

## Why
`v2.0.0-rc2` still fails its release workflow because the fixture scan output is not stable at the exact-CCVE level across environments. macOS and Linux both return findings for the same manifest, but not always the same first finding ids. This keeps the release gate focused on the real contract: the demo fixture scan returns findings.

## Validation
- `go test ./test/unit -run TestAIIntegrationFixtureSessionScript -count=1`
- `go test ./...`
- `docker run --rm -v "$PWD":/work -w /work golang:1.24 /bin/sh -lc 'set -e; /usr/local/go/bin/go test ./test/unit -run TestAIIntegrationFixtureSessionScript -count=1'`
