### PR TITLE
fix: parity script reads canonical CLI reference, not CLI-GUIDE

### DIFF
--- a/scripts/check-cli-guide-parity.sh
+++ b/scripts/check-cli-guide-parity.sh
@@ -5,7 +5,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "Checking CLI-GUIDE top-level command parity..."
+# The canonical A-Z command catalog moved from CLI-GUIDE.md to
+# docs/reference/cli-reference.md in the doc consolidation under #374.
+# CLI-GUIDE.md is now the workflow-first guide and intentionally does
+# not list every top-level command. Parity is enforced against the
+# canonical catalog instead.
+GUIDE_PATH="docs/reference/cli-reference.md"
+
+echo "Checking CLI reference top-level command parity (${GUIDE_PATH})..."
 
 help_cmds="$(
   go run ./cmd/cub-scout --help \
@@ -17,14 +24,14 @@ guide_cmds="$(
   awk '
     BEGIN { inside = 0 }
     /^## Top-Level Commands/ { inside = 1; next }
-    inside && /^---/ { inside = 0 }
+    inside && /^## / { inside = 0 }
     inside && /^\| `/ {
       cmd = $0
       sub(/^\| `/, "", cmd)
       sub(/`.*/, "", cmd)
       print cmd
     }
-  ' CLI-GUIDE.md | sort -u
+  ' "$GUIDE_PATH" | sort -u
 )"
 
 missing_from_guide="$(comm -23 <(printf "%s\n" "$help_cmds") <(printf "%s\n" "$guide_cmds") || true)"
@@ -34,22 +41,22 @@ failed=0
 
 if [[ -n "$missing_from_guide" ]]; then
   echo ""
-  echo "Commands in 'cub-scout --help' but missing from CLI-GUIDE top-level table:"
+  echo "Commands in 'cub-scout --help' but missing from ${GUIDE_PATH} top-level table:"
   printf "%s\n" "$missing_from_guide"
   failed=1
 fi
 
 if [[ -n "$extra_in_guide" ]]; then
   echo ""
-  echo "Commands in CLI-GUIDE top-level table but not in 'cub-scout --help':"
+  echo "Commands in ${GUIDE_PATH} top-level table but not in 'cub-scout --help':"
   printf "%s\n" "$extra_in_guide"
   failed=1
 fi
 
 if [[ "$failed" -ne 0 ]]; then
   echo ""
-  echo "CLI-GUIDE parity check failed."
+  echo "CLI reference parity check failed."
   exit 1
 fi
 
-echo "CLI-GUIDE parity check passed."
+echo "CLI reference parity check passed."


### PR DESCRIPTION
## Summary

Pre-existing main breakage. `scripts/check-cli-guide-parity.sh` has been failing CI on main since the doc consolidation in [f523327 (#374)](https://github.com/confighub/cub-scout/commit/f523327) moved the canonical A-Z command catalog from `CLI-GUIDE.md` to `docs/reference/cli-reference.md`. The script still pointed at the old path, so its awk came back empty and every top-level command was reported as "missing from the top-level table".

Per [HANDOVER.md](HANDOVER.md), the canonical doc layout is now:

| File | Purpose |
|---|---|
| `README.md` | overview + Fast Path |
| `CLI-GUIDE.md` | workflow-first guide (intentionally not the A-Z catalog) |
| `docs/reference/cli-reference.md` | **A-Z command catalog** (the right parity target) |
| `docs/reference/commands.md` | detailed usage and examples |
| `docs/reference/cli-contract.md` | stable flags, exit codes, schemas |

## Fix

`scripts/check-cli-guide-parity.sh`:

- Read `docs/reference/cli-reference.md` instead of `CLI-GUIDE.md`.
- Change section terminator from `^---` to `^## ` because the new file uses `## ` headings (not horizontal rules) to delimit sections.
- Update echo strings to say "CLI reference" not "CLI-GUIDE" for consistency.

The script's **filename is unchanged** to avoid touching the GitHub Actions workflow that calls it. The parity contract is preserved; only the file it checks against was corrected.

## Test plan

- [x] `./scripts/check-cli-guide-parity.sh` exits 0 locally on this branch
- [x] Verified the awk extracts the same 30 commands that appear in `go run ./cmd/cub-scout --help`
- [x] No code changes — script-only

## Why this PR exists

Discovered while CI on [#397](https://github.com/confighub/cub-scout/pull/397) failed after rebase on top of #398 (lint debt cleanup). The lint debt was one part of main's CI being red; this is the other. Filing as a separate small PR keeps #397's review surface focused on the truth-floor changes; once this lands, #397 rebases and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
