### PR TITLE
test: integration coverage for discoverWorkloads / getManagedResources (#396)

### DIFF
--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -1195,7 +1195,18 @@ func discoverWorkloads(namespace string) ([]WorkloadInfo, error) {
 		dynClient = nil // Non-fatal
 	}
 
-	ctx := context.Background()
+	return discoverWorkloadsFrom(context.Background(), clientset, dynClient, namespace)
+}
+
+// discoverWorkloadsFrom is the testable core of discoverWorkloads. The
+// outer function builds clients from kubeconfig; this one accepts
+// pre-built (or fake) clients so the readiness-classification slice can
+// be exercised by `kfake.NewSimpleClientset` without touching a real
+// cluster. Coverage gap tracked in #396.
+//
+// Accepts kubernetes.Interface (not *kubernetes.Clientset) so the fake
+// client satisfies the contract.
+func discoverWorkloadsFrom(ctx context.Context, clientset kubernetes.Interface, dynClient dynamic.Interface, namespace string) ([]WorkloadInfo, error) {
 	var workloads []WorkloadInfo
 
 	// Deployments

--- a/cmd/cub-scout/import_argocd.go
+++ b/cmd/cub-scout/import_argocd.go
@@ -737,7 +737,11 @@ func isArgoManagedResource(labels, annotations map[string]string, appName string
 }
 
 // getManagedResources finds all resources in the destination namespace that are managed by the Application
-func getManagedResources(ctx context.Context, clientset *kubernetes.Clientset, dynamicClient dynamic.Interface, appName, namespace string) ([]ManagedResource, error) {
+// getManagedResources fetches the live K8s objects an ArgoCD Application
+// manages. Accepts kubernetes.Interface (not *kubernetes.Clientset) so
+// `kfake.NewSimpleClientset` satisfies the signature for unit tests
+// (#396).
+func getManagedResources(ctx context.Context, clientset kubernetes.Interface, dynamicClient dynamic.Interface, appName, namespace string) ([]ManagedResource, error) {
 	var resources []ManagedResource
 
 	// Get Deployments - list all and filter by ArgoCD ownership

--- a/cmd/cub-scout/import_workloads_test.go
+++ b/cmd/cub-scout/import_workloads_test.go
@@ -1,0 +1,381 @@
+// Direct integration coverage for discoverWorkloadsFrom and
+// getManagedResources — back-fill for #394's narrow kstatus migration
+// per #396. Both functions previously had no fake-clientset coverage,
+// so the kstatus tightening (Stalled → Failed) only had wrapper-level
+// tests; this file proves the readiness verdict actually flows through
+// the call sites end-to-end.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// ----------------------------------------------------------------------
+// Helpers — workload-shape builders. The kstatus wrapper (#394) needs
+// both replica counts AND the right Conditions to call a workload
+// "Current"; happy fixtures populate both, sad fixtures omit one.
+// ----------------------------------------------------------------------
+
+func ptrI32(v int32) *int32 { return &v }
+
+func happyDeployment(name, ns string, labels, annotations map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Generation:  1,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptrI32(3),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "ghcr.io/example/app:1.0.0"}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:           3,
+			ReadyReplicas:      3,
+			AvailableReplicas:  3,
+			UpdatedReplicas:    3,
+			ObservedGeneration: 1,
+			Conditions: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+// stalledDeployment is the council's canonical trap: replica counts
+// match (which would have slipped through the old ReadyReplicas==Replicas
+// check) but Progressing=False with reason ProgressDeadlineExceeded.
+// kstatus correctly classifies this as Failed, so Ready must be false
+// after the migration.
+func stalledDeployment(name, ns string) *appsv1.Deployment {
+	d := happyDeployment(name, ns, nil, nil)
+	d.Status.Conditions = []appsv1.DeploymentCondition{
+		{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse, Reason: "ProgressDeadlineExceeded"},
+		{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+	}
+	return d
+}
+
+// rollingDeployment is the in-progress shape: only 1/3 ready replicas,
+// but conditions are still healthy. kstatus → InProgress → Ready=false.
+func rollingDeployment(name, ns string) *appsv1.Deployment {
+	d := happyDeployment(name, ns, nil, nil)
+	d.Status.ReadyReplicas = 1
+	d.Status.AvailableReplicas = 1
+	d.Status.UpdatedReplicas = 1
+	return d
+}
+
+func happyStatefulSet(name, ns string) *appsv1.StatefulSet {
+	rev := name + "-1"
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Generation: 1},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptrI32(3),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "ghcr.io/example/app:1.0.0"}},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:           3,
+			ReadyReplicas:      3,
+			AvailableReplicas:  3,
+			CurrentReplicas:    3,
+			CurrentRevision:    rev,
+			UpdateRevision:     rev,
+			ObservedGeneration: 1,
+		},
+	}
+}
+
+func rollingStatefulSet(name, ns string) *appsv1.StatefulSet {
+	s := happyStatefulSet(name, ns)
+	s.Status.ReadyReplicas = 1
+	s.Status.AvailableReplicas = 1
+	return s
+}
+
+func happyDaemonSet(name, ns string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Generation: 1},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "ghcr.io/example/app:1.0.0"}},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 5,
+			CurrentNumberScheduled: 5,
+			NumberReady:            5,
+			NumberAvailable:        5,
+			UpdatedNumberScheduled: 5,
+			ObservedGeneration:     1,
+		},
+	}
+}
+
+func rollingDaemonSet(name, ns string) *appsv1.DaemonSet {
+	d := happyDaemonSet(name, ns)
+	d.Status.NumberReady = 3
+	d.Status.NumberAvailable = 3
+	d.Status.UpdatedNumberScheduled = 3
+	return d
+}
+
+// emptyDynClient produces a dynamic client backed by an empty scheme +
+// no objects. discoverWorkloadsFrom uses it only for getKustomizationPath
+// / getApplicationPath lookups, which fail gracefully when nothing is
+// present — exactly what we want for readiness-only tests.
+func emptyDynClient(t *testing.T) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	return dynamicfake.NewSimpleDynamicClient(scheme)
+}
+
+// ----------------------------------------------------------------------
+// discoverWorkloadsFrom coverage — 3 kinds × happy/sad + Stalled trap.
+// ----------------------------------------------------------------------
+
+func TestDiscoverWorkloadsFrom_Readiness(t *testing.T) {
+	const ns = "demo"
+
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantKind   string
+		wantName   string
+		wantReady  bool
+	}{
+		{
+			name:      "Deployment fully rolled out → Ready=true",
+			objects:   []runtime.Object{happyDeployment("rag-server", ns, nil, nil)},
+			wantKind:  "Deployment",
+			wantName:  "rag-server",
+			wantReady: true,
+		},
+		{
+			name: "Deployment Stalled (kstatus Failed) → Ready=false (#394 trap)",
+			// Pre-#394 this slipped through as ready because replica
+			// counts matched. kstatus reads the condition and rejects.
+			objects:   []runtime.Object{stalledDeployment("rag-server", ns)},
+			wantKind:  "Deployment",
+			wantName:  "rag-server",
+			wantReady: false,
+		},
+		{
+			name:      "Deployment rollout in progress → Ready=false",
+			objects:   []runtime.Object{rollingDeployment("rag-server", ns)},
+			wantKind:  "Deployment",
+			wantName:  "rag-server",
+			wantReady: false,
+		},
+		{
+			name:      "StatefulSet fully rolled out → Ready=true",
+			objects:   []runtime.Object{happyStatefulSet("vector-db", ns)},
+			wantKind:  "StatefulSet",
+			wantName:  "vector-db",
+			wantReady: true,
+		},
+		{
+			name:      "StatefulSet rolling → Ready=false",
+			objects:   []runtime.Object{rollingStatefulSet("vector-db", ns)},
+			wantKind:  "StatefulSet",
+			wantName:  "vector-db",
+			wantReady: false,
+		},
+		{
+			name:      "DaemonSet fully scheduled → Ready=true",
+			objects:   []runtime.Object{happyDaemonSet("node-exporter", ns)},
+			wantKind:  "DaemonSet",
+			wantName:  "node-exporter",
+			wantReady: true,
+		},
+		{
+			name:      "DaemonSet rolling → Ready=false",
+			objects:   []runtime.Object{rollingDaemonSet("node-exporter", ns)},
+			wantKind:  "DaemonSet",
+			wantName:  "node-exporter",
+			wantReady: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset(tt.objects...)
+			dyn := emptyDynClient(t)
+
+			got, err := discoverWorkloadsFrom(context.Background(), cs, dyn, ns)
+			if err != nil {
+				t.Fatalf("discoverWorkloadsFrom error: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d workloads, want 1: %+v", len(got), got)
+			}
+			w := got[0]
+			if w.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", w.Kind, tt.wantKind)
+			}
+			if w.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", w.Name, tt.wantName)
+			}
+			if w.Ready != tt.wantReady {
+				t.Errorf("Ready = %v, want %v (Status: %+v)", w.Ready, tt.wantReady, tt.objects[0])
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------
+// getManagedResources coverage — 3 kinds × happy/sad on Argo-managed
+// resources. Argo ownership is keyed by the
+// `argocd.argoproj.io/instance` label — see isArgoManagedResource.
+// ----------------------------------------------------------------------
+
+func argoLabels(appName string) map[string]string {
+	return map[string]string{"argocd.argoproj.io/instance": appName}
+}
+
+func TestGetManagedResources_Health(t *testing.T) {
+	const (
+		ns      = "demo"
+		appName = "rag-stack"
+	)
+
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantKind   string
+		wantHealth string
+	}{
+		{
+			name:       "Argo-managed Deployment fully rolled out → Healthy",
+			objects:    []runtime.Object{happyDeployment("rag-server", ns, argoLabels(appName), nil)},
+			wantKind:   "Deployment",
+			wantHealth: "Healthy",
+		},
+		{
+			name: "Argo-managed Deployment Stalled → Progressing (#394 trap)",
+			objects: func() []runtime.Object {
+				d := stalledDeployment("rag-server", ns)
+				d.Labels = argoLabels(appName)
+				return []runtime.Object{d}
+			}(),
+			wantKind:   "Deployment",
+			wantHealth: "Progressing",
+		},
+		{
+			name: "Argo-managed StatefulSet fully rolled out → Healthy",
+			objects: func() []runtime.Object {
+				s := happyStatefulSet("vector-db", ns)
+				s.Labels = argoLabels(appName)
+				return []runtime.Object{s}
+			}(),
+			wantKind:   "StatefulSet",
+			wantHealth: "Healthy",
+		},
+		{
+			name: "Argo-managed StatefulSet rolling → Progressing",
+			objects: func() []runtime.Object {
+				s := rollingStatefulSet("vector-db", ns)
+				s.Labels = argoLabels(appName)
+				return []runtime.Object{s}
+			}(),
+			wantKind:   "StatefulSet",
+			wantHealth: "Progressing",
+		},
+		{
+			name: "Argo-managed DaemonSet fully scheduled → Healthy",
+			objects: func() []runtime.Object {
+				d := happyDaemonSet("node-exporter", ns)
+				d.Labels = argoLabels(appName)
+				return []runtime.Object{d}
+			}(),
+			wantKind:   "DaemonSet",
+			wantHealth: "Healthy",
+		},
+		{
+			name: "Argo-managed DaemonSet rolling → Progressing",
+			objects: func() []runtime.Object {
+				d := rollingDaemonSet("node-exporter", ns)
+				d.Labels = argoLabels(appName)
+				return []runtime.Object{d}
+			}(),
+			wantKind:   "DaemonSet",
+			wantHealth: "Progressing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset(tt.objects...)
+			dyn := emptyDynClient(t)
+
+			got, err := getManagedResources(context.Background(), cs, dyn, appName, ns)
+			if err != nil {
+				t.Fatalf("getManagedResources error: %v", err)
+			}
+
+			// Find the resource of the expected kind. The function may
+			// also pick up Services / ConfigMaps if seeded; we only
+			// assert on workloads.
+			var workload *ManagedResource
+			for i := range got {
+				if got[i].Kind == tt.wantKind {
+					workload = &got[i]
+					break
+				}
+			}
+			if workload == nil {
+				t.Fatalf("no %s in result: %+v", tt.wantKind, got)
+			}
+			if workload.Health != tt.wantHealth {
+				t.Errorf("Health = %q, want %q", workload.Health, tt.wantHealth)
+			}
+		})
+	}
+}
+
+// TestGetManagedResources_FilterByOwnership locks in that resources
+// without the Argo instance label are excluded from the result, even
+// when present in the cluster snapshot.
+func TestGetManagedResources_FilterByOwnership(t *testing.T) {
+	const ns = "demo"
+	const appName = "rag-stack"
+
+	owned := happyDeployment("rag-server", ns, argoLabels(appName), nil)
+	unowned := happyDeployment("unrelated", ns, nil, nil)
+
+	cs := fake.NewSimpleClientset(owned, unowned)
+	dyn := emptyDynClient(t)
+
+	got, err := getManagedResources(context.Background(), cs, dyn, appName, ns)
+	if err != nil {
+		t.Fatalf("getManagedResources error: %v", err)
+	}
+
+	for _, r := range got {
+		if r.Name == "unrelated" {
+			t.Fatalf("unowned resource %q included; ownership filter regression", r.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#396](https://github.com/confighub/cub-scout/issues/396). Back-fills the integration test gap left by [#394](https://github.com/confighub/cub-scout/issues/394)'s narrow kstatus migration: the wrapper at `pkg/agent/kstatus_wrapper_test.go` was unit-tested, but the migrated call sites had no fake-clientset coverage — so the council's Stalled-Deployment trap only had wrapper-level proof, not end-to-end-through-the-call-site proof.

## Changes

- **Refactor:** `discoverWorkloads(namespace string)` now delegates to `discoverWorkloadsFrom(ctx, clientset, dynClient, namespace)`. Outer function unchanged in behaviour; the new helper accepts `kubernetes.Interface` so `kfake.NewSimpleClientset` satisfies it.
- **Refactor:** `getManagedResources` clientset param widened from `*kubernetes.Clientset` (concrete) to `kubernetes.Interface`. No behaviour change.
- **New tests in `cmd/cub-scout/import_workloads_test.go`:**
  - 7 readiness cases on `discoverWorkloadsFrom` — happy/rolling per kind (Deployment, StatefulSet, DaemonSet), plus the **Stalled Deployment trap** (replica counts match but `Progressing=False ProgressDeadlineExceeded` → `Ready=false`, which the pre-#394 helper would have missed).
  - 6 health cases on `getManagedResources` — same 3-kind matrix on Argo-managed resources, all proving the `Healthy`/`Progressing` flip through the migrated call site.
  - 1 ownership-filter discriminator proving unowned resources are excluded.

## Test plan

- [x] `go test ./...` — all 37 packages green
- [x] `go vet ./...` clean
- [x] `golangci-lint run` (v1.64.8, matching CI) — exit 0
- [x] All 14 new test cases pass

## Acceptance criteria from #396

- [x] `discoverWorkloads` has at least 6 test cases (3 kinds × happy/sad) — 7 here
- [x] `getManagedResources` has at least 6 test cases (3 kinds × happy/sad) — 6 here
- [x] Tests use `kfake.NewSimpleClientset` and run without a live cluster
- [x] One Stalled Deployment fixture proves the kstatus tightening reaches the migrated call site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
