### PR TITLE
feat: --view flag on compare three-way (#408, #391 scope #1)

### DIFF
--- a/cmd/cub-scout/compare_three_way.go
+++ b/cmd/cub-scout/compare_three_way.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/confighub/cub-scout/pkg/hub"
 )
 
 type threeWayScopeType string
@@ -20,6 +23,7 @@ const (
 	threeWayScopeResource  threeWayScopeType = "resource"
 	threeWayScopeNamespace threeWayScopeType = "namespace"
 	threeWayScopeCluster   threeWayScopeType = "cluster"
+	threeWayScopeView      threeWayScopeType = "view"
 )
 
 type threeWayScope struct {
@@ -83,6 +87,7 @@ const (
 
 var (
 	compareThreeWayScopeRaw string
+	compareThreeWayView     string
 	compareThreeWayFormat   string
 	compareThreeWayJSON     bool
 	compareThreeWayFailOn   string
@@ -97,16 +102,26 @@ var compareThreeWayCmd = &cobra.Command{
 	Short: "Compare intent vs rendered vs observed state",
 	Long: `Connected three-way comparison (DRY/WET/LIVE) for a selected scope.
 
-Supported scopes:
+Supported scopes (--scope):
   deploy/my-app            (resource)
   resource:deploy/my-app   (resource)
   namespace/prod           (namespace)
   cluster                  (all namespaces)
 
+View-scoped comparison (--view):
+  Constrain the comparison to live cluster resources whose ConfigHub units
+  are selected by a View's filter. Accepts a bare UUID or a View Explorer
+  URL (paste from the browser address bar). --scope and --view are mutually
+  exclusive. Requires connected mode.
+
 Examples:
   cub-scout compare three-way --scope deploy/payment-api -n prod
   cub-scout compare three-way --scope namespace/prod --format json
   cub-scout compare three-way --scope cluster --format md
+
+  # View-scoped: compare only resources selected by a saved View
+  cub-scout compare three-way --view 806aac53-236c-446d-8ad6-91d6daf6810e
+  cub-scout compare three-way --view 'https://hub.confighub.com/x/view-explorer?view=806aac53-...'
 
   # CI/automation: fail if mismatches found
   cub-scout compare three-way --scope namespace/prod --fail-on warning
@@ -126,6 +141,7 @@ func init() {
 	combinedCmd.AddCommand(compareThreeWayCmd)
 
 	compareThreeWayCmd.Flags().StringVar(&compareThreeWayScopeRaw, "scope", "", "Scope: <kind/name>, resource:<kind/name>, namespace/<ns>, or cluster")
+	compareThreeWayCmd.Flags().StringVar(&compareThreeWayView, "view", "", "View UUID or View Explorer URL; mutually exclusive with --scope (requires connected mode)")
 	compareThreeWayCmd.Flags().StringVarP(&combinedNamespace, "namespace", "n", "", "Namespace override for resource scope")
 	compareThreeWayCmd.Flags().StringVar(&compareThreeWayFormat, "format", "ascii", "Output format: ascii, json, md")
 	compareThreeWayCmd.Flags().BoolVar(&compareThreeWayJSON, "json", false, "Output as JSON (shorthand for --format json)")
@@ -133,9 +149,22 @@ func init() {
 }
 
 func runCompareThreeWay(cmd *cobra.Command, args []string) error {
-	scope, err := parseThreeWayScope(compareThreeWayScopeRaw)
-	if err != nil {
-		return err
+	if compareThreeWayScopeRaw != "" && compareThreeWayView != "" {
+		return fmt.Errorf("--scope and --view are mutually exclusive")
+	}
+
+	var scope threeWayScope
+	if compareThreeWayView != "" {
+		if hub.QuickMode() != hub.Connected {
+			return fmt.Errorf("--view requires ConfigHub authentication (run `cub auth login` or set CONFIGHUB_API_KEY)")
+		}
+		scope = threeWayScope{ScopeType: threeWayScopeView, ScopeValue: compareThreeWayView}
+	} else {
+		var err error
+		scope, err = parseThreeWayScope(compareThreeWayScopeRaw)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Validate --fail-on if provided
@@ -187,7 +216,7 @@ func runCompareThreeWay(cmd *cobra.Command, args []string) error {
 func parseThreeWayScope(raw string) (threeWayScope, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return threeWayScope{}, fmt.Errorf("--scope is required")
+		return threeWayScope{}, fmt.Errorf("one of --scope or --view is required")
 	}
 
 	lower := strings.ToLower(value)
@@ -223,7 +252,7 @@ func parseThreeWayScope(raw string) (threeWayScope, error) {
 }
 
 func buildThreeWayReport(ctx context.Context, scope threeWayScope, failOnThreshold string) (threeWayReport, error) {
-	targets, err := collectThreeWayTargets(scope)
+	targets, err := collectThreeWayTargets(ctx, scope)
 	if err != nil {
 		return threeWayReport{}, err
 	}
@@ -642,7 +671,7 @@ func classifyResourcePattern(result compareResourceResult) ThreeWayPattern {
 	return PatternMultiChange
 }
 
-func collectThreeWayTargets(scope threeWayScope) ([]threeWayTarget, error) {
+func collectThreeWayTargets(ctx context.Context, scope threeWayScope) ([]threeWayTarget, error) {
 	switch scope.ScopeType {
 	case threeWayScopeResource:
 		kindRaw, name, err := parseResourceArg(scope.ScopeValue)
@@ -676,9 +705,88 @@ func collectThreeWayTargets(scope threeWayScope) ([]threeWayTarget, error) {
 			targets = append(targets, workloadsToThreeWayTargets(workloads, ns)...)
 		}
 		return targets, nil
+	case threeWayScopeView:
+		return collectThreeWayTargetsForView(ctx, scope.ScopeValue)
 	default:
 		return nil, fmt.Errorf("unsupported scope type %q", scope.ScopeType)
 	}
+}
+
+// collectThreeWayTargetsForView resolves a View reference to a set of
+// threeWayTargets. The resolution chain is:
+//
+//  1. Parse the view ref (UUID or View Explorer URL).
+//  2. Fetch the View via `cub view get` to extract Filter.Where.
+//  3. Run `cub unit list --where '<clause>'` to get matching unit slugs.
+//  4. Discover all cluster namespaces, then filter workloads whose
+//     UnitSlug matches one of the slugs from step 3.
+//
+// All subprocess calls go through viewCubRunner so tests can inject
+// fake JSON without a live ConfigHub or cluster.
+func collectThreeWayTargetsForView(ctx context.Context, viewRef string) ([]threeWayTarget, error) {
+	ref, err := agent.ParseViewRef(viewRef)
+	if err != nil {
+		return nil, fmt.Errorf("parse view reference: %w", err)
+	}
+
+	viewData, err := fetchView(ctx, ref.UUID, "*")
+	if err != nil {
+		return nil, fmt.Errorf("fetch view %s: %w", ref.UUID, err)
+	}
+
+	whereClause, err := extractWhereClause(viewData)
+	if err != nil {
+		return nil, fmt.Errorf("extract filter from view: %w", err)
+	}
+	if whereClause == "" {
+		return nil, fmt.Errorf("view %s has no Where filter — cannot scope comparison", ref.UUID)
+	}
+
+	unitSlugs, err := listUnitSlugsForFilter(ctx, whereClause, "*")
+	if err != nil {
+		return nil, fmt.Errorf("list units for view filter: %w", err)
+	}
+	if len(unitSlugs) == 0 {
+		return nil, fmt.Errorf("view filter matched no units (check the filter clause or space scope)")
+	}
+
+	slugSet := make(map[string]struct{}, len(unitSlugs))
+	for _, s := range unitSlugs {
+		slugSet[s] = struct{}{}
+	}
+
+	namespaces, err := discoverThreeWayNamespacesFn()
+	if err != nil {
+		return nil, fmt.Errorf("discover namespaces: %w", err)
+	}
+	sort.Strings(namespaces)
+
+	var targets []threeWayTarget
+	for _, ns := range namespaces {
+		workloads, err := discoverThreeWayWorkloadsFn(ns)
+		if err != nil {
+			return nil, err
+		}
+		for _, w := range workloads {
+			if _, ok := slugSet[w.UnitSlug]; !ok {
+				continue
+			}
+			kind := normalizeKind(w.Kind)
+			name := strings.TrimSpace(w.Name)
+			if kind == "" || name == "" {
+				continue
+			}
+			wsNs := strings.TrimSpace(w.Namespace)
+			if wsNs == "" {
+				wsNs = ns
+			}
+			targets = append(targets, threeWayTarget{
+				ResourceArg: kind + "/" + name,
+				Namespace:   wsNs,
+			})
+		}
+	}
+	return targets, nil
 }
 
 func workloadsToThreeWayTargets(workloads []WorkloadInfo, namespace string) []threeWayTarget {
@@ -885,6 +993,14 @@ func (scope threeWayScope) String() string {
 		return scope.ScopeValue
 	case threeWayScopeNamespace:
 		return "namespace/" + scope.ScopeValue
+	case threeWayScopeView:
+		// Prefer "view/<uuid>" regardless of whether the original input was a
+		// UUID or a URL, so output consumers get a stable, compact identifier.
+		ref, err := agent.ParseViewRef(scope.ScopeValue)
+		if err != nil {
+			return "view/" + scope.ScopeValue
+		}
+		return "view/" + ref.UUID
 	default:
 		return scope.ScopeValue
 	}

--- a/cmd/cub-scout/compare_three_way_view_test.go
+++ b/cmd/cub-scout/compare_three_way_view_test.go
@@ -1,0 +1,269 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fakeCubOutput builds a fake viewCubRunner that maps a command pattern to a
+// JSON response. Keys are matched by joining the args with a space and doing a
+// strings.Contains check — enough discrimination for these unit tests.
+func fakeCubOutput(responses map[string]string) cubRunner {
+	return func(_ context.Context, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		for pattern, resp := range responses {
+			if strings.Contains(joined, pattern) {
+				return []byte(resp), nil
+			}
+		}
+		return nil, fmt.Errorf("fakeCubRunner: no response for %q", joined)
+	}
+}
+
+// fakeViewJSON builds the minimal `cub view get` JSON for a View with the
+// given Where clause.
+func fakeViewJSON(whereClause string) string {
+	data := map[string]interface{}{
+		"UUID": "806aac53-236c-446d-8ad6-91d6daf6810e",
+		"Filter": map[string]interface{}{
+			"Where": whereClause,
+		},
+	}
+	b, _ := json.Marshal(data)
+	return string(b)
+}
+
+// fakeUnitListJSON returns a `cub unit list -o json` JSON blob with the given slugs.
+func fakeUnitListJSON(slugs []string) string {
+	type unitRow struct {
+		Slug string `json:"slug"`
+	}
+	rows := make([]unitRow, len(slugs))
+	for i, s := range slugs {
+		rows[i] = unitRow{Slug: s}
+	}
+	b, _ := json.Marshal(rows)
+	return string(b)
+}
+
+// installFakeRunner swaps viewCubRunner for the test duration and restores it.
+func installFakeRunner(t *testing.T, runner cubRunner) {
+	t.Helper()
+	orig := viewCubRunner
+	viewCubRunner = runner
+	t.Cleanup(func() { viewCubRunner = orig })
+}
+
+// installFakeDiscovery replaces the namespace/workload discovery fns for the
+// test duration and restores them.
+func installFakeDiscovery(t *testing.T, namespaceFn func() ([]string, error), workloadFn func(ns string) ([]WorkloadInfo, error)) {
+	t.Helper()
+	origNS := discoverThreeWayNamespacesFn
+	origWL := discoverThreeWayWorkloadsFn
+	discoverThreeWayNamespacesFn = namespaceFn
+	discoverThreeWayWorkloadsFn = workloadFn
+	t.Cleanup(func() {
+		discoverThreeWayNamespacesFn = origNS
+		discoverThreeWayWorkloadsFn = origWL
+	})
+}
+
+// TestCollectThreeWayTargetsForView_HappyPath verifies the full multi-hop
+// resolution: view get → extract filter → unit list → namespace/workload
+// discovery → slug-match → threeWayTarget slice.
+func TestCollectThreeWayTargetsForView_HappyPath(t *testing.T) {
+	const viewUUID = "806aac53-236c-446d-8ad6-91d6daf6810e"
+	const whereClause = "metadata.labels.env = 'prod'"
+
+	installFakeRunner(t, fakeCubOutput(map[string]string{
+		"view get " + viewUUID: fakeViewJSON(whereClause),
+		"unit list":            fakeUnitListJSON([]string{"payment-api", "checkout-svc"}),
+	}))
+
+	installFakeDiscovery(t,
+		func() ([]string, error) { return []string{"prod"}, nil },
+		func(ns string) ([]WorkloadInfo, error) {
+			return []WorkloadInfo{
+				{Kind: "Deployment", Name: "payment-api", Namespace: "prod", UnitSlug: "payment-api"},
+				{Kind: "Deployment", Name: "checkout-svc", Namespace: "prod", UnitSlug: "checkout-svc"},
+				{Kind: "Deployment", Name: "internal-tool", Namespace: "prod", UnitSlug: "internal-tool"}, // not in view
+			}, nil
+		},
+	)
+
+	targets, err := collectThreeWayTargetsForView(context.Background(), viewUUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d: %v", len(targets), targets)
+	}
+
+	// Order from sort.Strings on namespaces, then iteration order within ns.
+	got := make([]string, len(targets))
+	for i, tgt := range targets {
+		got[i] = tgt.Namespace + "/" + tgt.ResourceArg
+	}
+	sort.Strings(got)
+	want := []string{"prod/Deployment/checkout-svc", "prod/Deployment/payment-api"}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("target[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestCollectThreeWayTargetsForView_URLInput verifies that a View Explorer URL
+// is accepted and resolved to the same UUID as passing the UUID directly.
+func TestCollectThreeWayTargetsForView_URLInput(t *testing.T) {
+	const viewUUID = "806aac53-236c-446d-8ad6-91d6daf6810e"
+	const viewURL = "https://hub.confighub.com/x/view-explorer?view=" + viewUUID
+
+	installFakeRunner(t, fakeCubOutput(map[string]string{
+		"view get " + viewUUID: fakeViewJSON("metadata.labels.team = 'platform'"),
+		"unit list":            fakeUnitListJSON([]string{"platform-api"}),
+	}))
+
+	installFakeDiscovery(t,
+		func() ([]string, error) { return []string{"platform"}, nil },
+		func(_ string) ([]WorkloadInfo, error) {
+			return []WorkloadInfo{
+				{Kind: "Deployment", Name: "platform-api", Namespace: "platform", UnitSlug: "platform-api"},
+			}, nil
+		},
+	)
+
+	targets, err := collectThreeWayTargetsForView(context.Background(), viewURL)
+	if err != nil {
+		t.Fatalf("unexpected error from URL input: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if targets[0].ResourceArg != "Deployment/platform-api" {
+		t.Errorf("ResourceArg = %q, want %q", targets[0].ResourceArg, "Deployment/platform-api")
+	}
+}
+
+// TestCollectThreeWayTargetsForView_NoWhereClause verifies that a view with no
+// Filter.Where returns an actionable error rather than an empty result.
+func TestCollectThreeWayTargetsForView_NoWhereClause(t *testing.T) {
+	const viewUUID = "806aac53-236c-446d-8ad6-91d6daf6810e"
+
+	noFilter := `{"UUID":"` + viewUUID + `"}`
+	installFakeRunner(t, fakeCubOutput(map[string]string{
+		"view get " + viewUUID: noFilter,
+	}))
+
+	_, err := collectThreeWayTargetsForView(context.Background(), viewUUID)
+	if err == nil {
+		t.Fatal("expected error for view with no Where clause, got nil")
+	}
+	if !strings.Contains(err.Error(), "no Where filter") {
+		t.Errorf("error %q should mention 'no Where filter'", err.Error())
+	}
+}
+
+// TestCollectThreeWayTargetsForView_NoMatchingUnits verifies that an empty unit
+// list produces an actionable error, not silent empty results.
+func TestCollectThreeWayTargetsForView_NoMatchingUnits(t *testing.T) {
+	const viewUUID = "806aac53-236c-446d-8ad6-91d6daf6810e"
+
+	installFakeRunner(t, fakeCubOutput(map[string]string{
+		"view get " + viewUUID: fakeViewJSON("metadata.labels.env = 'staging'"),
+		"unit list":            `[]`,
+	}))
+
+	_, err := collectThreeWayTargetsForView(context.Background(), viewUUID)
+	if err == nil {
+		t.Fatal("expected error for view that matches no units, got nil")
+	}
+	if !strings.Contains(err.Error(), "matched no units") {
+		t.Errorf("error %q should mention 'matched no units'", err.Error())
+	}
+}
+
+// TestCollectThreeWayTargetsForView_SlugFilterIsStrict verifies that only
+// workloads whose UnitSlug appears in the view's unit list are included; all
+// others are silently excluded (not errors).
+func TestCollectThreeWayTargetsForView_SlugFilterIsStrict(t *testing.T) {
+	const viewUUID = "806aac53-236c-446d-8ad6-91d6daf6810e"
+
+	installFakeRunner(t, fakeCubOutput(map[string]string{
+		"view get " + viewUUID: fakeViewJSON("metadata.labels.team = 'payments'"),
+		"unit list":            fakeUnitListJSON([]string{"payments-api"}),
+	}))
+
+	installFakeDiscovery(t,
+		func() ([]string, error) { return []string{"prod", "staging"}, nil },
+		func(ns string) ([]WorkloadInfo, error) {
+			// Both namespaces have the same workload names but only "payments-api"
+			// is in the view. "unrelated" must be excluded.
+			return []WorkloadInfo{
+				{Kind: "Deployment", Name: "payments-api", Namespace: ns, UnitSlug: "payments-api"},
+				{Kind: "Deployment", Name: "unrelated", Namespace: ns, UnitSlug: "other-unit"},
+			}, nil
+		},
+	)
+
+	targets, err := collectThreeWayTargetsForView(context.Background(), viewUUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Two namespaces × one matching workload = 2 targets.
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets (one per namespace), got %d: %v", len(targets), targets)
+	}
+	for _, tgt := range targets {
+		if tgt.ResourceArg != "Deployment/payments-api" {
+			t.Errorf("unexpected target %v — only payments-api should be included", tgt)
+		}
+	}
+}
+
+// TestThreeWayScopeView_String verifies that the Scope field in the report
+// is "view/<uuid>" for both UUID and URL inputs.
+func TestThreeWayScopeView_String(t *testing.T) {
+	const uuid = "806aac53-236c-446d-8ad6-91d6daf6810e"
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{uuid, "view/" + uuid},
+		{"https://hub.confighub.com/x/view-explorer?view=" + uuid, "view/" + uuid},
+	}
+	for _, tc := range cases {
+		scope := threeWayScope{ScopeType: threeWayScopeView, ScopeValue: tc.input}
+		if got := scope.String(); got != tc.want {
+			t.Errorf("String() for %q = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestRunCompareThreeWay_MutualExclusion verifies that passing both --scope
+// and --view returns a clear error.
+func TestRunCompareThreeWay_MutualExclusion(t *testing.T) {
+	orig := compareThreeWayScopeRaw
+	origView := compareThreeWayView
+	compareThreeWayScopeRaw = "cluster"
+	compareThreeWayView = "806aac53-236c-446d-8ad6-91d6daf6810e"
+	t.Cleanup(func() {
+		compareThreeWayScopeRaw = orig
+		compareThreeWayView = origView
+	})
+
+	err := runCompareThreeWay(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for --scope + --view, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error %q should mention 'mutually exclusive'", err.Error())
+	}
+}

--- a/cmd/cub-scout/views.go
+++ b/cmd/cub-scout/views.go
@@ -139,12 +139,23 @@ func runViewsResolve(cmd *cobra.Command, args []string) error {
 	return emitResolvedView(out)
 }
 
+// cubRunner is the function signature for shelling out to `cub`. The
+// package-level var viewCubRunner holds the production implementation;
+// tests inject a fake to avoid real subprocess calls.
+type cubRunner func(ctx context.Context, args ...string) ([]byte, error)
+
+// viewCubRunner is the seam used by fetchView and listUnitSlugsForFilter.
+// Tests replace it with a function that returns prefab JSON, giving full
+// coverage of the multi-hop resolution path without a real `cub` binary.
+var viewCubRunner cubRunner = func(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "cub", args...).Output()
+}
+
 // fetchView shells out to `cub view get` to fetch the View JSON. The
 // `--space "*"` default makes a UUID alone sufficient (org-wide
 // search); narrower callers can pass --space <slug>.
 func fetchView(ctx context.Context, uuid, space string) (map[string]interface{}, error) {
-	args := []string{"view", "get", uuid, "--space", space, "--json"}
-	out, err := exec.CommandContext(ctx, "cub", args...).Output()
+	out, err := viewCubRunner(ctx, "view", "get", uuid, "--space", space, "--json")
 	if err != nil {
 		return nil, fmt.Errorf("cub view get failed: %w", err)
 	}
@@ -153,6 +164,45 @@ func fetchView(ctx context.Context, uuid, space string) (map[string]interface{},
 		return nil, fmt.Errorf("parse cub output: %w", err)
 	}
 	return raw, nil
+}
+
+// extractWhereClause reads the Filter.Where string from a `cub view get`
+// JSON blob. Returns an empty string (not an error) if the view has no
+// Where clause so callers can decide whether to block or skip.
+func extractWhereClause(view map[string]interface{}) (string, error) {
+	filter, ok := view["Filter"]
+	if !ok {
+		return "", nil
+	}
+	filterMap, ok := filter.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("view Filter is not an object")
+	}
+	where, _ := filterMap["Where"].(string)
+	return where, nil
+}
+
+// listUnitSlugsForFilter runs `cub unit list --where '<clause>'` and
+// returns the matching unit slugs. Uses viewCubRunner so tests can inject
+// prefab JSON without a live ConfigHub instance.
+func listUnitSlugsForFilter(ctx context.Context, whereClause, space string) ([]string, error) {
+	out, err := viewCubRunner(ctx, "unit", "list", "--space", space, "--where", whereClause, "-o", "json")
+	if err != nil {
+		return nil, fmt.Errorf("cub unit list: %w", err)
+	}
+	var units []struct {
+		Slug string `json:"slug"`
+	}
+	if err := json.Unmarshal(out, &units); err != nil {
+		return nil, fmt.Errorf("parse unit list: %w", err)
+	}
+	slugs := make([]string, 0, len(units))
+	for _, u := range units {
+		if u.Slug != "" {
+			slugs = append(slugs, u.Slug)
+		}
+	}
+	return slugs, nil
 }
 
 func emitResolvedView(rv ResolvedView) error {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -42,7 +42,7 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `import cluster-aggregator` | Aggregate multiple import proposals into a fleet view | v1.0 |
 | `import parse-repo` | Parse GitOps repository structure for import preview | v1.0 |
 | `compare` (alias: `combined`) | Compare Git and cluster/bundle structures, or show LIVE snapshot for one resource | v1.0 |
-| `compare three-way` | Connected intent/render/observed comparison for resource/namespace/cluster scopes | v1.6 |
+| `compare three-way` | Connected intent/render/observed comparison for resource/namespace/cluster/view scopes | v1.6 |
 | `context-pack` | Export deterministic AI context JSON bundle | v1.8 |
 | `debug` | Guided GitOps debugging wizard | v0.14.2 |
 | `discover` | Scout-style workload discovery | v0.5 |
@@ -1209,15 +1209,23 @@ Connected three-way comparison command for selected scopes.
 
 ```bash
 cub-scout compare three-way --scope <scope> [flags]
+cub-scout compare three-way --view <uuid-or-url> [flags]
 ```
 
-Supported scopes:
+Scoping options (mutually exclusive):
+
+**`--scope`** — explicit scope string:
 - `<kind/name>` or `resource:<kind/name>` (single resource)
 - `namespace/<ns>` (all workloads in namespace)
 - `cluster` (all discovered namespaces/workloads)
 
+**`--view <uuid-or-url>`** — constrain to the cluster resources whose
+ConfigHub units match a saved View's filter. Accepts a bare UUID or a View
+Explorer URL (paste from the browser address bar). Requires connected mode.
+`report.scope` is set to `view/<uuid>` in JSON output.
+
 Flags:
-- `--scope` (required)
+- `--scope` / `--view` (one required; mutually exclusive)
 - `-n, --namespace` (resource scope namespace override)
 - `--format ascii|json|md`
 - `--json` (shorthand for `--format json`)
@@ -1235,6 +1243,10 @@ cub-scout compare three-way --scope namespace/prod --format json
 # Cluster scope
 cub-scout compare three-way --scope cluster --format md
 
+# View-scoped: compare only resources selected by a saved View
+cub-scout compare three-way --view 806aac53-236c-446d-8ad6-91d6daf6810e
+cub-scout compare three-way --view 'https://hub.confighub.com/x/view-explorer?view=806aac53-...'
+
 # CI / automation
 cub-scout compare three-way --scope namespace/prod --fail-on warning
 ```
@@ -1244,6 +1256,7 @@ Output notes:
 - JSON includes `summary.agreement.{state,summary,reasons,sources}`
 - agreement states are `agreed`, `converging`, `diverged`, and `partial`
 - conformance exit codes still depend only on JSON facts + `--fail-on`
+- `--view` resolution chain: `cub view get` → extract `Filter.Where` → `cub unit list --where` → label-match cluster workloads
 
 ---
 
@@ -2301,7 +2314,6 @@ construction. Auth only matters once the browser reaches View Explorer.
 
 ### v0.1 scope items still pending
 
-- `--view <uuid-or-url>` filter on `compare three-way` / `map list` (scope item #1) — multi-hop CLI resolution, separate PR.
 - View column projection in TUI Hub view (scope item #2).
 - Reality overlay composing View columns with #393 source-truth verdicts (scope item #3) — unblocked now that the contract is in main.
 


### PR DESCRIPTION
## Summary

Closes #408. Delivers #391 scope item #1: `--view <uuid-or-url>` on `compare three-way`.

- **`--view` flag** accepts a bare UUID or View Explorer URL (URL-as-positional convention from #403). Mutually exclusive with `--scope`. Requires connected mode.
- **Resolution chain**: `cub view get` → extract `Filter.Where` → `cub unit list --where` → slug-match cluster workloads → `[]threeWayTarget`
- **`report.Scope`** is `view/<uuid>` for both UUID and URL inputs — stable, compact identifier for downstream consumers
- **`cubRunner` testability seam**: `viewCubRunner` func var replaces direct `exec.Command` calls in `views.go`, unblocking subprocess-injection tests without a live `cub` binary (also benefits `views resolve` going forward)

## Test plan

- [ ] 7 new unit tests in `compare_three_way_view_test.go` — all green
  - `HappyPath`: full multi-hop chain, 2 matching workloads from 3
  - `URLInput`: View Explorer URL resolves to same UUID as bare UUID
  - `NoWhereClause`: actionable error when view has no filter
  - `NoMatchingUnits`: actionable error when filter returns empty list
  - `SlugFilterIsStrict`: non-matching workloads excluded, not errored
  - `Scope.String()`: `view/<uuid>` for both UUID and URL inputs
  - `MutualExclusion`: `--scope` + `--view` together returns clear error
- [ ] `go test ./...` — all 37 packages pass

## What's still open in #391

- Scope item #2: View column projection in TUI Hub view
- Scope item #3: Reality overlay composing View columns with source-truth verdicts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)