### PR TITLE
docs: refresh HANDOVER + AI-README and add Initiatives design-held doc

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -64,8 +64,26 @@ Do not claim that `cub scout` can do SDK/renderer work locally unless the curren
 
 ## Current High-Signal Shipped Capabilities
 
-As of 2026-04-09, these areas are fully or materially shipped:
+As of 2026-05-08, these areas are fully or materially shipped:
 
+- **Source-truth contract** (`#393`, council-prescribed)
+  - `compare source-truth <kind>/<name> -n <ns> --strategy <s>` emits the structured JSON Pilot's acceptance kernel consumes
+  - 4 strategies: `confighub-oci-argo`, `confighub-oci-flux`, `git-argo`, `git-flux`
+  - Strategy-relative correctness + missing-proof rule enforced in tests, not just intent
+  - 6-fixture producer suite with byte-equal goldens at `test/fixtures/source-truth/`
+- **Architectural triad locked**
+  - cub-scout = read-only evidence provider
+  - Pilot = acceptance judge
+  - ConfigHub = authority and workflow engine
+  - cub-scout never mutates, repairs, approves, or infers authority
+- **kstatus migration complete** (`#394`)
+  - All readiness derivation flows through `sigs.k8s.io/cli-utils/pkg/kstatus`
+  - Same library Argo CD and Flux use upstream — operator expectations match
+  - Stalled / generation-lagging workloads correctly report `Ready=false`
+- **Views resolver v0.1** (`#391`)
+  - `cub-scout views resolve <uuid-or-url>` — accepts both bare UUIDs and View Explorer URLs
+  - URL-as-positional convention for ConfigHub primitives — paste from browser address bar
+  - On-prem ConfigHub deployments work (host not pinned)
 - `doctor` / `explain`
   - `--presentation human|ai|paired`
   - `--hint-mode default|beginner|operator`
@@ -93,12 +111,12 @@ As of 2026-04-09, these areas are fully or materially shipped:
 
 ## Current Open Queue
 
-Verify live state before acting, but the current open follow-ons are:
+Verify live state before acting, but the current open follow-ons are (2026-05-08):
 
