### PR TITLE
feat: views project — render View columns as table/JSON (#391 scope #2)

### DIFF
--- a/cmd/cub-scout/views.go
+++ b/cmd/cub-scout/views.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -45,6 +46,8 @@ var (
 	viewsResolveFormat string
 	viewsResolveSpace  string
 	viewsOpenPrintOnly bool
+	viewsProjectFormat string
+	viewsProjectSpace  string
 )
 
 var viewsCmd = &cobra.Command{
@@ -88,9 +91,12 @@ func init() {
 	rootCmd.AddCommand(viewsCmd)
 	viewsCmd.AddCommand(viewsResolveCmd)
 	viewsCmd.AddCommand(viewsOpenCmd)
+	viewsCmd.AddCommand(viewsProjectCmd)
 	viewsResolveCmd.Flags().StringVar(&viewsResolveFormat, "format", "json", "Output format. v0.1 supports: json")
 	viewsResolveCmd.Flags().StringVar(&viewsResolveSpace, "space", "*", "Space to search. Defaults to org-wide ('*') so a UUID alone is sufficient")
 	viewsOpenCmd.Flags().BoolVar(&viewsOpenPrintOnly, "print", false, "Print the View Explorer URL to stdout instead of opening the browser (useful for scripts and headless environments)")
+	viewsProjectCmd.Flags().StringVar(&viewsProjectFormat, "format", "table", "Output format: table, json")
+	viewsProjectCmd.Flags().StringVar(&viewsProjectSpace, "space", "*", "Space to search. Defaults to org-wide ('*')")
 }
 
 // ResolvedView is the JSON contract `views resolve` emits. Future
@@ -203,6 +209,166 @@ func listUnitSlugsForFilter(ctx context.Context, whereClause, space string) ([]s
 		}
 	}
 	return slugs, nil
+}
+
+// listUnitsForFilter is the projection-shaped sibling of
+// listUnitSlugsForFilter: it returns each matching unit's full
+// metadata blob (as `cub unit list -o json` emits it), so View column
+// evaluators can read attribute fields directly. Used by `views
+// project`. Same testability seam.
+func listUnitsForFilter(ctx context.Context, whereClause, space string) ([]map[string]interface{}, error) {
+	out, err := viewCubRunner(ctx, "unit", "list", "--space", space, "--where", whereClause, "-o", "json")
+	if err != nil {
+		return nil, fmt.Errorf("cub unit list: %w", err)
+	}
+	var units []map[string]interface{}
+	if err := json.Unmarshal(out, &units); err != nil {
+		return nil, fmt.Errorf("parse unit list: %w", err)
+	}
+	return units, nil
+}
+
+// extractColumnsSpec reads the View's Columns array out of the raw
+// `cub view get` JSON. Each Column has a Name + a ColumnSource
+// describing how to evaluate (MetadataAttribute / MetadataExpression /
+// DataPath / DataExpression). Returns nil + nil error when the View
+// has no columns — `views project` falls back to a default set in
+// that case.
+func extractColumnsSpec(view map[string]interface{}) ([]ViewColumnSpec, error) {
+	cols, ok := view["Columns"]
+	if !ok {
+		return nil, nil
+	}
+	arr, ok := cols.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("view Columns is not an array")
+	}
+	out := make([]ViewColumnSpec, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		col := ViewColumnSpec{
+			Name:       readStringField(m, "Name"),
+			ColumnType: readStringField(m, "ColumnType"),
+			DataType:   readStringField(m, "DataType"),
+		}
+		if src, ok := m["ColumnSource"].(map[string]interface{}); ok {
+			col.MetadataAttribute = readStringField(src, "MetadataAttribute")
+			col.MetadataExpression = readStringField(src, "MetadataExpression")
+			col.DataExpression = readStringField(src, "DataExpression")
+			// DataPath is itself an object (AttributeSelector); we
+			// stash the rendered path string for placeholder display
+			// until JSONPath evaluation lands.
+			if dp, ok := src["DataPath"].(map[string]interface{}); ok {
+				col.DataPath = readStringField(dp, "Path")
+			}
+		}
+		out = append(out, col)
+	}
+	return out, nil
+}
+
+func readStringField(m map[string]interface{}, key string) string {
+	v, _ := m[key].(string)
+	return strings.TrimSpace(v)
+}
+
+// ViewColumnSpec is the cub-scout-side flattening of ConfigHub's
+// Column + ColumnSource. v0.1 of `views project` evaluates only
+// MetadataAttribute (direct field reference); the other three forms
+// are surfaced as placeholders so the column header still appears
+// in output and operators can see the evaluator gap.
+type ViewColumnSpec struct {
+	Name               string `json:"name"`
+	ColumnType         string `json:"columnType,omitempty"`
+	DataType           string `json:"dataType,omitempty"`
+	MetadataAttribute  string `json:"metadataAttribute,omitempty"`
+	MetadataExpression string `json:"metadataExpression,omitempty"`
+	DataPath           string `json:"dataPath,omitempty"`
+	DataExpression     string `json:"dataExpression,omitempty"`
+}
+
+// evalKind classifies the column's evaluator. v0.1 supports
+// "metadata_attribute"; the other three are placeholder.
+func (c ViewColumnSpec) evalKind() string {
+	switch {
+	case c.MetadataAttribute != "":
+		return "metadata_attribute"
+	case c.MetadataExpression != "":
+		return "metadata_expression"
+	case c.DataPath != "":
+		return "data_path"
+	case c.DataExpression != "":
+		return "data_expression"
+	default:
+		return "unknown"
+	}
+}
+
+// evalCell evaluates the column against a single unit's JSON. Returns
+// the rendered string and a bool indicating whether the evaluator was
+// supported (false → placeholder was emitted).
+//
+// MetadataAttribute lookup is case-tolerant on the leading character
+// because ConfigHub serialises some fields PascalCase ("Slug") and
+// others camelCase ("slug"); `cub unit list -o json` emits the latter
+// style for the keys we care about, but we accept both so authoring-
+// side specs round-trip cleanly.
+func (c ViewColumnSpec) evalCell(unit map[string]interface{}) (string, bool) {
+	switch c.evalKind() {
+	case "metadata_attribute":
+		key := c.MetadataAttribute
+		if v, ok := unit[key]; ok {
+			return formatCellValue(v), true
+		}
+		// Try lowercase first letter (Slug → slug etc.).
+		if len(key) > 0 {
+			lc := strings.ToLower(key[:1]) + key[1:]
+			if v, ok := unit[lc]; ok {
+				return formatCellValue(v), true
+			}
+		}
+		return "", true // attribute not present on this unit; empty cell, still a supported eval
+	case "metadata_expression":
+		return "<cel: not yet supported>", false
+	case "data_path":
+		return "<jsonpath: not yet supported>", false
+	case "data_expression":
+		return "<cel: not yet supported>", false
+	}
+	return "", false
+}
+
+// formatCellValue renders an arbitrary JSON-decoded value as a string
+// suitable for table or JSON output. Maps and slices are JSON-encoded
+// inline so they can fit a single cell.
+func formatCellValue(v interface{}) string {
+	switch typed := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	case float64:
+		// JSON numbers decode as float64. Print integers without a
+		// decimal point for readability.
+		if typed == float64(int64(typed)) {
+			return fmt.Sprintf("%d", int64(typed))
+		}
+		return fmt.Sprintf("%g", typed)
+	default:
+		b, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprintf("%v", typed)
+		}
+		return string(b)
+	}
 }
 
 func emitResolvedView(rv ResolvedView) error {
@@ -321,3 +487,203 @@ func openInBrowser(url string) error {
 // to swap behaviour. Default delegates to runtime.GOOS.
 var runtimeGOOS = func() string { return runtime.GOOS }
 
+
+// viewsProjectCmd implements #391 scope #2 — render the Views
+// projection (filter + columns) as a table or JSON. v0.1 of this
+// subcommand evaluates MetadataAttribute columns directly against the
+// unit metadata `cub unit list` returns; CEL (MetadataExpression /
+// DataExpression) and JSONPath (DataPath) evaluators are placeholders
+// pending the dependency decision documented in the issue.
+//
+// `Columns` is the Views portable projection spec — defining columns
+// in ConfigHub once and rendering them anywhere is precisely the
+// "single source of truth, multiple surfaces" pattern the View
+// primitive is for.
+//
+// Output JSON has shape:
+//   { "view": "<uuid>", "columns": [<spec>], "rows": [{<col>: <value>}] }
+//
+// Connected mode is REQUIRED — the projection is meaningless without
+// `cub` access to the View definition and the matching units.
+var viewsProjectCmd = &cobra.Command{
+	Use:   "project <uuid-or-url>",
+	Short: "Render the View as a projected table",
+	Long: `Resolve the View, list its matching units, and render the
+Views columns as a table (or JSON).
+
+Accepts either form:
+
+  cub-scout views project 806aac53-236c-446d-8ad6-91d6daf6810e
+  cub-scout views project https://hub.confighub.com/x/view-explorer?view=806aac53-...
+
+Output formats:
+
+  --format table   ASCII table with one row per matching unit (default)
+  --format json    Structured JSON with the column spec + the rows
+
+v0.1 evaluates only MetadataAttribute columns directly. MetadataExpression /
+DataExpression (CEL) and DataPath (JSONPath) columns render placeholder
+text in the cell so the column header is preserved; full evaluator
+support is a follow-up dependency decision.
+
+Requires connected mode (cub auth login or CONFIGHUB_API_KEY).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runViewsProject,
+}
+
+// projectionRow is one rendered row in `views project` output. Keys
+// are the View column names; values are the rendered cell strings.
+// Map ordering is intentional — the JSON output preserves insertion
+// order via the parallel `columns` slice in ProjectedView.
+type projectionRow map[string]string
+
+// ProjectedView is the JSON-shaped output of `views project --format json`.
+type ProjectedView struct {
+	UUID    string           `json:"view"`
+	Space   string           `json:"space"`
+	Columns []ViewColumnSpec `json:"columns"`
+	Rows    []projectionRow  `json:"rows"`
+}
+
+func runViewsProject(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(viewsProjectFormat))
+	if format == "" {
+		format = "table"
+	}
+	if format != "table" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: table, json)", viewsProjectFormat)
+	}
+
+	ref, err := agent.ParseViewRef(args[0])
+	if err != nil {
+		return fmt.Errorf("parse view reference: %w", err)
+	}
+
+	if hub.QuickMode() != hub.Connected {
+		return fmt.Errorf("views project requires ConfigHub authentication (run `cub auth login` or set CONFIGHUB_API_KEY)")
+	}
+
+	view, err := fetchView(cmd.Context(), ref.UUID, viewsProjectSpace)
+	if err != nil {
+		return fmt.Errorf("fetch view: %w", err)
+	}
+
+	whereClause, err := extractWhereClause(view)
+	if err != nil {
+		return fmt.Errorf("extract filter from view: %w", err)
+	}
+	if whereClause == "" {
+		return fmt.Errorf("view %s has no Where filter — cannot project", ref.UUID)
+	}
+
+	columns, err := extractColumnsSpec(view)
+	if err != nil {
+		return fmt.Errorf("extract columns from view: %w", err)
+	}
+	if len(columns) == 0 {
+		// Fallback: minimal default projection so the command always
+		// produces something useful for Views that omit Columns.
+		columns = []ViewColumnSpec{{Name: "Slug", MetadataAttribute: "slug"}}
+	}
+
+	units, err := listUnitsForFilter(cmd.Context(), whereClause, viewsProjectSpace)
+	if err != nil {
+		return fmt.Errorf("list units for view filter: %w", err)
+	}
+
+	rows := make([]projectionRow, 0, len(units))
+	for _, u := range units {
+		row := make(projectionRow, len(columns))
+		for _, col := range columns {
+			cell, _ := col.evalCell(u)
+			row[col.Name] = cell
+		}
+		rows = append(rows, row)
+	}
+
+	pv := ProjectedView{
+		UUID:    ref.UUID,
+		Space:   viewsProjectSpace,
+		Columns: columns,
+		Rows:    rows,
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.SetEscapeHTML(false)
+		return enc.Encode(pv)
+	default:
+		return renderProjectionTable(os.Stdout, pv)
+	}
+}
+
+// renderProjectionTable writes the projected View as a fixed-width
+// ASCII table. Columns are sized to fit the widest cell (header or
+// any row value), capped at 64 chars to keep wide JSON-encoded values
+// from blowing out the terminal.
+func renderProjectionTable(w io.Writer, pv ProjectedView) error {
+	if len(pv.Columns) == 0 {
+		fmt.Fprintf(w, "view %s: no columns to project\n", pv.UUID)
+		return nil
+	}
+
+	widths := make([]int, len(pv.Columns))
+	for i, c := range pv.Columns {
+		widths[i] = len(c.Name)
+	}
+	for _, row := range pv.Rows {
+		for i, c := range pv.Columns {
+			if l := len(row[c.Name]); l > widths[i] {
+				widths[i] = l
+			}
+		}
+	}
+	for i, w := range widths {
+		if w > 64 {
+			widths[i] = 64
+		}
+	}
+
+	// Header
+	for i, c := range pv.Columns {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprintf(w, "%-*s", widths[i], truncateCell(c.Name, widths[i]))
+	}
+	fmt.Fprintln(w)
+	// Separator
+	for i, width := range widths {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprint(w, strings.Repeat("-", width))
+	}
+	fmt.Fprintln(w)
+	// Rows
+	for _, row := range pv.Rows {
+		for i, c := range pv.Columns {
+			if i > 0 {
+				fmt.Fprint(w, "  ")
+			}
+			fmt.Fprintf(w, "%-*s", widths[i], truncateCell(row[c.Name], widths[i]))
+		}
+		fmt.Fprintln(w)
+	}
+	if len(pv.Rows) == 0 {
+		fmt.Fprintln(w, "(no matching units)")
+	}
+	return nil
+}
+
+func truncateCell(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max < 4 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/cmd/cub-scout/views_project_test.go
+++ b/cmd/cub-scout/views_project_test.go
@@ -1,0 +1,271 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeProjectionRunner builds a viewCubRunner that maps argument-substring
+// patterns to JSON responses. Same shape as fakeCubOutput in
+// compare_three_way_view_test.go, but kept local to this file so the tests
+// stay self-contained.
+func fakeProjectionRunner(t *testing.T, responses map[string]string) {
+	t.Helper()
+	orig := viewCubRunner
+	viewCubRunner = func(_ context.Context, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		for pattern, resp := range responses {
+			if strings.Contains(joined, pattern) {
+				return []byte(resp), nil
+			}
+		}
+		return nil, fmt.Errorf("fakeProjectionRunner: no response for %q", joined)
+	}
+	t.Cleanup(func() { viewCubRunner = orig })
+}
+
+// TestExtractColumnsSpec covers the four ColumnSource shapes the View
+// model carries (#391 scope #2).
+func TestExtractColumnsSpec(t *testing.T) {
+	view := map[string]interface{}{
+		"Columns": []interface{}{
+			map[string]interface{}{
+				"Name": "Slug",
+				"ColumnSource": map[string]interface{}{
+					"MetadataAttribute": "slug",
+				},
+			},
+			map[string]interface{}{
+				"Name": "Replicas",
+				"ColumnSource": map[string]interface{}{
+					"DataPath": map[string]interface{}{
+						"Path": ".spec.replicas",
+					},
+				},
+			},
+			map[string]interface{}{
+				"Name": "EnvLabel",
+				"ColumnSource": map[string]interface{}{
+					"MetadataExpression": "labels['env']",
+				},
+			},
+			map[string]interface{}{
+				"Name": "DerivedReady",
+				"ColumnSource": map[string]interface{}{
+					"DataExpression": "spec.replicas > 0",
+				},
+			},
+		},
+	}
+	cols, err := extractColumnsSpec(view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cols) != 4 {
+		t.Fatalf("expected 4 columns, got %d", len(cols))
+	}
+	if cols[0].evalKind() != "metadata_attribute" {
+		t.Errorf("col 0 kind = %q, want metadata_attribute", cols[0].evalKind())
+	}
+	if cols[1].evalKind() != "data_path" {
+		t.Errorf("col 1 kind = %q, want data_path", cols[1].evalKind())
+	}
+	if cols[1].DataPath != ".spec.replicas" {
+		t.Errorf("col 1 DataPath = %q, want .spec.replicas", cols[1].DataPath)
+	}
+	if cols[2].evalKind() != "metadata_expression" {
+		t.Errorf("col 2 kind = %q, want metadata_expression", cols[2].evalKind())
+	}
+	if cols[3].evalKind() != "data_expression" {
+		t.Errorf("col 3 kind = %q, want data_expression", cols[3].evalKind())
+	}
+}
+
+// TestEvalCell_MetadataAttribute covers the single evaluator type
+// supported in v0.1 of `views project`.
+func TestEvalCell_MetadataAttribute(t *testing.T) {
+	col := ViewColumnSpec{Name: "Slug", MetadataAttribute: "slug"}
+	unit := map[string]interface{}{
+		"slug":  "payment-api",
+		"name":  "Payment API",
+		"value": float64(42),
+	}
+	got, ok := col.evalCell(unit)
+	if !ok {
+		t.Fatal("evalCell returned ok=false for supported eval type")
+	}
+	if got != "payment-api" {
+		t.Errorf("got %q, want payment-api", got)
+	}
+
+	// PascalCase MetadataAttribute → camelCase JSON field
+	col2 := ViewColumnSpec{Name: "Slug", MetadataAttribute: "Slug"}
+	got2, _ := col2.evalCell(unit)
+	if got2 != "payment-api" {
+		t.Errorf("PascalCase fallback: got %q, want payment-api", got2)
+	}
+
+	// Numeric value renders without decimal noise
+	col3 := ViewColumnSpec{Name: "Value", MetadataAttribute: "value"}
+	got3, _ := col3.evalCell(unit)
+	if got3 != "42" {
+		t.Errorf("numeric render: got %q, want 42", got3)
+	}
+
+	// Missing field → empty cell, still supported
+	col4 := ViewColumnSpec{Name: "Missing", MetadataAttribute: "nonexistent"}
+	got4, ok4 := col4.evalCell(unit)
+	if !ok4 {
+		t.Error("missing field should still report ok=true (just empty cell)")
+	}
+	if got4 != "" {
+		t.Errorf("missing field: got %q, want empty", got4)
+	}
+}
+
+// TestEvalCell_PlaceholdersForUnsupportedTypes locks in that v0.1
+// renders explicit placeholders for the three not-yet-supported
+// evaluator types so column headers still appear and operators see
+// the gap rather than getting silent empty cells.
+func TestEvalCell_PlaceholdersForUnsupportedTypes(t *testing.T) {
+	cases := []struct {
+		col      ViewColumnSpec
+		wantText string
+	}{
+		{ViewColumnSpec{Name: "C", MetadataExpression: "labels['x']"}, "<cel: not yet supported>"},
+		{ViewColumnSpec{Name: "C", DataPath: ".spec.replicas"}, "<jsonpath: not yet supported>"},
+		{ViewColumnSpec{Name: "C", DataExpression: "spec.x > 0"}, "<cel: not yet supported>"},
+	}
+	for _, tc := range cases {
+		got, ok := tc.col.evalCell(map[string]interface{}{})
+		if ok {
+			t.Errorf("eval for %s should report ok=false until supported", tc.col.evalKind())
+		}
+		if got != tc.wantText {
+			t.Errorf("placeholder for %s: got %q, want %q", tc.col.evalKind(), got, tc.wantText)
+		}
+	}
+}
+
+// TestRenderProjectionTable verifies the ASCII table output shape:
+// header line, separator, one row per unit, deterministic column
+// widths.
+func TestRenderProjectionTable(t *testing.T) {
+	pv := ProjectedView{
+		UUID:  "806aac53-236c-446d-8ad6-91d6daf6810e",
+		Space: "demo",
+		Columns: []ViewColumnSpec{
+			{Name: "Slug", MetadataAttribute: "slug"},
+			{Name: "Owner", MetadataAttribute: "owner"},
+		},
+		Rows: []projectionRow{
+			{"Slug": "payment-api", "Owner": "platform"},
+			{"Slug": "checkout-svc", "Owner": "checkout"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := renderProjectionTable(&buf, pv); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Slug") {
+		t.Error("table missing 'Slug' header")
+	}
+	if !strings.Contains(out, "payment-api") {
+		t.Error("table missing 'payment-api' row")
+	}
+	if !strings.Contains(out, "checkout-svc") {
+		t.Error("table missing 'checkout-svc' row")
+	}
+	if !strings.Contains(out, "----") {
+		t.Error("table missing separator")
+	}
+}
+
+// TestRenderProjectionTable_NoRows surfaces the empty-result case
+// rather than producing a silent header-only output.
+func TestRenderProjectionTable_NoRows(t *testing.T) {
+	pv := ProjectedView{
+		UUID:    "x",
+		Columns: []ViewColumnSpec{{Name: "Slug", MetadataAttribute: "slug"}},
+		Rows:    []projectionRow{},
+	}
+	var buf bytes.Buffer
+	if err := renderProjectionTable(&buf, pv); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "no matching units") {
+		t.Errorf("expected 'no matching units' marker, got: %q", buf.String())
+	}
+}
+
+// TestListUnitsForFilter_ParsesUnitMetadata covers the projection-
+// shaped sibling of listUnitSlugsForFilter — must return the full
+// metadata blob (not just slugs) so column evaluators can read
+// arbitrary fields.
+func TestListUnitsForFilter_ParsesUnitMetadata(t *testing.T) {
+	const unitsJSON = `[
+		{"slug": "payment-api", "owner": "platform", "labels": {"env": "prod"}},
+		{"slug": "checkout-svc", "owner": "checkout", "labels": {"env": "prod"}}
+	]`
+	fakeProjectionRunner(t, map[string]string{
+		"unit list": unitsJSON,
+	})
+	units, err := listUnitsForFilter(context.Background(), "metadata.labels.env = 'prod'", "*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(units) != 2 {
+		t.Fatalf("expected 2 units, got %d", len(units))
+	}
+	if units[0]["slug"] != "payment-api" {
+		t.Errorf("units[0].slug = %v, want payment-api", units[0]["slug"])
+	}
+	labels, ok := units[0]["labels"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("units[0].labels is not a map: %T", units[0]["labels"])
+	}
+	if labels["env"] != "prod" {
+		t.Errorf("units[0].labels.env = %v, want prod", labels["env"])
+	}
+}
+
+// TestProjectedViewJSON_RoundTrip locks in the JSON contract shape so
+// downstream consumers (the future TUI overlay, Pilot, demo scripts)
+// can pin against it.
+func TestProjectedViewJSON_RoundTrip(t *testing.T) {
+	pv := ProjectedView{
+		UUID:  "806aac53",
+		Space: "demo",
+		Columns: []ViewColumnSpec{
+			{Name: "Slug", MetadataAttribute: "slug"},
+		},
+		Rows: []projectionRow{
+			{"Slug": "payment-api"},
+		},
+	}
+	b, err := json.Marshal(pv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ProjectedView
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if got.UUID != pv.UUID || got.Space != pv.Space {
+		t.Errorf("round-trip identity lost: %+v", got)
+	}
+	if len(got.Columns) != 1 || got.Columns[0].MetadataAttribute != "slug" {
+		t.Errorf("round-trip columns: %+v", got.Columns)
+	}
+	if len(got.Rows) != 1 || got.Rows[0]["Slug"] != "payment-api" {
+		t.Errorf("round-trip rows: %+v", got.Rows)
+	}
+}

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -48,7 +48,7 @@ Source of truth:
 | `trace` | Trace ownership and source chain | [Command Reference](commands.md#trace) | [kro composition](../../examples/kro-composition/) |
 | `tree` | Runtime, ownership, git, and composition hierarchies | [Command Reference](commands.md#tree) | [kro composition](../../examples/kro-composition/) |
 | `version` | Print version/build information | [Command Reference](commands.md#version) | - |
-| `views` | Resolve ConfigHub View references (#391, v0.1) | [Command Reference](commands.md#views) | - |
+| `views` | Resolve, open, and project ConfigHub Views (#391) | [Command Reference](commands.md#views) | - |
 | `watch` | Stream observation events to webhook/file sinks | [Command Reference](commands.md#watch) | [Watch webhook](../../examples/watch-webhook/) |
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2337,10 +2337,64 @@ hostname the input URL carried (the operator's local config wins).
 Connected mode is **not** required — the URL itself is local
 construction. Auth only matters once the browser reaches View Explorer.
 
+### views project
+
+Render a View as a projected table. Resolves the View, lists its
+matching units, and evaluates the View's `Columns` spec against each
+unit's metadata. Closes the loop on #391 scope #2 (View-as-projection).
+
+```bash
+cub-scout views project <uuid-or-url> [flags]
+```
+
+Same input shapes as `views resolve` — bare UUID or View Explorer URL.
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--format table\|json` | Output format (default: `table`). |
+| `--space` | Space to search. Defaults to org-wide (`*`) so a UUID alone is sufficient. |
+
+#### Output
+
+`--format table` produces a fixed-width ASCII table — one row per unit,
+column headers from the View's `Columns` spec.
+
+`--format json` produces:
+
+```json
+{
+  "view": "<uuid>",
+  "space": "<space>",
+  "columns": [<column-spec>],
+  "rows": [{"<column-name>": "<value>", ...}]
+}
+```
+
+#### Evaluator support (v0.1)
+
+ConfigHub's `Column.ColumnSource` has four evaluator forms.
+v0.1 of `views project` evaluates the first directly:
+
+| ColumnSource form | v0.1 behaviour |
+|-------------------|----------------|
+| `MetadataAttribute` | Direct field lookup against unit metadata. Camel/Pascal-case fallback so spec strings like `"Slug"` and `"slug"` both resolve. |
+| `MetadataExpression` (CEL) | Renders `<cel: not yet supported>` placeholder. CEL evaluator is a follow-up dep decision. |
+| `DataPath` (JSONPath) | Renders `<jsonpath: not yet supported>` placeholder. |
+| `DataExpression` (CEL) | Renders `<cel: not yet supported>` placeholder. |
+
+The placeholder approach preserves column headers and ordering so
+operators see the evaluator gap rather than getting silent empty
+cells.
+
+Requires connected mode (`cub auth login` or `CONFIGHUB_API_KEY`).
+
 ### v0.1 scope items still pending
 
-- View column projection in TUI Hub view (scope item #2).
-- Reality overlay composing View columns with #393 source-truth verdicts (scope item #3) — unblocked now that the contract is in main.
+- TUI Hub view integration of View column projection (extends `views project` into the interactive `H` view).
+- Reality overlay composing View columns with #393 source-truth verdicts (scope item #3) — sits on top of `views project`.
+- CEL + JSONPath evaluators for `MetadataExpression`, `DataPath`, `DataExpression` columns.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes **#391 scope #2** (View-as-projection). New CLI subcommand `cub-scout views project <uuid-or-url>` resolves a View, lists its matching units, and renders the View's `Columns` spec as a fixed-width ASCII table or structured JSON.

```bash
# Default: ASCII table
cub-scout views project 806aac53-236c-446d-8ad6-91d6daf6810e
cub-scout views project 'https://hub.confighub.com/x/view-explorer?view=806aac53-...'

# JSON for downstream tooling
cub-scout views project <uuid-or-url> --format json
```

### Evaluator support (v0.1)

ConfigHub's `Column.ColumnSource` has four forms. v0.1 evaluates the first directly:

| ColumnSource | v0.1 |
|---|---|
| `MetadataAttribute` | Direct field lookup, case-tolerant (`Slug` ↔ `slug`) |
| `MetadataExpression` (CEL) | `<cel: not yet supported>` placeholder |
| `DataPath` (JSONPath) | `<jsonpath: not yet supported>` placeholder |
| `DataExpression` (CEL) | `<cel: not yet supported>` placeholder |

The placeholder approach preserves column headers + ordering so operators see the evaluator gap rather than getting silent empty cells. CEL is a follow-up dep decision (`cel-go` is a heavy transitive dep tree); JSONPath is lighter (`k8s.io/client-go/util/jsonpath` is already reachable). Both deferred until usage warrants the dep cost.

### Why this matters for scope #3

`views project` is the foundation for the reality overlay: the same row pipeline can append synthetic columns computed from cluster live state (`Applied?`, `Drift`, `Orphan?`, `LiveStatus`) — View defines the schema, cub-scout adds the cluster-truth join.

### Reuses existing infrastructure

Shares `viewCubRunner` testability seam from #408. Tests inject prefab JSON without a live `cub` binary.

## Test plan

- [ ] `TestExtractColumnsSpec`: parses all four ColumnSource shapes
- [ ] `TestEvalCell_MetadataAttribute`: 4 cases (lowercase, PascalCase fallback, numeric formatting, missing field)
- [ ] `TestEvalCell_PlaceholdersForUnsupportedTypes`: locks in the three placeholder strings
- [ ] `TestRenderProjectionTable` + `_NoRows`: ASCII table output shape
- [ ] `TestListUnitsForFilter_ParsesUnitMetadata`: full unit metadata round-trips
- [ ] `TestProjectedViewJSON_RoundTrip`: JSON contract shape
- [ ] All 37 packages pass

## What's still open in #391

- TUI Hub view integration of View column projection (extends `views project` into the interactive `H` view)
- Scope #3: reality overlay (sits on top of `views project`)
- CEL + JSONPath evaluators for the three placeholder column types

🤖 Generated with [Claude Code](https://claude.ai/claude-code)