### PR TITLE
truth-floor: stabilize tree patterns, flux trace, and workload readiness (council prereq for #393)

### DIFF
--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -1204,14 +1204,18 @@ func discoverWorkloads(namespace string) ([]WorkloadInfo, error) {
 		return nil, fmt.Errorf("list deployments: %w", err)
 	}
 
-	for _, d := range deployments.Items {
+	for i := range deployments.Items {
+		d := &deployments.Items[i]
 		owner, gitopsRef := detectOwnerAndRef(d.Labels, d.Annotations)
 		w := WorkloadInfo{
-			Kind:        "Deployment",
-			Namespace:   d.Namespace,
-			Name:        d.Name,
-			Replicas:    *d.Spec.Replicas,
-			Ready:       d.Status.ReadyReplicas == *d.Spec.Replicas,
+			Kind:      "Deployment",
+			Namespace: d.Namespace,
+			Name:      d.Name,
+			Replicas:  *d.Spec.Replicas,
+			// #394: kstatus matches what operators see in Argo CD / Flux. A
+			// Stalled or generation-lagging Deployment now reports Ready=false
+			// instead of slipping through the prior ReadyReplicas==Spec check.
+			Ready:       agent.IsDeploymentReady(d),
 			Owner:       owner,
 			Labels:      d.Labels,
 			Annotations: d.Annotations,
@@ -1242,14 +1246,16 @@ func discoverWorkloads(namespace string) ([]WorkloadInfo, error) {
 		return nil, fmt.Errorf("list statefulsets: %w", err)
 	}
 
-	for _, s := range statefulsets.Items {
+	for i := range statefulsets.Items {
+		s := &statefulsets.Items[i]
 		owner, gitopsRef := detectOwnerAndRef(s.Labels, s.Annotations)
 		w := WorkloadInfo{
-			Kind:        "StatefulSet",
-			Namespace:   s.Namespace,
-			Name:        s.Name,
-			Replicas:    *s.Spec.Replicas,
-			Ready:       s.Status.ReadyReplicas == *s.Spec.Replicas,
+			Kind:      "StatefulSet",
+			Namespace: s.Namespace,
+			Name:      s.Name,
+			Replicas:  *s.Spec.Replicas,
+			// #394: kstatus alignment — see Deployment site above.
+			Ready:       agent.IsStatefulSetReady(s),
 			Owner:       owner,
 			Labels:      s.Labels,
 			Annotations: s.Annotations,
@@ -1280,14 +1286,16 @@ func discoverWorkloads(namespace string) ([]WorkloadInfo, error) {
 		return nil, fmt.Errorf("list daemonsets: %w", err)
 	}
 
-	for _, d := range daemonsets.Items {
+	for i := range daemonsets.Items {
+		d := &daemonsets.Items[i]
 		owner, gitopsRef := detectOwnerAndRef(d.Labels, d.Annotations)
 		w := WorkloadInfo{
-			Kind:        "DaemonSet",
-			Namespace:   d.Namespace,
-			Name:        d.Name,
-			Replicas:    d.Status.DesiredNumberScheduled,
-			Ready:       d.Status.NumberReady == d.Status.DesiredNumberScheduled,
+			Kind:      "DaemonSet",
+			Namespace: d.Namespace,
+			Name:      d.Name,
+			Replicas:  d.Status.DesiredNumberScheduled,
+			// #394: kstatus alignment — see Deployment site above.
+			Ready:       agent.IsDaemonSetReady(d),
 			Owner:       owner,
 			Labels:      d.Labels,
 			Annotations: d.Annotations,

--- a/cmd/cub-scout/import_argocd.go
+++ b/cmd/cub-scout/import_argocd.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -742,7 +743,8 @@ func getManagedResources(ctx context.Context, clientset *kubernetes.Clientset, d
 	// Get Deployments - list all and filter by ArgoCD ownership
 	deployments, err := clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
 	if err == nil {
-		for _, d := range deployments.Items {
+		for i := range deployments.Items {
+			d := &deployments.Items[i]
 			if !isArgoManagedResource(d.Labels, d.Annotations, appName) {
 				continue
 			}
@@ -750,8 +752,11 @@ func getManagedResources(ctx context.Context, clientset *kubernetes.Clientset, d
 			d.APIVersion = "apps/v1"
 			d.Kind = "Deployment"
 			yamlBytes, _ := yaml.Marshal(d)
+			// #394: kstatus alignment — what Argo CD itself reports.
+			// A Stalled or generation-lagging Deployment now reports
+			// Progressing instead of Healthy.
 			health := "Progressing"
-			if d.Status.ReadyReplicas == *d.Spec.Replicas {
+			if agent.IsDeploymentReady(d) {
 				health = "Healthy"
 			}
 			resources = append(resources, ManagedResource{
@@ -768,15 +773,17 @@ func getManagedResources(ctx context.Context, clientset *kubernetes.Clientset, d
 	// Get StatefulSets
 	statefulsets, err := clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
 	if err == nil {
-		for _, s := range statefulsets.Items {
+		for i := range statefulsets.Items {
+			s := &statefulsets.Items[i]
 			if !isArgoManagedResource(s.Labels, s.Annotations, appName) {
 				continue
 			}
 			s.APIVersion = "apps/v1"
 			s.Kind = "StatefulSet"
 			yamlBytes, _ := yaml.Marshal(s)
+			// #394: kstatus alignment — see Deployment site above.
 			health := "Progressing"
-			if s.Status.ReadyReplicas == *s.Spec.Replicas {
+			if agent.IsStatefulSetReady(s) {
 				health = "Healthy"
 			}
 			resources = append(resources, ManagedResource{
@@ -880,15 +887,17 @@ func getManagedResources(ctx context.Context, clientset *kubernetes.Clientset, d
 	// Get DaemonSets
 	daemonsets, err := clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
 	if err == nil {
-		for _, d := range daemonsets.Items {
+		for i := range daemonsets.Items {
+			d := &daemonsets.Items[i]
 			if !isArgoManagedResource(d.Labels, d.Annotations, appName) {
 				continue
 			}
 			d.APIVersion = "apps/v1"
 			d.Kind = "DaemonSet"
 			yamlBytes, _ := yaml.Marshal(d)
+			// #394: kstatus alignment — see Deployment site above.
 			health := "Progressing"
-			if d.Status.NumberReady == d.Status.DesiredNumberScheduled {
+			if agent.IsDaemonSetReady(d) {
 				health = "Healthy"
 			}
 			resources = append(resources, ManagedResource{

--- a/cmd/cub-scout/patterns.go
+++ b/cmd/cub-scout/patterns.go
@@ -93,6 +93,12 @@ func init() {
 
 func runMapPatterns(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	if ctx == nil {
+		// Defensive: any caller that bypasses Cobra's Execute path (e.g. an
+		// internal dispatcher) would otherwise feed a nil context into
+		// client-go and panic inside klog.FromContext (#390).
+		ctx = context.Background()
+	}
 
 	cfg, err := buildConfig()
 	if err != nil {

--- a/cmd/cub-scout/tree.go
+++ b/cmd/cub-scout/tree.go
@@ -114,7 +114,7 @@ func runTree(cmd *cobra.Command, args []string) error {
 	case "git":
 		return runTreeGit(ctx)
 	case "patterns":
-		return runTreePatterns()
+		return runTreePatterns(ctx)
 	case "config":
 		return runTreeConfig()
 	case "suggest":
@@ -1132,8 +1132,13 @@ func resolveParentApplicationWithConfidence(app *unstructured.Unstructured) (str
 	return "", ""
 }
 
-func runTreePatterns() error {
-	// Run the patterns command
+func runTreePatterns(ctx context.Context) error {
+	// `cub-scout tree patterns` reaches `runMapPatterns` directly without going
+	// through Cobra's Execute path, so `mapPatternsCmd.Context()` would be nil
+	// and any client-go call would panic in klog.FromContext (#390). Seed the
+	// command's context here so the downstream code path is identical to the
+	// `cub-scout map patterns` invocation.
+	mapPatternsCmd.SetContext(ctx)
 	return runMapPatterns(mapPatternsCmd, []string{})
 }
 

--- a/cmd/cub-scout/tree_patterns_panic_test.go
+++ b/cmd/cub-scout/tree_patterns_panic_test.go
@@ -1,0 +1,62 @@
+// Regression coverage for #390: `cub-scout tree patterns` panicked at
+// klog.FromContext because runTreePatterns() bypassed Cobra's Execute path
+// and never seeded mapPatternsCmd's context, so client-go received a nil
+// context and dereferenced it.
+//
+// Two defenses exist now:
+//   - runTreePatterns(ctx) seeds mapPatternsCmd.Context() before delegating.
+//   - runMapPatterns defensively swaps a nil cmd.Context() for
+//     context.Background() so any other dispatcher that bypasses Execute
+//     does not regress the same surface.
+//
+// Both are covered below.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRunTreePatterns_PropagatesContext verifies the primary fix: the wrapper
+// must call mapPatternsCmd.SetContext(ctx) before invoking runMapPatterns, so
+// that cmd.Context() inside runMapPatterns returns the caller's context, not
+// nil.
+func TestRunTreePatterns_PropagatesContext(t *testing.T) {
+	type ctxKey struct{}
+	want := "tree-patterns-#390-marker"
+	ctx := context.WithValue(context.Background(), ctxKey{}, want)
+
+	// We do not care whether runTreePatterns succeeds; in a unit-test
+	// environment buildConfig() typically fails because there is no live
+	// kubeconfig pointing at a cluster. What we care about is that
+	// mapPatternsCmd's context is the one we passed in afterwards — proving
+	// runTreePatterns did the seeding before delegating.
+	_ = runTreePatterns(ctx)
+
+	got := mapPatternsCmd.Context()
+	if got == nil {
+		t.Fatal("mapPatternsCmd.Context() is nil after runTreePatterns; #390 regression")
+	}
+	if v := got.Value(ctxKey{}); v != want {
+		t.Fatalf("ctx not propagated: want %q, got %v", want, v)
+	}
+}
+
+// TestRunMapPatterns_NilContextDefense verifies the secondary fix: even if a
+// caller hands runMapPatterns a Cobra command without a context (i.e.
+// cmd.Context() returns nil), the function must not panic when it threads
+// the context into client-go. We only assert that the call returns rather
+// than panicking — the actual error from buildConfig() in a test environment
+// is environment-dependent and not interesting for this regression.
+func TestRunMapPatterns_NilContextDefense(t *testing.T) {
+	cmd := &cobra.Command{} // no SetContext → cmd.Context() returns nil
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("runMapPatterns panicked on nil context (#390 regression): %v", r)
+		}
+	}()
+	_ = runMapPatterns(cmd, []string{})
+}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
@@ -53,7 +53,7 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -70,6 +70,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
+	sigs.k8s.io/cli-utils v0.37.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
@@ -105,6 +107,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -201,6 +205,8 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+sigs.k8s.io/cli-utils v0.37.2 h1:GOfKw5RV2HDQZDJlru5KkfLO1tbxqMoyn1IYUxqBpNg=
+sigs.k8s.io/cli-utils v0.37.2/go.mod h1:V+IZZr4UoGj7gMJXklWBg6t5xbdThFBcpj4MrZuCYco=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/pkg/agent/flux_trace.go
+++ b/pkg/agent/flux_trace.go
@@ -255,6 +255,10 @@ func (f *FluxTracer) isReadyStatus(status string) bool {
 
 	// Positive indicators
 	// "managed by" indicates the resource is under GitOps control - a success state
+	// "reconciled" (past tense) indicates a successful reconciliation; this is
+	// distinct from the negative-indicator "reconciling" (present, in-flight)
+	// checked above. The order of the two checks matters because "reconciled"
+	// is a substring of "reconciling" (#387).
 	if strings.Contains(status, "applied") ||
 		strings.Contains(status, "succeeded") ||
 		strings.Contains(status, "ready") ||
@@ -263,6 +267,7 @@ func (f *FluxTracer) isReadyStatus(status string) bool {
 		strings.Contains(status, "artifact is") ||
 		strings.Contains(status, "managed by") ||
 		strings.Contains(status, "fetched") ||
+		strings.Contains(status, "reconciled") ||
 		strings.Contains(status, "health check passed") {
 		return true
 	}

--- a/pkg/agent/flux_trace_test.go
+++ b/pkg/agent/flux_trace_test.go
@@ -150,6 +150,15 @@ func TestFluxTracerIsReadyStatus(t *testing.T) {
 		{"Fetched revision main@sha1:abc123", true},
 		{"Health check passed", true},
 
+		// #387: a healthy GitRepository's Status is rendered as
+		// "Last reconciled at <timestamp>". The previous classifier matched
+		// none of the positive keywords and defaulted to false, producing
+		// "✗ Chain broken" for healthy resources. "reconciled" (past tense)
+		// is now a positive indicator distinct from the negative
+		// "reconciling" (in-flight, present tense) below.
+		{"Last reconciled at 2026-04-15 12:15:16 +0100 BST", true},
+		{"Reconciled", true},
+
 		// Negative cases
 		{"kustomize build failed", false},
 		{"Reconciliation failed", false},
@@ -159,6 +168,9 @@ func TestFluxTracerIsReadyStatus(t *testing.T) {
 		{"Suspended", false},
 
 		// Ambiguous - defaults to false
+		// #387 discriminator: "reconciling" (in-flight) must remain false even
+		// after "reconciled" was added as a positive indicator. They differ in
+		// their final letters and are not substrings of each other.
 		{"Reconciling", false},
 		{"Pending", false},
 	}

--- a/pkg/agent/kstatus_wrapper.go
+++ b/pkg/agent/kstatus_wrapper.go
@@ -1,0 +1,99 @@
+// Package agent — kstatus wrapper.
+//
+// Narrow slice of #394: provide deterministic readiness derivation for the
+// workload kinds touched by the source-truth contract (#393). Today this
+// covers Deployment, StatefulSet, DaemonSet — the three kinds the import
+// path observes on the live cluster surface.
+//
+// The wrapper backs kstatus from sigs.k8s.io/cli-utils, which is the same
+// library Argo CD and Flux use to compute resource health. Aligning on
+// kstatus means cub-scout's "ready" verdict matches what operators already
+// see in those tools, which is required for #393's source-truth verdicts to
+// be trustworthy.
+//
+// Behaviour delta vs. the prior ad-hoc `ReadyReplicas == Spec.Replicas`
+// pattern:
+//   - A workload with Stalled=True now reports `ready=false` instead of
+//     "ready or unknown". Stricter, and aligned with operator expectations.
+//   - Nil spec.replicas / missing fields no longer panic — kstatus handles
+//     them and returns InProgress or Unknown rather than dereferencing nil.
+//   - Generation/observedGeneration skew is honoured (a Deployment whose
+//     status reflects an older spec is correctly classified as InProgress,
+//     not "ready").
+
+package agent
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+// IsDeploymentReady returns true when kstatus considers d to be at its
+// desired state (CurrentStatus). Any other state returns false.
+func IsDeploymentReady(d *appsv1.Deployment) bool {
+	return computeStatus(d, "apps/v1", "Deployment") == status.CurrentStatus
+}
+
+// IsStatefulSetReady returns true when kstatus considers s to be at its
+// desired state (CurrentStatus). Any other state returns false.
+func IsStatefulSetReady(s *appsv1.StatefulSet) bool {
+	return computeStatus(s, "apps/v1", "StatefulSet") == status.CurrentStatus
+}
+
+// IsDaemonSetReady returns true when kstatus considers d to be at its
+// desired state (CurrentStatus). Any other state returns false.
+func IsDaemonSetReady(d *appsv1.DaemonSet) bool {
+	return computeStatus(d, "apps/v1", "DaemonSet") == status.CurrentStatus
+}
+
+// WorkloadStatus returns the kstatus verdict and message for a typed
+// apps/v1 workload. Useful when callers need to distinguish InProgress
+// (rollout pending) from Failed (Stalled) — for example when surfacing
+// evidence inside the #393 source-truth contract.
+//
+// kind must be one of "Deployment", "StatefulSet", "DaemonSet". For other
+// kinds the caller should compute status themselves from an unstructured
+// object.
+func WorkloadStatus(obj runtime.Object, kind string) (status.Status, string) {
+	u, err := toUnstructured(obj, "apps/v1", kind)
+	if err != nil {
+		return status.UnknownStatus, err.Error()
+	}
+	res, err := status.Compute(u)
+	if err != nil || res == nil {
+		return status.UnknownStatus, ""
+	}
+	return res.Status, res.Message
+}
+
+// computeStatus is the shared helper. Returns UnknownStatus on any error.
+func computeStatus(obj runtime.Object, apiVersion, kind string) status.Status {
+	u, err := toUnstructured(obj, apiVersion, kind)
+	if err != nil {
+		return status.UnknownStatus
+	}
+	res, err := status.Compute(u)
+	if err != nil || res == nil {
+		return status.UnknownStatus
+	}
+	return res.Status
+}
+
+// toUnstructured converts a typed object into the *unstructured.Unstructured
+// kstatus.Compute expects. The conversion drops the GVK if the typed object
+// did not have TypeMeta set (which the apps/v1 list APIs do not by default),
+// so we re-seed it from the caller-supplied apiVersion/kind. Without this,
+// kstatus's polymorphic dispatch falls through to the generic conditions
+// reader instead of using the kind-specific logic.
+func toUnstructured(obj runtime.Object, apiVersion, kind string) (*unstructured.Unstructured, error) {
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{Object: raw}
+	u.SetAPIVersion(apiVersion)
+	u.SetKind(kind)
+	return u, nil
+}

--- a/pkg/agent/kstatus_wrapper_test.go
+++ b/pkg/agent/kstatus_wrapper_test.go
@@ -1,0 +1,206 @@
+package agent
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+// ptrInt32 returns a pointer to an int32 — needed because Spec.Replicas is
+// *int32 in the apps/v1 API.
+func ptrInt32(v int32) *int32 { return &v }
+
+// makeDeployment builds a Deployment whose .status reflects the supplied
+// generation/observedGeneration/ready/spec values. Helper keeps the table
+// tests below readable.
+//
+// Caveat: kstatus's deployment classifier wants either Progressing=True
+// reason=NewReplicaSetAvailable AND Available=True conditions, or no
+// progressDeadlineSeconds set on the spec. Real Deployments populate these
+// conditions in normal operation. Pass extra conditions to override.
+func makeDeployment(replicas, ready, available int32, gen, observedGen int64, conditions ...appsv1.DeploymentCondition) *appsv1.Deployment {
+	if len(conditions) == 0 {
+		conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+		}
+	}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "demo",
+			Namespace:  "default",
+			Generation: gen,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptrInt32(replicas),
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:           replicas,
+			ReadyReplicas:      ready,
+			AvailableReplicas:  available,
+			UpdatedReplicas:    ready,
+			ObservedGeneration: observedGen,
+			Conditions:         conditions,
+		},
+	}
+	return d
+}
+
+func TestIsDeploymentReady(t *testing.T) {
+	tests := []struct {
+		name   string
+		dep    *appsv1.Deployment
+		wantUp bool
+	}{
+		{
+			name:   "fully rolled out — kstatus Current",
+			dep:    makeDeployment(3, 3, 3, 1, 1),
+			wantUp: true,
+		},
+		{
+			name:   "rollout in progress — kstatus InProgress",
+			dep:    makeDeployment(3, 1, 1, 1, 1),
+			wantUp: false,
+		},
+		{
+			name: "observedGeneration lag — kstatus InProgress (status reflects old spec)",
+			dep:  makeDeployment(3, 3, 3, 2, 1), // gen=2, observed=1 ⇒ stale
+			wantUp: false,
+		},
+		{
+			name: "stalled deployment — kstatus Failed (was 'ready or unknown' under prior helper, now correctly false)",
+			// #394 behaviour delta: a Stalled=True / Progressing=False ReplicaFailure
+			// previously slipped through the ad-hoc check because ReadyReplicas matched
+			// Spec.Replicas. kstatus reads the conditions and returns Failed.
+			dep: makeDeployment(3, 3, 3, 1, 1,
+				appsv1.DeploymentCondition{
+					Type:   appsv1.DeploymentProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "ProgressDeadlineExceeded",
+				},
+			),
+			wantUp: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDeploymentReady(tt.dep); got != tt.wantUp {
+				t.Fatalf("IsDeploymentReady = %v, want %v", got, tt.wantUp)
+			}
+		})
+	}
+}
+
+func TestIsStatefulSetReady(t *testing.T) {
+	curRev := "demo-7d9"
+	makeSS := func(replicas, ready, available, currentReplicas int32, gen, observedGen int64) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "demo",
+				Namespace:  "default",
+				Generation: gen,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas:            ptrInt32(replicas),
+				UpdateStrategy:      appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
+				PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			},
+			Status: appsv1.StatefulSetStatus{
+				Replicas:           replicas,
+				ReadyReplicas:      ready,
+				AvailableReplicas:  available,
+				CurrentReplicas:    currentReplicas,
+				CurrentRevision:    curRev,
+				UpdateRevision:     curRev,
+				ObservedGeneration: observedGen,
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		ss   *appsv1.StatefulSet
+		want bool
+	}{
+		{name: "fully rolled out", ss: makeSS(3, 3, 3, 3, 1, 1), want: true},
+		{name: "rollout in progress (only 1 ready)", ss: makeSS(3, 1, 1, 3, 1, 1), want: false},
+		{name: "generation lag", ss: makeSS(3, 3, 3, 3, 2, 1), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsStatefulSetReady(tt.ss); got != tt.want {
+				t.Fatalf("IsStatefulSetReady = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDaemonSetReady(t *testing.T) {
+	makeDS := func(desired, ready, available, updated int32, gen, observedGen int64) *appsv1.DaemonSet {
+		return &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "demo",
+				Namespace:  "default",
+				Generation: gen,
+			},
+			Spec: appsv1.DaemonSetSpec{
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+					Type: appsv1.RollingUpdateDaemonSetStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+						MaxUnavailable: func() *intstr.IntOrString { v := intstr.FromInt(1); return &v }(),
+					},
+				},
+			},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: desired,
+				CurrentNumberScheduled: desired,
+				NumberReady:            ready,
+				NumberAvailable:        available,
+				UpdatedNumberScheduled: updated,
+				ObservedGeneration:     observedGen,
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		ds   *appsv1.DaemonSet
+		want bool
+	}{
+		{name: "fully scheduled and ready", ds: makeDS(5, 5, 5, 5, 1, 1), want: true},
+		{name: "rollout in progress", ds: makeDS(5, 3, 3, 3, 1, 1), want: false},
+		{name: "generation lag", ds: makeDS(5, 5, 5, 5, 2, 1), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDaemonSetReady(tt.ds); got != tt.want {
+				t.Fatalf("IsDaemonSetReady = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkloadStatus_DistinguishesInProgressFromFailed(t *testing.T) {
+	// Same readiness verdict (false) under IsDeploymentReady, but
+	// WorkloadStatus must let callers distinguish the two cases for evidence
+	// surfacing (e.g. #393's source-truth contract).
+	rolling := makeDeployment(3, 1, 1, 1, 1) // 1/3 pods ready ⇒ InProgress
+	stalled := makeDeployment(3, 3, 3, 1, 1,
+		appsv1.DeploymentCondition{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionFalse,
+			Reason: "ProgressDeadlineExceeded",
+		},
+	)
+
+	if s, _ := WorkloadStatus(rolling, "Deployment"); s != status.InProgressStatus {
+		t.Fatalf("rolling deployment: want InProgress, got %s", s)
+	}
+	if s, _ := WorkloadStatus(stalled, "Deployment"); s != status.FailedStatus {
+		t.Fatalf("stalled deployment: want Failed, got %s", s)
+	}
+}


### PR DESCRIPTION
## Summary

Lands the truth-floor sequence the council placed as a prerequisite to [#393](https://github.com/confighub/cub-scout/issues/393#issuecomment-4407651183). Three semantically distinct commits:

- **`fix: tree patterns panic when ctx not seeded by Cobra Execute (#390)`** — `cub-scout tree patterns` panicked at `klog.FromContext` because the `switch` dispatch in `runTree` bypassed Cobra's `Execute` path, leaving `mapPatternsCmd.Context()` nil. Fixed with two defenses (seed the cmd's context in the wrapper + defensive nil-ctx swap in `runMapPatterns`) and two regression tests.
- **`fix: flux trace classifies "Last reconciled" as healthy (#387)`** — `cub-scout trace` rendered healthy Flux GitRepository / Kustomization resources as ✗ "Chain broken" because the status-string classifier had no positive indicator for the past participle "reconciled" (only "reconciling" as a negative). Added `"reconciled"` to the positive list with discriminator coverage so "reconciling" still returns `false`.
- **`feat: align workload readiness with kstatus (narrow slice of #394)`** — Replaced ad-hoc `ReadyReplicas == Spec.Replicas` checks at 6 import-path call sites with `sigs.k8s.io/cli-utils/pkg/kstatus`, the same library Argo CD and Flux use upstream. Behaviour delta: Stalled / generation-lagging workloads now report `Ready=false` instead of slipping through as ready-or-unknown. Three typed wrappers (`IsDeploymentReady` / `IsStatefulSetReady` / `IsDaemonSetReady`) plus a `WorkloadStatus` helper for callers that need to distinguish InProgress from Failed (relevant to #393's evidence shape).

Council verdict that motivates this sequence: [#393#issuecomment-4407651183](https://github.com/confighub/cub-scout/issues/393#issuecomment-4407651183) — cub-scout becomes the read-only evidence provider; the trust floor must be solid before the source-truth contract lands.

## What's *not* in this PR

- **#393 contract itself** — separate PR after this lands.
- **Full `pkg/agent/state_scanner.go` kstatus migration** — kept narrow per the council's "only the kinds touched by the source-truth surface" framing. Remaining 4 call sites (HelmRelease/Kustomization filters in `findSilentFailures` / `findTimingBombs`) are a follow-up slice.
- **Direct integration coverage on `discoverWorkloads` / `getManagedResources`** — neither has a fake-clientset test today; the kstatus migration's safety story rides on the wrapper unit tests + existing higher-level suite + `go build` type-check. Tracked at [#396](https://github.com/confighub/cub-scout/issues/396) as a back-fill.

## Test plan

- [x] `go test ./...` — all 39 packages green pre- and post-migration.
- [x] `cmd/cub-scout/tree_patterns_panic_test.go` — 2 new regression tests for #390 (context propagation + nil-ctx defense).
- [x] `pkg/agent/flux_trace_test.go` — extended `TestFluxTracerIsReadyStatus` with the failing string from the #387 issue body, bare "Reconciled", plus discriminator note.
- [x] `pkg/agent/kstatus_wrapper_test.go` — 4 test funcs covering Deployment / StatefulSet / DaemonSet × happy-path / in-progress / generation-lag, plus an explicit InProgress-vs-Failed discriminator through `WorkloadStatus`.
- [x] No goldens needed rebaselining — the existing test corpus contains no Stalled or generation-lagging workloads, so the kstatus tightening is purely additive against today's fixtures.

## Linked issues

- Truth floor: #390, #387, #394 (this PR)
- Source-truth contract: #393 (depends on this PR)
- Coverage back-fill: #396
- View Explorer integration (downstream consumer): #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)
