### PR TITLE
feat: complete kstatus migration in state_scanner (#394)

### DIFF
--- a/pkg/agent/kstatus_wrapper.go
+++ b/pkg/agent/kstatus_wrapper.go
@@ -30,6 +30,47 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
+// IsResourceReadyOrUnknown is the kstatus-backed replacement for the
+// custom `isReadyOrUnknown` helper that lived in pkg/agent/state_scanner.go.
+// Second slice of the #394 migration — covers the four call sites
+// (findSilentFailures × 2, findTimingBombs × 2) that filter Flux
+// HelmRelease / Kustomization resources before silent-failure / timing-
+// bomb detection.
+//
+// Returns true when kstatus considers item to be either Current
+// (definitely ready) or Unknown (no Ready signal — common on freshly-
+// created CRs before the controller stamps a condition). Returns false
+// for InProgress, Failed, Terminating, and NotFound.
+//
+// Behaviour delta vs. the prior helper, which only inspected the Ready
+// condition:
+//
+//   - Stalled=True now returns false (was true). Intended improvement:
+//     if Flux already reports Stalled, the silent-failure and timing-
+//     bomb detectors should not also probe — we already know the
+//     resource is broken, so additional probing is redundant.
+//   - No conditions returns true (kstatus reports UnknownStatus under
+//     the conditions-reader fallback). Matches the old helper.
+//   - Ready=True / Ready=Unknown / Ready=False classify the same way
+//     the old helper classified them.
+//
+// Accepts a value (not a pointer) to match the existing call-site
+// signature in state_scanner.go.
+func IsResourceReadyOrUnknown(item unstructured.Unstructured) bool {
+	res, err := status.Compute(&item)
+	if err != nil || res == nil {
+		// Could not classify — be lenient, matching the prior helper's
+		// "no conditions = treat as unknown" semantics.
+		return true
+	}
+	switch res.Status {
+	case status.CurrentStatus, status.UnknownStatus:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsDeploymentReady returns true when kstatus considers d to be at its
 // desired state (CurrentStatus). Any other state returns false.
 func IsDeploymentReady(d *appsv1.Deployment) bool {

--- a/pkg/agent/kstatus_wrapper_test.go
+++ b/pkg/agent/kstatus_wrapper_test.go
@@ -6,6 +6,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
@@ -202,5 +203,83 @@ func TestWorkloadStatus_DistinguishesInProgressFromFailed(t *testing.T) {
 	}
 	if s, _ := WorkloadStatus(stalled, "Deployment"); s != status.FailedStatus {
 		t.Fatalf("stalled deployment: want Failed, got %s", s)
+	}
+}
+
+// IsResourceReadyOrUnknown — the second slice of the #394 migration.
+// Covers the behaviour table the helper documents; specifically locks in
+// the Stalled=True delta vs. the prior receiver-method implementation.
+
+func unstructuredFlux(kind string, conditions []map[string]interface{}) unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name":      "demo",
+			"namespace": "flux-system",
+		},
+		"status": map[string]interface{}{},
+	}
+	if conditions != nil {
+		// unstructured.NestedSlice expects []interface{}.
+		condSlice := make([]interface{}, len(conditions))
+		for i, c := range conditions {
+			condSlice[i] = c
+		}
+		obj["status"].(map[string]interface{})["conditions"] = condSlice
+	}
+	return unstructured.Unstructured{Object: obj}
+}
+
+func TestIsResourceReadyOrUnknown(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  unstructured.Unstructured
+		want bool
+	}{
+		{
+			name: "no conditions → true (lenient, matches old helper)",
+			obj:  unstructuredFlux("Kustomization", nil),
+			want: true,
+		},
+		{
+			name: "Ready=True → true",
+			obj: unstructuredFlux("Kustomization", []map[string]interface{}{
+				{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+			}),
+			want: true,
+		},
+		{
+			name: "Ready=False → false",
+			obj: unstructuredFlux("HelmRelease", []map[string]interface{}{
+				{"type": "Ready", "status": "False", "reason": "InstallFailed"},
+			}),
+			want: false,
+		},
+		{
+			name: "Stalled=True (Ready unset) → false (#394 delta — was true under old helper)",
+			// Old helper only inspected Ready; with no Ready it returned
+			// true. kstatus reads Stalled and reports Failed → false.
+			obj: unstructuredFlux("HelmRelease", []map[string]interface{}{
+				{"type": "Stalled", "status": "True", "reason": "RetriesExhausted"},
+			}),
+			want: false,
+		},
+		{
+			name: "Stalled=True with Ready=True → false (Stalled wins under kstatus)",
+			obj: unstructuredFlux("HelmRelease", []map[string]interface{}{
+				{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded"},
+				{"type": "Stalled", "status": "True", "reason": "RetriesExhausted"},
+			}),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsResourceReadyOrUnknown(tc.obj); got != tc.want {
+				t.Errorf("IsResourceReadyOrUnknown = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/agent/state_scanner.go
+++ b/pkg/agent/state_scanner.go
@@ -1422,26 +1422,19 @@ func (s *StateScanner) scanKustomizationSilentFailures(ctx context.Context, warn
 	return findings
 }
 
-// isReadyOrUnknown checks if a resource appears healthy (Ready=True or Unknown)
+// isReadyOrUnknown checks if a resource appears healthy. Delegates to
+// IsResourceReadyOrUnknown (kstatus-backed) per the #394 migration's
+// second slice. Kept as a receiver method so the four call sites do not
+// have to change — the receiver carries no state used here, but the
+// method shape is the existing call-site contract.
+//
+// Behaviour delta from the prior implementation: a Stalled=True
+// resource now returns false instead of true, which intentionally
+// excludes it from silent-failure and timing-bomb detection (we already
+// know it is broken, so probing is redundant). See the doc comment on
+// IsResourceReadyOrUnknown for the full classification table.
 func (s *StateScanner) isReadyOrUnknown(item unstructured.Unstructured) bool {
-	conditions, found, _ := unstructured.NestedSlice(item.Object, "status", "conditions")
-	if !found {
-		return true // No conditions = assume unknown
-	}
-
-	for _, cond := range conditions {
-		condMap, ok := cond.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		condType, _ := condMap["type"].(string)
-		status, _ := condMap["status"].(string)
-
-		if condType == "Ready" {
-			return status == "True" || status == "Unknown"
-		}
-	}
-	return true
+	return IsResourceReadyOrUnknown(item)
 }
 
 // checkResourceExists checks if a ConfigMap or Secret exists


### PR DESCRIPTION
## Summary

Closes [#394](https://github.com/confighub/cub-scout/issues/394). Second slice of the kstatus migration the council scoped out of the truth-floor PR — the four call sites in `pkg/agent/state_scanner.go` that filter Flux HelmRelease / Kustomization resources before silent-failure / timing-bomb detection.

## Migrated call sites

| File:line | Function | Resource kind |
|---|---|---|
| `pkg/agent/state_scanner.go:239` | `findSilentFailures` | Flux HelmRelease |
| `pkg/agent/state_scanner.go:319` | `findSilentFailures` (second loop) | Flux Kustomization |
| `pkg/agent/state_scanner.go:1082` | `findTimingBombs` | Flux HelmRelease |
| `pkg/agent/state_scanner.go:1333` | `findTimingBombs` (second loop) | Flux Kustomization |

All four call `s.isReadyOrUnknown(item)`, which previously only inspected the Ready condition. The migration delegates the receiver method to a new `IsResourceReadyOrUnknown(unstructured.Unstructured)` helper backed by `kstatus.Compute`. **The receiver-method shape is preserved** so the four call sites do not change.

## Behaviour delta

| Condition shape | Old helper | kstatus | Result |
|---|---|---|---|
| No conditions | `true` | `true` | Same |
| Ready=True | `true` | `true` | Same |
| Ready=Unknown | `true` | `true` | Same |
| Ready=False | `false` | `false` | Same |
| **Stalled=True (no Ready)** | `true` | **`false`** | **Improvement** |
| **Stalled=True with Ready=True** | `true` | **`false`** | **Improvement** |

**Why the Stalled delta is correct:** if Flux already reports `Stalled`, the silent-failure and timing-bomb detectors should *not* also probe — we already know the resource is broken, so additional probing is redundant. Aligned with what operators see in `flux get all` / Argo CD UI.

## Test plan

New unit tests at `pkg/agent/kstatus_wrapper_test.go::TestIsResourceReadyOrUnknown`:

- [x] no conditions → true
- [x] Ready=True → true
- [x] Ready=False → false
- [x] **Stalled=True (no Ready) → false** — the #394 delta
- [x] **Stalled=True with Ready=True → false** — Stalled wins under kstatus

Plus:

- [x] `go test ./...` — all 37 packages green
- [x] `go vet ./...` clean
- [x] `golangci-lint run` (v1.64.8, matching CI) — exit 0

## Status after this PR

The kstatus migration is feature-complete. All readiness derivation in cub-scout now flows through `sigs.k8s.io/cli-utils/pkg/kstatus`, the same library that backs Argo CD and Flux upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
