### PR TITLE
feat: source-truth v0.2 multi-source Argo gap (#409 Phase 3)

### DIFF
--- a/cmd/cub-scout/source_truth.go
+++ b/cmd/cub-scout/source_truth.go
@@ -326,6 +326,7 @@ func controllerSurfaceFromArgo(ctx context.Context, kind, name, namespace string
 		Source:           strings.TrimSpace(firstNonEmpty(root.URL, root.Kind)),
 		RevisionOrDigest: strings.TrimSpace(root.Revision),
 		Health:           controllerHealthLabel(root.Ready, root.Status),
+		MultiSource:      res.MultiSource,
 	}
 }
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1356,8 +1356,10 @@ plus strategy-relative correctness) until the ConfigHub-side field exists.
 
 Other known v0.2 gaps:
 - **Multi-source Argo Applications** (`spec.sources[]`, plural): only the
-  first source is parsed. Multi-source apps will be flagged with an
-  explicit proof gap in a follow-up.
+  first source is parsed. Detected and surfaced via
+  `proof_gaps: ["controller.multi_source"]` (#409 Phase 3) — the verdict
+  is always `WATCH` / `INCOMPLETE` regardless of strategy, because
+  equality across un-parsed sources is unverifiable.
 - Runtime kinds in v0.2: `Deployment`, `StatefulSet`, `DaemonSet`. Other
   kinds emit a `BLOCK` with the reason naming the unsupported kind.
 

--- a/pkg/agent/argo_trace.go
+++ b/pkg/agent/argo_trace.go
@@ -199,6 +199,17 @@ type argoOwnerRef struct {
 	Controller *bool  `json:"controller,omitempty"`
 }
 
+// argoSource is one entry in spec.source (singular) or spec.sources (plural).
+// Argo CD ≥ v2.6 supports multi-source Applications via spec.sources[]; older
+// apps use spec.source. Both shapes are parsed into argoSource so the rest of
+// the tracer is shape-agnostic.
+type argoSource struct {
+	RepoURL        string `json:"repoURL"`
+	Path           string `json:"path"`
+	TargetRevision string `json:"targetRevision"`
+	Chart          string `json:"chart"`
+}
+
 // argoApp represents the structure of argocd app get output
 type argoApp struct {
 	Metadata struct {
@@ -209,12 +220,8 @@ type argoApp struct {
 		OwnerReferences []argoOwnerRef    `json:"ownerReferences,omitempty"`
 	} `json:"metadata"`
 	Spec struct {
-		Source struct {
-			RepoURL        string `json:"repoURL"`
-			Path           string `json:"path"`
-			TargetRevision string `json:"targetRevision"`
-			Chart          string `json:"chart"`
-		} `json:"source"`
+		Source  argoSource   `json:"source"`
+		Sources []argoSource `json:"sources,omitempty"`
 		Destination struct {
 			Server    string `json:"server"`
 			Namespace string `json:"namespace"`
@@ -260,6 +267,17 @@ func (a *ArgoTracer) parseAppOutput(data []byte, appName, namespace string) (*Tr
 		return nil, fmt.Errorf("parse argocd output: %w", err)
 	}
 
+	// Argo CD ≥ v2.6 supports spec.sources[] (plural). For single-source apps
+	// expressed as a one-element array, copy Sources[0] into Source so the rest
+	// of the parser is shape-agnostic. For multi-source apps (len > 1) we still
+	// pick the first source for the chain link, but flag the result so #409's
+	// equality logic emits an explicit "controller.multi_source" proof gap —
+	// cub-scout cannot honestly assert equality across sources it didn't parse.
+	if app.Spec.Source.RepoURL == "" && len(app.Spec.Sources) > 0 {
+		app.Spec.Source = app.Spec.Sources[0]
+	}
+	multiSource := len(app.Spec.Sources) > 1
+
 	result := &TraceResult{
 		Object: ResourceRef{
 			Kind:      "Application",
@@ -270,6 +288,7 @@ func (a *ArgoTracer) parseAppOutput(data []byte, appName, namespace string) (*Tr
 		FullyManaged: true,
 		Tool:         "argocd",
 		TracedAt:     time.Now(),
+		MultiSource:  multiSource,
 	}
 
 	sourceSync := strings.TrimSpace(app.Status.Sync.Status)

--- a/pkg/agent/argo_trace_test.go
+++ b/pkg/agent/argo_trace_test.go
@@ -296,6 +296,73 @@ func TestArgoTracerParseAppOutputError(t *testing.T) {
 	}
 }
 
+// TestArgoTracer_MultiSource covers Argo CD ≥ v2.6 spec.sources[]
+// detection (#409 Phase 3). Single-source apps use spec.source; new-form
+// single-source apps use a one-element spec.sources[]; multi-source apps
+// have len > 1. Only the last form should set MultiSource=true.
+func TestArgoTracer_MultiSource(t *testing.T) {
+	tracer := &ArgoTracer{}
+
+	cases := []struct {
+		name           string
+		json           string
+		wantMultiSrc   bool
+		wantSourceURL  string
+	}{
+		{
+			name: "legacy single-source via spec.source",
+			json: `{
+				"metadata": {"name": "a", "namespace": "argocd"},
+				"spec": {"source": {"repoURL": "https://github.com/x/y", "targetRevision": "abc"}, "destination": {}},
+				"status": {"sync": {}, "health": {}}
+			}`,
+			wantMultiSrc:  false,
+			wantSourceURL: "https://github.com/x/y",
+		},
+		{
+			name: "single-source new form: spec.sources[] with one entry",
+			json: `{
+				"metadata": {"name": "a", "namespace": "argocd"},
+				"spec": {"sources": [{"repoURL": "https://github.com/x/y", "targetRevision": "abc"}], "destination": {}},
+				"status": {"sync": {}, "health": {}}
+			}`,
+			wantMultiSrc:  false,
+			wantSourceURL: "https://github.com/x/y",
+		},
+		{
+			name: "multi-source: spec.sources[] with two entries",
+			json: `{
+				"metadata": {"name": "a", "namespace": "argocd"},
+				"spec": {"sources": [
+					{"repoURL": "https://github.com/x/y", "targetRevision": "abc"},
+					{"repoURL": "https://charts.example.com", "chart": "redis", "targetRevision": "17.0.0"}
+				], "destination": {}},
+				"status": {"sync": {}, "health": {}}
+			}`,
+			wantMultiSrc:  true,
+			wantSourceURL: "https://github.com/x/y",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tracer.parseAppOutput([]byte(tc.json), "a", "argocd")
+			if err != nil {
+				t.Fatalf("parseAppOutput error: %v", err)
+			}
+			if res.MultiSource != tc.wantMultiSrc {
+				t.Errorf("MultiSource = %v, want %v", res.MultiSource, tc.wantMultiSrc)
+			}
+			if len(res.Chain) == 0 {
+				t.Fatal("chain is empty")
+			}
+			if res.Chain[0].URL != tc.wantSourceURL {
+				t.Errorf("Chain[0].URL = %q, want %q", res.Chain[0].URL, tc.wantSourceURL)
+			}
+		})
+	}
+}
+
 func TestArgoTrace_SourceSyncSignals_OutOfSync(t *testing.T) {
 	tracer := NewArgoTracer()
 

--- a/pkg/agent/source_truth.go
+++ b/pkg/agent/source_truth.go
@@ -200,6 +200,14 @@ type ControllerSurface struct {
 	Source           string `json:"source,omitempty"`            // observed source URL/identifier
 	RevisionOrDigest string `json:"revision_or_digest,omitempty"` // SHA, digest, tag the controller observed
 	Health           string `json:"health,omitempty"`            // human label: "Ready", "Reconciling", etc.
+
+	// MultiSource is true when the controller observes multiple sources
+	// (Argo CD's spec.sources[] with len > 1). cub-scout parses the first
+	// source for the rest of the surface; equality across sources beyond
+	// index 0 is unverifiable, so Derive emits an explicit
+	// "controller.multi_source" proof gap. Strategy-agnostic — the gap
+	// applies under any declared strategy.
+	MultiSource bool `json:"multi_source,omitempty"`
 }
 
 // RuntimeSurface is what cub-scout reads from the live cluster.

--- a/pkg/agent/source_truth_logic.go
+++ b/pkg/agent/source_truth_logic.go
@@ -249,6 +249,18 @@ type revisionAgreement struct {
 // v0.1's presence-based behaviour pending the ConfigHub-side rendered-
 // digest field.
 func compareRevisions(strategy SourceTruthStrategy, surfaces SourceTruthSurfaces) revisionAgreement {
+	// Multi-source is strategy-agnostic. If the controller declares more
+	// than one source and cub-scout only parsed the first, equality
+	// across the un-parsed sources is fundamentally unverifiable —
+	// regardless of strategy, regardless of whether the parsed source
+	// matches the runtime. Surface as an explicit proof gap.
+	if surfaces.Controller != nil && surfaces.Controller.MultiSource {
+		return revisionAgreement{
+			Incomplete: true,
+			ProofGaps:  []string{"controller.multi_source"},
+		}
+	}
+
 	switch strategy {
 	case StrategyGitArgo, StrategyGitFlux:
 		return compareGitRevisions(surfaces)

--- a/pkg/agent/source_truth_logic_test.go
+++ b/pkg/agent/source_truth_logic_test.go
@@ -336,6 +336,49 @@ func TestDerive_GitMismatch_ControllerOutlier(t *testing.T) {
 	}
 }
 
+// TestDerive_MultiSourceArgo_IncompleteRegardlessOfStrategy locks in the
+// Phase 3 rule: when the controller surface flags MultiSource=true,
+// equality is unverifiable beyond the parsed source. Derive must emit
+// the proof gap and downgrade to WATCH/INCOMPLETE under any strategy —
+// even when the parsed source's anchor would otherwise have produced
+// a clean PASS.
+func TestDerive_MultiSourceArgo_IncompleteRegardlessOfStrategy(t *testing.T) {
+	strategies := []SourceTruthStrategy{
+		StrategyGitArgo,
+		StrategyGitFlux,
+		StrategyConfigHubOCIArgo,
+		StrategyConfigHubOCIFlux,
+	}
+
+	for _, strategy := range strategies {
+		t.Run(string(strategy), func(t *testing.T) {
+			ev := Derive(strategy, SourceTruthSurfaces{
+				ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "rag-server", Revision: "47"},
+				Controller: &ControllerSurface{
+					Kind:             "Argo",
+					Source:           "oci://oci.confighub.com/demo/rag-server",
+					RevisionOrDigest: "abc123def456",
+					Health:           "Synced/Healthy",
+					MultiSource:      true,
+				},
+				Runtime: &RuntimeSurface{
+					Resource: "Deployment/rag-server in demo",
+					Field:    "spec.template.spec.containers[0].image",
+					Value:    "ghcr.io/example/rag:v1.2.3-abc123de",
+					Health:   "Current",
+				},
+			})
+
+			if ev.Status == StatusPASS {
+				t.Fatalf("status = PASS with multi_source=true under strategy %s — equality across un-parsed sources cannot be PASS", strategy)
+			}
+			if !containsString(ev.ProofGaps, "controller.multi_source") {
+				t.Errorf("proof_gaps = %v, want to contain controller.multi_source", ev.ProofGaps)
+			}
+		})
+	}
+}
+
 // TestNormalizeGitSHA_AcceptsCommonShapes locks in the parser's
 // tolerance for the shapes the existing tracers emit.
 func TestNormalizeGitSHA_AcceptsCommonShapes(t *testing.T) {

--- a/pkg/agent/trace.go
+++ b/pkg/agent/trace.go
@@ -56,6 +56,12 @@ type TraceResult struct {
 	// "explicit" = ownerReference, "inferred" = label/annotation match.
 	LineageConfidence string `json:"lineageConfidence,omitempty"`
 
+	// MultiSource is true when the controller declares multiple sources (e.g.
+	// Argo CD's spec.sources[] with len > 1). cub-scout only parses the first
+	// source today; downstream consumers (#409 Phase 3) treat this as an
+	// equality proof gap.
+	MultiSource bool `json:"multiSource,omitempty"`
+
 	// Secrets contains evidence about secrets referenced by the traced resource.
 	// Only populated for workloads (Deployment, StatefulSet, DaemonSet, Pod) and
 	// Flux sources/deployers. Does NOT expose secret data, only safe metadata.

--- a/test/fixtures/source-truth/09-watch-argo-multi-source/expected.json
+++ b/test/fixtures/source-truth/09-watch-argo-multi-source/expected.json
@@ -1,0 +1,30 @@
+{
+  "declared_strategy": "Git -> Argo -> Kubernetes",
+  "status": "WATCH",
+  "source_truth": "INCOMPLETE",
+  "outlier": "unknown",
+  "surfaces": {
+    "confighub": {
+      "space": "demo",
+      "unit": "rag-server",
+      "revision": "47"
+    },
+    "controller": {
+      "kind": "Argo",
+      "source": "https://github.com/example/rag-deploy",
+      "revision_or_digest": "abc123def456",
+      "health": "Synced/Healthy",
+      "multi_source": true
+    },
+    "runtime": {
+      "resource": "Deployment/rag-server in demo",
+      "field": "spec.template.spec.containers[0].image",
+      "value": "ghcr.io/example/rag:v1.2.3-abc123de",
+      "health": "Current"
+    }
+  },
+  "proof_gaps": [
+    "controller.multi_source"
+  ],
+  "safe_next_action": "Read-only diagnostic: confirm the missing fields (controller.multi_source) before acceptance."
+}

--- a/test/fixtures/source-truth/09-watch-argo-multi-source/strategy.txt
+++ b/test/fixtures/source-truth/09-watch-argo-multi-source/strategy.txt
@@ -1,0 +1,1 @@
+git-argo

--- a/test/fixtures/source-truth/09-watch-argo-multi-source/surfaces.json
+++ b/test/fixtures/source-truth/09-watch-argo-multi-source/surfaces.json
@@ -1,0 +1,20 @@
+{
+  "confighub": {
+    "space": "demo",
+    "unit": "rag-server",
+    "revision": "47"
+  },
+  "controller": {
+    "kind": "Argo",
+    "source": "https://github.com/example/rag-deploy",
+    "revision_or_digest": "abc123def456",
+    "health": "Synced/Healthy",
+    "multi_source": true
+  },
+  "runtime": {
+    "resource": "Deployment/rag-server in demo",
+    "field": "spec.template.spec.containers[0].image",
+    "value": "ghcr.io/example/rag:v1.2.3-abc123de",
+    "health": "Current"
+  }
+}

--- a/test/fixtures/source-truth/README.md
+++ b/test/fixtures/source-truth/README.md
@@ -19,7 +19,7 @@ test/fixtures/source-truth/
 │   └── expected.json   exact byte-equal SourceTruthEvidence output
 ```
 
-## What this covers (8 fixtures)
+## What this covers (9 fixtures)
 
 | # | Strategy | Verdict | Council case |
 |---|---|---|---|
@@ -31,6 +31,7 @@ test/fixtures/source-truth/
 | 06 | (empty) | `ASK` / `UNKNOWN` | empty strategy short-circuits to ASK |
 | 07 | `git-argo` | `BLOCK` / `MISMATCH` outlier=controller | **v0.2** cross-surface mismatch — controller and runtime image tag carry different SHAs |
 | 08 | `git-flux` | `WATCH` / `INCOMPLETE` proof_gap=`runtime.commit_sha_anchor` | **v0.2** runtime image has a semver tag with no SHA segment — equality unverifiable |
+| 09 | `git-argo` | `WATCH` / `INCOMPLETE` proof_gap=`controller.multi_source` | **v0.2 Phase 3** Argo Application has multiple sources; equality across un-parsed sources is unverifiable regardless of strategy |
 
 ## Adding a fixture
 

--- a/test/unit/release_distribution_contract_test.go
+++ b/test/unit/release_distribution_contract_test.go
@@ -27,9 +27,9 @@ type goreleaserConfig struct {
 			Formats []string `yaml:"formats"`
 		} `yaml:"format_overrides"`
 	} `yaml:"archives"`
-	Brews []struct {
+	HomebrewCasks []struct {
 		Name string `yaml:"name"`
-	} `yaml:"brews"`
+	} `yaml:"homebrew_casks"`
 	Dockers []struct {
 		ImageTemplates []string `yaml:"image_templates"`
 	} `yaml:"dockers"`
@@ -104,8 +104,8 @@ func TestGoReleaser_DistributionTargets(t *testing.T) {
 		t.Fatal("expected default archive to allow different binary counts across platforms")
 	}
 
-	if len(cfg.Brews) == 0 {
-		t.Fatal("expected at least one Homebrew config in goreleaser")
+	if len(cfg.HomebrewCasks) == 0 {
+		t.Fatal("expected at least one homebrew_casks entry in goreleaser (post-#389 / #413 migration)")
 	}
 	if len(cfg.Dockers) == 0 {
 		t.Fatal("expected at least one Docker image config in goreleaser")


### PR DESCRIPTION
## Summary

#409 Phase 3. Detect Argo CD multi-source Applications (`spec.sources[]` with len > 1) and surface as an explicit proof gap rather than silently producing a verdict based on the first source alone.

### What changed

- **argo tracer**: parses `spec.sources[]` alongside `spec.source`. Single-source apps in either form parse to identical shape; multi-source apps set `TraceResult.MultiSource = true`.
- **`ControllerSurface.MultiSource`**: optional bool field carries the signal into `Derive`.
- **`compareRevisions`**: short-circuits with `proof_gaps: [\"controller.multi_source\"]` when set, before strategy-specific equality. Strategy-agnostic — multi-source never produces PASS under any strategy.

### Drive-by

`test/unit/release_distribution_contract_test.go` was still using the old `brews:` YAML key after #413's `homebrew_casks:` migration. One-line fix included so the suite goes green again.

## Test plan

- [ ] Fixture 09 (`09-watch-argo-multi-source`) lands at byte-equal golden
- [ ] `TestArgoTracer_MultiSource`: three input shapes (legacy `spec.source`, new-form single-source `sources[]`, multi-source `sources[]`)
- [ ] `TestDerive_MultiSourceArgo_IncompleteRegardlessOfStrategy`: sweeps all four strategies — none produce PASS when `MultiSource=true`
- [ ] All existing fixtures (01-08) still byte-equal
- [ ] Full `go test ./...` green (37 packages)

## What's still open in #409

- Phase 2 (next): strategy enum expansion (`helm-*`, `kustomize-flux`, `oci-*` non-ConfigHub)
- OCI-strategy equality: still parked on the ConfigHub-side `Unit.RenderedDigest` field

🤖 Generated with [Claude Code](https://claude.ai/claude-code)