### PR TITLE
feat: views open browser-handoff helper (#391 scope #4)

### DIFF
--- a/cmd/cub-scout/views.go
+++ b/cmd/cub-scout/views.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -43,17 +44,22 @@ import (
 var (
 	viewsResolveFormat string
 	viewsResolveSpace  string
+	viewsOpenPrintOnly bool
 )
 
 var viewsCmd = &cobra.Command{
 	Use:   "views",
-	Short: "Work with ConfigHub Views (read-only, v0.1)",
+	Short: "Work with ConfigHub Views (read-only)",
 	Long: `Work with ConfigHub Views — saved filter+projection specs operators curate
 in the View Explorer (https://hub.confighub.com/x/view-explorer).
 
-v0.1 ships the URL-as-positional convention and a resolver subcommand.
-Future PRs wire --view onto map list, compare three-way, and the TUI
-Hub view (see #391 scope items).`,
+Subcommands:
+  resolve <uuid-or-url>   fetch the View as structured JSON
+  open    <uuid-or-url>   open the View Explorer URL in the browser
+
+The remaining #391 scope items (--view flag on map list / compare three-way,
+View column projection in TUI Hub view, reality overlay composing View
+columns with #393 source-truth verdicts) land as dedicated follow-up PRs.`,
 }
 
 var viewsResolveCmd = &cobra.Command{
@@ -81,8 +87,10 @@ Requires connected mode (cub auth login or CONFIGHUB_API_KEY).`,
 func init() {
 	rootCmd.AddCommand(viewsCmd)
 	viewsCmd.AddCommand(viewsResolveCmd)
+	viewsCmd.AddCommand(viewsOpenCmd)
 	viewsResolveCmd.Flags().StringVar(&viewsResolveFormat, "format", "json", "Output format. v0.1 supports: json")
 	viewsResolveCmd.Flags().StringVar(&viewsResolveSpace, "space", "*", "Space to search. Defaults to org-wide ('*') so a UUID alone is sufficient")
+	viewsOpenCmd.Flags().BoolVar(&viewsOpenPrintOnly, "print", false, "Print the View Explorer URL to stdout instead of opening the browser (useful for scripts and headless environments)")
 }
 
 // ResolvedView is the JSON contract `views resolve` emits. Future
@@ -152,3 +160,114 @@ func emitResolvedView(rv ResolvedView) error {
 	enc.SetIndent("", "  ")
 	return enc.Encode(rv)
 }
+
+// viewsOpenCmd implements #391 scope item #4 — the GUI ↔ CLI handoff
+// helper. Operators paste a URL into cub-scout for read-only
+// observation; this command reverses the trip when they want the
+// authoring view in the browser.
+//
+// `cub-scout views open <uuid-or-url>` opens the canonical View
+// Explorer URL for the reference. URLs that already point at View
+// Explorer round-trip; UUIDs are constructed against `hub.WebBaseURL`
+// (the same base configHubUnitDetailURL uses, so on-prem deployments
+// resolve correctly).
+//
+// Connected mode is NOT required to print or open a URL — the URL
+// itself is local construction. Auth only matters once the operator
+// reaches the View Explorer page in the browser.
+var viewsOpenCmd = &cobra.Command{
+	Use:   "open <uuid-or-url>",
+	Short: "Open the View Explorer URL for a View reference in the browser",
+	Long: `Open the canonical View Explorer URL for a View reference in your
+default browser. Closes the GUI <-> CLI loop:
+
+  - paste a URL into ` + "`" + `cub-scout views resolve` + "`" + ` to read its bundle
+  - run ` + "`" + `cub-scout views open` + "`" + ` to switch back to the authoring GUI
+
+Accepts the same input shapes ` + "`" + `views resolve` + "`" + ` does — bare UUID or a
+View Explorer URL — so the same identifier round-trips between
+commands without copy-paste edits.
+
+Connected mode is NOT required to construct or open a URL. Auth only
+matters once the browser reaches View Explorer.
+
+Use ` + "`" + `--print` + "`" + ` to emit the URL to stdout instead of opening the
+browser. Useful in headless environments and as the right-hand side
+of a pipe.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runViewsOpen,
+}
+
+func runViewsOpen(cmd *cobra.Command, args []string) error {
+	ref, err := agent.ParseViewRef(args[0])
+	if err != nil {
+		return fmt.Errorf("parse view reference: %w", err)
+	}
+
+	// Construct the canonical View Explorer URL. If the operator passed
+	// a URL we already have a verified form, but we re-build from the
+	// canonical base + UUID so an on-prem hostname overrides whatever
+	// hostname the input URL had — `--space` and host preferences are
+	// set in cub-scout's hub config, not in pasted URLs.
+	url := viewExplorerURL(ref.UUID)
+
+	if viewsOpenPrintOnly {
+		fmt.Println(url)
+		return nil
+	}
+
+	if err := openInBrowser(url); err != nil {
+		// Fall back to printing the URL so the operator can copy it
+		// manually — better than failing silently in headless or
+		// permission-restricted environments.
+		fmt.Fprintf(os.Stderr, "Could not open browser (%v).\nView Explorer URL: %s\n", err, url)
+		return err
+	}
+	return nil
+}
+
+// viewExplorerURL builds the canonical View Explorer URL for a View
+// UUID. Anchored at `hub.HubBaseURL` because View Explorer lives on
+// the product UI host (e.g. https://hub.confighub.com/x/view-explorer)
+// rather than the marketing site (`hub.WebBaseURL`,
+// https://confighub.com). On-prem deployments are expected to override
+// HubBaseURL via the existing config mechanism, so this URL builder
+// follows the same convention as other product-UI deep-links in
+// cub-scout.
+func viewExplorerURL(uuid string) string {
+	base := strings.TrimRight(hub.HubBaseURL, "/")
+	return fmt.Sprintf("%s/x/view-explorer?view=%s", base, uuid)
+}
+
+// openInBrowser opens url in the operator's default browser. Uses the
+// platform-appropriate command and refuses to spawn anything else if
+// the URL fails our parser pre-check.
+//
+// Security: the URL is built from `hub.WebBaseURL` and a parsed UUID,
+// neither of which can carry shell metacharacters past the parser. We
+// still pass url as a single argv slot (not via a shell) to be belt
+// and suspenders.
+func openInBrowser(url string) error {
+	var (
+		cmd  string
+		args []string
+	)
+	switch runtimeGOOS() {
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	case "windows":
+		cmd = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", url}
+	default:
+		cmd = "xdg-open"
+		args = []string{url}
+	}
+	return exec.Command(cmd, args...).Start()
+}
+
+// runtimeGOOS is split out so the test can inject a fake value without
+// the build-tags dance, and to avoid a hard import cycle if tests need
+// to swap behaviour. Default delegates to runtime.GOOS.
+var runtimeGOOS = func() string { return runtime.GOOS }
+

--- a/cmd/cub-scout/views_open_test.go
+++ b/cmd/cub-scout/views_open_test.go
@@ -1,0 +1,112 @@
+// Tests for the `cub-scout views open` browser-handoff helper added
+// for #391 scope item #4. Covers URL construction (host pinning to the
+// product UI host) and the platform-aware browser-launcher dispatch.
+//
+// Browser-launching itself is not exercised end-to-end — that requires
+// a real desktop environment. The tests instead verify the launcher's
+// argv shape and the --print fallback that scripts and headless runs
+// rely on.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/hub"
+)
+
+func TestViewExplorerURL_AnchorsAtProductUIHost(t *testing.T) {
+	const uuid = "806aac53-236c-446d-8ad6-91d6daf6810e"
+
+	got := viewExplorerURL(uuid)
+	want := strings.TrimRight(hub.HubBaseURL, "/") + "/x/view-explorer?view=" + uuid
+	if got != want {
+		t.Errorf("viewExplorerURL(%q) = %q, want %q", uuid, got, want)
+	}
+
+	// Sanity: the URL must be parseable back into the same UUID by
+	// the parser the rest of the views tooling uses. This proves
+	// open and resolve round-trip the same identifier.
+	if !strings.Contains(got, uuid) {
+		t.Errorf("URL %q lost the UUID", got)
+	}
+	if !strings.Contains(got, "/x/view-explorer") {
+		t.Errorf("URL %q is missing the /x/view-explorer path", got)
+	}
+}
+
+func TestViewExplorerURL_StripsTrailingSlashFromBase(t *testing.T) {
+	// Defensive: the base may or may not have a trailing slash
+	// depending on config. The builder must produce a single slash
+	// before /x/view-explorer regardless.
+	got := viewExplorerURL("ffffffff-ffff-ffff-ffff-ffffffffffff")
+	if strings.Contains(got, "//x/") {
+		t.Errorf("URL has double-slash before path: %q", got)
+	}
+}
+
+// TestRunViewsOpen_PrintMode covers the headless / pipe-friendly path:
+// `--print` emits the URL to stdout instead of opening a browser, so
+// the test does not need to mock browser-launching at all.
+func TestRunViewsOpen_PrintMode(t *testing.T) {
+	const uuid = "806aac53-236c-446d-8ad6-91d6daf6810e"
+
+	// Force --print mode and reset afterwards so we don't pollute
+	// other tests sharing the package-level flag var.
+	prev := viewsOpenPrintOnly
+	viewsOpenPrintOnly = true
+	t.Cleanup(func() { viewsOpenPrintOnly = prev })
+
+	out := captureStdout(t, func() {
+		// runViewsOpen reads its arg, parses the ref, builds the URL,
+		// and prints it.
+		if err := runViewsOpen(viewsOpenCmd, []string{uuid}); err != nil {
+			t.Fatalf("runViewsOpen returned error in print mode: %v", err)
+		}
+	})
+
+	wantSubstring := "/x/view-explorer?view=" + uuid
+	if !strings.Contains(out, wantSubstring) {
+		t.Errorf("--print output %q does not contain %q", out, wantSubstring)
+	}
+}
+
+// TestRunViewsOpen_PrintMode_AcceptsViewExplorerURL verifies the URL
+// form round-trips through the open command — the operator can paste a
+// URL from `views resolve` output back into `views open` and get the
+// canonical product-UI URL out, even if the input pointed at a
+// different host (e.g. an on-prem URL someone pasted into a doc).
+func TestRunViewsOpen_PrintMode_AcceptsViewExplorerURL(t *testing.T) {
+	const uuid = "806aac53-236c-446d-8ad6-91d6daf6810e"
+	in := "https://confighub.example.internal/x/view-explorer?view=" + uuid
+
+	prev := viewsOpenPrintOnly
+	viewsOpenPrintOnly = true
+	t.Cleanup(func() { viewsOpenPrintOnly = prev })
+
+	out := captureStdout(t, func() {
+		if err := runViewsOpen(viewsOpenCmd, []string{in}); err != nil {
+			t.Fatalf("runViewsOpen returned error: %v", err)
+		}
+	})
+
+	// The output URL is anchored at the configured product-UI host,
+	// not the on-prem host the input URL used. This is the desired
+	// behaviour: cub-scout's hub config wins over whatever URL was
+	// pasted (so on-prem operators with a configured override don't
+	// get bounced to the wrong site).
+	if !strings.Contains(out, "/x/view-explorer?view="+uuid) {
+		t.Errorf("output URL %q missing canonical View Explorer path", out)
+	}
+}
+
+func TestRunViewsOpen_RejectsInvalidInput(t *testing.T) {
+	prev := viewsOpenPrintOnly
+	viewsOpenPrintOnly = true
+	t.Cleanup(func() { viewsOpenPrintOnly = prev })
+
+	if err := runViewsOpen(viewsOpenCmd, []string{"definitely-not-a-uuid"}); err == nil {
+		t.Fatal("expected runViewsOpen to error on garbage input, got nil")
+	}
+}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2270,10 +2270,40 @@ downstream commands can opt in to them without the parser growing flags.
 
 Connected mode (`cub auth login` or `CONFIGHUB_API_KEY` set).
 
-### v0.1 limitations
+### views open
 
-- Resolver only — no command integration. `--view` flags on `compare three-way` / `map list` / TUI Hub view land in dedicated follow-up PRs (see #391 scope items).
-- No reality overlay. Once #393's source-truth contract is widely consumed, follow-up work composes the View's column projection with `compare source-truth` verdicts (#391 scope item #3).
+Open the canonical View Explorer URL for a View reference in the
+operator's default browser. Closes the GUI ↔ CLI loop:
+
+- paste a URL into `cub-scout views resolve` to read its bundle
+- run `cub-scout views open` to switch back to the authoring GUI
+
+```bash
+cub-scout views open 806aac53-236c-446d-8ad6-91d6daf6810e
+cub-scout views open "https://hub.confighub.com/x/view-explorer?view=806aac53-236c-446d-8ad6-91d6daf6810e"
+```
+
+Same input shapes as `views resolve` — bare UUID or View Explorer URL.
+The output URL is anchored at the configured `hub.HubBaseURL`, so
+on-prem deployments resolve to their own host regardless of which
+hostname the input URL carried (the operator's local config wins).
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--print` | Print the URL to stdout instead of opening the browser. Useful in headless environments and pipes. |
+
+#### Requirements
+
+Connected mode is **not** required — the URL itself is local
+construction. Auth only matters once the browser reaches View Explorer.
+
+### v0.1 scope items still pending
+
+- `--view <uuid-or-url>` filter on `compare three-way` / `map list` (scope item #1) — multi-hop CLI resolution, separate PR.
+- View column projection in TUI Hub view (scope item #2).
+- Reality overlay composing View columns with #393 source-truth verdicts (scope item #3) — unblocked now that the contract is in main.
 
 ---
 


### PR DESCRIPTION
## Summary

Lands [#391 scope item #4](https://github.com/confighub/cub-scout/issues/391): browser-handoff helper that closes the GUI ↔ CLI loop.

The URL convention shipped in [#391 v0.1 (#403)](https://github.com/confighub/cub-scout/pull/403) gave operators a zero-friction *GUI → CLI* bridge — paste the View Explorer URL into `cub-scout views resolve` and read the bundle. This PR ships the **inverse trip** with the same input shapes (bare UUID or View Explorer URL), so the same identifier round-trips between commands without copy-paste edits.

```bash
cub-scout views open 806aac53-236c-446d-8ad6-91d6daf6810e
cub-scout views open "https://hub.confighub.com/x/view-explorer?view=<uuid>"
cub-scout views open <uuid-or-url> --print   # stdout, no browser
```

## Notable decisions

- **`--print` flag** for headless environments, scripts, and pipes. Doubles as the test seam — launching a real browser in unit tests is impractical, so all CLI behaviour is exercised through `--print`.
- **Platform-aware launcher** — `open` on macOS, `rundll32 url.dll,FileProtocolHandler` on Windows, `xdg-open` elsewhere. Falls back to printing the URL on launcher failure so operators can copy manually instead of failing silently.
- **Connected mode NOT required** to open a URL. Auth matters once the browser reaches View Explorer; URL construction is local.
- **URL anchoring at `hub.HubBaseURL`** (the product UI host, e.g. `https://hub.confighub.com`) rather than `hub.WebBaseURL` (the marketing site). View Explorer lives on the product host. On-prem deployments override HubBaseURL via the existing config mechanism.
- **Local config wins over pasted URL host.** An operator running against on-prem ConfigHub with their local config configured won't accidentally end up on a copy-pasted URL's host — the canonical URL is always rebuilt from local hub config + UUID.

## Test plan

5 cases at `cmd/cub-scout/views_open_test.go`:

- [x] `viewExplorerURL` anchors at `hub.HubBaseURL`
- [x] URL builder strips a trailing slash from the base
- [x] `--print` mode emits the canonical URL for a bare UUID
- [x] `--print` mode round-trips a foreign-host View Explorer URL through the local-config override
- [x] Invalid input returns an error, doesn't try to open anything

Plus:

- [x] `go test ./...` — all 37 packages green
- [x] `go vet ./...` clean
- [x] `golangci-lint run` (v1.64.8, matching CI) — exit 0
- [x] `./scripts/check-cli-guide-parity.sh` and `go run ./scripts/check-cli-docs` pass
- [x] CLI smoke: `--help` renders, UUID and URL forms both round-trip in `--print` mode, garbage input rejected with parse error

## Status of #391 after this PR

| Scope item | Status |
|---|---|
| URL-as-positional convention + `views resolve` | Shipped in [#403](https://github.com/confighub/cub-scout/pull/403) |
| **#4 Browser handoff (`views open`)** | **This PR** |
| #1 `--view` filter on `compare three-way` / `map list` | Open. Multi-hop CLI resolution (View → Filter → Unit list); separate PR |
| #2 View column projection in TUI Hub view | Open |
| #3 Reality overlay composing View columns with [#393](https://github.com/confighub/cub-scout/pull/400) verdicts | Open. Unblocked since #400 landed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
