### PR TITLE
feat: views resolver with URL-as-positional convention v0.1 (#391)

### DIFF
--- a/cmd/cub-scout/command_layout_test.go
+++ b/cmd/cub-scout/command_layout_test.go
@@ -16,8 +16,12 @@ func TestRootCommandLayout_VisibleTopLevelCount(t *testing.T) {
 		count++
 	}
 
-	if count > 30 {
-		t.Fatalf("visible top-level command count = %d, want <= 30", count)
+	// Cap is a soft governance signal. Bumped 30 -> 31 in #391 to admit
+	// `views` as a real new top-level capability (View Explorer
+	// integration per the council verdict on #393). Deliberate; do not
+	// bump again without a paired discussion.
+	if count > 31 {
+		t.Fatalf("visible top-level command count = %d, want <= 31", count)
 	}
 }
 

--- a/cmd/cub-scout/views.go
+++ b/cmd/cub-scout/views.go
@@ -1,0 +1,154 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+// cub-scout views — v0.1 of the View Explorer integration per #391. This
+// file establishes the URL-as-positional convention and the View
+// resolution shape downstream commands consume.
+//
+// v0.1 ships a single subcommand: `cub-scout views resolve`. It accepts
+// a UUID or a View Explorer URL, fetches the View via `cub view get`,
+// and prints structured JSON. The output shape is the contract future
+// commands (--view flag on map list / compare three-way / etc.) consume
+// when they need to scope to the units a View selects.
+//
+// What this file does NOT do:
+//
+//   - Wire --view onto compare three-way / map list. Each command has
+//     its own scope mechanics; v0.1 keeps them separate so the URL
+//     convention can land first and the integrations follow as
+//     dedicated PRs (council framing — no over-bundling).
+//   - Render View columns or Hub-view filtering. Those are scope items
+//     #2 and following on #391, deferred to follow-ups.
+//
+// This file lives under `views` (top-level) rather than under `compare`
+// because resolution is orthogonal to comparison — it serves any
+// command or operator that wants the resolved View bundle.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/confighub/cub-scout/pkg/hub"
+)
+
+var (
+	viewsResolveFormat string
+	viewsResolveSpace  string
+)
+
+var viewsCmd = &cobra.Command{
+	Use:   "views",
+	Short: "Work with ConfigHub Views (read-only, v0.1)",
+	Long: `Work with ConfigHub Views — saved filter+projection specs operators curate
+in the View Explorer (https://hub.confighub.com/x/view-explorer).
+
+v0.1 ships the URL-as-positional convention and a resolver subcommand.
+Future PRs wire --view onto map list, compare three-way, and the TUI
+Hub view (see #391 scope items).`,
+}
+
+var viewsResolveCmd = &cobra.Command{
+	Use:   "resolve <uuid-or-url>",
+	Short: "Resolve a View reference and print its structured JSON",
+	Long: `Resolve a ConfigHub View reference and print structured JSON describing
+the View, its filter clauses, and the originating identity.
+
+Accepts either form:
+
+  cub-scout views resolve 806aac53-236c-446d-8ad6-91d6daf6810e
+  cub-scout views resolve https://hub.confighub.com/x/view-explorer?view=806aac53-236c-446d-8ad6-91d6daf6810e
+
+The URL form is preferred — it is the canonical share-link operators
+copy from the View Explorer address bar, so "paste from browser, run
+cub-scout" is the cheapest GUI -> CLI bridge (#391 design rationale).
+
+Output is JSON only in v0.1.
+
+Requires connected mode (cub auth login or CONFIGHUB_API_KEY).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runViewsResolve,
+}
+
+func init() {
+	rootCmd.AddCommand(viewsCmd)
+	viewsCmd.AddCommand(viewsResolveCmd)
+	viewsResolveCmd.Flags().StringVar(&viewsResolveFormat, "format", "json", "Output format. v0.1 supports: json")
+	viewsResolveCmd.Flags().StringVar(&viewsResolveSpace, "space", "*", "Space to search. Defaults to org-wide ('*') so a UUID alone is sufficient")
+}
+
+// ResolvedView is the JSON contract `views resolve` emits. Future
+// commands that consume View resolution import this shape — keeping the
+// UUID and OriginalURL fields lets them deep-link back to the GUI.
+type ResolvedView struct {
+	UUID        string                 `json:"uuid"`
+	SourceForm  agent.ViewRefSource    `json:"source_form"`           // "uuid" | "url"
+	OriginalURL string                 `json:"original_url,omitempty"`
+	Extras      map[string][]string    `json:"extras,omitempty"`      // Round-tripped query params (group, etc.)
+	Space       string                 `json:"space,omitempty"`
+	View        map[string]interface{} `json:"view,omitempty"`        // Verbatim from `cub view get`
+}
+
+func runViewsResolve(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(viewsResolveFormat))
+	if format != "json" {
+		return fmt.Errorf("invalid --format %q (v0.1 supports: json)", viewsResolveFormat)
+	}
+
+	ref, err := agent.ParseViewRef(args[0])
+	if err != nil {
+		return fmt.Errorf("parse view reference: %w", err)
+	}
+
+	if hub.QuickMode() != hub.Connected {
+		return fmt.Errorf("views resolve requires ConfigHub authentication (run `cub auth login` or set CONFIGHUB_API_KEY)")
+	}
+
+	out := ResolvedView{
+		UUID:        ref.UUID,
+		SourceForm:  ref.SourceForm,
+		OriginalURL: ref.OriginalURL,
+		Space:       viewsResolveSpace,
+	}
+	if len(ref.Extras) > 0 {
+		out.Extras = map[string][]string(ref.Extras)
+	}
+
+	view, err := fetchView(cmd.Context(), ref.UUID, viewsResolveSpace)
+	if err != nil {
+		return fmt.Errorf("fetch view: %w", err)
+	}
+	out.View = view
+
+	return emitResolvedView(out)
+}
+
+// fetchView shells out to `cub view get` to fetch the View JSON. The
+// `--space "*"` default makes a UUID alone sufficient (org-wide
+// search); narrower callers can pass --space <slug>.
+func fetchView(ctx context.Context, uuid, space string) (map[string]interface{}, error) {
+	args := []string{"view", "get", uuid, "--space", space, "--json"}
+	out, err := exec.CommandContext(ctx, "cub", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("cub view get failed: %w", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse cub output: %w", err)
+	}
+	return raw, nil
+}
+
+func emitResolvedView(rv ResolvedView) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rv)
+}

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -48,6 +48,7 @@ Source of truth:
 | `trace` | Trace ownership and source chain | [Command Reference](commands.md#trace) | [kro composition](../../examples/kro-composition/) |
 | `tree` | Runtime, ownership, git, and composition hierarchies | [Command Reference](commands.md#tree) | [kro composition](../../examples/kro-composition/) |
 | `version` | Print version/build information | [Command Reference](commands.md#version) | - |
+| `views` | Resolve ConfigHub View references (#391, v0.1) | [Command Reference](commands.md#views) | - |
 | `watch` | Stream observation events to webhook/file sinks | [Command Reference](commands.md#watch) | [Watch webhook](../../examples/watch-webhook/) |
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2216,6 +2216,67 @@ cub-scout app [command]
 
 ---
 
+## views
+
+Work with ConfigHub Views — saved filter+projection specs operators
+curate in the View Explorer. v0.1 (#391) ships the URL-as-positional
+convention and a resolver subcommand.
+
+### views resolve
+
+Resolve a View reference and emit structured JSON.
+
+```bash
+cub-scout views resolve <uuid-or-url> [--space <slug>] [--format json]
+```
+
+Accepts either form:
+
+```bash
+cub-scout views resolve 806aac53-236c-446d-8ad6-91d6daf6810e
+cub-scout views resolve "https://hub.confighub.com/x/view-explorer?view=806aac53-236c-446d-8ad6-91d6daf6810e"
+```
+
+The URL form is the canonical share-link operators copy from the View
+Explorer address bar — pasting it into `cub-scout` is the cheapest
+GUI → CLI bridge across the ConfigHub stack.
+
+### Output
+
+JSON (only format in v0.1):
+
+```json
+{
+  "uuid": "...",
+  "source_form": "url" | "uuid",
+  "original_url": "...",
+  "extras": { "group": ["prod"] },
+  "space": "...",
+  "view": { ... cub view get JSON ... }
+}
+```
+
+`extras` round-trips View Explorer query parameters (`group`, etc.) so
+downstream commands can opt in to them without the parser growing flags.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--space` | Space to search. Default `*` (org-wide) so a UUID alone is sufficient |
+| `--format` | Output format. v0.1: `json` |
+
+### Requirements
+
+Connected mode (`cub auth login` or `CONFIGHUB_API_KEY` set).
+
+### v0.1 limitations
+
+- Resolver only — no command integration. `--view` flags on `compare three-way` / `map list` / TUI Hub view land in dedicated follow-up PRs (see #391 scope items).
+- No reality overlay. Once #393's source-truth contract is widely consumed, follow-up work composes the View's column projection with `compare source-truth` verdicts (#391 scope item #3).
+
+---
+
 ## version
 
 Print version information for the local cub-scout binary.

--- a/pkg/agent/view_ref.go
+++ b/pkg/agent/view_ref.go
@@ -1,0 +1,145 @@
+// Package agent — ConfigHub View reference parsing.
+//
+// v0.1 of #391: lock in the URL-as-positional convention and the View
+// reference shape downstream commands consume.
+//
+// Background: ConfigHub Views are saved filter+projection specs (filter
+// clause + columns + grouping + ordering), addressable by stable UUID.
+// The user explicitly preferred URL-as-positional input over UUID flags
+// across cub-scout's ConfigHub integrations — see the saved memory at
+// `principle_url_as_input` and the comment chain on #391. This file
+// implements the parser side of that convention.
+//
+// Two accepted input forms (both produce the same ViewRef):
+//
+//   1. Bare UUID:
+//        806aac53-236c-446d-8ad6-91d6daf6810e
+//
+//   2. View Explorer URL:
+//        https://hub.confighub.com/x/view-explorer?view=<uuid>
+//        https://hub.confighub.com/x/view-explorer?view=<uuid>&group=<v>
+//
+// The parser accepts any ConfigHub-shaped URL with a ?view= query
+// parameter; future View Explorer URL parameters (`group`, paging,
+// etc.) round-trip in ViewRef.Extras so consumers can use them
+// without the parser growing flags.
+
+package agent
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// ViewRef is a parsed reference to a ConfigHub View.
+type ViewRef struct {
+	// UUID is the canonical View identifier (stable, server-side).
+	UUID string
+
+	// SourceForm captures whether the caller passed a UUID or a URL —
+	// useful for emitting back the same shape they typed (e.g. in
+	// hint output) and for telemetry.
+	SourceForm ViewRefSource
+
+	// OriginalURL is set when SourceForm == ViewRefURL. Empty for
+	// UUID-only inputs. Stored verbatim so consumers can deep-link
+	// back to the View Explorer if they want to.
+	OriginalURL string
+
+	// Extras carries any additional View Explorer query parameters the
+	// parser did not interpret (e.g. `group`, future filters). The
+	// parser does not act on these — downstream commands opt in to
+	// the params they understand. Always non-nil; empty when the
+	// input had no extra params.
+	Extras url.Values
+}
+
+// ViewRefSource discriminates the input shape a ViewRef was parsed from.
+type ViewRefSource string
+
+const (
+	ViewRefUUID ViewRefSource = "uuid"
+	ViewRefURL  ViewRefSource = "url"
+)
+
+// uuidPattern matches the canonical 8-4-4-4-12 UUID shape with
+// case-insensitive hex digits. ConfigHub UUIDs are lowercase but the
+// parser is tolerant.
+var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// ParseViewRef parses a CLI-friendly View identifier. Accepts bare UUIDs
+// and ConfigHub View Explorer URLs. Empty input returns ("", false) so
+// callers can distinguish "not set" from "invalid".
+//
+// The parser does NOT validate that the UUID corresponds to a real View
+// — that requires a connected-mode `cub view get` call. It only validates
+// shape.
+//
+// Hostname check: ConfigHub URLs are accepted regardless of host
+// (hub.confighub.com, on-prem deployments, dev clusters). The parser
+// does not pin the host because cub-scout users may run against any
+// ConfigHub instance.
+//
+// Errors are descriptive — ParseViewRef is intended to back CLI flag
+// parsing where users see the message directly.
+func ParseViewRef(input string) (*ViewRef, error) {
+	s := strings.TrimSpace(input)
+	if s == "" {
+		return nil, fmt.Errorf("view reference is empty; expected a UUID or a ConfigHub View Explorer URL")
+	}
+
+	// Bare UUID.
+	if uuidPattern.MatchString(s) {
+		return &ViewRef{
+			UUID:       strings.ToLower(s),
+			SourceForm: ViewRefUUID,
+			Extras:     url.Values{},
+		}, nil
+	}
+
+	// URL form. Accept anything URL-shaped that has a ?view= param.
+	// strings.Contains is a cheap pre-check before the parser cost.
+	if !strings.Contains(s, "://") {
+		return nil, fmt.Errorf("view reference %q is neither a UUID nor a URL (got non-URL input)", input)
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("view reference %q is not a parseable URL: %w", input, err)
+	}
+
+	// We do not pin the host — see comment above. We do require that
+	// the URL path mentions view-explorer so we don't accept arbitrary
+	// URLs that happen to have a ?view= param.
+	if !strings.Contains(u.Path, "view-explorer") {
+		return nil, fmt.Errorf("URL %q is not a View Explorer URL (path does not contain view-explorer)", input)
+	}
+
+	q := u.Query()
+	uuid := strings.TrimSpace(q.Get("view"))
+	if uuid == "" {
+		return nil, fmt.Errorf("URL %q is missing the ?view=<uuid> query parameter", input)
+	}
+	if !uuidPattern.MatchString(uuid) {
+		return nil, fmt.Errorf("URL %q has ?view=%q which is not a valid UUID", input, uuid)
+	}
+
+	// Strip the `view` param from extras so consumers can iterate
+	// without re-encountering it.
+	extras := url.Values{}
+	for k, vs := range q {
+		if k == "view" {
+			continue
+		}
+		extras[k] = vs
+	}
+
+	return &ViewRef{
+		UUID:        strings.ToLower(uuid),
+		SourceForm:  ViewRefURL,
+		OriginalURL: s,
+		Extras:      extras,
+	}, nil
+}

--- a/pkg/agent/view_ref_test.go
+++ b/pkg/agent/view_ref_test.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"testing"
+)
+
+// TestParseViewRef covers the council-required URL-as-positional contract.
+// Each case maps to an input shape downstream commands will need to
+// handle: bare UUIDs, View Explorer URLs (with and without extras),
+// invalid inputs that should return clear errors.
+func TestParseViewRef(t *testing.T) {
+	const (
+		validUUID    = "806aac53-236c-446d-8ad6-91d6daf6810e"
+		validURL     = "https://hub.confighub.com/x/view-explorer?view=806aac53-236c-446d-8ad6-91d6daf6810e"
+		validURLWithGroup = "https://hub.confighub.com/x/view-explorer?view=806aac53-236c-446d-8ad6-91d6daf6810e&group=prod"
+	)
+
+	t.Run("bare UUID", func(t *testing.T) {
+		ref, err := ParseViewRef(validUUID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref.UUID != validUUID {
+			t.Errorf("UUID = %q, want %q", ref.UUID, validUUID)
+		}
+		if ref.SourceForm != ViewRefUUID {
+			t.Errorf("SourceForm = %q, want %q", ref.SourceForm, ViewRefUUID)
+		}
+		if ref.OriginalURL != "" {
+			t.Errorf("OriginalURL = %q, want empty for UUID input", ref.OriginalURL)
+		}
+		if len(ref.Extras) != 0 {
+			t.Errorf("Extras non-empty for UUID input: %v", ref.Extras)
+		}
+	})
+
+	t.Run("View Explorer URL", func(t *testing.T) {
+		ref, err := ParseViewRef(validURL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref.UUID != validUUID {
+			t.Errorf("UUID = %q, want %q", ref.UUID, validUUID)
+		}
+		if ref.SourceForm != ViewRefURL {
+			t.Errorf("SourceForm = %q, want %q", ref.SourceForm, ViewRefURL)
+		}
+		if ref.OriginalURL != validURL {
+			t.Errorf("OriginalURL = %q, want %q", ref.OriginalURL, validURL)
+		}
+	})
+
+	t.Run("View Explorer URL with extra params", func(t *testing.T) {
+		ref, err := ParseViewRef(validURLWithGroup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := ref.Extras.Get("group"); got != "prod" {
+			t.Errorf("Extras[group] = %q, want %q", got, "prod")
+		}
+		if ref.Extras.Get("view") != "" {
+			t.Errorf("Extras retained the view param: %v", ref.Extras)
+		}
+	})
+
+	t.Run("uppercase UUID is normalized to lowercase", func(t *testing.T) {
+		upper := "806AAC53-236C-446D-8AD6-91D6DAF6810E"
+		ref, err := ParseViewRef(upper)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref.UUID != "806aac53-236c-446d-8ad6-91d6daf6810e" {
+			t.Errorf("UUID = %q, want lowercase normalized", ref.UUID)
+		}
+	})
+
+	t.Run("on-prem ConfigHub URL accepted (no host pin)", func(t *testing.T) {
+		// Council framing: the parser does not pin hub.confighub.com so
+		// users running against on-prem ConfigHub aren't excluded.
+		onprem := "https://confighub.example.internal/x/view-explorer?view=" + validUUID
+		ref, err := ParseViewRef(onprem)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref.UUID != validUUID {
+			t.Errorf("UUID = %q, want %q", ref.UUID, validUUID)
+		}
+	})
+
+	errorCases := []struct {
+		name  string
+		input string
+		want  string // substring of the error message
+	}{
+		{"empty input", "", "empty"},
+		{"random non-URL non-UUID", "not a uuid or url", "non-URL"},
+		{"URL without view-explorer path", "https://hub.confighub.com/units/" + validUUID, "view-explorer"},
+		{"URL missing ?view= param", "https://hub.confighub.com/x/view-explorer", "view=<uuid>"},
+		{"URL with malformed UUID", "https://hub.confighub.com/x/view-explorer?view=not-a-uuid", "valid UUID"},
+		{"unparseable URL", "https://[::1:invalid/x/view-explorer?view=" + validUUID, "parseable URL"},
+	}
+
+	for _, tc := range errorCases {
+		t.Run("error: "+tc.name, func(t *testing.T) {
+			_, err := ParseViewRef(tc.input)
+			if err == nil {
+				t.Fatalf("expected error for input %q, got nil", tc.input)
+			}
+			if tc.want != "" && !viewRefContainsSubstring(err.Error(), tc.want) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// viewRefContainsSubstring is a local helper. Named with the file's
+// prefix to avoid colliding with sibling test files that already define
+// `contains` and `containsSubstring`.
+func viewRefContainsSubstring(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

v0.1 of [#391](https://github.com/confighub/cub-scout/issues/391). Establishes the **URL-as-positional convention** for ConfigHub View references and ships a working resolver subcommand. The full View Explorer integration (—view flags on compare three-way / map list / TUI Hub view, reality overlay) lands in dedicated follow-up PRs — this PR locks the URL contract first so each integration can ship cleanly.

## What lands

- **Parser** at `pkg/agent/view_ref.go::ParseViewRef` accepts both:
  - Bare UUID: `806aac53-236c-446d-8ad6-91d6daf6810e`
  - View Explorer URL: `https://hub.confighub.com/x/view-explorer?view=<uuid>` (with `&group=prod` etc. round-tripped in `Extras`)
  - Hostname not pinned so on-prem ConfigHub deployments work
- **CLI** at `cmd/cub-scout/views.go`:

  ```bash
  cub-scout views resolve 806aac53-236c-446d-8ad6-91d6daf6810e
  cub-scout views resolve "https://hub.confighub.com/x/view-explorer?view=<uuid>"
  ```

  Connected-mode required. Calls `cub view get` and emits structured JSON.
- **Tests** at `pkg/agent/view_ref_test.go` — table-driven, covering bare UUID, URL with/without extras, uppercase normalization, on-prem URL, and 6 error cases.
- **Docs** in `cli-reference.md` (new top-level row) and `commands.md` (full `views` / `views resolve` reference with v0.1 limitations spelled out).

## URL contract

Why URL-as-positional is the foundation: it's the cheapest GUI → CLI bridge. Operators copy the share-link from the View Explorer address bar and paste it. No buttons in the web UI, no custom URL schemes, no MCP daemon required. This convention will repeat across future ConfigHub-primitive integrations (Initiatives once #392 unblocks, etc.).

## Deliberately deferred (filed under #391 follow-ups)

- `--view <uuid-or-url>` flag on `compare three-way` / `map list` / `compare source-truth`
- View column rendering / Hub-view selector
- Reality overlay composing View columns with [#393 source-truth verdicts](https://github.com/confighub/cub-scout/pull/400) (#391 scope item #3)

## CLI surface budget

Top-level command count cap bumped 30 → 31 in `command_layout_test.go`. Deliberate single-step bump for a real new capability; comment documents the rationale.

## Test plan

- [x] `go test ./...` — all 37 packages green
- [x] `go vet ./...` clean
- [x] `golangci-lint run` (v1.64.8, matching CI) — exit 0
- [x] `./scripts/check-cli-guide-parity.sh` — clean
- [x] `go run ./scripts/check-cli-docs` — clean
- [x] CLI smoke: `--help`, parse error, connected-mode gate, URL-with-extras parsing all behave as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
