### PR TITLE
feat: source-truth v0.2 strategy enum expansion (#409 Phase 2)

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1278,12 +1278,17 @@ cub-scout compare source-truth <kind>/<name> -n <namespace> --strategy <name>
 
 `--strategy` is required input. cub-scout never infers the delivery path.
 
-| Strategy | Delivery path |
-|----------|---------------|
-| `confighub-oci-argo` | ConfigHub → OCI → Argo CD → Kubernetes |
-| `confighub-oci-flux` | ConfigHub → OCI → Flux → Kubernetes |
-| `git-argo` | Git → Argo CD → Kubernetes |
-| `git-flux` | Git → Flux → Kubernetes |
+| Strategy | Delivery path | Equality anchor |
+|----------|---------------|-----------------|
+| `confighub-oci-argo` | ConfigHub → OCI → Argo CD → Kubernetes | OCI digest *(deferred)* |
+| `confighub-oci-flux` | ConfigHub → OCI → Flux → Kubernetes | OCI digest *(deferred)* |
+| `git-argo` | Git → Argo CD → Kubernetes | Git commit SHA |
+| `git-flux` | Git → Flux → Kubernetes | Git commit SHA |
+| `helm-argo` | Helm → Argo CD → Kubernetes | Chart version *(runtime extractor pending)* |
+| `helm-flux` | Helm → Flux → Kubernetes | Chart version *(runtime extractor pending)* |
+| `kustomize-flux` | Kustomize over Git → Flux → Kubernetes | Git commit SHA |
+| `oci-argo` | OCI (non-ConfigHub) → Argo CD → Kubernetes | OCI digest |
+| `oci-flux` | OCI (non-ConfigHub) → Flux → Kubernetes | OCI digest |
 
 ### Output contract
 
@@ -1347,14 +1352,19 @@ cub scout compare source-truth Deployment rag-server -n demo --strategy git-argo
 
 ### Limitations
 
-v0.2 (#409) ships cross-surface revision equality for the **git-* strategies
-only**. Equality for `confighub-oci-*` strategies is still deferred: ConfigHub
-does not yet expose a rendered OCI digest per unit revision, so cub-scout
-cannot honestly assert that the controller pulled *the* ConfigHub-rendered
-artifact. OCI strategies retain v0.1 behaviour (presence-based gap detection
-plus strategy-relative correctness) until the ConfigHub-side field exists.
+v0.2 (#409) ships cross-surface revision equality for git-*, kustomize-flux,
+and oci-* (non-ConfigHub) strategies. Equality for `confighub-oci-*` is still
+deferred: ConfigHub does not yet expose a rendered OCI digest per unit
+revision, so cub-scout cannot honestly assert that the controller pulled *the*
+ConfigHub-rendered artifact. The `confighub-oci-*` strategies retain v0.1
+behaviour (presence-based gap detection plus strategy-relative correctness)
+until the ConfigHub-side field exists.
 
 Other known v0.2 gaps:
+- **Helm strategies** (`helm-flux`, `helm-argo`): the chart-version anchor
+  is read from the runtime via `helm.sh/chart` labels, but the extractor
+  isn't wired into `RuntimeSurface` yet. Until then, helm-* strategies emit
+  `proof_gaps: ["runtime.helm_chart_anchor"]` and never PASS.
 - **Multi-source Argo Applications** (`spec.sources[]`, plural): only the
   first source is parsed. Detected and surfaced via
   `proof_gaps: ["controller.multi_source"]` (#409 Phase 3) — the verdict

--- a/pkg/agent/source_truth.go
+++ b/pkg/agent/source_truth.go
@@ -57,17 +57,49 @@ const (
 
 	// StrategyGitFlux: vanilla GitOps with Flux.
 	StrategyGitFlux SourceTruthStrategy = "git-flux"
+
+	// StrategyHelmArgo: Argo CD pulls a Helm chart from a chart registry
+	// and applies to Kubernetes. Source-of-truth anchor is the chart
+	// version. ConfigHub is not in the chain.
+	StrategyHelmArgo SourceTruthStrategy = "helm-argo"
+
+	// StrategyHelmFlux: Flux pulls a Helm chart via HelmRepository or
+	// HelmChart and applies to Kubernetes. Same anchor shape as
+	// helm-argo.
+	StrategyHelmFlux SourceTruthStrategy = "helm-flux"
+
+	// StrategyKustomizeFlux: Flux Kustomization built from a Git source.
+	// Source-of-truth anchor is the Git commit SHA — equality semantics
+	// match git-flux but the controller-source shape is a GitRepository
+	// + a Kustomization overlay.
+	StrategyKustomizeFlux SourceTruthStrategy = "kustomize-flux"
+
+	// StrategyOCIArgo: Argo CD pulls an OCI artifact from a non-ConfigHub
+	// registry. Source-of-truth anchor is the OCI digest. Distinct from
+	// confighub-oci-argo in that ConfigHub is not in the chain — equality
+	// is controller↔runtime only.
+	StrategyOCIArgo SourceTruthStrategy = "oci-argo"
+
+	// StrategyOCIFlux: Flux OCIRepository pointed at a non-ConfigHub
+	// registry. Same anchor shape as oci-argo.
+	StrategyOCIFlux SourceTruthStrategy = "oci-flux"
 )
 
-// AllStrategies is the closed enum of strategies v0.1 understands. Adding
-// a strategy requires updating expectsConfigHubOCISource and the human
-// rendering below.
+// AllStrategies is the closed enum of strategies cub-scout understands.
+// Adding a strategy requires updating expectsConfigHubOCISource,
+// ExpectsArgoController, the Human rendering, and compareRevisions
+// dispatch.
 func AllStrategies() []SourceTruthStrategy {
 	return []SourceTruthStrategy{
 		StrategyConfigHubOCIArgo,
 		StrategyConfigHubOCIFlux,
 		StrategyGitArgo,
 		StrategyGitFlux,
+		StrategyHelmArgo,
+		StrategyHelmFlux,
+		StrategyKustomizeFlux,
+		StrategyOCIArgo,
+		StrategyOCIFlux,
 	}
 }
 
@@ -102,6 +134,16 @@ func (s SourceTruthStrategy) Human() string {
 		return "Git -> Argo -> Kubernetes"
 	case StrategyGitFlux:
 		return "Git -> Flux -> Kubernetes"
+	case StrategyHelmArgo:
+		return "Helm -> Argo -> Kubernetes"
+	case StrategyHelmFlux:
+		return "Helm -> Flux -> Kubernetes"
+	case StrategyKustomizeFlux:
+		return "Kustomize -> Flux -> Kubernetes"
+	case StrategyOCIArgo:
+		return "OCI -> Argo -> Kubernetes"
+	case StrategyOCIFlux:
+		return "OCI -> Flux -> Kubernetes"
 	default:
 		return string(s)
 	}
@@ -109,7 +151,9 @@ func (s SourceTruthStrategy) Human() string {
 
 // expectsConfigHubOCISource reports whether the strategy requires the
 // controller surface to be reading from a ConfigHub-rendered OCI artifact
-// (vs. directly from Git).
+// (vs. directly from Git). The non-ConfigHub OCI strategies (oci-flux,
+// oci-argo) intentionally return false — they accept any OCI registry,
+// not just ConfigHub.
 func (s SourceTruthStrategy) expectsConfigHubOCISource() bool {
 	return s == StrategyConfigHubOCIArgo || s == StrategyConfigHubOCIFlux
 }
@@ -120,7 +164,11 @@ func (s SourceTruthStrategy) expectsConfigHubOCISource() bool {
 // because that would mask the controller-kind mismatch the contract is
 // supposed to surface.
 func (s SourceTruthStrategy) ExpectsArgoController() bool {
-	return s == StrategyConfigHubOCIArgo || s == StrategyGitArgo
+	switch s {
+	case StrategyConfigHubOCIArgo, StrategyGitArgo, StrategyHelmArgo, StrategyOCIArgo:
+		return true
+	}
+	return false
 }
 
 // SourceTruthStatus is cub-scout's evidence-quality verdict. Pilot layers

--- a/pkg/agent/source_truth_logic.go
+++ b/pkg/agent/source_truth_logic.go
@@ -9,20 +9,25 @@
 // v0.1 scope: presence-based gap detection plus the strategy-relative
 // correctness check.
 //
-// v0.2 scope (this version, #409): cross-surface revision equality for
-// the git-* strategies. When the controller and runtime both expose a
-// commit-SHA-shaped anchor, Derive asserts equality and emits MISMATCH
-// (with controller as the outlier) when the anchors disagree. If the
-// runtime image carries no SHA-bearing tag, that's a soft proof gap
-// ("runtime.commit_sha_anchor") — incomplete, not PASS.
+// v0.2 scope (#409): cross-surface revision equality for git-* and
+// kustomize-flux strategies (Git SHA anchor) and oci-* non-ConfigHub
+// strategies (OCI digest anchor). When the controller and runtime both
+// expose the strategy's canonical anchor, Derive asserts equality and
+// emits MISMATCH (with controller as the outlier) when they disagree.
+// Missing anchors surface as soft proof gaps — incomplete, not PASS.
 //
-// Still deferred: OCI-strategy equality. ConfigHub does not yet expose
-// a rendered digest per unit revision (verified 2026-05-09), so under
-// confighub-oci-* strategies cub-scout cannot honestly assert that the
-// controller pulled *the* ConfigHub-rendered artifact (only that *some*
-// digest matches end-to-end). Equality for OCI strategies will land in
-// a follow-up once the ConfigHub-side field exists; until then, OCI
-// strategies retain v0.1 behaviour (presence-based gap detection only).
+// Phase 2 (#409 enum expansion): added helm-flux, helm-argo,
+// kustomize-flux, oci-flux, oci-argo. Helm strategies emit
+// "runtime.helm_chart_anchor" until the runtime extractor is wired
+// (Helm chart version is already readable from `helm.sh/chart` labels
+// via pkg/agent/ownership.go but not yet plumbed into RuntimeSurface).
+//
+// Still deferred: confighub-oci-* equality. ConfigHub does not yet
+// expose a rendered digest per unit revision (verified 2026-05-09), so
+// cub-scout cannot honestly assert that the controller pulled *the*
+// ConfigHub-rendered artifact (only that *some* digest matches end-to-
+// end). Equality for confighub-oci-* will land once the ConfigHub-side
+// field exists.
 
 package agent
 
@@ -245,9 +250,19 @@ type revisionAgreement struct {
 }
 
 // compareRevisions performs strategy-aware cross-surface revision
-// equality. v0.2 implements git-* strategies; OCI strategies retain
-// v0.1's presence-based behaviour pending the ConfigHub-side rendered-
-// digest field.
+// equality. Strategy dispatch:
+//
+//   - git-* and kustomize-flux: Git-SHA controller↔runtime equality
+//     (kustomize-flux uses the same anchor — the Git commit SHA flows
+//     through Flux's Kustomization unchanged)
+//   - oci-* (non-ConfigHub): OCI digest controller↔runtime equality
+//   - confighub-oci-*: deferred (ConfigHub-side rendered digest field
+//     does not exist yet — see file header)
+//   - helm-*: emit "runtime.helm_chart_anchor" proof gap. Helm runtime
+//     anchor is the chart-version label (`helm.sh/chart`) and is
+//     extractable from ownership.go, but RuntimeSurface does not yet
+//     carry it. Wired as future work; until then helm-* is honestly
+//     INCOMPLETE.
 func compareRevisions(strategy SourceTruthStrategy, surfaces SourceTruthSurfaces) revisionAgreement {
 	// Multi-source is strategy-agnostic. If the controller declares more
 	// than one source and cub-scout only parsed the first, equality
@@ -262,8 +277,15 @@ func compareRevisions(strategy SourceTruthStrategy, surfaces SourceTruthSurfaces
 	}
 
 	switch strategy {
-	case StrategyGitArgo, StrategyGitFlux:
+	case StrategyGitArgo, StrategyGitFlux, StrategyKustomizeFlux:
 		return compareGitRevisions(surfaces)
+	case StrategyOCIArgo, StrategyOCIFlux:
+		return compareOCIRevisions(surfaces)
+	case StrategyHelmArgo, StrategyHelmFlux:
+		return revisionAgreement{
+			Incomplete: true,
+			ProofGaps:  []string{"runtime.helm_chart_anchor"},
+		}
 	case StrategyConfigHubOCIArgo, StrategyConfigHubOCIFlux:
 		// Deferred: OCI equality requires the controller-observed digest
 		// to be matched against the ConfigHub-rendered digest. ConfigHub
@@ -275,6 +297,100 @@ func compareRevisions(strategy SourceTruthStrategy, surfaces SourceTruthSurfaces
 	}
 	// Unknown / future strategies: don't block.
 	return revisionAgreement{Agreed: true}
+}
+
+// compareOCIRevisions performs controller↔runtime OCI digest equality
+// for the non-ConfigHub OCI strategies (oci-flux, oci-argo). Anchors:
+//
+//   - Controller: Chain[0].Revision in `sha256:hex` form (Flux
+//     OCIRepository) or in `<tag>@sha256:hex` form (some Argo
+//     emissions). normalizeOCIDigest accepts both.
+//   - Runtime: the `@sha256:hex` suffix on the container image
+//     reference. extractOCIDigestFromImage returns the canonical
+//     `sha256:hex` form.
+//
+// If the controller emits a tag-only revision (no `sha256:` prefix or
+// embedded digest), equality is unverifiable — proof gap
+// "controller.oci_digest". Same for tag-only runtime images
+// ("runtime.oci_digest"). Direct hex compare on the digest portion.
+func compareOCIRevisions(s SourceTruthSurfaces) revisionAgreement {
+	if s.Controller == nil || s.Runtime == nil {
+		return revisionAgreement{Incomplete: true}
+	}
+
+	ctrlDigest := normalizeOCIDigest(s.Controller.RevisionOrDigest)
+	if ctrlDigest == "" {
+		if strings.TrimSpace(s.Controller.RevisionOrDigest) == "" {
+			return revisionAgreement{Incomplete: true}
+		}
+		return revisionAgreement{
+			Incomplete: true,
+			ProofGaps:  []string{"controller.oci_digest"},
+		}
+	}
+
+	runtimeDigest := extractOCIDigestFromImage(s.Runtime.Value)
+	if runtimeDigest == "" {
+		return revisionAgreement{
+			Incomplete: true,
+			ProofGaps:  []string{"runtime.oci_digest"},
+		}
+	}
+
+	if ctrlDigest == runtimeDigest {
+		return revisionAgreement{Agreed: true}
+	}
+
+	return revisionAgreement{
+		Agreed:  false,
+		Outlier: OutlierController,
+	}
+}
+
+// normalizeOCIDigest extracts a canonical "sha256:hex" digest from an
+// arbitrary controller revision string. Accepts:
+//
+//   - "sha256:abc123..."        — direct
+//   - "main@sha256:abc123..."   — tag@digest form
+//   - "v1.0.0@sha256:abc123..." — same
+//
+// Returns "" if no sha256-shaped digest is found. Hex must be at least
+// 7 chars for the parser to consider it a valid digest.
+func normalizeOCIDigest(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	// Tag@digest form: take the part after "@".
+	if at := strings.Index(s, "@"); at >= 0 && at+1 < len(s) {
+		s = s[at+1:]
+	}
+	if !strings.HasPrefix(s, "sha256:") {
+		return ""
+	}
+	hex := s[len("sha256:"):]
+	if len(hex) < 7 {
+		return ""
+	}
+	for _, c := range hex {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return ""
+		}
+	}
+	return s
+}
+
+// extractOCIDigestFromImage pulls the @sha256:hex suffix from a
+// container image reference. Returns "" if the image carries no
+// digest suffix (tag-only images are a runtime proof gap under
+// OCI strategies).
+func extractOCIDigestFromImage(image string) string {
+	image = strings.TrimSpace(image)
+	at := strings.LastIndex(image, "@")
+	if at < 0 {
+		return ""
+	}
+	return normalizeOCIDigest(image[at+1:])
 }
 
 // compareGitRevisions performs controller↔runtime Git-SHA equality for

--- a/pkg/agent/source_truth_logic_test.go
+++ b/pkg/agent/source_truth_logic_test.go
@@ -403,6 +403,227 @@ func TestNormalizeGitSHA_AcceptsCommonShapes(t *testing.T) {
 	}
 }
 
+// TestNormalizeOCIDigest covers the controller-side digest shapes the
+// existing tracers emit (#409 Phase 2).
+func TestNormalizeOCIDigest(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"sha256:abc123def456", "sha256:abc123def456"},
+		{"SHA256:ABC123DEF456", "sha256:abc123def456"},
+		{"latest@sha256:abc123def456", "sha256:abc123def456"}, // tag@digest form
+		{"v1.0.0@sha256:abc123def456", "sha256:abc123def456"},
+		{"abc123def456", ""}, // raw hex with no sha256: prefix is a Git SHA, not OCI
+		{"sha256:abc", ""},   // hex too short
+		{"sha256:xyz123abc", ""}, // non-hex chars
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := normalizeOCIDigest(c.input)
+		if got != c.want {
+			t.Errorf("normalizeOCIDigest(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// TestExtractOCIDigestFromImage covers the runtime image-reference
+// shapes that carry an OCI digest suffix.
+func TestExtractOCIDigestFromImage(t *testing.T) {
+	cases := []struct {
+		image string
+		want  string
+	}{
+		{"ghcr.io/x/y@sha256:abc123def456", "sha256:abc123def456"},
+		{"ghcr.io/x/y:v1.0@sha256:abc123def456", "sha256:abc123def456"},
+		{"ghcr.io/x/y:v1.0", ""},          // tag-only, no digest
+		{"ghcr.io/x/y", ""},                // no tag, no digest
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := extractOCIDigestFromImage(c.image)
+		if got != c.want {
+			t.Errorf("extractOCIDigestFromImage(%q) = %q, want %q", c.image, got, c.want)
+		}
+	}
+}
+
+// TestDerive_OCIStrategy_DigestEquality locks in the Phase 2 OCI
+// equality behaviour for non-ConfigHub OCI strategies. PASS when
+// digests agree, BLOCK/MISMATCH/controller-outlier when they don't,
+// WATCH/INCOMPLETE with proof gaps when an anchor is missing.
+func TestDerive_OCIStrategy_DigestEquality(t *testing.T) {
+	mkSurfaces := func(ctrlRev, runtimeImage string) SourceTruthSurfaces {
+		return SourceTruthSurfaces{
+			ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "u", Revision: "1"},
+			Controller: &ControllerSurface{
+				Kind:             "Flux",
+				Source:           "oci://ghcr.io/example/u",
+				RevisionOrDigest: ctrlRev,
+				Health:           "Ready",
+			},
+			Runtime: &RuntimeSurface{
+				Resource: "Deployment/u in demo",
+				Field:    "spec.template.spec.containers[0].image",
+				Value:    runtimeImage,
+				Health:   "Current",
+			},
+		}
+	}
+
+	t.Run("digests match -> PASS", func(t *testing.T) {
+		ev := Derive(StrategyOCIFlux, mkSurfaces(
+			"sha256:abc123def456",
+			"ghcr.io/example/u@sha256:abc123def456",
+		))
+		if ev.Status != StatusPASS {
+			t.Errorf("status = %s, want PASS (gaps=%v)", ev.Status, ev.ProofGaps)
+		}
+	})
+
+	t.Run("digests disagree -> BLOCK/MISMATCH/controller", func(t *testing.T) {
+		ev := Derive(StrategyOCIArgo, mkSurfaces(
+			"sha256:abc123def456",
+			"ghcr.io/example/u@sha256:def456abc123",
+		))
+		if ev.Status != StatusBLOCK {
+			t.Errorf("status = %s, want BLOCK", ev.Status)
+		}
+		if ev.SourceTruth != VerdictMISMATCH {
+			t.Errorf("source_truth = %s, want MISMATCH", ev.SourceTruth)
+		}
+		if ev.Outlier != OutlierController {
+			t.Errorf("outlier = %s, want controller", ev.Outlier)
+		}
+	})
+
+	t.Run("runtime tag-only -> WATCH/INCOMPLETE/runtime.oci_digest gap", func(t *testing.T) {
+		ev := Derive(StrategyOCIFlux, mkSurfaces(
+			"sha256:abc123def456",
+			"ghcr.io/example/u:v1.2.3", // no @sha256: suffix
+		))
+		if ev.Status != StatusWATCH {
+			t.Errorf("status = %s, want WATCH", ev.Status)
+		}
+		if !containsString(ev.ProofGaps, "runtime.oci_digest") {
+			t.Errorf("proof_gaps = %v, want runtime.oci_digest", ev.ProofGaps)
+		}
+	})
+
+	t.Run("controller tag-only -> WATCH/INCOMPLETE/controller.oci_digest gap", func(t *testing.T) {
+		ev := Derive(StrategyOCIFlux, mkSurfaces(
+			"v1.2.3", // no sha256: prefix
+			"ghcr.io/example/u@sha256:abc123def456",
+		))
+		if ev.Status != StatusWATCH {
+			t.Errorf("status = %s, want WATCH", ev.Status)
+		}
+		if !containsString(ev.ProofGaps, "controller.oci_digest") {
+			t.Errorf("proof_gaps = %v, want controller.oci_digest", ev.ProofGaps)
+		}
+	})
+}
+
+// TestDerive_HelmStrategy_AlwaysIncomplete locks in Phase 2's intentional
+// limitation: helm-* strategies emit "runtime.helm_chart_anchor" as a
+// proof gap because the runtime extractor for helm.sh/chart labels is
+// not yet wired into RuntimeSurface. Helm strategies will go from WATCH
+// to PASS-capable in a follow-up.
+func TestDerive_HelmStrategy_AlwaysIncomplete(t *testing.T) {
+	for _, strategy := range []SourceTruthStrategy{StrategyHelmFlux, StrategyHelmArgo} {
+		t.Run(string(strategy), func(t *testing.T) {
+			ev := Derive(strategy, SourceTruthSurfaces{
+				ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "redis", Revision: "1"},
+				Controller: &ControllerSurface{
+					Kind:             "Flux",
+					Source:           "https://charts.bitnami.com/bitnami",
+					RevisionOrDigest: "17.0.0",
+					Health:           "Ready",
+				},
+				Runtime: &RuntimeSurface{
+					Resource: "Deployment/redis in demo",
+					Field:    "spec.template.spec.containers[0].image",
+					Value:    "docker.io/bitnami/redis:7.0.0",
+					Health:   "Current",
+				},
+			})
+			if ev.Status != StatusWATCH {
+				t.Errorf("status = %s, want WATCH (helm equality not wired yet)", ev.Status)
+			}
+			if !containsString(ev.ProofGaps, "runtime.helm_chart_anchor") {
+				t.Errorf("proof_gaps = %v, want runtime.helm_chart_anchor", ev.ProofGaps)
+			}
+		})
+	}
+}
+
+// TestStrategy_KustomizeFluxReusesGitEquality verifies that
+// kustomize-flux dispatches to the git equality path (the anchor
+// is a Git commit SHA — the Kustomize overlay sits on top but
+// doesn't change the source-of-truth identifier).
+func TestStrategy_KustomizeFluxReusesGitEquality(t *testing.T) {
+	ev := Derive(StrategyKustomizeFlux, SourceTruthSurfaces{
+		ConfigHub: &ConfigHubSurface{Space: "demo", Unit: "u", Revision: "1"},
+		Controller: &ControllerSurface{
+			Kind:             "Flux",
+			Source:           "https://github.com/example/repo",
+			RevisionOrDigest: "main@sha1:abc123def456",
+			Health:           "Ready",
+		},
+		Runtime: &RuntimeSurface{
+			Resource: "Deployment/u in demo",
+			Field:    "spec.template.spec.containers[0].image",
+			Value:    "ghcr.io/example/u:v1.2.3-abc123de",
+			Health:   "Current",
+		},
+	})
+	if ev.Status != StatusPASS {
+		t.Errorf("status = %s, want PASS (kustomize-flux should reuse git equality)", ev.Status)
+	}
+}
+
+// TestAllStrategies_HumanRenderingsExist verifies every enum value has
+// a Human() rendering distinct from the raw enum string.
+func TestAllStrategies_HumanRenderingsExist(t *testing.T) {
+	for _, s := range AllStrategies() {
+		human := s.Human()
+		if human == "" {
+			t.Errorf("strategy %q has empty Human() rendering", s)
+		}
+		if human == string(s) {
+			t.Errorf("strategy %q Human() = %q, want a council-shaped arrow string", s, human)
+		}
+	}
+}
+
+// TestExpectsArgoController_AllStrategies sweeps all strategies to
+// catch the case where a new strategy is added without updating the
+// controller-kind dispatch.
+func TestExpectsArgoController_AllStrategies(t *testing.T) {
+	want := map[SourceTruthStrategy]bool{
+		StrategyConfigHubOCIArgo: true,
+		StrategyConfigHubOCIFlux: false,
+		StrategyGitArgo:          true,
+		StrategyGitFlux:          false,
+		StrategyHelmArgo:         true,
+		StrategyHelmFlux:         false,
+		StrategyKustomizeFlux:    false,
+		StrategyOCIArgo:          true,
+		StrategyOCIFlux:          false,
+	}
+	for _, s := range AllStrategies() {
+		got := s.ExpectsArgoController()
+		w, ok := want[s]
+		if !ok {
+			t.Errorf("strategy %q in AllStrategies() but missing from test table", s)
+			continue
+		}
+		if got != w {
+			t.Errorf("ExpectsArgoController(%q) = %v, want %v", s, got, w)
+		}
+	}
+}
+
 // TestExtractGitSHAFromImage covers the segment-splitting cases real
 // release pipelines produce.
 func TestExtractGitSHAFromImage(t *testing.T) {

--- a/test/fixtures/source-truth/10-pass-kustomize-flux-git-sha/expected.json
+++ b/test/fixtures/source-truth/10-pass-kustomize-flux-git-sha/expected.json
@@ -1,0 +1,25 @@
+{
+  "declared_strategy": "Kustomize -> Flux -> Kubernetes",
+  "status": "PASS",
+  "source_truth": "AGREED",
+  "outlier": "unknown",
+  "surfaces": {
+    "confighub": {
+      "space": "demo",
+      "unit": "rag-server",
+      "revision": "47"
+    },
+    "controller": {
+      "kind": "Flux",
+      "source": "https://github.com/example/rag-deploy",
+      "revision_or_digest": "main@sha1:abc123def456",
+      "health": "Ready"
+    },
+    "runtime": {
+      "resource": "Deployment/rag-server in demo",
+      "field": "spec.template.spec.containers[0].image",
+      "value": "ghcr.io/example/rag:v1.2.3-abc123de",
+      "health": "Current"
+    }
+  }
+}

--- a/test/fixtures/source-truth/10-pass-kustomize-flux-git-sha/strategy.txt
+++ b/test/fixtures/source-truth/10-pass-kustomize-flux-git-sha/strategy.txt
@@ -1,0 +1,1 @@
+kustomize-flux

--- a/test/fixtures/source-truth/10-pass-kustomize-flux-git-sha/surfaces.json
+++ b/test/fixtures/source-truth/10-pass-kustomize-flux-git-sha/surfaces.json
@@ -1,0 +1,19 @@
+{
+  "confighub": {
+    "space": "demo",
+    "unit": "rag-server",
+    "revision": "47"
+  },
+  "controller": {
+    "kind": "Flux",
+    "source": "https://github.com/example/rag-deploy",
+    "revision_or_digest": "main@sha1:abc123def456",
+    "health": "Ready"
+  },
+  "runtime": {
+    "resource": "Deployment/rag-server in demo",
+    "field": "spec.template.spec.containers[0].image",
+    "value": "ghcr.io/example/rag:v1.2.3-abc123de",
+    "health": "Current"
+  }
+}

--- a/test/fixtures/source-truth/11-pass-oci-flux-digests-agree/expected.json
+++ b/test/fixtures/source-truth/11-pass-oci-flux-digests-agree/expected.json
@@ -1,0 +1,25 @@
+{
+  "declared_strategy": "OCI -> Flux -> Kubernetes",
+  "status": "PASS",
+  "source_truth": "AGREED",
+  "outlier": "unknown",
+  "surfaces": {
+    "confighub": {
+      "space": "demo",
+      "unit": "rag-server",
+      "revision": "47"
+    },
+    "controller": {
+      "kind": "Flux",
+      "source": "oci://ghcr.io/example/rag-server",
+      "revision_or_digest": "sha256:abc123def456abc123",
+      "health": "Ready"
+    },
+    "runtime": {
+      "resource": "Deployment/rag-server in demo",
+      "field": "spec.template.spec.containers[0].image",
+      "value": "ghcr.io/example/rag-server@sha256:abc123def456abc123",
+      "health": "Current"
+    }
+  }
+}

--- a/test/fixtures/source-truth/11-pass-oci-flux-digests-agree/strategy.txt
+++ b/test/fixtures/source-truth/11-pass-oci-flux-digests-agree/strategy.txt
@@ -1,0 +1,1 @@
+oci-flux

--- a/test/fixtures/source-truth/11-pass-oci-flux-digests-agree/surfaces.json
+++ b/test/fixtures/source-truth/11-pass-oci-flux-digests-agree/surfaces.json
@@ -1,0 +1,19 @@
+{
+  "confighub": {
+    "space": "demo",
+    "unit": "rag-server",
+    "revision": "47"
+  },
+  "controller": {
+    "kind": "Flux",
+    "source": "oci://ghcr.io/example/rag-server",
+    "revision_or_digest": "sha256:abc123def456abc123",
+    "health": "Ready"
+  },
+  "runtime": {
+    "resource": "Deployment/rag-server in demo",
+    "field": "spec.template.spec.containers[0].image",
+    "value": "ghcr.io/example/rag-server@sha256:abc123def456abc123",
+    "health": "Current"
+  }
+}

--- a/test/fixtures/source-truth/12-block-oci-argo-digests-disagree/expected.json
+++ b/test/fixtures/source-truth/12-block-oci-argo-digests-disagree/expected.json
@@ -1,0 +1,26 @@
+{
+  "declared_strategy": "OCI -> Argo -> Kubernetes",
+  "status": "BLOCK",
+  "source_truth": "MISMATCH",
+  "outlier": "controller",
+  "surfaces": {
+    "confighub": {
+      "space": "demo",
+      "unit": "rag-server",
+      "revision": "47"
+    },
+    "controller": {
+      "kind": "Argo",
+      "source": "oci://ghcr.io/example/rag-server",
+      "revision_or_digest": "sha256:abc123def456abc123",
+      "health": "Synced/Healthy"
+    },
+    "runtime": {
+      "resource": "Deployment/rag-server in demo",
+      "field": "spec.template.spec.containers[0].image",
+      "value": "ghcr.io/example/rag-server@sha256:def456abc123def456",
+      "health": "Current"
+    }
+  },
+  "safe_next_action": "Read-only diagnostic: cross-surface revision equality failed; the controller surface diverges. Confirm which commit each surface observed before acceptance."
+}

--- a/test/fixtures/source-truth/12-block-oci-argo-digests-disagree/strategy.txt
+++ b/test/fixtures/source-truth/12-block-oci-argo-digests-disagree/strategy.txt
@@ -1,0 +1,1 @@
+oci-argo

--- a/test/fixtures/source-truth/12-block-oci-argo-digests-disagree/surfaces.json
+++ b/test/fixtures/source-truth/12-block-oci-argo-digests-disagree/surfaces.json
@@ -1,0 +1,19 @@
+{
+  "confighub": {
+    "space": "demo",
+    "unit": "rag-server",
+    "revision": "47"
+  },
+  "controller": {
+    "kind": "Argo",
+    "source": "oci://ghcr.io/example/rag-server",
+    "revision_or_digest": "sha256:abc123def456abc123",
+    "health": "Synced/Healthy"
+  },
+  "runtime": {
+    "resource": "Deployment/rag-server in demo",
+    "field": "spec.template.spec.containers[0].image",
+    "value": "ghcr.io/example/rag-server@sha256:def456abc123def456",
+    "health": "Current"
+  }
+}

--- a/test/fixtures/source-truth/13-watch-helm-flux-no-runtime-anchor/expected.json
+++ b/test/fixtures/source-truth/13-watch-helm-flux-no-runtime-anchor/expected.json
@@ -1,0 +1,29 @@
+{
+  "declared_strategy": "Helm -> Flux -> Kubernetes",
+  "status": "WATCH",
+  "source_truth": "INCOMPLETE",
+  "outlier": "unknown",
+  "surfaces": {
+    "confighub": {
+      "space": "demo",
+      "unit": "redis",
+      "revision": "12"
+    },
+    "controller": {
+      "kind": "Flux",
+      "source": "https://charts.bitnami.com/bitnami",
+      "revision_or_digest": "17.0.0",
+      "health": "Ready"
+    },
+    "runtime": {
+      "resource": "Deployment/redis in demo",
+      "field": "spec.template.spec.containers[0].image",
+      "value": "docker.io/bitnami/redis:7.0.0",
+      "health": "Current"
+    }
+  },
+  "proof_gaps": [
+    "runtime.helm_chart_anchor"
+  ],
+  "safe_next_action": "Read-only diagnostic: confirm the missing fields (runtime.helm_chart_anchor) before acceptance."
+}

--- a/test/fixtures/source-truth/13-watch-helm-flux-no-runtime-anchor/strategy.txt
+++ b/test/fixtures/source-truth/13-watch-helm-flux-no-runtime-anchor/strategy.txt
@@ -1,0 +1,1 @@
+helm-flux

--- a/test/fixtures/source-truth/13-watch-helm-flux-no-runtime-anchor/surfaces.json
+++ b/test/fixtures/source-truth/13-watch-helm-flux-no-runtime-anchor/surfaces.json
@@ -1,0 +1,19 @@
+{
+  "confighub": {
+    "space": "demo",
+    "unit": "redis",
+    "revision": "12"
+  },
+  "controller": {
+    "kind": "Flux",
+    "source": "https://charts.bitnami.com/bitnami",
+    "revision_or_digest": "17.0.0",
+    "health": "Ready"
+  },
+  "runtime": {
+    "resource": "Deployment/redis in demo",
+    "field": "spec.template.spec.containers[0].image",
+    "value": "docker.io/bitnami/redis:7.0.0",
+    "health": "Current"
+  }
+}

--- a/test/fixtures/source-truth/README.md
+++ b/test/fixtures/source-truth/README.md
@@ -19,7 +19,7 @@ test/fixtures/source-truth/
 │   └── expected.json   exact byte-equal SourceTruthEvidence output
 ```
 
-## What this covers (9 fixtures)
+## What this covers (13 fixtures)
 
 | # | Strategy | Verdict | Council case |
 |---|---|---|---|
@@ -32,6 +32,10 @@ test/fixtures/source-truth/
 | 07 | `git-argo` | `BLOCK` / `MISMATCH` outlier=controller | **v0.2** cross-surface mismatch — controller and runtime image tag carry different SHAs |
 | 08 | `git-flux` | `WATCH` / `INCOMPLETE` proof_gap=`runtime.commit_sha_anchor` | **v0.2** runtime image has a semver tag with no SHA segment — equality unverifiable |
 | 09 | `git-argo` | `WATCH` / `INCOMPLETE` proof_gap=`controller.multi_source` | **v0.2 Phase 3** Argo Application has multiple sources; equality across un-parsed sources is unverifiable regardless of strategy |
+| 10 | `kustomize-flux` | `PASS` / `AGREED` | **Phase 2** kustomize-flux dispatches to git-SHA equality (Kustomize overlay over Git source) |
+| 11 | `oci-flux` | `PASS` / `AGREED` | **Phase 2** non-ConfigHub OCI digest equality — controller `sha256:` matches runtime `@sha256:` |
+| 12 | `oci-argo` | `BLOCK` / `MISMATCH` outlier=controller | **Phase 2** non-ConfigHub OCI digest mismatch |
+| 13 | `helm-flux` | `WATCH` / `INCOMPLETE` proof_gap=`runtime.helm_chart_anchor` | **Phase 2** helm runtime extractor not yet wired (`helm.sh/chart` label visible to ownership.go but not yet in RuntimeSurface) |
 
 ## Adding a fixture
 


### PR DESCRIPTION
## Summary

#409 Phase 2. Expands the strategy enum from 4 → 9 to cover the GitOps shapes operators actually run, with honest per-strategy equality semantics.

| Strategy | Anchor | This PR |
|---|---|---|
| `helm-flux` / `helm-argo` | Chart version (`helm.sh/chart`) | Emits `proof_gaps: [\"runtime.helm_chart_anchor\"]` — runtime extractor wired in follow-up |
| `kustomize-flux` | Git commit SHA | Reuses `compareGitRevisions` (Kustomize over Git source) |
| `oci-flux` / `oci-argo` | OCI digest | Full controller↔runtime equality via new `compareOCIRevisions` |
| `confighub-oci-*` | OCI digest | Still deferred (ConfigHub-side rendered-digest field doesn't exist yet) |

The Phase 2 OCI logic is **reusable for `confighub-oci-*`** once that field exists — same function signature, just adds the ConfigHub-side anchor check. So this PR also de-risks the deferred work.

### What changed

- 5 new strategy constants + Human() renderings + AllStrategies() + ExpectsArgoController() update
- `compareRevisions` dispatch grew: kustomize-flux → git path, oci-* → new OCI path, helm-* → proof gap
- New helpers: `compareOCIRevisions`, `normalizeOCIDigest`, `extractOCIDigestFromImage` — all unit-tested
- 4 new fixtures (slot 09 reserved for Phase 3's multi-source fixture)
- 7 new test functions covering: OCI parsers, OCI equality (4 cases), helm proof-gap rule, kustomize dispatch, full enum sweep tests for Human and ExpectsArgoController

### Drive-by

Same `release_distribution_contract_test.go` `brews:` → `homebrew_casks:` fix as #417. Included so this branch's CI is green independent of merge order between the two PRs.

## Test plan

- [ ] All existing fixtures (01-08) byte-equal
- [ ] 4 new fixtures (10, 11, 12, 13) byte-equal
- [ ] All inline tests pass
- [ ] Full `go test ./...` green
- [ ] Rebases cleanly on top of #417 once that lands (slot 09 stays open for the multi-source fixture)

## What's still open in #409

- **OCI-strategy equality for `confighub-oci-*`** — needs `Unit.RenderedDigest` on the ConfigHub side. Out of scope per maintainer (cross-repo work not authorized).
- **Helm runtime anchor extraction** — read `helm.sh/chart` labels from runtime workloads into `RuntimeSurface`. Small follow-up.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)