-- `#370` structured action-typed next-step hints in JSON and MCP outputs
-- `#368` broader “beat Argo CD GUI” troubleshooting umbrella
-- `#364` investigated render-integration follow-on
-- `#359`, `#360`, `#362` lower-priority polish / compat / test stability
+- `#391` — Views integration follow-ups (v0.1 foundation landed; `--view` flag on commands, projection, reality overlay, browser handoff still open)
+- `#392` — Initiatives compliance overlay; **deferred** until ConfigHub side exposes Initiative as an addressable backend primitive. Design doc at `docs/howto/initiatives-integration-when-ready.md` is ready to consume the day the prerequisite lands.
+- `confighubai/confighub#4356` — cross-repo dependency for the ArgoCDOCI Helm-source shape symptom classifier in `compare source-truth`.
+- `confighub-ai-demo#264` — Pilot consumer-side fixtures (paired with cub-scout #395 producer fixtures).
 
 ## Non-Negotiables
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,6 +1,6 @@
 # cub-scout Handover for the Next AI Coder
 
-Last updated: 2026-04-14
+Last updated: 2026-05-08
 
 ## Current repo state
 
@@ -14,6 +14,39 @@ Last updated: 2026-04-14
   - `docs/reference/cli-reference.md` = A-Z command catalog
   - `docs/reference/commands.md` = detailed usage and examples
   - `docs/reference/cli-contract.md` = stable flags, exit codes, and schemas
+
+## May 2026 completions — council source-truth track
+
+The council (April 2026) prescribed the **truth-floor → source-truth contract → fixtures** sequence. The full sequence is now in main:
+
+| PR | Issue(s) | Subject |
+|----|----------|---------|
+| [#397](https://github.com/confighub/cub-scout/pull/397) | #387, #390, narrow #394 | Truth-floor: Flux false-pessimism fix, tree-patterns nil panic, kstatus narrow slice |
+| [#398](https://github.com/confighub/cub-scout/pull/398) | #384 | Pre-existing main lint debt cleanup (5 dead funcs + 1 ineffassign) |
+| [#399](https://github.com/confighub/cub-scout/pull/399) | — | Parity script reads canonical CLI reference (post-#374 doc move) |
+| [#400](https://github.com/confighub/cub-scout/pull/400) | #393 | Source-truth evidence contract v0.1 (`compare source-truth`) |
+| [#401](https://github.com/confighub/cub-scout/pull/401) | #396 | Direct integration coverage for `discoverWorkloads` / `getManagedResources` |
+| [#402](https://github.com/confighub/cub-scout/pull/402) | #394 (rest) | kstatus migration complete (state_scanner.go) |
+| [#403](https://github.com/confighub/cub-scout/pull/403) | #391 v0.1 | Views resolver with URL-as-positional convention (`views resolve`) |
+| [#404](https://github.com/confighub/cub-scout/pull/404) | #395 v0.1 | Source-truth producer fixture suite (6 fixtures, byte-equal goldens) |
+
+### Architectural triad locked in code (not just intent)
+
+- **cub-scout** = read-only evidence provider for source truth
+- **Pilot** = acceptance judge (lives in `confighubai/confighub-ai-demo`)
+- **ConfigHub** = authority and workflow engine
+
+cub-scout never mutates, repairs, approves, or infers authority. The source-truth contract enforces this surface in code.
+
+### Strict rules locked in tests
+
+- **Strategy-relative correctness.** Identical observations get opposite verdicts under different declared strategies. Argo reading Git is `PASS` under `git-argo` and `BLOCK` (controller outlier) under `confighub-oci-argo`. Locked by `TestDerive_StrategyMismatch_ControllerOutlier` + `TestDerive_VanillaGitOps_PASS`.
+- **Missing proof never produces PASS.** Any blank source/digest/runtime field forces at least `WATCH` / `INCOMPLETE`. Locked by `TestDerive_NeverPASS_OnAnyMissingProof` sweep.
+- **Connected-mode gate.** `compare source-truth` and `views resolve` refuse to run without `cub` auth — both contracts are meaningless without the ConfigHub surface.
+
+### Pre-existing main CI breakage (cleared)
+
+Discovered while landing the truth-floor: main CI had been red since 2026-04-19, broken by two pre-existing issues unrelated to this work — `#384` lint debt and a parity-script path drift introduced by the `#374` doc consolidation. Both fixed in `#398` / `#399` so subsequent PRs inherit a green baseline.
 
 ## Recent completions
 
@@ -60,13 +93,20 @@ Key deliverables now in place:
 
 ## Open issues
 
-Current tracked follow-ons:
+Current tracked follow-ons (verified 2026-05-08):
 
-- none at the moment
+- **#391 (v0.1 landed)** — Views integration follow-up scope. v0.1 ships the URL-as-positional convention via `views resolve`; the four scope items remaining are tracked in the issue:
+  1. `--view <uuid-or-url>` filter on `map list` / `compare three-way`
+  2. View column projection in TUI Hub view
+  3. Reality overlay composing View columns with #393 verdicts
+  4. Browser handoff helper (`o`-key / `views open`)
+- **#392** — Initiatives compliance overlay. **Still deferred.** Re-checked 2026-05-08: ConfigHub side has no `internal/models/initiative.go`, no `/api/initiative` route, no `cub initiative` subcommand. Recent ConfigHub UI commits (e.g. confighub#4244) expanded the UI but did not promote Initiative to a backend primitive. Design doc at [`docs/howto/initiatives-integration-when-ready.md`](docs/howto/initiatives-integration-when-ready.md) holds the integration spec until the prerequisite ships.
+- **confighubai/confighub#4356** — cross-repo dependency. ArgoCDOCI Helm-source shape uses full unit OCI URL instead of parent repo. Once fixed upstream, cub-scout adds a symptom classifier into `compare source-truth` so Pilot's BLOCK verdict gets explicit upstream linkage.
+- **confighub-ai-demo#264** — Pilot consumer-side fixtures pairing with cub-scout #395. Driven from the AI demo repo.
 
 ## Current checkpoint
 
-`go test ./...` is green again as of 2026-04-14.
+`go test ./...` is green as of 2026-05-08 with all 37 packages passing. `golangci-lint run` (v1.64.8, matching CI) is clean. Main CI is green.
 
 The practical state heading into the `cub scout` plugin switchover is:
 

--- a/docs/howto/initiatives-integration-when-ready.md
+++ b/docs/howto/initiatives-integration-when-ready.md
@@ -1,0 +1,206 @@
+# ConfigHub Initiatives integration: design (held pending backend surface)
+
+This document is the design spec for cub-scout's planned integration with
+ConfigHub Initiatives. It exists so the day ConfigHub exposes Initiative
+as an addressable primitive, cub-scout has an agreed-on plan rather than
+a fresh discussion.
+
+**Status: held.** The prerequisite has not shipped on the ConfigHub side
+as of 2026-05-08. See [Why this is deferred](#why-this-is-deferred) below
+and [confighub/cub-scout#392](https://github.com/confighub/cub-scout/issues/392)
+for the tracking issue.
+
+## Background
+
+ConfigHub Initiatives are operator-curated, prioritised policy goals
+("Pin Model Versions", "GPU Resource Limits", "Guardrail Policy
+Required") visible in the ConfigHub web UI under `/initiatives`.
+
+Each Initiative is a UI composite of three backend primitives:
+
+- A **Filter** — selects the unit set the policy applies to (`Where`,
+  `WhereData`, `ResourceType` clauses)
+- A **View** — display + a stable annotation `initiative-check-summary`
+  carrying passing / failing / notApplicable counts (capped at 1024
+  chars)
+- A **Trigger** — embedded Kyverno policy YAML; `Trigger.Warn=false`
+  means blocking ApplyGate, `Trigger.Warn=true` means non-blocking
+  ApplyWarning. Per-unit results come from `FunctionInvocationsResponse`.
+
+The UI assembles the Initiative shape via `useInitiatives()` from the
+underlying `useGetTriggerQuery`, `useDeleteFilterMutation`, and
+`useDeleteViewMutation` hooks. It is reconstructed at render time from
+the three persistent primitives.
+
+See [`ui/src/types/initiative.ts:13-84`](https://github.com/confighubai/confighub/blob/main/ui/src/types/initiative.ts) on the ConfigHub side for the canonical UI type shape.
+
+## Why this is deferred
+
+The council ruling on cub-scout #393 ("evidence provider, not judge")
+explicitly forbade reverse-engineering the UI composite from cub-scout:
+
+> Reverse-engineering the UI composite from cub-scout would create a
+> parallel implementation that drifts the moment ConfigHub picks a
+> canonical surface.
+
+cub-scout could technically resolve an Initiative today by chaining
+three calls — `cub view get`, `cub` filter resolve, and reading the
+trigger annotation — and assembling the shape itself. We don't, because:
+
+1. The drift risk is real. ConfigHub UI work is active (e.g. the recent
+   `confighub#4244` "Track initiative runs as ChangeSets" added 12,000
+   lines, all UI). When the team picks a canonical Initiative shape
+   server-side, any cub-scout-side reconstruction will diverge in the
+   first month.
+2. The contract is acceptance-bearing. Pilot's compliance verdicts
+   pivot on Initiative shape; a transitively-defined source of truth
+   undermines the architectural triad we just locked in #393.
+
+So cub-scout waits for one of two prerequisite paths:
+
+### Path 1 (preferred): Initiative as a backend primitive
+
+`internal/models/initiative.go` with the field shape mirroring the UI's
+current `Initiative` type, plus standard CRUD HTTP endpoints (`GET
+/api/space/{space}/initiative`, etc.). Followed by a corresponding
+`sdk/cmd/cub/initiative_*.go` set so `cub initiative list|get|create`
+exists as a first-class CLI surface.
+
+### Path 2 (also acceptable): `cub initiative get --resolve` helper
+
+Keep Initiative as a UI composite, but ship a `cub` CLI helper that
+returns the resolved bundle (filter clauses + view metadata + trigger
++ Kyverno YAML + per-unit results) for a given Initiative ID. Cheaper
+to build than Path 1, but every consumer reimplements its own composite
+around it.
+
+When either path lands, the integration described below is what
+cub-scout ships.
+
+## Planned implementation (when prerequisite is ready)
+
+The shape mirrors cub-scout's existing Views integration pattern (#391)
+so operators see a consistent CLI surface across ConfigHub primitives.
+
+### CLI surface
+
+```bash
+# URL-as-positional, mirroring `views resolve`
+cub-scout initiatives resolve <uuid-or-url>
+
+# Concrete examples
+cub-scout initiatives resolve 4f8d9c-2a1b-...
+cub-scout initiatives resolve "https://hub.confighub.com/initiatives/<uuid>"
+```
+
+The same parser pattern from `pkg/agent/view_ref.go::ParseViewRef`
+applies here. New file: `pkg/agent/initiative_ref.go` with a parallel
+`ParseInitiativeRef`. URL parser accepts the canonical
+`https://hub.confighub.com/initiatives/<uuid>` shape and any future
+extras (`?priority=HIGH`, etc.).
+
+### JSON contract
+
+```json
+{
+  "uuid": "...",
+  "source_form": "url" | "uuid",
+  "original_url": "...",
+  "extras": { ... },
+  "initiative": {
+    "name": "Pin Model Versions",
+    "priority": "HIGH",
+    "status": "in_progress",
+    "filter": { ... },
+    "kyverno_policy": "...",
+    "enforced": true,
+    "check_summary": {
+      "passing": 8,
+      "failing": 2,
+      "notApplicable": 1,
+      "total": 11,
+      "checkedAt": "2026-05-08T12:34:56Z"
+    }
+  }
+}
+```
+
+Shape mirrors the UI's `Initiative` type so cross-repo diffs are
+trivial. cub-scout does not transform — it surfaces the resolved bundle
+and lets Pilot judge.
+
+### Compliance overlay (#391-style scope item)
+
+Once the resolver lands, the compliance overlay composes with the
+source-truth evidence already shipped in #393. For each unit selected
+by an Initiative's filter, cub-scout joins:
+
+- **ConfigHub policy verdict** — from `UnitCheckResult.success` /
+  `violations` (read from the trigger's invocation results)
+- **Live cluster presence** — applied? orphan? missing?
+- **Enforcement reality** — was the trigger blocking
+  (`Warn=false`) at apply time, and did the running resource come
+  from a passing or failing check?
+
+The overlay verdict is per-unit, with a stable JSON shape:
+
+```json
+{
+  "unit": "rag-server",
+  "initiative_compliance": "PASSING|FAILING|NOT_APPLICABLE",
+  "live_presence": "applied|orphan|missing",
+  "enforcement": "blocking|non-blocking|none",
+  "reality_verdict": "consistent|gap|undetermined"
+}
+```
+
+The `reality_verdict` field captures the council's framing: ConfigHub
+says X, runtime says Y, here's whether they agree.
+
+### Strict rules
+
+The same rules locked into #393 apply here, in code:
+
+1. **No silent fallback.** If `cub initiative get` (or whatever the
+   prerequisite ships) returns an error, cub-scout emits `BLOCK` /
+   `BLOCKED` evidence. It does not reverse-engineer the bundle from
+   underlying primitives just because the resolver is missing.
+2. **Missing proof never produces PASSING.** If a per-unit result is
+   absent, the compliance verdict is `NOT_APPLICABLE` or
+   `undetermined` — never silently passing.
+3. **Connected-mode required.** Initiatives are inherently a
+   ConfigHub surface; offline mode refuses.
+
+### Out of scope (initial Initiative integration)
+
+- Authoring or editing Initiatives from cub-scout. Read-only contract
+  holds. Pilot does not author Initiatives either; ConfigHub UI does.
+- Running Kyverno policies inside cub-scout. cub-scout consumes results,
+  ConfigHub computes them.
+- Multi-source / ApplicationSet child resolution. Handled by the View
+  filter (since Initiative wraps a Filter).
+
+## How to know when this design unblocks
+
+The prerequisite has shipped when **all** of the following are true:
+
+1. `find /Users/alexis/code/confighub/internal -iname '*initiative*' -path '*models*'` returns at least one Go file (Path 1)
+   **— OR —**
+   `find /Users/alexis/code/sdk/cmd/cub -iname 'initiative*'` returns CLI files (Path 2 via SDK)
+2. `cub initiative` (or the equivalent helper) responds to `--help`
+   without error
+3. The shape returned by `cub initiative get <uuid> -o json` is
+   documented or self-evidently stable (round-trips, has matching field
+   names with the UI Initiative type)
+
+When all three hold, this document graduates from "design held" to
+"design in progress", and cub-scout #392 reopens for the
+implementation PRs.
+
+## Linked issues and references
+
+- [confighub/cub-scout#392](https://github.com/confighub/cub-scout/issues/392) — tracking issue
+- [confighub/cub-scout#391](https://github.com/confighub/cub-scout/issues/391) — Views integration that this mirrors
+- [confighub/cub-scout#393](https://github.com/confighub/cub-scout/issues/393) — source-truth contract that compliance overlay composes with
+- [confighubai/confighub-ai-demo#264](https://github.com/confighubai/confighub-ai-demo/issues/264) — Pilot consumer-side fixtures
+- Council verdict on #393 capturing the evidence-vs-judge split: [#393#issuecomment-4407651183](https://github.com/confighub/cub-scout/issues/393#issuecomment-4407651183)


### PR DESCRIPTION
## Summary

Refreshes the two AI-cold-start docs (HANDOVER, AI-README-FIRST) that have gone three weeks stale through the council source-truth track, plus adds a held design doc for the Initiatives integration that explicitly cannot ship today.

## Why

HANDOVER was last touched 2026-04-14. Since then **8 substantive PRs landed**: truth-floor (#397), lint debt (#398), parity script (#399), source-truth contract (#400), coverage back-fill (#401), kstatus migration complete (#402), Views resolver v0.1 (#403), producer fixtures (#404). Plus three issues closed (#384, #387, #390, #393, #394, #395, #396) and two open with active follow-up (#391, #392). Anyone reading HANDOVER cold today gets a wildly inaccurate picture.

## Changes

- **`HANDOVER.md`** — new top section `May 2026 completions — council source-truth track` listing the 8 PRs, the architectural triad locked in code, the strict rules locked in tests, and the pre-existing CI breakage story. Existing March 2026 history preserved. `Open issues` rewritten from "none at the moment" (stale) to the verified current queue. Checkpoint bumped.
- **`AI-README-FIRST.md`** — `As of 2026-04-09` bumped to 2026-05-08. Shipped-capabilities list now leads with source-truth contract, architectural triad, kstatus complete, Views v0.1. Open queue rewritten — old entries (#370/#368/#364/#359/#360/#362) are all closed.
- **`docs/howto/initiatives-integration-when-ready.md`** (new) — design spec for what cub-scout will ship once ConfigHub exposes Initiative as a backend primitive. Held per council ruling. Includes:
  - Background on why Initiatives are UI-only today
  - Two prerequisite paths (backend primitive preferred; `cub` CLI resolver acceptable)
  - Concrete signals for when each unblocks
  - Planned CLI surface (mirrors Views resolver), JSON contract, and compliance overlay shape that composes with #393 verdicts
  - Strict rules ported from #393 (no silent fallback, missing proof never PASSING, connected-mode required)

## Test plan

- [x] `go vet ./...` clean
- [x] `./scripts/check-cli-guide-parity.sh` passes
- [x] `go run ./scripts/check-cli-docs` passes
- [x] No code changes — pure docs

## Why this matters

The next AI coder (cold session) reads HANDOVER + AI-README-FIRST first. The architectural triad and strict rules from #393 are the most important things they should learn before touching anything else; with this PR they show up at the top of the first file they read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
