### PR TITLE
chore(ci): bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,10 +34,10 @@ jobs:
       coverage_total: ${{ steps.coverage_metric.outputs.coverage_total }}
       coverage_min: ${{ steps.coverage_metric.outputs.coverage_min }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -45,7 +45,7 @@ jobs:
         run: go build ./cmd/cub-scout
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -81,7 +81,7 @@ jobs:
           echo "coverage_min=25.0" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: |
@@ -92,7 +92,7 @@ jobs:
         run: go test -tags=integration ./test/integration/... -run '^TestRealExamplesCatalog$' -count=1 -v
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cub-scout-linux
           path: cub-scout
@@ -105,15 +105,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Download binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cub-scout-linux
 
@@ -152,15 +152,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Download binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cub-scout-linux
 
@@ -250,10 +250,10 @@ jobs:
     needs: gitops
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.level == 'demos' || github.event.inputs.level == 'full'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -301,15 +301,15 @@ jobs:
     needs: integration
     if: github.event_name == 'workflow_dispatch' && (github.event.inputs.level == 'connected' || github.event.inputs.level == 'full')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Download binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cub-scout-linux
 
@@ -352,7 +352,7 @@ jobs:
       - full
     if: always()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Emit proof artifact
         run: ./scripts/ci/emit-proof-artifact.sh ./proof-artifact
@@ -367,7 +367,7 @@ jobs:
           PROOF_COVERAGE_MIN: ${{ needs.unit.outputs.coverage_min }}
 
       - name: Upload proof artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-proof-artifact
           path: ./proof-artifact
@@ -380,10 +380,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.level == 'full'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -21,7 +21,7 @@ jobs:
         run: ./scripts/perf-bench.sh
 
       - name: Upload perf artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-results
           path: perf/out/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -31,14 +31,14 @@ jobs:
         run: go test ./...
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Closes #385

## Summary

Bumps all GitHub Actions to their latest Node 24-compatible major versions:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `golangci/golangci-lint-action` | v6 | v9 |
| `docker/login-action` | v3 | v4 |
| `goreleaser/goreleaser-action` | v6 | v7 |
| `helm/kind-action` | v1 | v1 (no v2 available) |

**`actions/upload-artifact` note:** No `compression-level` input is used anywhere in these workflows, so the v4→v7 bump is a clean drop-in with no field changes needed.

## Test plan

- [ ] CI passes on this PR (unit + integration jobs run on `ubuntu-latest`)
- [ ] Release workflow compiles (goreleaser-action v7 interface is unchanged)
- [ ] Perf workflow compiles (upload-artifact v7 interface is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)