### PR TITLE
build: isolate goreleaser dist output

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,11 @@ version: 2
 
 project_name: cub-scout
 
+# Keep GoReleaser outputs out of the repo-tracked `dist/` tree. This repo
+# stores source templates and bundled scan artifacts under `dist/`, while
+# GoReleaser's `release --clean` expects to own its output directory.
+dist: .goreleaser-dist
+
 before:
   hooks:
     - go mod tidy

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -23,6 +23,7 @@ Every tagged release automatically produces:
 
 4. **Krew Manifest Template**
    - Source template: `dist/krew/cub-scout.yaml`
+   - GoReleaser outputs release artifacts into `.goreleaser-dist/` so `release --clean` does not delete the tracked `dist/` source templates
    - Update `spec.version`, `uri`, and `sha256` values per release before submitting to krew-index
 
 ## How to Release

--- a/test/unit/release_distribution_contract_test.go
+++ b/test/unit/release_distribution_contract_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 type goreleaserConfig struct {
+	Dist string `yaml:"dist"`
 	Builds []struct {
 		ID     string   `yaml:"id"`
 		Goos   []string `yaml:"goos"`
@@ -43,6 +44,10 @@ func TestGoReleaser_DistributionTargets(t *testing.T) {
 	var cfg goreleaserConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("parse goreleaser config: %v", err)
+	}
+
+	if cfg.Dist != ".goreleaser-dist" {
+		t.Fatalf("goreleaser dist dir = %q, want %q to avoid tracked dist/ collisions", cfg.Dist, ".goreleaser-dist")
 	}
 
 	requiredBuilds := map[string]bool{


### PR DESCRIPTION
## Summary
- move GoReleaser output into `.goreleaser-dist/` instead of the repo-tracked `dist/` tree
- lock that output directory into the release distribution contract test
- document the split between tracked `dist/krew` source templates and generated release artifacts

## Why
`v2.0.0-rc3` cleared tests but failed in `Run GoReleaser` before any assets were uploaded.

Root cause: this repo tracks `dist/krew/cub-scout.yaml`, but the release workflow runs `goreleaser release --clean`. GoReleaser cleans its output directory before publishing, so using the default `dist/` directory deleted a tracked file and then aborted with a dirty git state:

- `git is in a dirty state`
- `D dist/krew/cub-scout.yaml`

This change gives GoReleaser its own output directory while preserving the tracked `dist/` tree for Krew templates and bundled scan artifacts.

## Validation
- `go test ./test/unit -run TestGoReleaser_DistributionTargets -count=1`
- `go test ./...`
- local GoReleaser snapshot initialization confirmed outputs are written under `.goreleaser-dist/` instead of `dist/`
