### PR TITLE
chore: clean up pre-existing main lint debt (#384)

### DIFF
--- a/cmd/cub-scout/explain.go
+++ b/cmd/cub-scout/explain.go
@@ -820,8 +820,7 @@ func renderEventsSection(events *agent.ResourceEventSummary, mode PresentationMo
 
 	// Event list
 	for _, ev := range events.Events {
-		icon := "•"
-		color := ""
+		var icon, color string
 		reset := ""
 		switch ev.Severity {
 		case "error":

--- a/cmd/cub-scout/navigation_hints.go
+++ b/cmd/cub-scout/navigation_hints.go
@@ -362,11 +362,6 @@ func doctorTryNextHintsWithContext(summary DoctorSummary, ctx HintContext) []str
 	return hintsToStrings(hints)
 }
 
-// doctorHints generates structured hints for doctor output.
-func doctorHints(summary DoctorSummary) []Hint {
-	return doctorHintsWithContext(summary, DefaultHintContext())
-}
-
 // doctorHintsWithContext generates structured hints with explicit context control.
 // The context affects hint ranking:
 // - Beginner/default: quickstart is prominent, general exploration hints included
@@ -450,10 +445,6 @@ func doctorHintsWithContext(summary DoctorSummary, ctx HintContext) []Hint {
 	})
 
 	return hints
-}
-
-func explainTryNextHints(summary ExplainSummary) []string {
-	return explainTryNextHintsWithContext(summary, DefaultHintContext())
 }
 
 // explainTryNextHintsWithContext generates hints with explicit context control.

--- a/pkg/gitops/parser.go
+++ b/pkg/gitops/parser.go
@@ -959,28 +959,6 @@ func parseApplicationSets(repoPath string) (*RepoStructure, error) {
 	return result, nil
 }
 
-// findAppBasePath attempts to find the base path for an app discovered via ApplicationSet
-func findAppBasePath(repoPath, appName string) string {
-	// Common patterns for app locations
-	searchPatterns := []string{
-		filepath.Join("apps", appName),
-		filepath.Join("apps", "base", appName),
-		filepath.Join("applications", appName),
-		filepath.Join("workloads", appName),
-		appName,
-	}
-
-	for _, pattern := range searchPatterns {
-		fullPath := filepath.Join(repoPath, pattern)
-		if dirExists(fullPath) {
-			return pattern
-		}
-	}
-
-	// Return empty if not found - the app was discovered but path is unknown
-	return ""
-}
-
 // parseApplicationSet parses an ApplicationSet YAML and extracts git generator patterns
 func parseApplicationSet(path, repoPath string) *ApplicationSetDef {
 	data, err := os.ReadFile(path)
@@ -1114,12 +1092,6 @@ func extractGitGeneratorPatternsWithExcludes(gitGen interface{}) gitGeneratorPat
 	return patterns
 }
 
-// extractMatrixGitPatterns extracts git patterns from matrix generators
-func extractMatrixGitPatterns(matrixGen interface{}) []string {
-	patterns := extractMatrixGitPatternsWithExcludes(matrixGen)
-	return patterns.Include
-}
-
 // extractMatrixGitPatternsWithExcludes extracts git patterns from matrix generators including excludes
 func extractMatrixGitPatternsWithExcludes(matrixGen interface{}) gitGeneratorPatterns {
 	var patterns gitGeneratorPatterns
@@ -1160,17 +1132,6 @@ func extractMatrixGitPatternsWithExcludes(matrixGen interface{}) gitGeneratorPat
 // scanGitGeneratorPatterns scans the repo for directories matching git generator patterns
 func scanGitGeneratorPatterns(repoPath string, patterns []string) []string {
 	discovered := scanGitGeneratorPatternsWithExcludesFullPaths(repoPath, gitGeneratorPatterns{Include: patterns})
-	names := make([]string, len(discovered))
-	for i, d := range discovered {
-		names[i] = d.Name
-	}
-	return names
-}
-
-// scanGitGeneratorPatternsWithExcludes scans the repo for directories matching git generator patterns
-// while filtering out directories that match exclude patterns. Returns only app names for backward compatibility.
-func scanGitGeneratorPatternsWithExcludes(repoPath string, patterns gitGeneratorPatterns) []string {
-	discovered := scanGitGeneratorPatternsWithExcludesFullPaths(repoPath, patterns)
 	names := make([]string, len(discovered))
 	for i, d := range discovered {
 		names[i] = d.Name


### PR DESCRIPTION
## Summary

Closes [#384](https://github.com/confighub/cub-scout/issues/384). Removes the five dead helpers and one ineffectual assignment that have been failing CI on `main` since 2026-04-19. Single chore commit, no behaviour change.

| File | Change | Why safe |
|---|---|---|
| `pkg/gitops/parser.go` | Remove `findAppBasePath` | No callers anywhere in the repo |
| `pkg/gitops/parser.go` | Remove `extractMatrixGitPatterns` | Only forwarded to `extractMatrixGitPatternsWithExcludes` (the live API); never called externally |
| `pkg/gitops/parser.go` | Remove `scanGitGeneratorPatternsWithExcludes` | Same — `…FullPaths` variant is the live API. **Note:** `scanGitGeneratorPatterns` (no suffix) is retained because `parser_test.go:578` uses it |
| `cmd/cub-scout/navigation_hints.go` | Remove `doctorHints` | Only forwards to `doctorHintsWithContext`; all tests and callers use the `…WithContext` form directly |
| `cmd/cub-scout/navigation_hints.go` | Remove `explainTryNextHints` | Same pattern — `explainTryNextHintsWithContext` is the live callee |
| `cmd/cub-scout/explain.go:823` | `icon := "•"` → `var icon, color string` | Every arm of the immediately-following switch (including `default`) reassigns both `icon` and `color`. Initial values were dead. Behaviour identical, `ineffassign` silent |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./pkg/gitops/ ./cmd/cub-scout/` — both packages green
- [x] `golangci-lint run` (v1.64.8, matching CI) — exit 0 locally
- [x] No symbols deleted that have any caller anywhere in the repo (verified by `grep`)

## Why this PR exists

Discovered while investigating CI failures on [#397](https://github.com/confighub/cub-scout/pull/397) (truth-floor sequence). The lint errors did not touch any file modified by #397 — they have been on `main` since `c438347`'s CI run on 2026-04-19. Filing this as a separate small PR keeps #397's review surface focused on the truth-floor changes; once this lands, #397 rebases and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
