### PR TITLE
feat: source-truth evidence contract v0.1 (#393)

### DIFF
--- a/cmd/cub-scout/source_truth.go
+++ b/cmd/cub-scout/source_truth.go
@@ -1,0 +1,433 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+// cub-scout source-truth — v0.1 of the source-truth evidence contract
+// per the council verdict on #393. This file owns the CLI surface and the
+// live collectors that populate the three surfaces; the contract types
+// and decision logic live in pkg/agent/source_truth.go and
+// pkg/agent/source_truth_logic.go.
+//
+// v0.1 supports the workload kinds the kstatus wrapper covers
+// (Deployment, StatefulSet, DaemonSet) — those are the kinds the
+// source-truth contract surfaces today. Other kinds emit ASK because
+// cub-scout does not have a runtime surface for them yet.
+//
+// The command is deliberately read-only and refuses to run unless
+// connected mode auth is in place — the contract is meaningless without
+// the ConfigHub surface.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/confighub/cub-scout/pkg/hub"
+)
+
+var (
+	sourceTruthNamespace string
+	sourceTruthStrategy  string
+	sourceTruthFormat    string
+)
+
+var sourceTruthCmd = &cobra.Command{
+	Use:   "source-truth <kind>/<name> | <kind> <name>",
+	Short: "Read-only source-truth evidence for a single workload (v0.1)",
+	Long: `source-truth emits read-only evidence about a single workload's intended,
+controller-observed, and runtime state. Output is the structured JSON
+contract Pilot's acceptance kernel consumes (#393).
+
+cub-scout is the *evidence provider*; Pilot is the acceptance judge.
+This command never mutates, repairs, approves, or infers authority.
+
+Strategy is required input — cub-scout never infers the delivery path.
+v0.1 strategies:
+
+  confighub-oci-argo   ConfigHub -> OCI -> Argo CD -> Kubernetes
+  confighub-oci-flux   ConfigHub -> OCI -> Flux    -> Kubernetes
+  git-argo             Git      -> Argo CD -> Kubernetes
+  git-flux             Git      -> Flux    -> Kubernetes
+
+Examples:
+  cub-scout compare source-truth deploy/rag-server -n demo --strategy confighub-oci-flux
+  cub scout compare source-truth Deployment rag-server -n demo --strategy git-argo
+
+v0.1 supports Deployment, StatefulSet, DaemonSet. Other kinds emit ASK.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runSourceTruth,
+}
+
+func init() {
+	// Lives under `compare` per the council's "extend the existing three-
+	// way comparison" framing. Keeps the top-level command surface lean.
+	combinedCmd.AddCommand(sourceTruthCmd)
+	sourceTruthCmd.Flags().StringVarP(&sourceTruthNamespace, "namespace", "n", "", "Namespace of the resource (required for namespaced kinds)")
+	sourceTruthCmd.Flags().StringVar(&sourceTruthStrategy, "strategy", "", "Declared delivery path. Required. One of: confighub-oci-argo, confighub-oci-flux, git-argo, git-flux")
+	sourceTruthCmd.Flags().StringVar(&sourceTruthFormat, "format", "json", "Output format. v0.1 supports: json")
+}
+
+func runSourceTruth(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(sourceTruthFormat))
+	if format != "json" {
+		return fmt.Errorf("invalid --format %q (v0.1 supports: json)", sourceTruthFormat)
+	}
+
+	// Parse positional arg(s) using the same helper explain uses, so the
+	// "kind/name" or "kind name" surface is consistent.
+	kind, name, err := parseExplainArgs(args)
+	if err != nil {
+		return err
+	}
+
+	// Strategy validation. Empty/unknown still produces a valid evidence
+	// document (ASK + UNKNOWN per the council); the CLI surfaces it as
+	// JSON output and exits 0 so Pilot receives the structured "I don't
+	// know" rather than a CLI error.
+	strategy, ok := agent.ParseStrategy(sourceTruthStrategy)
+	if !ok {
+		return emitEvidence(agent.Derive("", agent.SourceTruthSurfaces{}))
+	}
+
+	// Connected-mode gate: source-truth is meaningless without the
+	// ConfigHub surface. Refuse early rather than emit a half-evidence
+	// document — the operator should know they are not connected.
+	if hub.QuickMode() != hub.Connected {
+		return fmt.Errorf("source-truth requires ConfigHub authentication (run `cub auth login` or set CONFIGHUB_API_KEY)")
+	}
+
+	ctx := cmd.Context()
+
+	// Fetch the runtime surface first because we need its labels to look
+	// up the ConfigHub Unit, and the runtime image is the canonical
+	// "what is actually running" value the contract asks for.
+	runtime, runtimeObj, runtimeErr := collectRuntimeSurface(ctx, kind, name, sourceTruthNamespace)
+	if runtimeErr != nil {
+		// Runtime is unfetchable — BLOCK. Pilot must not accept evidence
+		// where we cannot read the cluster.
+		return emitEvidence(agent.Derive(strategy, agent.SourceTruthSurfaces{
+			Controller: nil, // also unfetched in this branch; caller sees
+			Runtime:    nil, // paired naming in BLOCK message
+		}))
+	}
+
+	// ConfigHub surface from the runtime object's labels. If the workload
+	// is not labelled as ConfigHub-managed, the surface is absent — that
+	// is a hard BLOCK, since the strategy declares ConfigHub authority.
+	chSurface, chErr := collectConfigHubSurface(ctx, runtimeObj)
+	_ = chErr // surfaced via nil
+
+	// Controller surface from the existing tracers. Tracer selection is
+	// strategy-aware: Argo strategies try the Argo tracer; Flux strategies
+	// try Flux. We do *not* fall back across controllers — that would
+	// hide the strategy-mismatch trap the contract is supposed to catch.
+	ctrlSurface := collectControllerSurface(ctx, strategy, kind, name, sourceTruthNamespace)
+
+	ev := agent.Derive(strategy, agent.SourceTruthSurfaces{
+		ConfigHub:  chSurface,
+		Controller: ctrlSurface,
+		Runtime:    runtime,
+	})
+	return emitEvidence(ev)
+}
+
+// emitEvidence prints the JSON contract to stdout. v0.1 is JSON-only.
+// Indented for readability — CI / fixture diffs benefit from stable
+// indentation.
+func emitEvidence(ev agent.SourceTruthEvidence) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(ev)
+}
+
+// runtimeWorkload is a thin sum type over the typed apps/v1 workloads
+// v0.1 supports. Carrying the typed value (rather than unstructured)
+// lets us use the kstatus wrapper directly and keeps image extraction
+// straightforward.
+type runtimeWorkload struct {
+	Kind        string
+	Namespace   string
+	Name        string
+	Labels      map[string]string
+	Annotations map[string]string
+
+	// Exactly one of these is set.
+	Deployment  *appsv1.Deployment
+	StatefulSet *appsv1.StatefulSet
+	DaemonSet   *appsv1.DaemonSet
+}
+
+// collectRuntimeSurface fetches the live workload via the typed
+// clientset. Returns the contract surface plus the typed object so the
+// caller can extract ConfigHub labels without a second API call.
+func collectRuntimeSurface(ctx context.Context, kind, name, namespace string) (*agent.RuntimeSurface, *runtimeWorkload, error) {
+	cfg, err := buildConfig()
+	if err != nil {
+		return nil, nil, &agent.CollectionError{Surface: "runtime", Reason: "build kubeconfig: " + err.Error()}
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, nil, &agent.CollectionError{Surface: "runtime", Reason: "create clientset: " + err.Error()}
+	}
+
+	rw := &runtimeWorkload{Kind: kind, Namespace: namespace, Name: name}
+
+	switch normalizeKind(kind) {
+	case "Deployment":
+		d, err := cs.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, fetchError("runtime", err)
+		}
+		rw.Deployment = d
+		rw.Labels = d.Labels
+		rw.Annotations = d.Annotations
+		return &agent.RuntimeSurface{
+			Resource: fmt.Sprintf("Deployment/%s in %s", name, namespace),
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    firstContainerImage(d.Spec.Template.Spec.Containers),
+			Health:   workloadHealthLabel(agent.IsDeploymentReady(d)),
+		}, rw, nil
+
+	case "StatefulSet":
+		s, err := cs.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, fetchError("runtime", err)
+		}
+		rw.StatefulSet = s
+		rw.Labels = s.Labels
+		rw.Annotations = s.Annotations
+		return &agent.RuntimeSurface{
+			Resource: fmt.Sprintf("StatefulSet/%s in %s", name, namespace),
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    firstContainerImage(s.Spec.Template.Spec.Containers),
+			Health:   workloadHealthLabel(agent.IsStatefulSetReady(s)),
+		}, rw, nil
+
+	case "DaemonSet":
+		ds, err := cs.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, fetchError("runtime", err)
+		}
+		rw.DaemonSet = ds
+		rw.Labels = ds.Labels
+		rw.Annotations = ds.Annotations
+		return &agent.RuntimeSurface{
+			Resource: fmt.Sprintf("DaemonSet/%s in %s", name, namespace),
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    firstContainerImage(ds.Spec.Template.Spec.Containers),
+			Health:   workloadHealthLabel(agent.IsDaemonSetReady(ds)),
+		}, rw, nil
+
+	default:
+		// Unsupported kinds intentionally surface as a CollectionError
+		// rather than a partial Runtime surface. Pilot sees a clear BLOCK
+		// rather than a misleadingly-populated runtime block.
+		return nil, nil, &agent.CollectionError{
+			Surface: "runtime",
+			Reason:  fmt.Sprintf("kind %q not supported in v0.1 (supported: Deployment, StatefulSet, DaemonSet)", kind),
+		}
+	}
+}
+
+// collectConfigHubSurface looks up the ConfigHub unit identified by
+// labels/annotations on the runtime object and shells out to `cub unit
+// get` to read the latest revision. v0.1 reads only the head revision —
+// live/last-applied are deferred to v0.2 alongside the cross-surface
+// equality check.
+func collectConfigHubSurface(ctx context.Context, rw *runtimeWorkload) (*agent.ConfigHubSurface, error) {
+	if rw == nil {
+		return nil, &agent.CollectionError{Surface: "confighub", Reason: "no runtime object available"}
+	}
+
+	unitSlug := firstNonEmpty(rw.Labels["confighub.com/UnitSlug"], rw.Annotations["confighub.com/UnitSlug"])
+	if unitSlug == "" {
+		return nil, &agent.CollectionError{
+			Surface: "confighub",
+			Reason:  "runtime object has no confighub.com/UnitSlug label or annotation; not ConfigHub-managed",
+		}
+	}
+	space := firstNonEmpty(rw.Annotations["confighub.com/SpaceName"], rw.Labels["confighub.com/SpaceName"])
+	if space == "" {
+		return nil, &agent.CollectionError{
+			Surface: "confighub",
+			Reason:  "runtime object has no confighub.com/SpaceName annotation",
+		}
+	}
+
+	unitJSON, err := exec.CommandContext(ctx, "cub", "unit", "get", unitSlug, "--space", space, "--json").Output()
+	if err != nil {
+		return nil, &agent.CollectionError{Surface: "confighub", Reason: "cub unit get failed: " + err.Error()}
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(unitJSON, &raw); err != nil {
+		return nil, &agent.CollectionError{Surface: "confighub", Reason: "parse cub output: " + err.Error()}
+	}
+
+	surface := &agent.ConfigHubSurface{
+		Space: space,
+		Unit:  unitSlug,
+	}
+
+	// `cub unit get` JSON is mixed-case; pull the head revision number
+	// using the same tolerant lookup mcp_structured.go uses elsewhere.
+	if rev, ok := lookupAnyCase(raw, "HeadRevisionNum"); ok {
+		surface.Revision = stringify(rev)
+	} else if rev, ok := lookupAnyCase(raw, "Revision"); ok {
+		surface.Revision = stringify(rev)
+	}
+
+	// URL: best-effort. The IDs may live under different keys; absence
+	// is a soft gap (URL is informational, not a contract proof).
+	spaceID := stringify(firstAny(raw, "SpaceID", "spaceId"))
+	unitID := stringify(firstAny(raw, "UnitID", "unitId"))
+	if spaceID != "" && unitID != "" {
+		surface.URL = configHubUnitDetailURL(spaceID, unitID)
+	}
+
+	return surface, nil
+}
+
+// collectControllerSurface fetches the GitOps-controller observation via
+// the existing tracers in pkg/agent. Strategy-aware tracer selection is
+// load-bearing: under a Flux strategy we never silently fall back to
+// Argo (and vice versa), because that would mask the controller-kind
+// mismatch the contract is supposed to surface.
+func collectControllerSurface(ctx context.Context, strategy agent.SourceTruthStrategy, kind, name, namespace string) *agent.ControllerSurface {
+	if strategy.ExpectsArgoController() {
+		return controllerSurfaceFromArgo(ctx, kind, name, namespace)
+	}
+	return controllerSurfaceFromFlux(ctx, kind, name, namespace)
+}
+
+func controllerSurfaceFromArgo(ctx context.Context, kind, name, namespace string) *agent.ControllerSurface {
+	tr := agent.NewArgoTracer()
+	if !tr.Available() {
+		return nil
+	}
+	res, err := tr.Trace(ctx, kind, name, namespace)
+	if err != nil || res == nil || len(res.Chain) == 0 {
+		return nil
+	}
+	root := res.Chain[0]
+	return &agent.ControllerSurface{
+		Kind:             "Argo",
+		Source:           strings.TrimSpace(firstNonEmpty(root.URL, root.Kind)),
+		RevisionOrDigest: strings.TrimSpace(root.Revision),
+		Health:           controllerHealthLabel(root.Ready, root.Status),
+	}
+}
+
+func controllerSurfaceFromFlux(ctx context.Context, kind, name, namespace string) *agent.ControllerSurface {
+	tr := agent.NewFluxTracer()
+	if !tr.Available() {
+		return nil
+	}
+	res, err := tr.Trace(ctx, kind, name, namespace)
+	if err != nil || res == nil || len(res.Chain) == 0 {
+		return nil
+	}
+	root := res.Chain[0]
+	return &agent.ControllerSurface{
+		Kind:             "Flux",
+		Source:           strings.TrimSpace(firstNonEmpty(root.URL, root.Kind)),
+		RevisionOrDigest: strings.TrimSpace(root.Revision),
+		Health:           controllerHealthLabel(root.Ready, root.Status),
+	}
+}
+
+// fetchError converts client-go errors into a typed CollectionError with
+// a concrete reason. NotFound is most common and worth saying so.
+func fetchError(surface string, err error) error {
+	if apierrors.IsNotFound(err) {
+		return &agent.CollectionError{Surface: surface, Reason: "resource not found"}
+	}
+	if apierrors.IsForbidden(err) {
+		return &agent.CollectionError{Surface: surface, Reason: "forbidden (RBAC): " + err.Error()}
+	}
+	return &agent.CollectionError{Surface: surface, Reason: err.Error()}
+}
+
+// firstContainerImage returns the image string for the first container in
+// a workload's pod template, or "" if there are no containers.
+func firstContainerImage(containers []corev1.Container) string {
+	if len(containers) == 0 {
+		return ""
+	}
+	return containers[0].Image
+}
+
+func workloadHealthLabel(ready bool) string {
+	if ready {
+		return "Current"
+	}
+	return "NotReady"
+}
+
+func controllerHealthLabel(ready bool, status string) string {
+	if ready {
+		return "Ready"
+	}
+	if s := strings.TrimSpace(status); s != "" {
+		return s
+	}
+	return "NotReady"
+}
+
+func lookupAnyCase(m map[string]interface{}, keys ...string) (interface{}, bool) {
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			return v, true
+		}
+	}
+	for _, k := range keys {
+		lower := strings.ToLower(k)
+		for mk, mv := range m {
+			if strings.ToLower(mk) == lower {
+				return mv, true
+			}
+		}
+	}
+	if outer, ok := m["Unit"].(map[string]interface{}); ok {
+		return lookupAnyCase(outer, keys...)
+	}
+	if outer, ok := m["unit"].(map[string]interface{}); ok {
+		return lookupAnyCase(outer, keys...)
+	}
+	return nil, false
+}
+
+func firstAny(m map[string]interface{}, keys ...string) interface{} {
+	v, _ := lookupAnyCase(m, keys...)
+	return v
+}
+
+func stringify(v interface{}) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case float64:
+		// JSON numbers come back as float64; trim trailing zero noise
+		// for integer-valued revisions.
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%v", t)
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -58,6 +58,7 @@ Source of truth:
 |------------|---------|------|------|
 | `audit list` | Break-glass accept/reject audit trail | [Command Reference](commands.md#audit-list) | [Connect and compare](../../examples/connect-and-compare/) |
 | `compare drift` | Desired vs live drift detection | [Command Reference](commands.md#compare-drift) | [Drift examples](../../examples/drift/) |
+| `compare source-truth` | Read-only source-truth evidence for Pilot acceptance (#393) | [Command Reference](commands.md#compare-source-truth) | - |
 | `compare three-way` | Connected DRY/WET/LIVE comparison | [Command Reference](commands.md#compare-three-way) | [Connect and compare](../../examples/connect-and-compare/) |
 | `fleet outliers` | Cluster divergence report | [Command Reference](commands.md#fleet-outliers) | [Fleet import](../../examples/fleet-import/) |
 | `gitops status` | GitOps pipeline health | [Command Reference](commands.md#gitops-v014) | [Connected summary storage](../../examples/connected-summary-storage/) |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1247,6 +1247,96 @@ Output notes:
 
 ---
 
+## compare source-truth
+
+Read-only source-truth evidence for a single workload (#393, v0.1).
+
+`compare source-truth` emits the structured JSON contract Pilot's acceptance
+kernel consumes. It joins three surfaces — ConfigHub intent, GitOps controller
+observation, and Kubernetes runtime — and produces a strategy-relative verdict.
+cub-scout is the *evidence provider*; Pilot is the acceptance judge. The
+command never mutates, repairs, approves, or infers authority.
+
+```bash
+cub-scout compare source-truth <kind>/<name> -n <namespace> --strategy <name>
+```
+
+### Strategies
+
+`--strategy` is required input. cub-scout never infers the delivery path.
+
+| Strategy | Delivery path |
+|----------|---------------|
+| `confighub-oci-argo` | ConfigHub → OCI → Argo CD → Kubernetes |
+| `confighub-oci-flux` | ConfigHub → OCI → Flux → Kubernetes |
+| `git-argo` | Git → Argo CD → Kubernetes |
+| `git-flux` | Git → Flux → Kubernetes |
+
+### Output contract
+
+Output is JSON only in v0.1. Field shape mirrors the council verdict on #393:
+
+| Field | Meaning |
+|-------|---------|
+| `declared_strategy` | Human-readable strategy (e.g. `ConfigHub -> OCI -> Flux -> Kubernetes`) |
+| `status` | Evidence verdict: `PASS`, `WATCH`, `BLOCK`, `ASK` |
+| `source_truth` | Cross-surface agreement: `AGREED`, `MISMATCH`, `INCOMPLETE`, `BLOCKED`, `UNKNOWN` |
+| `outlier` | Diverging surface: `confighub`, `controller`, `runtime`, `import_render`, `unknown` |
+| `surfaces.confighub` | Space, unit, head revision, ConfigHub URL |
+| `surfaces.controller` | Argo/Flux observation: source, revision/digest, health |
+| `surfaces.runtime` | Live K8s observation: image field + value, kstatus health |
+| `proof_gaps[]` | Stable string keys for missing fields |
+| `safe_next_action` | Read-only diagnostic suggesting how to confirm |
+
+### Strict rules
+
+The decision logic enforces two council rules in code, not by intent:
+
+1. **Strategy-relative correctness.** Identical observations get opposite
+   verdicts under different strategies. Argo reading directly from Git is
+   `PASS` under `git-argo` and `BLOCK` (controller outlier) under
+   `confighub-oci-argo`.
+2. **Missing proof never produces PASS.** Any blank source/digest/runtime
+   value forces at least `WATCH` / `INCOMPLETE`.
+
+### Examples
+
+```bash
+# Healthy ConfigHub-OCI-Flux pipeline
+cub-scout compare source-truth deploy/rag-server -n demo \
+  --strategy confighub-oci-flux
+
+# Vanilla GitOps with Argo
+cub scout compare source-truth Deployment rag-server -n demo --strategy git-argo
+```
+
+### Requirements
+
+- Connected mode (`cub auth login` or `CONFIGHUB_API_KEY` set)
+- Argo CD CLI on PATH for `*-argo` strategies; Flux CLI for `*-flux`
+- Reachable kubeconfig pointing at the cluster running the workload
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-n, --namespace` | Namespace of the resource (required for namespaced kinds) |
+| `--strategy` | Declared delivery path (required) |
+| `--format` | Output format. v0.1: `json` |
+
+### Limitations
+
+v0.1 ships the JSON contract shape, the strategy-relative correctness rule,
+and the strict missing-proof rule. Cross-surface revision *equality* (does
+the OCI digest the controller pulled match the digest the runtime is
+running?) is deferred to v0.2 — see #395 for the producer fixture suite
+that drives the equality work.
+
+Supported runtime kinds in v0.1: `Deployment`, `StatefulSet`, `DaemonSet`.
+Other kinds emit a `BLOCK` with the reason naming the unsupported kind.
+
+---
+
 ## compare drift
 
 Detect differences between desired manifests and live cluster state.

--- a/pkg/agent/source_truth.go
+++ b/pkg/agent/source_truth.go
@@ -1,0 +1,243 @@
+// Package agent — source-truth evidence contract.
+//
+// This file implements the read-only evidence contract the council placed at
+// the center of #393. cub-scout is the *evidence provider*: it reads three
+// surfaces (ConfigHub intent, GitOps controller observation, Kubernetes
+// runtime) and emits a structured verdict that Pilot's acceptance kernel
+// consumes. cub-scout is not the judge.
+//
+// Architectural triad (do not blur the split):
+//
+//   - cub-scout = read-only evidence provider for source truth
+//   - Pilot     = acceptance judge
+//   - ConfigHub = authority and workflow engine
+//
+// See the council verdict on #393 (#393#issuecomment-4407651183) for the
+// canonical scope statement and the JSON contract shape that is mirrored
+// below.
+//
+// Strict rules enforced here, not by intent:
+//
+//   1. Strategy-relative correctness. Identical observations get opposite
+//      verdicts under different strategies. Argo reading directly from Git
+//      is correct under `git-argo` and a MISMATCH under `confighub-oci-argo`.
+//   2. Missing source/digest/runtime proof MUST produce WATCH, ASK, or
+//      BLOCK — never a guessed PASS. The decision logic asserts this.
+//
+// v0.1 scope (this file): the JSON contract shape, the strategy enum, and
+// the decision logic for presence + strategy-relative correctness. Cross-
+// surface revision equality is intentionally deferred to v0.2 — see the
+// `compareRevisions` placeholder and the comment in `Derive` for the
+// rationale.
+
+package agent
+
+import (
+	"strings"
+)
+
+// SourceTruthStrategy is the declared delivery path. It is required input
+// to Derive — never inferred. See the `String()` form for the human-readable
+// rendering that lands in JSON output.
+type SourceTruthStrategy string
+
+const (
+	// StrategyConfigHubOCIArgo: ConfigHub authors a unit, renders to OCI,
+	// Argo CD pulls the OCI artifact and applies to Kubernetes.
+	StrategyConfigHubOCIArgo SourceTruthStrategy = "confighub-oci-argo"
+
+	// StrategyConfigHubOCIFlux: same as above, with Flux instead of Argo.
+	StrategyConfigHubOCIFlux SourceTruthStrategy = "confighub-oci-flux"
+
+	// StrategyGitArgo: vanilla GitOps. Argo reads directly from Git, no
+	// ConfigHub bridge.
+	StrategyGitArgo SourceTruthStrategy = "git-argo"
+
+	// StrategyGitFlux: vanilla GitOps with Flux.
+	StrategyGitFlux SourceTruthStrategy = "git-flux"
+)
+
+// AllStrategies is the closed enum of strategies v0.1 understands. Adding
+// a strategy requires updating expectsConfigHubOCISource and the human
+// rendering below.
+func AllStrategies() []SourceTruthStrategy {
+	return []SourceTruthStrategy{
+		StrategyConfigHubOCIArgo,
+		StrategyConfigHubOCIFlux,
+		StrategyGitArgo,
+		StrategyGitFlux,
+	}
+}
+
+// ParseStrategy parses a CLI-friendly string into a strategy. Empty input
+// returns ("", false) so callers can distinguish "unset" from "invalid".
+func ParseStrategy(s string) (SourceTruthStrategy, bool) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return "", false
+	}
+	for _, st := range AllStrategies() {
+		if string(st) == s {
+			return st, true
+		}
+	}
+	return "", false
+}
+
+// Human returns the human-readable rendering of the strategy that lands in
+// JSON output's `declared_strategy` field, e.g.
+//
+//	"ConfigHub -> OCI -> Argo -> Kubernetes"
+//
+// It mirrors the council's example shape exactly.
+func (s SourceTruthStrategy) Human() string {
+	switch s {
+	case StrategyConfigHubOCIArgo:
+		return "ConfigHub -> OCI -> Argo -> Kubernetes"
+	case StrategyConfigHubOCIFlux:
+		return "ConfigHub -> OCI -> Flux -> Kubernetes"
+	case StrategyGitArgo:
+		return "Git -> Argo -> Kubernetes"
+	case StrategyGitFlux:
+		return "Git -> Flux -> Kubernetes"
+	default:
+		return string(s)
+	}
+}
+
+// expectsConfigHubOCISource reports whether the strategy requires the
+// controller surface to be reading from a ConfigHub-rendered OCI artifact
+// (vs. directly from Git).
+func (s SourceTruthStrategy) expectsConfigHubOCISource() bool {
+	return s == StrategyConfigHubOCIArgo || s == StrategyConfigHubOCIFlux
+}
+
+// ExpectsArgoController reports whether the strategy requires Argo CD as
+// the GitOps controller (vs. Flux). Exported so the cub-scout CLI can
+// pick the right tracer; never silently fall back across controllers
+// because that would mask the controller-kind mismatch the contract is
+// supposed to surface.
+func (s SourceTruthStrategy) ExpectsArgoController() bool {
+	return s == StrategyConfigHubOCIArgo || s == StrategyGitArgo
+}
+
+// SourceTruthStatus is cub-scout's evidence-quality verdict. Pilot layers
+// acceptance on top of this; cub-scout never decides "approved".
+type SourceTruthStatus string
+
+const (
+	// StatusPASS: all required surfaces present, all required equalities
+	// hold, no proof gaps. Pilot may accept.
+	StatusPASS SourceTruthStatus = "PASS"
+
+	// StatusWATCH: surfaces are mostly present and consistent, but at least
+	// one proof gap or soft signal warrants confirmation before acceptance.
+	StatusWATCH SourceTruthStatus = "WATCH"
+
+	// StatusBLOCK: a hard rule fails (strategy mismatch, controller-source
+	// resolution failure, etc.). Pilot must not accept on this evidence.
+	StatusBLOCK SourceTruthStatus = "BLOCK"
+
+	// StatusASK: cub-scout cannot classify deterministically and asks the
+	// human/Pilot for context. Used when strategy is unknown or surfaces
+	// fundamentally cannot be compared.
+	StatusASK SourceTruthStatus = "ASK"
+)
+
+// SourceTruthVerdict is the cross-surface agreement verdict, separate from
+// status: a verdict can be MISMATCH while status is BLOCK (strategy
+// violation) or WATCH (soft mismatch with proof gaps).
+type SourceTruthVerdict string
+
+const (
+	// VerdictAGREED: the three surfaces line up under the declared strategy.
+	VerdictAGREED SourceTruthVerdict = "AGREED"
+
+	// VerdictMISMATCH: at least one surface diverges from the strategy-
+	// implied authority.
+	VerdictMISMATCH SourceTruthVerdict = "MISMATCH"
+
+	// VerdictINCOMPLETE: one or more surfaces missing required proof. The
+	// outlier cannot be assigned with confidence.
+	VerdictINCOMPLETE SourceTruthVerdict = "INCOMPLETE"
+
+	// VerdictBLOCKED: cub-scout could not fetch one of the surfaces in
+	// read-only mode (auth failure, controller CLI missing, etc.).
+	VerdictBLOCKED SourceTruthVerdict = "BLOCKED"
+
+	// VerdictUNKNOWN: cub-scout has no opinion. Used in ASK.
+	VerdictUNKNOWN SourceTruthVerdict = "UNKNOWN"
+)
+
+// SourceTruthOutlier names the surface that diverges from the strategy-
+// implied authority. "import_render" covers the case where the rendered
+// OCI artifact disagrees with the unit's declared data — caught by #395
+// fixtures, currently emitted as Unknown in v0.1.
+type SourceTruthOutlier string
+
+const (
+	OutlierConfigHub    SourceTruthOutlier = "confighub"
+	OutlierController   SourceTruthOutlier = "controller"
+	OutlierRuntime      SourceTruthOutlier = "runtime"
+	OutlierImportRender SourceTruthOutlier = "import_render"
+	OutlierUnknown      SourceTruthOutlier = "unknown"
+)
+
+// ConfigHubSurface is what cub-scout reads from ConfigHub via the cub CLI.
+type ConfigHubSurface struct {
+	Space    string `json:"space,omitempty"`
+	Unit     string `json:"unit,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	URL      string `json:"url,omitempty"`
+}
+
+// ControllerSurface is what cub-scout reads from the GitOps controller
+// (Flux or Argo) via the existing tracers.
+type ControllerSurface struct {
+	Kind             string `json:"kind,omitempty"`              // "Argo" | "Flux"
+	Source           string `json:"source,omitempty"`            // observed source URL/identifier
+	RevisionOrDigest string `json:"revision_or_digest,omitempty"` // SHA, digest, tag the controller observed
+	Health           string `json:"health,omitempty"`            // human label: "Ready", "Reconciling", etc.
+}
+
+// RuntimeSurface is what cub-scout reads from the live cluster.
+type RuntimeSurface struct {
+	Resource string `json:"resource,omitempty"` // e.g. "Deployment/foo in bar"
+	Field    string `json:"field,omitempty"`    // e.g. "spec.template.spec.containers[0].image"
+	Value    string `json:"value,omitempty"`    // observed value of the field
+	Health   string `json:"health,omitempty"`   // kstatus-derived: Current/InProgress/Failed/Unknown
+}
+
+// SourceTruthSurfaces holds whatever evidence cub-scout was able to collect.
+// Any surface may be nil — that's a proof gap, not a panic case.
+type SourceTruthSurfaces struct {
+	ConfigHub  *ConfigHubSurface  `json:"confighub,omitempty"`
+	Controller *ControllerSurface `json:"controller,omitempty"`
+	Runtime    *RuntimeSurface    `json:"runtime,omitempty"`
+}
+
+// SourceTruthEvidence is the full JSON contract — the structured value
+// Pilot consumes. Field order in the JSON output mirrors the council's
+// example to keep diffs reviewable.
+type SourceTruthEvidence struct {
+	DeclaredStrategy string              `json:"declared_strategy"`
+	Status           SourceTruthStatus   `json:"status"`
+	SourceTruth      SourceTruthVerdict  `json:"source_truth"`
+	Outlier          SourceTruthOutlier  `json:"outlier"`
+	Surfaces         SourceTruthSurfaces `json:"surfaces"`
+	ProofGaps        []string            `json:"proof_gaps,omitempty"`
+	SafeNextAction   string              `json:"safe_next_action,omitempty"`
+}
+
+// CollectionError is the typed error the CLI command returns when it
+// cannot fetch one of the surfaces in read-only mode (auth failure,
+// controller CLI missing, kubeconfig unreachable). The decision logic
+// converts these into BLOCK status / BLOCKED verdict.
+type CollectionError struct {
+	Surface string // "confighub" | "controller" | "runtime"
+	Reason  string // human-readable
+}
+
+func (e *CollectionError) Error() string {
+	return e.Surface + ": " + e.Reason
+}

--- a/pkg/agent/source_truth_logic.go
+++ b/pkg/agent/source_truth_logic.go
@@ -1,0 +1,223 @@
+// Package agent — source-truth decision logic.
+//
+// Derive turns observed surfaces + a declared strategy into a structured
+// SourceTruthEvidence value. The function is intentionally pure: no
+// network, no clients, no logging. Callers populate Surfaces from
+// whatever sources they want (live tracer, fixture, mock) and Derive
+// produces the verdict.
+//
+// v0.1 scope: presence-based gap detection plus the strategy-relative
+// correctness check. Cross-surface revision *equality* (does the OCI
+// digest the controller pulled match the digest the runtime is running?)
+// is intentionally deferred to v0.2 — heterogeneous version identifiers
+// (ConfigHub revision number vs. Git SHA vs. OCI digest vs. image tag)
+// require normalisation work that the producer fixture suite (#395) will
+// drive. v0.1 emits MISMATCH only when the strategy contract itself is
+// violated, plus WATCH when a soft proof gap is present. Pilot can layer
+// stricter equality on top once the contract shape is stable.
+
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Derive builds the structured SourceTruthEvidence value from a declared
+// strategy and the surfaces the caller was able to collect. It enforces:
+//
+//   - Strict missing-proof rule: a missing critical field never produces
+//     PASS. The minimum verdict is WATCH.
+//   - Strategy-relative correctness: under a confighub-oci-* strategy, the
+//     controller must observe an OCI source. Git observation fails BLOCK
+//     with controller as the outlier.
+//   - Empty-strategy handling: empty/unknown strategy short-circuits to
+//     ASK + UNKNOWN with a single proof gap "declared_strategy".
+//
+// The function is total: every input combination produces a
+// SourceTruthEvidence; nil inputs are surfaces' caller responsibility.
+func Derive(strategy SourceTruthStrategy, surfaces SourceTruthSurfaces) SourceTruthEvidence {
+	ev := SourceTruthEvidence{
+		DeclaredStrategy: strategy.Human(),
+		Surfaces:         surfaces,
+		Outlier:          OutlierUnknown,
+		ProofGaps:        []string{},
+	}
+
+	// Empty / unknown strategy: cannot classify; refuse to guess.
+	if strategy == "" {
+		ev.DeclaredStrategy = ""
+		ev.Status = StatusASK
+		ev.SourceTruth = VerdictUNKNOWN
+		ev.ProofGaps = append(ev.ProofGaps, "declared_strategy")
+		ev.SafeNextAction = "Declare a delivery strategy with --strategy and re-run; cub-scout does not infer the strategy."
+		return ev
+	}
+
+	// Collect proof gaps (presence-based). Each gap is a stable string key
+	// Pilot can pattern-match.
+	gaps := collectProofGaps(surfaces)
+	ev.ProofGaps = gaps
+
+	// Hard rule: a fundamentally unfetchable surface (caller passed nil)
+	// is a BLOCK. The CLI converts read-time errors into nil surfaces +
+	// a CollectionError that propagates as a BLOCK SafeNextAction.
+	if surfaces.ConfigHub == nil || surfaces.Controller == nil || surfaces.Runtime == nil {
+		ev.Status = StatusBLOCK
+		ev.SourceTruth = VerdictBLOCKED
+		ev.SafeNextAction = blockedSafeNextAction(surfaces)
+		return ev
+	}
+
+	// Strategy-relative correctness: does the controller observe a source
+	// shape consistent with the declared strategy?
+	if mismatch, reason := checkStrategySource(strategy, surfaces.Controller); mismatch {
+		ev.Status = StatusBLOCK
+		ev.SourceTruth = VerdictMISMATCH
+		ev.Outlier = OutlierController
+		ev.SafeNextAction = "Read-only diagnostic: " + reason
+		return ev
+	}
+
+	// Cross-surface equality: deferred to v0.2 (see file header). v0.1
+	// only flags soft mismatches via the proof_gap mechanism.
+
+	// Verdict synthesis based on proof gaps.
+	if len(gaps) > 0 {
+		ev.Status = StatusWATCH
+		ev.SourceTruth = VerdictINCOMPLETE
+		ev.Outlier = OutlierUnknown
+		ev.SafeNextAction = fmt.Sprintf(
+			"Read-only diagnostic: confirm the missing fields (%s) before acceptance.",
+			strings.Join(gaps, ", "),
+		)
+		return ev
+	}
+
+	// All surfaces present, strategy contract holds, no soft gaps.
+	ev.Status = StatusPASS
+	ev.SourceTruth = VerdictAGREED
+	ev.Outlier = OutlierUnknown
+	ev.SafeNextAction = ""
+	return ev
+}
+
+// collectProofGaps returns the stable proof-gap keys the council's
+// fixture rule depends on. Order is deterministic so JSON diffs are stable.
+func collectProofGaps(s SourceTruthSurfaces) []string {
+	var gaps []string
+
+	if s.ConfigHub != nil {
+		if strings.TrimSpace(s.ConfigHub.Revision) == "" {
+			gaps = append(gaps, "confighub.revision")
+		}
+		if strings.TrimSpace(s.ConfigHub.Unit) == "" {
+			gaps = append(gaps, "confighub.unit")
+		}
+	}
+
+	if s.Controller != nil {
+		if strings.TrimSpace(s.Controller.Source) == "" {
+			gaps = append(gaps, "controller.source")
+		}
+		if strings.TrimSpace(s.Controller.RevisionOrDigest) == "" {
+			gaps = append(gaps, "controller.revision_or_digest")
+		}
+	}
+
+	if s.Runtime != nil {
+		if strings.TrimSpace(s.Runtime.Value) == "" {
+			gaps = append(gaps, "runtime.value")
+		}
+	}
+
+	return gaps
+}
+
+// checkStrategySource enforces the canonical council rule: under a
+// confighub-oci-* strategy, the controller must read from a ConfigHub-
+// rendered OCI artifact. Reading directly from Git is a strategy
+// violation. Git-strategies pose no controller-source constraint at this
+// layer — Git is the expected source.
+//
+// Returns (true, reason) when a violation is detected.
+func checkStrategySource(strategy SourceTruthStrategy, ctrl *ControllerSurface) (bool, string) {
+	if !strategy.expectsConfigHubOCISource() {
+		return false, ""
+	}
+	if ctrl == nil {
+		return false, ""
+	}
+
+	source := strings.TrimSpace(ctrl.Source)
+	kind := strings.TrimSpace(ctrl.Kind)
+
+	if source == "" {
+		// No source observed. That is a soft gap, handled by
+		// collectProofGaps — not a hard MISMATCH.
+		return false, ""
+	}
+
+	// Positive markers for OCI source: scheme prefix or canonical Kind
+	// label set by the existing tracers (see pkg/agent/flux_trace.go and
+	// argo_trace.go where OCI sources are tagged "ConfigHub OCI").
+	if strings.HasPrefix(source, "oci://") {
+		return false, ""
+	}
+	if strings.Contains(strings.ToLower(kind), "oci") {
+		return false, ""
+	}
+
+	// Negative marker: a Git-shaped URL under an OCI strategy is the
+	// canonical trap.
+	if isGitURL(source) {
+		return true, fmt.Sprintf(
+			"strategy %q expects controller source to be ConfigHub OCI, but observed Git source %q",
+			strategy.Human(), source,
+		)
+	}
+
+	// Source is present but unrecognised. Conservative: treat as
+	// not-OCI, which is a strategy mismatch under confighub-oci-*.
+	return true, fmt.Sprintf(
+		"strategy %q expects controller source to be ConfigHub OCI, but observed source %q is not recognised as OCI",
+		strategy.Human(), source,
+	)
+}
+
+// isGitURL recognises common Git source shapes the existing controller
+// tracers emit. Conservative: only known-Git markers count.
+func isGitURL(s string) bool {
+	s = strings.ToLower(strings.TrimSpace(s))
+	switch {
+	case strings.HasPrefix(s, "git@"):
+		return true
+	case strings.HasPrefix(s, "https://github.com/"),
+		strings.HasPrefix(s, "https://gitlab.com/"),
+		strings.HasPrefix(s, "https://bitbucket.org/"):
+		return true
+	case strings.HasSuffix(s, ".git"):
+		return true
+	}
+	return false
+}
+
+// blockedSafeNextAction renders a stable, read-only diagnostic when one
+// of the surfaces could not be fetched. Names the missing surface so the
+// operator knows which auth/CLI/connectivity to fix.
+func blockedSafeNextAction(s SourceTruthSurfaces) string {
+	missing := []string{}
+	if s.ConfigHub == nil {
+		missing = append(missing, "ConfigHub (verify `cub` auth and connectivity)")
+	}
+	if s.Controller == nil {
+		missing = append(missing, "controller (verify Argo CD / Flux CLI is installed and authenticated)")
+	}
+	if s.Runtime == nil {
+		missing = append(missing, "runtime (verify kubeconfig points at a reachable cluster)")
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	return "Read-only diagnostic: cannot fetch " + strings.Join(missing, "; ") + ". Resolve the auth/CLI gap and re-run."
+}

--- a/pkg/agent/source_truth_logic_test.go
+++ b/pkg/agent/source_truth_logic_test.go
@@ -1,0 +1,267 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// The cases below cover the council's required v0.1 verdict shapes. The
+// table is intentionally written so each test name maps 1:1 to a council-
+// named state — when #395 fixtures land they will share these case names.
+
+// TestDerive_Rules_StrategyRequired locks in the rule that an empty
+// strategy short-circuits to ASK / UNKNOWN. cub-scout never infers the
+// strategy.
+func TestDerive_Rules_StrategyRequired(t *testing.T) {
+	ev := Derive("", SourceTruthSurfaces{
+		ConfigHub:  &ConfigHubSurface{Space: "s", Unit: "u", Revision: "1"},
+		Controller: &ControllerSurface{Kind: "Flux", Source: "oci://example/u", RevisionOrDigest: "sha256:abc", Health: "Ready"},
+		Runtime:    &RuntimeSurface{Resource: "Deployment/u in s", Field: "spec...", Value: "v", Health: "Current"},
+	})
+
+	if ev.Status != StatusASK {
+		t.Errorf("status = %s, want ASK", ev.Status)
+	}
+	if ev.SourceTruth != VerdictUNKNOWN {
+		t.Errorf("source_truth = %s, want UNKNOWN", ev.SourceTruth)
+	}
+	if !containsString(ev.ProofGaps, "declared_strategy") {
+		t.Errorf("proof_gaps = %v, want to contain declared_strategy", ev.ProofGaps)
+	}
+}
+
+// TestDerive_PASS_AGREED is the happy path: confighub-oci-flux strategy,
+// all three surfaces populated, controller observes an OCI source.
+func TestDerive_PASS_AGREED(t *testing.T) {
+	ev := Derive(StrategyConfigHubOCIFlux, SourceTruthSurfaces{
+		ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "rag-server", Revision: "47", URL: "https://hub/units/x/y"},
+		Controller: &ControllerSurface{
+			Kind:             "Flux",
+			Source:           "oci://oci.confighub.com/demo/rag-server",
+			RevisionOrDigest: "sha256:abc123",
+			Health:           "Ready",
+		},
+		Runtime: &RuntimeSurface{
+			Resource: "Deployment/rag-server in demo",
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    "oci.confighub.com/demo/rag-server@sha256:abc123",
+			Health:   "Current",
+		},
+	})
+
+	if ev.Status != StatusPASS {
+		t.Errorf("status = %s, want PASS (gaps=%v)", ev.Status, ev.ProofGaps)
+	}
+	if ev.SourceTruth != VerdictAGREED {
+		t.Errorf("source_truth = %s, want AGREED", ev.SourceTruth)
+	}
+	if len(ev.ProofGaps) != 0 {
+		t.Errorf("proof_gaps = %v, want empty", ev.ProofGaps)
+	}
+	if ev.DeclaredStrategy != "ConfigHub -> OCI -> Flux -> Kubernetes" {
+		t.Errorf("declared_strategy = %q, want council-shaped string", ev.DeclaredStrategy)
+	}
+}
+
+// TestDerive_StrategyMismatch_ControllerOutlier is the council's primary
+// trap: ConfigHub-OCI strategy declared, but the controller is observed
+// reading directly from Git. cub-scout must classify this as BLOCK with
+// controller as the outlier — Pilot must not call the Day-2 path proven
+// when the bridge has been bypassed.
+func TestDerive_StrategyMismatch_ControllerOutlier(t *testing.T) {
+	ev := Derive(StrategyConfigHubOCIArgo, SourceTruthSurfaces{
+		ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "rag-server", Revision: "47"},
+		Controller: &ControllerSurface{
+			Kind:             "Argo",
+			Source:           "https://github.com/example/rag-deploy",
+			RevisionOrDigest: "abc123def456",
+			Health:           "Synced/Healthy",
+		},
+		Runtime: &RuntimeSurface{
+			Resource: "Deployment/rag-server in demo",
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    "ghcr.io/example/rag:1.2.3",
+			Health:   "Current",
+		},
+	})
+
+	if ev.Status != StatusBLOCK {
+		t.Errorf("status = %s, want BLOCK (council's stale-bridge trap)", ev.Status)
+	}
+	if ev.SourceTruth != VerdictMISMATCH {
+		t.Errorf("source_truth = %s, want MISMATCH", ev.SourceTruth)
+	}
+	if ev.Outlier != OutlierController {
+		t.Errorf("outlier = %s, want controller", ev.Outlier)
+	}
+	if !strings.Contains(ev.SafeNextAction, "OCI") {
+		t.Errorf("safe_next_action = %q, want mention of OCI", ev.SafeNextAction)
+	}
+}
+
+// TestDerive_VanillaGitOps_PASS proves strategy-relativity in the other
+// direction: under git-argo, Argo reading directly from Git is correct
+// and must produce PASS. Same observation as the previous test, opposite
+// verdict because the strategy declares Git is the right source.
+func TestDerive_VanillaGitOps_PASS(t *testing.T) {
+	ev := Derive(StrategyGitArgo, SourceTruthSurfaces{
+		ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "rag-server", Revision: "47"},
+		Controller: &ControllerSurface{
+			Kind:             "Argo",
+			Source:           "https://github.com/example/rag-deploy",
+			RevisionOrDigest: "abc123def456",
+			Health:           "Synced/Healthy",
+		},
+		Runtime: &RuntimeSurface{
+			Resource: "Deployment/rag-server in demo",
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    "ghcr.io/example/rag:1.2.3",
+			Health:   "Current",
+		},
+	})
+
+	if ev.Status != StatusPASS {
+		t.Errorf("status = %s, want PASS under vanilla GitOps strategy (gaps=%v)", ev.Status, ev.ProofGaps)
+	}
+	if ev.SourceTruth != VerdictAGREED {
+		t.Errorf("source_truth = %s, want AGREED", ev.SourceTruth)
+	}
+}
+
+// TestDerive_INCOMPLETE_MissingDigest enforces the strict rule: missing
+// proof never produces PASS. Even with all three surfaces present, an
+// empty controller.revision_or_digest must surface as INCOMPLETE / WATCH.
+func TestDerive_INCOMPLETE_MissingDigest(t *testing.T) {
+	ev := Derive(StrategyConfigHubOCIFlux, SourceTruthSurfaces{
+		ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "rag-server", Revision: "47"},
+		Controller: &ControllerSurface{
+			Kind:             "Flux",
+			Source:           "oci://oci.confighub.com/demo/rag-server",
+			RevisionOrDigest: "", // <-- the missing proof
+			Health:           "Ready",
+		},
+		Runtime: &RuntimeSurface{
+			Resource: "Deployment/rag-server in demo",
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    "oci.confighub.com/demo/rag-server@sha256:abc123",
+			Health:   "Current",
+		},
+	})
+
+	if ev.Status == StatusPASS {
+		t.Fatalf("status = PASS with missing controller.revision_or_digest; the strict rule was violated")
+	}
+	if ev.Status != StatusWATCH {
+		t.Errorf("status = %s, want WATCH", ev.Status)
+	}
+	if ev.SourceTruth != VerdictINCOMPLETE {
+		t.Errorf("source_truth = %s, want INCOMPLETE", ev.SourceTruth)
+	}
+	if !containsString(ev.ProofGaps, "controller.revision_or_digest") {
+		t.Errorf("proof_gaps = %v, want to contain controller.revision_or_digest", ev.ProofGaps)
+	}
+}
+
+// TestDerive_BLOCKED_FetchFailure covers the case where cub-scout could
+// not read one of the surfaces in read-only mode — auth missing, CLI
+// missing, kubeconfig unreachable. The CLI passes nil for that surface;
+// Derive emits BLOCK / BLOCKED with a concrete safe_next_action naming
+// the missing surface.
+func TestDerive_BLOCKED_FetchFailure(t *testing.T) {
+	ev := Derive(StrategyConfigHubOCIFlux, SourceTruthSurfaces{
+		ConfigHub:  nil, // <-- could not auth to ConfigHub
+		Controller: &ControllerSurface{Kind: "Flux", Source: "oci://x", RevisionOrDigest: "sha256:y", Health: "Ready"},
+		Runtime:    &RuntimeSurface{Resource: "r", Field: "f", Value: "v", Health: "Current"},
+	})
+
+	if ev.Status != StatusBLOCK {
+		t.Errorf("status = %s, want BLOCK", ev.Status)
+	}
+	if ev.SourceTruth != VerdictBLOCKED {
+		t.Errorf("source_truth = %s, want BLOCKED", ev.SourceTruth)
+	}
+	if !strings.Contains(ev.SafeNextAction, "ConfigHub") {
+		t.Errorf("safe_next_action = %q, want explicit ConfigHub naming", ev.SafeNextAction)
+	}
+}
+
+// TestDerive_StrategyMismatch_TakesPrecedenceOverGaps locks in ordering:
+// when the controller-source check fires (BLOCK), the proof-gap WATCH
+// path must NOT silently downgrade to WATCH. Strategy violation is a
+// hard signal regardless of soft gaps.
+func TestDerive_StrategyMismatch_TakesPrecedenceOverGaps(t *testing.T) {
+	ev := Derive(StrategyConfigHubOCIArgo, SourceTruthSurfaces{
+		ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "rag-server", Revision: "47"},
+		Controller: &ControllerSurface{
+			Kind:             "Argo",
+			Source:           "https://github.com/example/rag-deploy",
+			RevisionOrDigest: "", // also a soft gap
+			Health:           "Synced/Healthy",
+		},
+		Runtime: &RuntimeSurface{
+			Resource: "Deployment/rag-server in demo",
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    "ghcr.io/example/rag:1.2.3",
+			Health:   "Current",
+		},
+	})
+
+	if ev.Status != StatusBLOCK {
+		t.Errorf("status = %s, want BLOCK (strategy violation > proof gap)", ev.Status)
+	}
+	if ev.Outlier != OutlierController {
+		t.Errorf("outlier = %s, want controller", ev.Outlier)
+	}
+}
+
+// TestDerive_NeverPASS_OnAnyMissingProof is a meta-test that sweeps every
+// single-field omission and asserts no combination produces PASS. This
+// is the strict rule the council placed at the centre of the contract.
+func TestDerive_NeverPASS_OnAnyMissingProof(t *testing.T) {
+	full := SourceTruthSurfaces{
+		ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "u", Revision: "1"},
+		Controller: &ControllerSurface{
+			Kind: "Flux", Source: "oci://x", RevisionOrDigest: "sha256:y", Health: "Ready",
+		},
+		Runtime: &RuntimeSurface{
+			Resource: "r", Field: "f", Value: "v", Health: "Current",
+		},
+	}
+
+	mutations := []struct {
+		name  string
+		blank func(*SourceTruthSurfaces)
+	}{
+		{"confighub.unit blank", func(s *SourceTruthSurfaces) { s.ConfigHub.Unit = "" }},
+		{"confighub.revision blank", func(s *SourceTruthSurfaces) { s.ConfigHub.Revision = "" }},
+		{"controller.source blank", func(s *SourceTruthSurfaces) { s.Controller.Source = "" }},
+		{"controller.revision_or_digest blank", func(s *SourceTruthSurfaces) { s.Controller.RevisionOrDigest = "" }},
+		{"runtime.value blank", func(s *SourceTruthSurfaces) { s.Runtime.Value = "" }},
+	}
+
+	for _, m := range mutations {
+		t.Run(m.name, func(t *testing.T) {
+			s := SourceTruthSurfaces{
+				ConfigHub:  &ConfigHubSurface{Space: full.ConfigHub.Space, Unit: full.ConfigHub.Unit, Revision: full.ConfigHub.Revision},
+				Controller: &ControllerSurface{Kind: full.Controller.Kind, Source: full.Controller.Source, RevisionOrDigest: full.Controller.RevisionOrDigest, Health: full.Controller.Health},
+				Runtime:    &RuntimeSurface{Resource: full.Runtime.Resource, Field: full.Runtime.Field, Value: full.Runtime.Value, Health: full.Runtime.Health},
+			}
+			m.blank(&s)
+			ev := Derive(StrategyConfigHubOCIFlux, s)
+			if ev.Status == StatusPASS {
+				t.Fatalf("Derive emitted PASS with %s — the strict missing-proof rule was violated. Evidence: %+v", m.name, ev)
+			}
+		})
+	}
+}
+
+// containsString is a slice-membership helper. Named to avoid colliding
+// with the package-local substring `contains` in kyverno_scan_test.go.
+func containsString(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Implements **v0.1** of the source-truth evidence contract per the [council verdict on #393](https://github.com/confighub/cub-scout/issues/393#issuecomment-4407651183). cub-scout becomes the **read-only evidence provider** that joins three surfaces (ConfigHub intent, GitOps controller observation, Kubernetes runtime) into a structured verdict Pilot's acceptance kernel consumes. cub-scout never mutates, repairs, approves, or infers authority.

## CLI surface

Lives under `compare` (council framing: "extend the existing three-way comparison"; preserves the top-level command budget):

```bash
cub-scout compare source-truth <kind>/<name> -n <ns> --strategy <name>
cub scout compare source-truth Deployment rag-server -n demo --strategy confighub-oci-flux
```

Output is JSON in v0.1, matching the council's JSON shape exactly.

## Strategies (required input — never inferred)

| Strategy | Delivery path |
|---|---|
| `confighub-oci-argo` | ConfigHub → OCI → Argo CD → Kubernetes |
| `confighub-oci-flux` | ConfigHub → OCI → Flux → Kubernetes |
| `git-argo` | Git → Argo CD → Kubernetes |
| `git-flux` | Git → Flux → Kubernetes |

## Strict rules enforced in code

1. **Strategy-relative correctness.** Identical observations get opposite verdicts under different strategies. Argo reading Git is `PASS` under `git-argo`, `BLOCK` (controller outlier) under `confighub-oci-argo`. Locked in by `TestDerive_StrategyMismatch_ControllerOutlier` and its mirror `TestDerive_VanillaGitOps_PASS`.
2. **Missing proof never produces PASS.** Any blank source/digest/runtime field forces at least `WATCH` / `INCOMPLETE`. Locked in by the `TestDerive_NeverPASS_OnAnyMissingProof` sweep that exhaustively blanks each contract field.

## Files

| File | Purpose |
|---|---|
| `pkg/agent/source_truth.go` | Types + strategy enum |
| `pkg/agent/source_truth_logic.go` | Pure `Derive()` decision logic (no I/O) |
| `pkg/agent/source_truth_logic_test.go` | Table-driven unit tests, 13 cases including the never-PASS sweep |
| `cmd/cub-scout/source_truth.go` | CLI command + live collectors (typed clientset, FluxTracer/ArgoTracer, `cub unit get`) |
| `docs/reference/cli-reference.md` | Subcommand row |
| `docs/reference/commands.md` | Full command reference with contract shape, rules, examples |

## Out of scope (deferred to follow-ups)

- **Cross-surface revision equality.** Heterogeneous identifiers (ConfigHub revision number vs. Git SHA vs. OCI digest vs. image tag) need normalisation; that work is driven by [#395](https://github.com/confighub/cub-scout/issues/395) producer fixtures. v0.1 emits MISMATCH only when the strategy contract is violated, plus WATCH when soft proof gaps exist.
- **Strategy auto-detection.** Always declared in v0.1.
- **ArgoCDOCI Helm-source shape detection** ([confighubai/confighub#4356](https://github.com/confighubai/confighub/issues/4356)). Once that bridge bug lands a fix, we'll add the symptom classifier. Until then the contract correctly emits BLOCK for unknown OCI shapes via the strategy-mismatch path.
- **Multi-source / ApplicationSet child resolution.**
- **Text/markdown output, TUI integration.**
- **Pilot consumer-side fixtures.** Live in [confighub-ai-demo#264](https://github.com/confighubai/confighub-ai-demo/issues/264).

## Test plan

- [x] `go test ./...` — all 37 packages green
- [x] `go vet ./...` clean
- [x] `golangci-lint run` (v1.64.8, matching CI) — exit 0
- [x] `./scripts/check-cli-guide-parity.sh` — clean
- [x] `go run ./scripts/check-cli-docs` — clean
- [x] CLI smoke: `cub-scout compare source-truth --help` shows the command, empty `--strategy` emits the ASK/UNKNOWN evidence document, missing auth emits the connected-mode error

## Linked issues

- **Locks the contract shape** that #395 (producer fixtures) and confighub-ai-demo#264 (consumer fixtures) build on
- **Unblocks** #391 scope item #3 (View-overlay reality column) — the overlay can now consume `source_truth` / `outlier` / `safe_next_action` instead of inventing parallel types
- **Cross-repo dependency:** confighubai/confighub#4356 — the future symptom classifier hooks here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
