### PR TITLE
build: allow mixed archive binary counts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,6 +90,10 @@ archives:
       - cub-scout
       - kubectl-cub-scout
       - cub-scout-plugin
+    # Windows intentionally ships without the plugin-form `main` binary because
+    # cub's plugin exec path relies on syscall.Exec, which is not available on
+    # windows. Linux and darwin archives include one extra binary as a result.
+    allow_different_binary_count: true
     formats:
       - tar.gz
     format_overrides:

--- a/test/unit/release_distribution_contract_test.go
+++ b/test/unit/release_distribution_contract_test.go
@@ -18,9 +18,10 @@ type goreleaserConfig struct {
 		Goarch []string `yaml:"goarch"`
 	} `yaml:"builds"`
 	Archives []struct {
-		ID              string `yaml:"id"`
-		Formats         []string
-		FormatOverrides []struct {
+		ID                        string `yaml:"id"`
+		AllowDifferentBinaryCount bool   `yaml:"allow_different_binary_count"`
+		Formats                   []string
+		FormatOverrides           []struct {
 			Goos    string   `yaml:"goos"`
 			Format  string   `yaml:"format"`
 			Formats []string `yaml:"formats"`
@@ -81,7 +82,11 @@ func TestGoReleaser_DistributionTargets(t *testing.T) {
 	}
 
 	hasWindowsZip := false
+	hasMixedBinaryArchiveAllowance := false
 	for _, arc := range cfg.Archives {
+		if arc.ID == "default" && arc.AllowDifferentBinaryCount {
+			hasMixedBinaryArchiveAllowance = true
+		}
 		for _, override := range arc.FormatOverrides {
 			formats := override.Formats
 			if override.Format != "" {
@@ -94,6 +99,9 @@ func TestGoReleaser_DistributionTargets(t *testing.T) {
 	}
 	if !hasWindowsZip {
 		t.Fatal("expected windows archive zip format override")
+	}
+	if !hasMixedBinaryArchiveAllowance {
+		t.Fatal("expected default archive to allow different binary counts across platforms")
 	}
 
 	if len(cfg.Brews) == 0 {


### PR DESCRIPTION
## Summary
- tell GoReleaser the default archive intentionally has different binary counts across platforms
- lock that expectation into the release distribution contract test

## Why
`v2.0.0-rc4` got past tests and the previous `dist/` collision, but failed in GoReleaser during the archive phase:

- `invalid archive: archive has different count of binaries for each platform`

That is expected for this repo:
- linux/darwin archives include `cub-scout`, `kubectl-cub_scout`, and plugin-form `main`
- windows archives intentionally exclude `main` because `cub` plugin exec depends on `syscall.Exec`, which is not available on windows

This change makes that archive shape explicit instead of letting GoReleaser reject it as accidental.

## Validation
- `go test ./test/unit -run TestGoReleaser_DistributionTargets -count=1`
- local GoReleaser config validation via `goreleaser check`
