### PR TITLE
chore(ci): migrate .goreleaser.yaml brews to homebrew_casks (#389)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -120,10 +120,7 @@ changelog:
       - '^test:'
       - '^ci:'
 
-# Note: brews and dockers use deprecated syntax but still work
-# Will be updated when GoReleaser v2 stabilizes new API
-
-brews:
+homebrew_casks:
   - name: cub-scout
     repository:
       owner: confighub
@@ -132,12 +129,9 @@ brews:
     homepage: "https://confighub.com"
     description: "Explore and map GitOps in your clusters"
     license: "MIT"
-    install: |
-      bin.install "cub-scout"
-      bin.install "kubectl-cub_scout"
-    test: |
-      system "#{bin}/cub-scout", "version"
-      system "#{bin}/kubectl-cub_scout", "version"
+    binaries:
+      - cub-scout
+      - kubectl-cub_scout
 
 dockers:
   - image_templates:


### PR DESCRIPTION
## Summary

- Renames the deprecated `brews:` key to `homebrew_casks:` as required by GoReleaser v2
- Replaces the old Ruby-DSL `install:` and `test:` blocks with the `binaries:` list field — GoReleaser generates the Cask stanza automatically from this list
- Drops the stale "will be updated" comment that tracked this TODO

Verified against: https://goreleaser.com/deprecations#brews and https://goreleaser.com/customization/homebrew_casks/

## Test plan

- [ ] YAML validated as well-formed (`python3 -c "import yaml; yaml.safe_load(...)"` passes)
- [ ] `goreleaser check` clean (requires goreleaser installed; CI will confirm)
- [ ] Next release publishes cask to `confighub/homebrew-tap` under `Casks/` as expected

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)