### PR TITLE
feat: expose compare source-truth as MCP tool (#393)

### DIFF
--- a/cmd/cub-scout/mcp.go
+++ b/cmd/cub-scout/mcp.go
@@ -351,6 +351,57 @@ func newMCPGatewayWithMode(runner mcpToolRunner, connectedRunner mcpToolRunner, 
 				return args, nil
 			},
 		}
+		tools["compare_source_truth"] = mcpTool{
+			Descriptor: mcpToolDescriptor{
+				Name: "compare_source_truth",
+				// The description is deliberate about the architectural triad:
+				// this tool emits *evidence*, not an acceptance verdict. Pilot
+				// (or any agent) layers acceptance on top. Wording must never
+				// imply that the tool can approve, repair, or mutate.
+				Description: "Connected-only read-only source-truth EVIDENCE document for a single workload (compare source-truth --format json). Joins ConfigHub intent, the GitOps controller's observed source/revision/digest, and the live runtime into one structured verdict relative to a declared delivery strategy. Use when the user asks 'is this workload's source of truth consistent end-to-end?' or 'where is the disagreement between ConfigHub, the controller, and the cluster?'. Strategy is REQUIRED input — never inferred — and the contract refuses to emit PASS when any source/digest/runtime field is missing. Load after doctor, explain, or compare_three_way has identified the workload you care about. DO NOT use this tool to approve, repair, or accept anything; it produces evidence only, and acceptance is a Pilot/operator decision. DO NOT load for first-pass cluster troubleshooting; use doctor first.",
+				Annotations: readOnly,
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"target": map[string]interface{}{
+							"type":        "string",
+							"description": "Workload reference in `kind/name` form (e.g. `Deployment/rag-server`). Supported kinds in v0.1: Deployment, StatefulSet, DaemonSet.",
+						},
+						"namespace": map[string]interface{}{
+							"type":        "string",
+							"description": "Required Kubernetes namespace of the workload.",
+						},
+						"strategy": map[string]interface{}{
+							"type":        "string",
+							"description": "Declared delivery path. Required, never inferred. One of: confighub-oci-argo, confighub-oci-flux, git-argo, git-flux.",
+							"enum":        []string{"confighub-oci-argo", "confighub-oci-flux", "git-argo", "git-flux"},
+						},
+					},
+					"required":             []string{"target", "namespace", "strategy"},
+					"additionalProperties": false,
+				},
+			},
+			BuildArgs: func(arguments map[string]interface{}) ([]string, error) {
+				target := argString(arguments, "target")
+				if target == "" {
+					return nil, fmt.Errorf("missing required argument: target")
+				}
+				namespace := argString(arguments, "namespace")
+				if namespace == "" {
+					return nil, fmt.Errorf("missing required argument: namespace")
+				}
+				strategy := argString(arguments, "strategy")
+				if strategy == "" {
+					return nil, fmt.Errorf("missing required argument: strategy")
+				}
+				return []string{
+					"compare", "source-truth", target,
+					"-n", namespace,
+					"--strategy", strategy,
+					"--format", "json",
+				}, nil
+			},
+		}
 		tools["confighub_changesets"] = mcpTool{
 			Descriptor: mcpToolDescriptor{
 				Name:        "confighub_changesets",

--- a/cmd/cub-scout/mcp_structured.go
+++ b/cmd/cub-scout/mcp_structured.go
@@ -45,6 +45,14 @@ func buildMCPStructuredContent(toolName, output string) interface{} {
 	switch toolName {
 	case "compare_three_way":
 		return mcpWrapStructuredData(payload)
+	case "compare_source_truth":
+		// Source-truth's JSON already carries the architectural triad's
+		// fields (declared_strategy, status, source_truth, outlier,
+		// surfaces, proof_gaps, safe_next_action) at the top level. Wrap
+		// the payload under `data` so MCP consumers see it via the same
+		// envelope shape as compare_three_way; downstream agents can
+		// read evidence directly without re-parsing the text content.
+		return mcpWrapStructuredData(payload)
 	case "confighub_units":
 		return buildMCPUnitsStructuredContent(payload)
 	case "confighub_unit_get":

--- a/cmd/cub-scout/mcp_test.go
+++ b/cmd/cub-scout/mcp_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -35,6 +36,7 @@ func TestNewMCPGatewayWithMode_ConnectedAddsConfigHubTools(t *testing.T) {
 	}
 
 	want := []string{
+		"compare_source_truth",
 		"compare_three_way",
 		"confighub_changesets",
 		"confighub_unit_get",
@@ -96,6 +98,7 @@ func TestNewMCPGateway_ToolDescriptionsExpressChainBoundaries(t *testing.T) {
 		contains []string
 	}{
 		{name: "compare_three_way", contains: []string{"governed state agrees with live state", "Load after doctor, explain, or trace", "use doctor first"}},
+		{name: "compare_source_truth", contains: []string{"EVIDENCE", "single workload", "REQUIRED input", "never inferred", "DO NOT use this tool to approve, repair, or accept", "Load after doctor, explain, or compare_three_way", "use doctor first"}},
 		{name: "doctor", contains: []string{"FIRST standalone tool", "whether cub-scout is the right first read-only step", "stale kubeconfig", "Use before explain, trace, or scan"}},
 		{name: "map", contains: []string{"what's running in this cluster", "raw `kubectl get` output", "use doctor first"}},
 		{name: "scan", contains: []string{"Use AFTER doctor", "awareness scan of live state", "DO NOT use this as a governed promotion or revision-safety gate"}},
@@ -396,6 +399,152 @@ func TestMCPGatewayHandleRequest_ToolsCallCompareThreeWay(t *testing.T) {
 	}
 	if _, ok := result.StructuredContent.Data["agreement"]; !ok {
 		t.Fatalf("expected structuredContent.data to include parsed compare JSON, got %+v", result.StructuredContent.Data)
+	}
+}
+
+// TestMCPGatewayHandleRequest_ToolsCallCompareSourceTruth proves the
+// new connected-mode tool registration. The args BuildArgs produces
+// must match cub-scout's CLI surface byte-for-byte (so the MCP-driven
+// invocation and a hand-typed CLI invocation produce identical
+// output), and the structuredContent envelope must wrap the source-
+// truth JSON under `data` so agents can read evidence directly without
+// re-parsing the text content.
+func TestMCPGatewayHandleRequest_ToolsCallCompareSourceTruth(t *testing.T) {
+	var gotStandaloneArgs []string
+
+	// Synthetic source-truth payload that mirrors the contract types in
+	// pkg/agent/source_truth.go. Field names must match exactly, since
+	// the structuredContent wrapper just hands the parsed JSON back.
+	const syntheticPayload = `{
+		"declared_strategy": "ConfigHub -> OCI -> Flux -> Kubernetes",
+		"status": "PASS",
+		"source_truth": "AGREED",
+		"outlier": "unknown",
+		"surfaces": {
+			"confighub":  {"space":"demo","unit":"rag-server","revision":"47"},
+			"controller": {"kind":"Flux","source":"oci://oci.confighub.com/demo/rag-server","revision_or_digest":"sha256:abc","health":"Ready"},
+			"runtime":    {"resource":"Deployment/rag-server in demo","field":"spec.template.spec.containers[0].image","value":"oci.confighub.com/demo/rag-server@sha256:abc","health":"Current"}
+		}
+	}`
+
+	gateway := newMCPGatewayWithMode(
+		func(ctx context.Context, args []string) (string, error) {
+			gotStandaloneArgs = append([]string(nil), args...)
+			return syntheticPayload, nil
+		},
+		nil,
+		true,
+	)
+
+	req := mcpRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`12.1`),
+		Method:  "tools/call",
+		Params: json.RawMessage(`{
+			"name":"compare_source_truth",
+			"arguments":{
+				"target":"Deployment/rag-server",
+				"namespace":"demo",
+				"strategy":"confighub-oci-flux"
+			}
+		}`),
+	}
+
+	resp := gateway.handleRequest(context.Background(), req)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected rpc error: %+v", resp.Error)
+	}
+
+	wantStandalone := []string{
+		"compare", "source-truth", "Deployment/rag-server",
+		"-n", "demo",
+		"--strategy", "confighub-oci-flux",
+		"--format", "json",
+	}
+	if !reflect.DeepEqual(gotStandaloneArgs, wantStandalone) {
+		t.Fatalf("standalone args = %v, want %v", gotStandaloneArgs, wantStandalone)
+	}
+
+	var result struct {
+		StructuredContent struct {
+			Data map[string]interface{} `json:"data"`
+		} `json:"structuredContent"`
+	}
+	if err := marshalInto(resp.Result, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+
+	// Source-truth's contract fields must round-trip through the
+	// structuredContent envelope under `data`. Spot-check the three
+	// council-anchored fields plus the strategy-rendered string.
+	for _, want := range []string{"declared_strategy", "status", "source_truth", "outlier", "surfaces"} {
+		if _, ok := result.StructuredContent.Data[want]; !ok {
+			gotKeys := make([]string, 0, len(result.StructuredContent.Data))
+			for k := range result.StructuredContent.Data {
+				gotKeys = append(gotKeys, k)
+			}
+			sort.Strings(gotKeys)
+			t.Errorf("structuredContent.data missing field %q (got keys: %v)", want, gotKeys)
+		}
+	}
+	if got := result.StructuredContent.Data["status"]; got != "PASS" {
+		t.Errorf("status field = %v, want PASS", got)
+	}
+}
+
+// TestMCPGatewayHandleRequest_ToolsCallCompareSourceTruthValidationError
+// exercises the BuildArgs validation path — every required argument
+// (target, namespace, strategy) must produce a clear error before the
+// runner is ever called. Mirrors the compare_three_way validation
+// test below.
+func TestMCPGatewayHandleRequest_ToolsCallCompareSourceTruthValidationError(t *testing.T) {
+	gateway := newMCPGatewayWithMode(
+		func(ctx context.Context, args []string) (string, error) {
+			t.Fatal("runner should not be called for validation error")
+			return "", nil
+		},
+		nil,
+		true,
+	)
+
+	cases := []struct {
+		name string
+		args string
+	}{
+		{name: "missing all", args: `{}`},
+		{name: "missing namespace+strategy", args: `{"target":"Deployment/x"}`},
+		{name: "missing strategy", args: `{"target":"Deployment/x","namespace":"demo"}`},
+		{name: "missing target", args: `{"namespace":"demo","strategy":"confighub-oci-flux"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpRequest{
+				JSONRPC: "2.0",
+				ID:      json.RawMessage(`12.2`),
+				Method:  "tools/call",
+				Params:  json.RawMessage(`{"name":"compare_source_truth","arguments":` + tc.args + `}`),
+			}
+			resp := gateway.handleRequest(context.Background(), req)
+			if resp == nil {
+				t.Fatal("response is nil")
+			}
+			// Validation errors come back through the result envelope
+			// as isError=true, not as JSON-RPC errors — the gateway
+			// uses mcpToolError for tool-level failures.
+			var result struct {
+				IsError bool `json:"isError"`
+			}
+			if err := marshalInto(resp.Result, &result); err != nil {
+				t.Fatalf("decode result: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("expected isError=true for %s, got %+v", tc.name, resp.Result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Promotes the source-truth evidence contract ([#393](https://github.com/confighub/cub-scout/pull/400) v0.1) from a CLI command to a first-class read-only tool on the MCP gateway. AI agents now see `compare_source_truth` alongside the existing connected-mode tools, with deliberate description wording that locks the council's architectural triad at the agent surface.

## The triad lives in the tool description

```
> Use when the user asks 'is this workload's source of truth consistent
> end-to-end?' [...]
> DO NOT use this tool to approve, repair, or accept anything; it produces
> evidence only, and acceptance is a Pilot/operator decision.
```

cub-scout = read-only evidence. Pilot = judge. ConfigHub = authority. The text above is the contract Pilot and AI hosts both read.

## Tool surface

| | |
|---|---|
| **Name** | `compare_source_truth` |
| **Annotations** | `readOnly` |
| **Inputs** | `target` (kind/name), `namespace`, `strategy` (enum-validated against the four v0.1 paths) |
| **Outputs** | text content (the source-truth JSON) + structuredContent envelope wrapping the parsed JSON under `data`, same shape as compare_three_way |

`BuildArgs` produces exactly the CLI surface — `["compare", "source-truth", "<target>", "-n", "<namespace>", "--strategy", "<strategy>", "--format", "json"]` — so MCP-driven and CLI invocations are byte-identical via `agent.EncodeEvidence`.

## Test plan

5 new test cases on `cmd/cub-scout/mcp_test.go`:

- [x] Tools list now includes `compare_source_truth` (alphabetical)
- [x] Chain-boundaries description includes the triad-anchored strings (`EVIDENCE`, `REQUIRED input`, `never inferred`, `DO NOT use this tool to approve, repair, or accept`, `Load after doctor, explain, or compare_three_way`, `use doctor first`)
- [x] tools/call happy path: BuildArgs match the CLI surface byte-for-byte; structuredContent.data carries the council-anchored fields (`declared_strategy`, `status`, `source_truth`, `outlier`, `surfaces`); status round-trips `PASS`
- [x] tools/call validation: every required arg (target, namespace, strategy) absent produces isError=true without invoking the runner (4 sub-cases)

Plus:

- [x] `go test ./...` — all 37 packages green
- [x] `go vet ./...` clean
- [x] `golangci-lint run` (v1.64.8, matching CI) — exit 0
- [x] Parity scripts pass

## Why this is the right next step after #393 v0.1

The contract was already locked in cub-scout's CLI; this PR makes it the **single agent-facing primitive for source-truth questions**. AI hosts and Pilot's eventual integration both call MCP rather than each shelling out to the CLI separately, so the wire shape converges on one path through `agent.EncodeEvidence`. Future #391 work (`--view` on `compare three-way`, reality overlay) lands on the same MCP surface without rebuilding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
