### PR TITLE
feat: views project --with-reality (#391 scope #3)

### DIFF
--- a/cmd/cub-scout/views.go
+++ b/cmd/cub-scout/views.go
@@ -43,11 +43,12 @@ import (
 )
 
 var (
-	viewsResolveFormat string
-	viewsResolveSpace  string
-	viewsOpenPrintOnly bool
-	viewsProjectFormat string
-	viewsProjectSpace  string
+	viewsResolveFormat       string
+	viewsResolveSpace        string
+	viewsOpenPrintOnly       bool
+	viewsProjectFormat       string
+	viewsProjectSpace        string
+	viewsProjectWithReality  bool
 )
 
 var viewsCmd = &cobra.Command{
@@ -97,6 +98,7 @@ func init() {
 	viewsOpenCmd.Flags().BoolVar(&viewsOpenPrintOnly, "print", false, "Print the View Explorer URL to stdout instead of opening the browser (useful for scripts and headless environments)")
 	viewsProjectCmd.Flags().StringVar(&viewsProjectFormat, "format", "table", "Output format: table, json")
 	viewsProjectCmd.Flags().StringVar(&viewsProjectSpace, "space", "*", "Space to search. Defaults to org-wide ('*')")
+	viewsProjectCmd.Flags().BoolVar(&viewsProjectWithReality, "with-reality", false, "Append synthetic columns (Applied?, LiveStatus) computed from the live cluster (#391 scope #3)")
 }
 
 // ResolvedView is the JSON contract `views resolve` emits. Future
@@ -545,6 +547,80 @@ type ProjectedView struct {
 	Rows    []projectionRow  `json:"rows"`
 }
 
+// buildProjectedView is the pure (no-stdout, no-connected-mode-gate)
+// projection builder. runViewsProject wraps this for CLI use; tests
+// call this directly so they can assert on the structured output
+// without a stdout dance.
+func buildProjectedView(ctx context.Context, ref *agent.ViewRef, space string, withReality bool) (ProjectedView, error) {
+	view, err := fetchView(ctx, ref.UUID, space)
+	if err != nil {
+		return ProjectedView{}, fmt.Errorf("fetch view: %w", err)
+	}
+
+	whereClause, err := extractWhereClause(view)
+	if err != nil {
+		return ProjectedView{}, fmt.Errorf("extract filter from view: %w", err)
+	}
+	if whereClause == "" {
+		return ProjectedView{}, fmt.Errorf("view %s has no Where filter — cannot project", ref.UUID)
+	}
+
+	columns, err := extractColumnsSpec(view)
+	if err != nil {
+		return ProjectedView{}, fmt.Errorf("extract columns from view: %w", err)
+	}
+	if len(columns) == 0 {
+		// Fallback: minimal default projection so the command always
+		// produces something useful for Views that omit Columns.
+		columns = []ViewColumnSpec{{Name: "Slug", MetadataAttribute: "slug"}}
+	}
+
+	units, err := listUnitsForFilter(ctx, whereClause, space)
+	if err != nil {
+		return ProjectedView{}, fmt.Errorf("list units for view filter: %w", err)
+	}
+
+	// #391 scope #3 (reality overlay): when withReality is set, build a
+	// slug→workload index of the live cluster and append synthetic columns
+	// (Applied?, LiveStatus) the web View Explorer cannot show. The View
+	// supplies the schema; cub-scout joins in cluster truth.
+	var workloadIndex map[string]WorkloadInfo
+	if withReality {
+		idx, err := buildWorkloadIndexFn()
+		if err != nil {
+			return ProjectedView{}, fmt.Errorf("build workload index for reality overlay: %w", err)
+		}
+		workloadIndex = idx
+		columns = append(columns, realityColumns()...)
+	}
+
+	rows := make([]projectionRow, 0, len(units))
+	for _, u := range units {
+		row := make(projectionRow, len(columns))
+		for _, col := range columns {
+			if isRealityColumn(col.Name) {
+				continue // synthetic — filled below if reality is enabled
+			}
+			cell, _ := col.evalCell(u)
+			row[col.Name] = cell
+		}
+		if workloadIndex != nil {
+			slug := readStringField(u, "slug")
+			applied, status := computeRealityCells(slug, workloadIndex)
+			row["Applied?"] = applied
+			row["LiveStatus"] = status
+		}
+		rows = append(rows, row)
+	}
+
+	return ProjectedView{
+		UUID:    ref.UUID,
+		Space:   space,
+		Columns: columns,
+		Rows:    rows,
+	}, nil
+}
+
 func runViewsProject(cmd *cobra.Command, args []string) error {
 	format := strings.ToLower(strings.TrimSpace(viewsProjectFormat))
 	if format == "" {
@@ -563,49 +639,9 @@ func runViewsProject(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("views project requires ConfigHub authentication (run `cub auth login` or set CONFIGHUB_API_KEY)")
 	}
 
-	view, err := fetchView(cmd.Context(), ref.UUID, viewsProjectSpace)
+	pv, err := buildProjectedView(cmd.Context(), ref, viewsProjectSpace, viewsProjectWithReality)
 	if err != nil {
-		return fmt.Errorf("fetch view: %w", err)
-	}
-
-	whereClause, err := extractWhereClause(view)
-	if err != nil {
-		return fmt.Errorf("extract filter from view: %w", err)
-	}
-	if whereClause == "" {
-		return fmt.Errorf("view %s has no Where filter — cannot project", ref.UUID)
-	}
-
-	columns, err := extractColumnsSpec(view)
-	if err != nil {
-		return fmt.Errorf("extract columns from view: %w", err)
-	}
-	if len(columns) == 0 {
-		// Fallback: minimal default projection so the command always
-		// produces something useful for Views that omit Columns.
-		columns = []ViewColumnSpec{{Name: "Slug", MetadataAttribute: "slug"}}
-	}
-
-	units, err := listUnitsForFilter(cmd.Context(), whereClause, viewsProjectSpace)
-	if err != nil {
-		return fmt.Errorf("list units for view filter: %w", err)
-	}
-
-	rows := make([]projectionRow, 0, len(units))
-	for _, u := range units {
-		row := make(projectionRow, len(columns))
-		for _, col := range columns {
-			cell, _ := col.evalCell(u)
-			row[col.Name] = cell
-		}
-		rows = append(rows, row)
-	}
-
-	pv := ProjectedView{
-		UUID:    ref.UUID,
-		Space:   viewsProjectSpace,
-		Columns: columns,
-		Rows:    rows,
+		return err
 	}
 
 	switch format {
@@ -686,4 +722,85 @@ func truncateCell(s string, max int) string {
 		return s[:max]
 	}
 	return s[:max-3] + "..."
+}
+
+// realityColumns returns the synthetic column specs appended to a
+// `views project` projection when --with-reality is set. Names match
+// the issue's framing (#391 scope #3).
+//
+// v0.1 of the overlay ships Applied? and LiveStatus only. Drift and
+// Orphan? are deferred — see the file header in views.go for the
+// scope rationale.
+func realityColumns() []ViewColumnSpec {
+	return []ViewColumnSpec{
+		{Name: "Applied?"},
+		{Name: "LiveStatus"},
+	}
+}
+
+// isRealityColumn reports whether a column name is one of the
+// synthetic reality columns. Used in row rendering to skip the
+// MetadataAttribute eval path for these columns (they're filled
+// from the workload index, not the unit JSON).
+func isRealityColumn(name string) bool {
+	return name == "Applied?" || name == "LiveStatus"
+}
+
+// buildWorkloadIndexFn is the testability seam for the reality
+// overlay. Production walks the cluster via the existing helpers;
+// tests inject a prefab map.
+var buildWorkloadIndexFn = buildWorkloadIndexFromCluster
+
+// buildWorkloadIndexFromCluster discovers all namespaces with
+// workloads, lists each namespace's workloads, and returns the
+// slug→workload index. Workloads without a UnitSlug label are
+// excluded — they're not joinable to the View's unit set.
+//
+// Single-cluster scope is the assumed mode (cub-scout's default).
+// Multi-cluster overlays are not in scope; the index reflects only
+// the current kubeconfig context.
+func buildWorkloadIndexFromCluster() (map[string]WorkloadInfo, error) {
+	namespaces, err := discoverNamespacesWithWorkloads()
+	if err != nil {
+		return nil, fmt.Errorf("discover namespaces: %w", err)
+	}
+	index := make(map[string]WorkloadInfo)
+	for _, ns := range namespaces {
+		workloads, err := discoverWorkloads(ns)
+		if err != nil {
+			return nil, fmt.Errorf("discover workloads in %s: %w", ns, err)
+		}
+		for _, w := range workloads {
+			if w.UnitSlug == "" {
+				continue
+			}
+			// First wins: if the same slug appears in multiple
+			// namespaces (split-deploy or migration mid-flight), the
+			// first one parsed is good enough for v0.1. Multi-target
+			// rendering can be a follow-up.
+			if _, exists := index[w.UnitSlug]; !exists {
+				index[w.UnitSlug] = w
+			}
+		}
+	}
+	return index, nil
+}
+
+// computeRealityCells returns the rendered Applied? and LiveStatus
+// strings for a single unit. When the unit has no matching live
+// workload, both cells reflect the "not applied" state honestly
+// rather than emitting empty strings — silent absence reads as a
+// bug, explicit "no" reads as a fact.
+func computeRealityCells(slug string, index map[string]WorkloadInfo) (applied, status string) {
+	if slug == "" {
+		return "?", "(no slug)"
+	}
+	w, ok := index[slug]
+	if !ok {
+		return "no", "(not applied)"
+	}
+	if w.Ready {
+		return "yes", "Ready"
+	}
+	return "yes", "NotReady"
 }

--- a/cmd/cub-scout/views.go
+++ b/cmd/cub-scout/views.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -45,6 +46,8 @@ var (
 	viewsResolveFormat string
 	viewsResolveSpace  string
 	viewsOpenPrintOnly bool
+	viewsProjectFormat string
+	viewsProjectSpace  string
 )
 
 var viewsCmd = &cobra.Command{
@@ -88,9 +91,12 @@ func init() {
 	rootCmd.AddCommand(viewsCmd)
 	viewsCmd.AddCommand(viewsResolveCmd)
 	viewsCmd.AddCommand(viewsOpenCmd)
+	viewsCmd.AddCommand(viewsProjectCmd)
 	viewsResolveCmd.Flags().StringVar(&viewsResolveFormat, "format", "json", "Output format. v0.1 supports: json")
 	viewsResolveCmd.Flags().StringVar(&viewsResolveSpace, "space", "*", "Space to search. Defaults to org-wide ('*') so a UUID alone is sufficient")
 	viewsOpenCmd.Flags().BoolVar(&viewsOpenPrintOnly, "print", false, "Print the View Explorer URL to stdout instead of opening the browser (useful for scripts and headless environments)")
+	viewsProjectCmd.Flags().StringVar(&viewsProjectFormat, "format", "table", "Output format: table, json")
+	viewsProjectCmd.Flags().StringVar(&viewsProjectSpace, "space", "*", "Space to search. Defaults to org-wide ('*')")
 }
 
 // ResolvedView is the JSON contract `views resolve` emits. Future
@@ -203,6 +209,166 @@ func listUnitSlugsForFilter(ctx context.Context, whereClause, space string) ([]s
 		}
 	}
 	return slugs, nil
+}
+
+// listUnitsForFilter is the projection-shaped sibling of
+// listUnitSlugsForFilter: it returns each matching unit's full
+// metadata blob (as `cub unit list -o json` emits it), so View column
+// evaluators can read attribute fields directly. Used by `views
+// project`. Same testability seam.
+func listUnitsForFilter(ctx context.Context, whereClause, space string) ([]map[string]interface{}, error) {
+	out, err := viewCubRunner(ctx, "unit", "list", "--space", space, "--where", whereClause, "-o", "json")
+	if err != nil {
+		return nil, fmt.Errorf("cub unit list: %w", err)
+	}
+	var units []map[string]interface{}
+	if err := json.Unmarshal(out, &units); err != nil {
+		return nil, fmt.Errorf("parse unit list: %w", err)
+	}
+	return units, nil
+}
+
+// extractColumnsSpec reads the View's Columns array out of the raw
+// `cub view get` JSON. Each Column has a Name + a ColumnSource
+// describing how to evaluate (MetadataAttribute / MetadataExpression /
+// DataPath / DataExpression). Returns nil + nil error when the View
+// has no columns — `views project` falls back to a default set in
+// that case.
+func extractColumnsSpec(view map[string]interface{}) ([]ViewColumnSpec, error) {
+	cols, ok := view["Columns"]
+	if !ok {
+		return nil, nil
+	}
+	arr, ok := cols.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("view Columns is not an array")
+	}
+	out := make([]ViewColumnSpec, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		col := ViewColumnSpec{
+			Name:       readStringField(m, "Name"),
+			ColumnType: readStringField(m, "ColumnType"),
+			DataType:   readStringField(m, "DataType"),
+		}
+		if src, ok := m["ColumnSource"].(map[string]interface{}); ok {
+			col.MetadataAttribute = readStringField(src, "MetadataAttribute")
+			col.MetadataExpression = readStringField(src, "MetadataExpression")
+			col.DataExpression = readStringField(src, "DataExpression")
+			// DataPath is itself an object (AttributeSelector); we
+			// stash the rendered path string for placeholder display
+			// until JSONPath evaluation lands.
+			if dp, ok := src["DataPath"].(map[string]interface{}); ok {
+				col.DataPath = readStringField(dp, "Path")
+			}
+		}
+		out = append(out, col)
+	}
+	return out, nil
+}
+
+func readStringField(m map[string]interface{}, key string) string {
+	v, _ := m[key].(string)
+	return strings.TrimSpace(v)
+}
+
+// ViewColumnSpec is the cub-scout-side flattening of ConfigHub's
+// Column + ColumnSource. v0.1 of `views project` evaluates only
+// MetadataAttribute (direct field reference); the other three forms
+// are surfaced as placeholders so the column header still appears
+// in output and operators can see the evaluator gap.
+type ViewColumnSpec struct {
+	Name               string `json:"name"`
+	ColumnType         string `json:"columnType,omitempty"`
+	DataType           string `json:"dataType,omitempty"`
+	MetadataAttribute  string `json:"metadataAttribute,omitempty"`
+	MetadataExpression string `json:"metadataExpression,omitempty"`
+	DataPath           string `json:"dataPath,omitempty"`
+	DataExpression     string `json:"dataExpression,omitempty"`
+}
+
+// evalKind classifies the column's evaluator. v0.1 supports
+// "metadata_attribute"; the other three are placeholder.
+func (c ViewColumnSpec) evalKind() string {
+	switch {
+	case c.MetadataAttribute != "":
+		return "metadata_attribute"
+	case c.MetadataExpression != "":
+		return "metadata_expression"
+	case c.DataPath != "":
+		return "data_path"
+	case c.DataExpression != "":
+		return "data_expression"
+	default:
+		return "unknown"
+	}
+}
+
+// evalCell evaluates the column against a single unit's JSON. Returns
+// the rendered string and a bool indicating whether the evaluator was
+// supported (false → placeholder was emitted).
+//
+// MetadataAttribute lookup is case-tolerant on the leading character
+// because ConfigHub serialises some fields PascalCase ("Slug") and
+// others camelCase ("slug"); `cub unit list -o json` emits the latter
+// style for the keys we care about, but we accept both so authoring-
+// side specs round-trip cleanly.
+func (c ViewColumnSpec) evalCell(unit map[string]interface{}) (string, bool) {
+	switch c.evalKind() {
+	case "metadata_attribute":
+		key := c.MetadataAttribute
+		if v, ok := unit[key]; ok {
+			return formatCellValue(v), true
+		}
+		// Try lowercase first letter (Slug → slug etc.).
+		if len(key) > 0 {
+			lc := strings.ToLower(key[:1]) + key[1:]
+			if v, ok := unit[lc]; ok {
+				return formatCellValue(v), true
+			}
+		}
+		return "", true // attribute not present on this unit; empty cell, still a supported eval
+	case "metadata_expression":
+		return "<cel: not yet supported>", false
+	case "data_path":
+		return "<jsonpath: not yet supported>", false
+	case "data_expression":
+		return "<cel: not yet supported>", false
+	}
+	return "", false
+}
+
+// formatCellValue renders an arbitrary JSON-decoded value as a string
+// suitable for table or JSON output. Maps and slices are JSON-encoded
+// inline so they can fit a single cell.
+func formatCellValue(v interface{}) string {
+	switch typed := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	case float64:
+		// JSON numbers decode as float64. Print integers without a
+		// decimal point for readability.
+		if typed == float64(int64(typed)) {
+			return fmt.Sprintf("%d", int64(typed))
+		}
+		return fmt.Sprintf("%g", typed)
+	default:
+		b, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprintf("%v", typed)
+		}
+		return string(b)
+	}
 }
 
 func emitResolvedView(rv ResolvedView) error {
@@ -321,3 +487,203 @@ func openInBrowser(url string) error {
 // to swap behaviour. Default delegates to runtime.GOOS.
 var runtimeGOOS = func() string { return runtime.GOOS }
 
+
+// viewsProjectCmd implements #391 scope #2 — render the Views
+// projection (filter + columns) as a table or JSON. v0.1 of this
+// subcommand evaluates MetadataAttribute columns directly against the
+// unit metadata `cub unit list` returns; CEL (MetadataExpression /
+// DataExpression) and JSONPath (DataPath) evaluators are placeholders
+// pending the dependency decision documented in the issue.
+//
+// `Columns` is the Views portable projection spec — defining columns
+// in ConfigHub once and rendering them anywhere is precisely the
+// "single source of truth, multiple surfaces" pattern the View
+// primitive is for.
+//
+// Output JSON has shape:
+//   { "view": "<uuid>", "columns": [<spec>], "rows": [{<col>: <value>}] }
+//
+// Connected mode is REQUIRED — the projection is meaningless without
+// `cub` access to the View definition and the matching units.
+var viewsProjectCmd = &cobra.Command{
+	Use:   "project <uuid-or-url>",
+	Short: "Render the View as a projected table",
+	Long: `Resolve the View, list its matching units, and render the
+Views columns as a table (or JSON).
+
+Accepts either form:
+
+  cub-scout views project 806aac53-236c-446d-8ad6-91d6daf6810e
+  cub-scout views project https://hub.confighub.com/x/view-explorer?view=806aac53-...
+
+Output formats:
+
+  --format table   ASCII table with one row per matching unit (default)
+  --format json    Structured JSON with the column spec + the rows
+
+v0.1 evaluates only MetadataAttribute columns directly. MetadataExpression /
+DataExpression (CEL) and DataPath (JSONPath) columns render placeholder
+text in the cell so the column header is preserved; full evaluator
+support is a follow-up dependency decision.
+
+Requires connected mode (cub auth login or CONFIGHUB_API_KEY).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runViewsProject,
+}
+
+// projectionRow is one rendered row in `views project` output. Keys
+// are the View column names; values are the rendered cell strings.
+// Map ordering is intentional — the JSON output preserves insertion
+// order via the parallel `columns` slice in ProjectedView.
+type projectionRow map[string]string
+
+// ProjectedView is the JSON-shaped output of `views project --format json`.
+type ProjectedView struct {
+	UUID    string           `json:"view"`
+	Space   string           `json:"space"`
+	Columns []ViewColumnSpec `json:"columns"`
+	Rows    []projectionRow  `json:"rows"`
+}
+
+func runViewsProject(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(viewsProjectFormat))
+	if format == "" {
+		format = "table"
+	}
+	if format != "table" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: table, json)", viewsProjectFormat)
+	}
+
+	ref, err := agent.ParseViewRef(args[0])
+	if err != nil {
+		return fmt.Errorf("parse view reference: %w", err)
+	}
+
+	if hub.QuickMode() != hub.Connected {
+		return fmt.Errorf("views project requires ConfigHub authentication (run `cub auth login` or set CONFIGHUB_API_KEY)")
+	}
+
+	view, err := fetchView(cmd.Context(), ref.UUID, viewsProjectSpace)
+	if err != nil {
+		return fmt.Errorf("fetch view: %w", err)
+	}
+
+	whereClause, err := extractWhereClause(view)
+	if err != nil {
+		return fmt.Errorf("extract filter from view: %w", err)
+	}
+	if whereClause == "" {
+		return fmt.Errorf("view %s has no Where filter — cannot project", ref.UUID)
+	}
+
+	columns, err := extractColumnsSpec(view)
+	if err != nil {
+		return fmt.Errorf("extract columns from view: %w", err)
+	}
+	if len(columns) == 0 {
+		// Fallback: minimal default projection so the command always
+		// produces something useful for Views that omit Columns.
+		columns = []ViewColumnSpec{{Name: "Slug", MetadataAttribute: "slug"}}
+	}
+
+	units, err := listUnitsForFilter(cmd.Context(), whereClause, viewsProjectSpace)
+	if err != nil {
+		return fmt.Errorf("list units for view filter: %w", err)
+	}
+
+	rows := make([]projectionRow, 0, len(units))
+	for _, u := range units {
+		row := make(projectionRow, len(columns))
+		for _, col := range columns {
+			cell, _ := col.evalCell(u)
+			row[col.Name] = cell
+		}
+		rows = append(rows, row)
+	}
+
+	pv := ProjectedView{
+		UUID:    ref.UUID,
+		Space:   viewsProjectSpace,
+		Columns: columns,
+		Rows:    rows,
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.SetEscapeHTML(false)
+		return enc.Encode(pv)
+	default:
+		return renderProjectionTable(os.Stdout, pv)
+	}
+}
+
+// renderProjectionTable writes the projected View as a fixed-width
+// ASCII table. Columns are sized to fit the widest cell (header or
+// any row value), capped at 64 chars to keep wide JSON-encoded values
+// from blowing out the terminal.
+func renderProjectionTable(w io.Writer, pv ProjectedView) error {
+	if len(pv.Columns) == 0 {
+		fmt.Fprintf(w, "view %s: no columns to project\n", pv.UUID)
+		return nil
+	}
+
+	widths := make([]int, len(pv.Columns))
+	for i, c := range pv.Columns {
+		widths[i] = len(c.Name)
+	}
+	for _, row := range pv.Rows {
+		for i, c := range pv.Columns {
+			if l := len(row[c.Name]); l > widths[i] {
+				widths[i] = l
+			}
+		}
+	}
+	for i, w := range widths {
+		if w > 64 {
+			widths[i] = 64
+		}
+	}
+
+	// Header
+	for i, c := range pv.Columns {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprintf(w, "%-*s", widths[i], truncateCell(c.Name, widths[i]))
+	}
+	fmt.Fprintln(w)
+	// Separator
+	for i, width := range widths {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprint(w, strings.Repeat("-", width))
+	}
+	fmt.Fprintln(w)
+	// Rows
+	for _, row := range pv.Rows {
+		for i, c := range pv.Columns {
+			if i > 0 {
+				fmt.Fprint(w, "  ")
+			}
+			fmt.Fprintf(w, "%-*s", widths[i], truncateCell(row[c.Name], widths[i]))
+		}
+		fmt.Fprintln(w)
+	}
+	if len(pv.Rows) == 0 {
+		fmt.Fprintln(w, "(no matching units)")
+	}
+	return nil
+}
+
+func truncateCell(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max < 4 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/cmd/cub-scout/views_project_test.go
+++ b/cmd/cub-scout/views_project_test.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
 )
 
 // fakeProjectionRunner builds a viewCubRunner that maps argument-substring
@@ -235,6 +237,183 @@ func TestListUnitsForFilter_ParsesUnitMetadata(t *testing.T) {
 	if labels["env"] != "prod" {
 		t.Errorf("units[0].labels.env = %v, want prod", labels["env"])
 	}
+}
+
+// installFakeWorkloadIndex swaps the buildWorkloadIndexFn seam for the
+// test duration so reality-overlay tests don't need a real cluster
+// (#391 scope #3).
+func installFakeWorkloadIndex(t *testing.T, index map[string]WorkloadInfo) {
+	t.Helper()
+	orig := buildWorkloadIndexFn
+	buildWorkloadIndexFn = func() (map[string]WorkloadInfo, error) {
+		return index, nil
+	}
+	t.Cleanup(func() { buildWorkloadIndexFn = orig })
+}
+
+// fakeViewWithColumns builds a minimal `cub view get` JSON blob with
+// both Filter.Where and Columns populated.
+func fakeViewWithColumns(uuid, whereClause string, columns []map[string]interface{}) string {
+	cols := make([]interface{}, len(columns))
+	for i, c := range columns {
+		cols[i] = c
+	}
+	view := map[string]interface{}{
+		"UUID": uuid,
+		"Filter": map[string]interface{}{
+			"Where": whereClause,
+		},
+		"Columns": cols,
+	}
+	b, _ := json.Marshal(view)
+	return string(b)
+}
+
+// fakeUnitListJSONFromMaps returns a `cub unit list -o json` blob
+// from arbitrary metadata maps. (Distinct from the slug-only helper
+// in compare_three_way_view_test.go.)
+func fakeUnitListJSONFromMaps(units []map[string]interface{}) string {
+	b, _ := json.Marshal(units)
+	return string(b)
+}
+
+// TestComputeRealityCells covers the four states of the synthetic
+// columns: applied + Ready, applied + NotReady, not applied, no slug.
+func TestComputeRealityCells(t *testing.T) {
+	index := map[string]WorkloadInfo{
+		"payment-api":  {UnitSlug: "payment-api", Ready: true, Kind: "Deployment", Name: "payment-api"},
+		"checkout-svc": {UnitSlug: "checkout-svc", Ready: false, Kind: "Deployment", Name: "checkout-svc"},
+	}
+
+	cases := []struct {
+		slug        string
+		wantApplied string
+		wantStatus  string
+	}{
+		{"payment-api", "yes", "Ready"},
+		{"checkout-svc", "yes", "NotReady"},
+		{"orphan-unit", "no", "(not applied)"},
+		{"", "?", "(no slug)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.slug, func(t *testing.T) {
+			gotApplied, gotStatus := computeRealityCells(tc.slug, index)
+			if gotApplied != tc.wantApplied {
+				t.Errorf("Applied? for %q = %q, want %q", tc.slug, gotApplied, tc.wantApplied)
+			}
+			if gotStatus != tc.wantStatus {
+				t.Errorf("LiveStatus for %q = %q, want %q", tc.slug, gotStatus, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestBuildProjectedView_WithReality exercises the full overlay
+// flow: fetch view, list units, build workload index, append
+// synthetic columns. Uses both fake seams (cubRunner + workload
+// index).
+func TestBuildProjectedView_WithReality(t *testing.T) {
+	const viewUUID = "806aac53-236c-446d-8ad6-91d6daf6810e"
+	const whereClause = "metadata.labels.team = 'payments'"
+
+	fakeProjectionRunner(t, map[string]string{
+		"view get " + viewUUID: fakeViewWithColumns(viewUUID, whereClause, []map[string]interface{}{
+			{
+				"Name": "Slug",
+				"ColumnSource": map[string]interface{}{
+					"MetadataAttribute": "slug",
+				},
+			},
+		}),
+		"unit list": fakeUnitListJSONFromMaps([]map[string]interface{}{
+			{"slug": "payment-api"},
+			{"slug": "checkout-svc"},
+			{"slug": "future-unit"}, // declared in ConfigHub, not yet applied
+		}),
+	})
+
+	installFakeWorkloadIndex(t, map[string]WorkloadInfo{
+		"payment-api":  {UnitSlug: "payment-api", Ready: true},
+		"checkout-svc": {UnitSlug: "checkout-svc", Ready: false},
+		// future-unit intentionally absent — overlay marks unapplied
+	})
+
+	pv, err := buildProjectedView(context.Background(), mockViewRef(viewUUID), "*", true)
+	if err != nil {
+		t.Fatalf("buildProjectedView failed: %v", err)
+	}
+
+	// Columns should include the synthetic reality columns at the end.
+	gotColNames := make([]string, len(pv.Columns))
+	for i, c := range pv.Columns {
+		gotColNames[i] = c.Name
+	}
+	want := []string{"Slug", "Applied?", "LiveStatus"}
+	for i, w := range want {
+		if i >= len(gotColNames) || gotColNames[i] != w {
+			t.Errorf("columns = %v, want prefix %v", gotColNames, want)
+			break
+		}
+	}
+
+	if len(pv.Rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(pv.Rows))
+	}
+	bySlug := map[string]projectionRow{}
+	for _, r := range pv.Rows {
+		bySlug[r["Slug"]] = r
+	}
+	if bySlug["payment-api"]["Applied?"] != "yes" || bySlug["payment-api"]["LiveStatus"] != "Ready" {
+		t.Errorf("payment-api row = %v", bySlug["payment-api"])
+	}
+	if bySlug["checkout-svc"]["Applied?"] != "yes" || bySlug["checkout-svc"]["LiveStatus"] != "NotReady" {
+		t.Errorf("checkout-svc row = %v", bySlug["checkout-svc"])
+	}
+	if bySlug["future-unit"]["Applied?"] != "no" || bySlug["future-unit"]["LiveStatus"] != "(not applied)" {
+		t.Errorf("future-unit row = %v", bySlug["future-unit"])
+	}
+}
+
+// TestBuildProjectedView_WithoutReality verifies the default does
+// NOT call the workload-index helper and does NOT add synthetic
+// columns. Locks in the opt-in behaviour.
+func TestBuildProjectedView_WithoutReality(t *testing.T) {
+	const viewUUID = "806aac53-236c-446d-8ad6-91d6daf6810e"
+	fakeProjectionRunner(t, map[string]string{
+		"view get " + viewUUID: fakeViewWithColumns(viewUUID, "metadata.labels.x = 'y'", []map[string]interface{}{
+			{"Name": "Slug", "ColumnSource": map[string]interface{}{"MetadataAttribute": "slug"}},
+		}),
+		"unit list": fakeUnitListJSONFromMaps([]map[string]interface{}{
+			{"slug": "payment-api"},
+		}),
+	})
+
+	called := false
+	orig := buildWorkloadIndexFn
+	buildWorkloadIndexFn = func() (map[string]WorkloadInfo, error) {
+		called = true
+		return nil, nil
+	}
+	t.Cleanup(func() { buildWorkloadIndexFn = orig })
+
+	pv, err := buildProjectedView(context.Background(), mockViewRef(viewUUID), "*", false)
+	if err != nil {
+		t.Fatalf("buildProjectedView failed: %v", err)
+	}
+	if called {
+		t.Error("buildWorkloadIndexFn was called even without --with-reality")
+	}
+	for _, c := range pv.Columns {
+		if isRealityColumn(c.Name) {
+			t.Errorf("synthetic column %q present without --with-reality", c.Name)
+		}
+	}
+}
+
+// mockViewRef is a small helper to construct an agent.ViewRef value
+// for tests (the real one is built by ParseViewRef on user input).
+func mockViewRef(uuid string) *agent.ViewRef {
+	return &agent.ViewRef{UUID: uuid, SourceForm: agent.ViewRefUUID}
 }
 
 // TestProjectedViewJSON_RoundTrip locks in the JSON contract shape so

--- a/cmd/cub-scout/views_project_test.go
+++ b/cmd/cub-scout/views_project_test.go
@@ -1,0 +1,271 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeProjectionRunner builds a viewCubRunner that maps argument-substring
+// patterns to JSON responses. Same shape as fakeCubOutput in
+// compare_three_way_view_test.go, but kept local to this file so the tests
+// stay self-contained.
+func fakeProjectionRunner(t *testing.T, responses map[string]string) {
+	t.Helper()
+	orig := viewCubRunner
+	viewCubRunner = func(_ context.Context, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		for pattern, resp := range responses {
+			if strings.Contains(joined, pattern) {
+				return []byte(resp), nil
+			}
+		}
+		return nil, fmt.Errorf("fakeProjectionRunner: no response for %q", joined)
+	}
+	t.Cleanup(func() { viewCubRunner = orig })
+}
+
+// TestExtractColumnsSpec covers the four ColumnSource shapes the View
+// model carries (#391 scope #2).
+func TestExtractColumnsSpec(t *testing.T) {
+	view := map[string]interface{}{
+		"Columns": []interface{}{
+			map[string]interface{}{
+				"Name": "Slug",
+				"ColumnSource": map[string]interface{}{
+					"MetadataAttribute": "slug",
+				},
+			},
+			map[string]interface{}{
+				"Name": "Replicas",
+				"ColumnSource": map[string]interface{}{
+					"DataPath": map[string]interface{}{
+						"Path": ".spec.replicas",
+					},
+				},
+			},
+			map[string]interface{}{
+				"Name": "EnvLabel",
+				"ColumnSource": map[string]interface{}{
+					"MetadataExpression": "labels['env']",
+				},
+			},
+			map[string]interface{}{
+				"Name": "DerivedReady",
+				"ColumnSource": map[string]interface{}{
+					"DataExpression": "spec.replicas > 0",
+				},
+			},
+		},
+	}
+	cols, err := extractColumnsSpec(view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cols) != 4 {
+		t.Fatalf("expected 4 columns, got %d", len(cols))
+	}
+	if cols[0].evalKind() != "metadata_attribute" {
+		t.Errorf("col 0 kind = %q, want metadata_attribute", cols[0].evalKind())
+	}
+	if cols[1].evalKind() != "data_path" {
+		t.Errorf("col 1 kind = %q, want data_path", cols[1].evalKind())
+	}
+	if cols[1].DataPath != ".spec.replicas" {
+		t.Errorf("col 1 DataPath = %q, want .spec.replicas", cols[1].DataPath)
+	}
+	if cols[2].evalKind() != "metadata_expression" {
+		t.Errorf("col 2 kind = %q, want metadata_expression", cols[2].evalKind())
+	}
+	if cols[3].evalKind() != "data_expression" {
+		t.Errorf("col 3 kind = %q, want data_expression", cols[3].evalKind())
+	}
+}
+
+// TestEvalCell_MetadataAttribute covers the single evaluator type
+// supported in v0.1 of `views project`.
+func TestEvalCell_MetadataAttribute(t *testing.T) {
+	col := ViewColumnSpec{Name: "Slug", MetadataAttribute: "slug"}
+	unit := map[string]interface{}{
+		"slug":  "payment-api",
+		"name":  "Payment API",
+		"value": float64(42),
+	}
+	got, ok := col.evalCell(unit)
+	if !ok {
+		t.Fatal("evalCell returned ok=false for supported eval type")
+	}
+	if got != "payment-api" {
+		t.Errorf("got %q, want payment-api", got)
+	}
+
+	// PascalCase MetadataAttribute → camelCase JSON field
+	col2 := ViewColumnSpec{Name: "Slug", MetadataAttribute: "Slug"}
+	got2, _ := col2.evalCell(unit)
+	if got2 != "payment-api" {
+		t.Errorf("PascalCase fallback: got %q, want payment-api", got2)
+	}
+
+	// Numeric value renders without decimal noise
+	col3 := ViewColumnSpec{Name: "Value", MetadataAttribute: "value"}
+	got3, _ := col3.evalCell(unit)
+	if got3 != "42" {
+		t.Errorf("numeric render: got %q, want 42", got3)
+	}
+
+	// Missing field → empty cell, still supported
+	col4 := ViewColumnSpec{Name: "Missing", MetadataAttribute: "nonexistent"}
+	got4, ok4 := col4.evalCell(unit)
+	if !ok4 {
+		t.Error("missing field should still report ok=true (just empty cell)")
+	}
+	if got4 != "" {
+		t.Errorf("missing field: got %q, want empty", got4)
+	}
+}
+
+// TestEvalCell_PlaceholdersForUnsupportedTypes locks in that v0.1
+// renders explicit placeholders for the three not-yet-supported
+// evaluator types so column headers still appear and operators see
+// the gap rather than getting silent empty cells.
+func TestEvalCell_PlaceholdersForUnsupportedTypes(t *testing.T) {
+	cases := []struct {
+		col      ViewColumnSpec
+		wantText string
+	}{
+		{ViewColumnSpec{Name: "C", MetadataExpression: "labels['x']"}, "<cel: not yet supported>"},
+		{ViewColumnSpec{Name: "C", DataPath: ".spec.replicas"}, "<jsonpath: not yet supported>"},
+		{ViewColumnSpec{Name: "C", DataExpression: "spec.x > 0"}, "<cel: not yet supported>"},
+	}
+	for _, tc := range cases {
+		got, ok := tc.col.evalCell(map[string]interface{}{})
+		if ok {
+			t.Errorf("eval for %s should report ok=false until supported", tc.col.evalKind())
+		}
+		if got != tc.wantText {
+			t.Errorf("placeholder for %s: got %q, want %q", tc.col.evalKind(), got, tc.wantText)
+		}
+	}
+}
+
+// TestRenderProjectionTable verifies the ASCII table output shape:
+// header line, separator, one row per unit, deterministic column
+// widths.
+func TestRenderProjectionTable(t *testing.T) {
+	pv := ProjectedView{
+		UUID:  "806aac53-236c-446d-8ad6-91d6daf6810e",
+		Space: "demo",
+		Columns: []ViewColumnSpec{
+			{Name: "Slug", MetadataAttribute: "slug"},
+			{Name: "Owner", MetadataAttribute: "owner"},
+		},
+		Rows: []projectionRow{
+			{"Slug": "payment-api", "Owner": "platform"},
+			{"Slug": "checkout-svc", "Owner": "checkout"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := renderProjectionTable(&buf, pv); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Slug") {
+		t.Error("table missing 'Slug' header")
+	}
+	if !strings.Contains(out, "payment-api") {
+		t.Error("table missing 'payment-api' row")
+	}
+	if !strings.Contains(out, "checkout-svc") {
+		t.Error("table missing 'checkout-svc' row")
+	}
+	if !strings.Contains(out, "----") {
+		t.Error("table missing separator")
+	}
+}
+
+// TestRenderProjectionTable_NoRows surfaces the empty-result case
+// rather than producing a silent header-only output.
+func TestRenderProjectionTable_NoRows(t *testing.T) {
+	pv := ProjectedView{
+		UUID:    "x",
+		Columns: []ViewColumnSpec{{Name: "Slug", MetadataAttribute: "slug"}},
+		Rows:    []projectionRow{},
+	}
+	var buf bytes.Buffer
+	if err := renderProjectionTable(&buf, pv); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "no matching units") {
+		t.Errorf("expected 'no matching units' marker, got: %q", buf.String())
+	}
+}
+
+// TestListUnitsForFilter_ParsesUnitMetadata covers the projection-
+// shaped sibling of listUnitSlugsForFilter — must return the full
+// metadata blob (not just slugs) so column evaluators can read
+// arbitrary fields.
+func TestListUnitsForFilter_ParsesUnitMetadata(t *testing.T) {
+	const unitsJSON = `[
+		{"slug": "payment-api", "owner": "platform", "labels": {"env": "prod"}},
+		{"slug": "checkout-svc", "owner": "checkout", "labels": {"env": "prod"}}
+	]`
+	fakeProjectionRunner(t, map[string]string{
+		"unit list": unitsJSON,
+	})
+	units, err := listUnitsForFilter(context.Background(), "metadata.labels.env = 'prod'", "*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(units) != 2 {
+		t.Fatalf("expected 2 units, got %d", len(units))
+	}
+	if units[0]["slug"] != "payment-api" {
+		t.Errorf("units[0].slug = %v, want payment-api", units[0]["slug"])
+	}
+	labels, ok := units[0]["labels"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("units[0].labels is not a map: %T", units[0]["labels"])
+	}
+	if labels["env"] != "prod" {
+		t.Errorf("units[0].labels.env = %v, want prod", labels["env"])
+	}
+}
+
+// TestProjectedViewJSON_RoundTrip locks in the JSON contract shape so
+// downstream consumers (the future TUI overlay, Pilot, demo scripts)
+// can pin against it.
+func TestProjectedViewJSON_RoundTrip(t *testing.T) {
+	pv := ProjectedView{
+		UUID:  "806aac53",
+		Space: "demo",
+		Columns: []ViewColumnSpec{
+			{Name: "Slug", MetadataAttribute: "slug"},
+		},
+		Rows: []projectionRow{
+			{"Slug": "payment-api"},
+		},
+	}
+	b, err := json.Marshal(pv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ProjectedView
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if got.UUID != pv.UUID || got.Space != pv.Space {
+		t.Errorf("round-trip identity lost: %+v", got)
+	}
+	if len(got.Columns) != 1 || got.Columns[0].MetadataAttribute != "slug" {
+		t.Errorf("round-trip columns: %+v", got.Columns)
+	}
+	if len(got.Rows) != 1 || got.Rows[0]["Slug"] != "payment-api" {
+		t.Errorf("round-trip rows: %+v", got.Rows)
+	}
+}

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -48,7 +48,7 @@ Source of truth:
 | `trace` | Trace ownership and source chain | [Command Reference](commands.md#trace) | [kro composition](../../examples/kro-composition/) |
 | `tree` | Runtime, ownership, git, and composition hierarchies | [Command Reference](commands.md#tree) | [kro composition](../../examples/kro-composition/) |
 | `version` | Print version/build information | [Command Reference](commands.md#version) | - |
-| `views` | Resolve ConfigHub View references (#391, v0.1) | [Command Reference](commands.md#views) | - |
+| `views` | Resolve, open, and project ConfigHub Views (#391) | [Command Reference](commands.md#views) | - |
 | `watch` | Stream observation events to webhook/file sinks | [Command Reference](commands.md#watch) | [Watch webhook](../../examples/watch-webhook/) |
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2337,10 +2337,64 @@ hostname the input URL carried (the operator's local config wins).
 Connected mode is **not** required — the URL itself is local
 construction. Auth only matters once the browser reaches View Explorer.
 
+### views project
+
+Render a View as a projected table. Resolves the View, lists its
+matching units, and evaluates the View's `Columns` spec against each
+unit's metadata. Closes the loop on #391 scope #2 (View-as-projection).
+
+```bash
+cub-scout views project <uuid-or-url> [flags]
+```
+
+Same input shapes as `views resolve` — bare UUID or View Explorer URL.
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--format table\|json` | Output format (default: `table`). |
+| `--space` | Space to search. Defaults to org-wide (`*`) so a UUID alone is sufficient. |
+
+#### Output
+
+`--format table` produces a fixed-width ASCII table — one row per unit,
+column headers from the View's `Columns` spec.
+
+`--format json` produces:
+
+```json
+{
+  "view": "<uuid>",
+  "space": "<space>",
+  "columns": [<column-spec>],
+  "rows": [{"<column-name>": "<value>", ...}]
+}
+```
+
+#### Evaluator support (v0.1)
+
+ConfigHub's `Column.ColumnSource` has four evaluator forms.
+v0.1 of `views project` evaluates the first directly:
+
+| ColumnSource form | v0.1 behaviour |
+|-------------------|----------------|
+| `MetadataAttribute` | Direct field lookup against unit metadata. Camel/Pascal-case fallback so spec strings like `"Slug"` and `"slug"` both resolve. |
+| `MetadataExpression` (CEL) | Renders `<cel: not yet supported>` placeholder. CEL evaluator is a follow-up dep decision. |
+| `DataPath` (JSONPath) | Renders `<jsonpath: not yet supported>` placeholder. |
+| `DataExpression` (CEL) | Renders `<cel: not yet supported>` placeholder. |
+
+The placeholder approach preserves column headers and ordering so
+operators see the evaluator gap rather than getting silent empty
+cells.
+
+Requires connected mode (`cub auth login` or `CONFIGHUB_API_KEY`).
+
 ### v0.1 scope items still pending
 
-- View column projection in TUI Hub view (scope item #2).
-- Reality overlay composing View columns with #393 source-truth verdicts (scope item #3) — unblocked now that the contract is in main.
+- TUI Hub view integration of View column projection (extends `views project` into the interactive `H` view).
+- Reality overlay composing View columns with #393 source-truth verdicts (scope item #3) — sits on top of `views project`.
+- CEL + JSONPath evaluators for `MetadataExpression`, `DataPath`, `DataExpression` columns.
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2355,6 +2355,7 @@ Same input shapes as `views resolve` — bare UUID or View Explorer URL.
 |------|-------------|
 | `--format table\|json` | Output format (default: `table`). |
 | `--space` | Space to search. Defaults to org-wide (`*`) so a UUID alone is sufficient. |
+| `--with-reality` | Append synthetic columns (`Applied?`, `LiveStatus`) computed from the live cluster. Closes the loop on #391 scope #3 — same View, with cluster reality joined in. |
 
 #### Output
 
@@ -2388,13 +2389,30 @@ The placeholder approach preserves column headers and ordering so
 operators see the evaluator gap rather than getting silent empty
 cells.
 
+#### Reality overlay (`--with-reality`)
+
+When `--with-reality` is set, two synthetic columns are appended to
+the projection — values cub-scout computes from the live cluster,
+not from the View definition:
+
+| Column | Values |
+|--------|--------|
+| `Applied?` | `yes` (live workload exists with matching `confighub.com/UnitSlug`), `no` (unit declared but not deployed), `?` (unit has no slug) |
+| `LiveStatus` | `Ready` (workload reports kstatus Ready), `NotReady`, `(not applied)`, `(no slug)` |
+
+This is the differentiator over the web View Explorer — same View,
+but cub-scout joins in cluster truth. Single-cluster scope assumed
+(reflects only the current kubeconfig context). `Drift` and
+`Orphan?` columns are intentional follow-ups rather than v0.1
+scope.
+
 Requires connected mode (`cub auth login` or `CONFIGHUB_API_KEY`).
 
 ### v0.1 scope items still pending
 
-- TUI Hub view integration of View column projection (extends `views project` into the interactive `H` view).
-- Reality overlay composing View columns with #393 source-truth verdicts (scope item #3) — sits on top of `views project`.
-- CEL + JSONPath evaluators for `MetadataExpression`, `DataPath`, `DataExpression` columns.
+- TUI Hub view integration of View column projection (extends `views project` into the interactive `H` view) — tracked as a follow-up issue.
+- CEL + JSONPath evaluators for `MetadataExpression`, `DataPath`, `DataExpression` columns — dep decision tracked as a follow-up issue.
+- Reality-overlay extensions: `Drift` and `Orphan?` columns alongside the v0.1 `Applied?` / `LiveStatus`.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes **#391 scope #3** (reality overlay). Adds `--with-reality` to `views project`, appending two synthetic columns the web View Explorer cannot show:

| Column | Values |
|---|---|
| `Applied?` | `yes` / `no` / `?` (no slug) |
| `LiveStatus` | `Ready` / `NotReady` / `(not applied)` / `(no slug)` |

This is the View Explorer differentiator the issue framed: same View, cub-scout joins in cluster truth. The View defines the schema, the overlay adds the join.

```bash
# Without overlay: pure ConfigHub projection
cub-scout views project <uuid-or-url>

# With overlay: same rows, plus cluster reality
cub-scout views project <uuid-or-url> --with-reality
```

### Stacked on #419

This PR branches off `claude/391-scope2-views-project` because scope #3 builds directly on `views project`. After #419 merges, GitHub should fast-forward the diff cleanly.

### Refactor

Extracted `buildProjectedView` from `runViewsProject` as a pure (no-stdout, no-connected-mode-gate) function. The CLI runner wraps it; tests call it directly with a fake `ViewRef`. Cleaner seam than playing games with `os.Stdout` substitution.

### Honest scope choice

`Drift` and `Orphan?` columns are intentional follow-ups, **not** in this PR. They require richer machinery:
- `Drift` needs DRY/WET/LIVE diff per row — basically running `compare three-way` for each unit
- `Orphan?` needs the inverse-direction join (live workloads with `confighub.com/UnitSlug` labels not present in the View's filter)

Shipping `Applied?` + `LiveStatus` first because they unlock the demo narrative immediately and the foundation slots cleanly into the next overlay extension.

## Test plan

- [ ] `TestComputeRealityCells`: 4 states (applied+ready, applied+notready, not applied, no slug)
- [ ] `TestBuildProjectedView_WithReality`: full overlay flow with both fake seams; 3 rows verified including the "declared but not yet applied" case
- [ ] `TestBuildProjectedView_WithoutReality`: opt-in behaviour locked — workload-index helper must NOT be called without the flag, and synthetic columns must NOT appear
- [ ] All 37 packages pass

## What's still open in #391

I'll file two follow-up issues this session covering:
1. **CEL + JSONPath evaluators** for the `MetadataExpression` / `DataPath` / `DataExpression` columns (dep decision: `cel-go` is heavy, `k8s.io/client-go/util/jsonpath` is reachable transitively)
2. **TUI Hub view integration** of `views project` rows (extends the interactive `H` view to render the projection table inline)

Plus the `Drift` / `Orphan?` overlay-extension columns mentioned above.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)