### PR TITLE
docs: clarify trust thesis, cub-scout vs cub boundary, and MCP framing

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -25,14 +25,19 @@ Use these for different AI scenarios:
 
 ### `cub scout` / `cub-scout`
 
-`cub scout` is the preferred documented form for the read-only Kubernetes and GitOps observer.
-In this repo, local command examples still use `./cub-scout ...`.
+**`cub scout` observes and explains; it never decides.** It is the
+read-only Kubernetes and GitOps observer — it surfaces evidence, never
+mutates the cluster, and never makes authority calls about what *should* be
+true.
+
+`cub scout` is the preferred documented form. In this repo, local command
+examples still use `./cub-scout ...`.
 
 Use it for:
 - `doctor`, `explain`, `trace`, `map`, `scan`
 - connected comparison such as `compare three-way`
 - local Git structure discovery with `import --git-path` and `parse-repo`
-- MCP serving via `mcp serve`
+- Model Context Protocol (MCP) serving via `mcp serve`
 
 Important:
 - `cub scout` is cluster read-only by default
@@ -98,7 +103,7 @@ As of 2026-05-08, these areas are fully or materially shipped:
   - connected DRY/WET/LIVE comparison
   - `--fail-on` conformance exit codes
   - agreement/convergence summary in CLI + JSON
-- MCP gateway
+- MCP (Model Context Protocol) gateway
   - `mcp serve` exposes `doctor` as the first standalone troubleshooting tool, including when the problem might be local access uncertainty such as wrong context, stale kubeconfig, or API reachability
   - standalone tool set: `doctor`, `explain`, `map`, `scan`, `trace`
   - connected mode adds read-only ConfigHub query tools

--- a/CLI-GUIDE.md
+++ b/CLI-GUIDE.md
@@ -1,7 +1,11 @@
 # cub-scout CLI Guide
 
-Workflow-first guide for learning how to use cub-scout without turning this file
-into a second command encyclopedia.
+**cub-scout observes and explains; it never decides.** It is the read-only
+Kubernetes and GitOps observer — every command in this guide reads cluster
+or ConfigHub state and explains it, but nothing here mutates the cluster.
+
+Workflow-first guide for learning how to use cub-scout without turning this
+file into a second command encyclopedia.
 
 Need a specific command or flag?
 - [Complete CLI Reference (A-Z)](docs/reference/cli-reference.md)
@@ -113,7 +117,9 @@ If you need more on import:
 
 ## AI And Automation
 
-cub-scout is designed to expose read-only cluster facts to automation and AI agents.
+cub-scout is designed to expose read-only cluster facts to automation and AI
+agents. The primary AI gateway is a Model Context Protocol (MCP) server that
+exposes the same read-only commands you use from the CLI.
 
 High-value entrypoints:
 
@@ -126,7 +132,7 @@ cub-scout compare three-way --scope namespace/prod --format json
 ```
 
 Use:
-- `mcp serve` when you want a read-only MCP server over stdio
+- `mcp serve` when you want a read-only MCP (Model Context Protocol) server over stdio
 - `context-pack` when you want a bounded AI handoff bundle
 - JSON outputs when you want stable machine-readable facts
 
@@ -143,7 +149,7 @@ For AI-specific operating guidance:
 |-----------|----------|------------|
 | TUI | Interactive exploration and keyboard-driven debugging | `cub-scout map` |
 | CLI | One-off commands, shell use, pipelines | `cub-scout doctor`, `cub-scout explain`, `cub-scout trace` |
-| JSON | Automation, AI, MCP-backed workflows | `--format json` or `--json` |
+| JSON | Automation, AI, Model Context Protocol (MCP) workflows | `--format json` or `--json` |
 
 Good rule of thumb:
 - start with `doctor` if you do not know where to begin

--- a/README.md
+++ b/README.md
@@ -1,24 +1,53 @@
-# cub-scout -- explore and map GitOps clusters!  
+# cub-scout — explore and map GitOps clusters
 
-**Offline-first. Deterministic. Cluster read-only. Cub plugin option.**
+**Read-only. Deterministic. Offline-capable. Optional `cub` plugin.**
 
-cub-scout is an open-source cluster explorer for Kubernetes and GitOps. 
+cub-scout is an open-source observer for Kubernetes and GitOps.
+**It observes and explains; it never decides.** It diagnoses, explains,
+traces, maps, and scans Kubernetes resources and their GitOps origins — but
+never modifies cluster state and never makes authority calls about what
+*should* be true. It is safe to run against production.
 
 It helps you answer:
-- what owns this resource?
-- where did it come from?
-- what is broken right now?
-- how does governed state compare to live state?
+- what owns this resource, really?
+- where did it come from in Git?
+- what is broken right now, and what should I do next?
+- how does **intended** (governed) state compare to **live** (cluster) state?
 
 It works standalone with your current kube context, or connected to
-[ConfigHub](https://confighub.com) for comparison, import, history, fleet, and
-AI-friendly read-only workflows.
+[ConfigHub](https://confighub.com) for governed comparison, change history,
+import, fleet queries, and AI-friendly read-only workflows.
 
-**New in v2.0:** cub-scout now also ships as one of our first `cub` plugins.
+### Who reaches for cub-scout?
 
-Run `cub plugin install confighub/cub-scout` and invoke it as `cub scout ...`
-with inherited auth from `cub`. Standalone `cub-scout` is unchanged and fully
-supported. See [Three Invocation Forms](#three-invocation-forms) and the
+- **SREs and on-call** — when a workload is unhealthy and you need to know
+  *why* and *who owns it* in seconds, not by clicking through Argo or Flux UIs.
+- **Platform engineers** — when you inherit a cluster and need a
+  trustworthy ownership map across Flux, ArgoCD, Helm, Crossplane, ConfigHub,
+  and naked YAML.
+- **AI agents and automation** — when you need stable, deterministic JSON or
+  a Model Context Protocol (MCP) gateway for read-only cluster facts.
+
+### `cub-scout` vs `cub`: the boundary
+
+cub-scout and [`cub`](https://confighub.com) are designed to be complementary,
+not interchangeable:
+
+| | `cub-scout` | `cub` |
+|---|---|---|
+| Role | **Observe and explain** | **Act and govern** |
+| Cluster state | Read-only | Read + reconcile via workers |
+| ConfigHub state | Read-only queries | Authoring, import, promotion |
+| Best for | Diagnosis, ownership, drift, audit, AI tools | Intended-state authoring, GitOps pipelines |
+
+cub-scout is the **read-only witness**. ConfigHub (driven by `cub`) is the
+**authority**. The two ship as separate binaries and never overlap on writes.
+
+**New in v2.0:** cub-scout also ships as one of our first `cub` plugins. Run
+`cub plugin install confighub/cub-scout` and invoke it as `cub scout ...`
+with inherited auth from `cub` — same binary, same JSON, same MCP tools.
+Standalone `cub-scout` is unchanged and fully supported. See
+[Three Invocation Forms](#three-invocation-forms) and the
 [migration guide](docs/releases/v2.0.0-migration-guide.md).
 
 **New here?** Start with the [Fast Path](#fast-path-2-minutes), then use:
@@ -29,6 +58,24 @@ supported. See [Three Invocation Forms](#three-invocation-forms) and the
 
 Please send feedback by [opening an issue](https://github.com/confighub/cub-scout/issues)
 or joining [Discord](https://discord-auth.confighub.net/discord/join) via ConfigHub signup.
+
+---
+
+## What cub-scout does, at a glance
+
+| Capability | Command | What you get |
+|---|---|---|
+| **Diagnose** cluster health | `doctor` | One-screen summary of ownership, health, drift, and risk, with concrete next steps. |
+| **Explain** any resource | `explain` | Plain-English ownership and lineage for one resource — auto-detects Flux, ArgoCD, Helm, Crossplane, or native. |
+| **Trace** workloads to Git | `trace` | The full ownership chain from a Kubernetes object back to its Git source, ApplicationSet, or OCI registry. |
+| **Map** the cluster interactively | `map` | TUI for browsing ownership, health, and dependencies across a cluster. |
+| **Scan** for risk | `scan` | Audits live clusters or manifest files against 46 built-in risk patterns (and 3,513 in the [confighub-scan](https://github.com/confighubai/confighub-scan) catalog). |
+| **Compare** intent vs reality | `compare three-way` | DRY (intended) vs WET (rendered) vs LIVE (cluster) — shows drift no live API can. *Connected only.* |
+| **Serve** as an AI gateway | `mcp serve` | Read-only Model Context Protocol (MCP) server over stdio for Claude, Codex, and other agents. |
+
+All commands emit deterministic JSON via `--format json` for scripts and
+agents. Same input, same output — no AI/ML inference inside the core
+ownership logic.
 
 ---
 
@@ -132,9 +179,19 @@ cub-scout import --dry-run -n prod
 
 ### 3. Plugin mode (new in v2.0) — `cub scout ...`
 
-Install once, inherit `cub`'s auth automatically, and use the preferred `cub
-scout ...` invocation form. Recommended for AI tooling because the MCP tool
-descriptions and hint output explicitly route through `cub scout ...`.
+A **`cub` plugin** is an installable extension to the `cub` CLI that lets you
+invoke another tool as a `cub` subcommand. cub-scout was the first tool we
+shipped this way: after `cub plugin install confighub/cub-scout`, the plugin
+form `cub scout ...` runs the same binary as standalone `cub-scout ...` but
+inherits `cub`'s authentication, context, and ConfigHub session
+automatically — no separate login step.
+
+Use plugin form when:
+- you already have `cub` installed and authenticated
+- you want a single auth surface instead of two
+- you want to invoke cub-scout from AI tools — MCP tool descriptions,
+  structured `nextSteps` hints, and trust URLs all canonicalize to
+  `cub scout ...` so downstream agents see one consistent command shape
 
 ```bash
 cub plugin install confighub/cub-scout
@@ -146,6 +203,10 @@ cub scout mcp serve
 Under the hood, `cub` exec's the plugin binary with `CUB_PLUGIN=1`,
 `CUB_TOKEN`, and `CUB_CONTEXT` set. The plugin form inherits auth without a
 separate login step and never recursively shells out to `cub auth get-token`.
+
+**Same binary, same JSON, same MCP tools.** Standalone and plugin forms are
+held to byte-equivalence by the `TestPluginParity_StandaloneMatchesPlugin`
+release-gate test.
 
 ---
 
@@ -279,10 +340,31 @@ For detailed scanner behavior and output shape, use
 
 ## Standalone vs Connected
 
-cub-scout works fully offline. Connected mode is optional. The capability
-axis is orthogonal to the [invocation form](#three-invocation-forms) — every
-feature below works identically whether you run `cub-scout ...` standalone
-or `cub scout ...` through the plugin.
+cub-scout works fully offline. Connected mode is optional but unlocks the
+questions a live cluster alone cannot answer.
+
+**Standalone (no signup):** Works from your current kube context. You get
+ownership detection, ownership tracing, health diagnosis, drift hints,
+risk scanning, JSON, and an MCP gateway — everything you need to triage
+*right now* on the cluster in front of you.
+
+**Connected (`cub auth login`):** Adds the historical and cross-cluster
+context that the Kubernetes API does not have. Specifically:
+
+- **DRY vs WET vs LIVE** — compare what ConfigHub *intended* to deploy
+  (DRY), what the renderer *produced* (WET), and what is actually
+  *running* (LIVE). Catches drift the live cluster can't tell you about.
+- **Change history** — ask "when did this change, who changed it, and
+  why?" against ConfigHub's governed timeline, not just `kubectl events`.
+- **Fleet queries** — answer "is this version running everywhere it
+  should?" across many clusters at once.
+- **Import preview** — propose how a live workload should be modeled in
+  ConfigHub before writing anything.
+
+The capability axis is orthogonal to the [invocation form](#three-invocation-forms):
+every row below works identically in `cub-scout ...` standalone and `cub
+scout ...` plugin form. Parity is enforced by a release-gate test
+(`TestPluginParity_StandaloneMatchesPlugin`).
 
 | Capability | Standalone | Connected |
 |------------|:----------:|:---------:|
@@ -291,20 +373,18 @@ or `cub scout ...` through the plugin.
 | Trace to Git source | ✓ | ✓ |
 | Scan for risk issues | ✓ | ✓ |
 | Deterministic JSON output | ✓ | ✓ |
-| MCP gateway | ✓ | ✓ |
-| Import workloads into ConfigHub | — | ✓ |
-| Connected change history | — | ✓ |
+| Model Context Protocol (MCP) gateway | ✓ | ✓ |
 | DRY vs WET vs LIVE comparison | — | ✓ |
+| Connected change history | — | ✓ |
 | Fleet-level queries | — | ✓ |
+| Import workloads into ConfigHub | — | ✓ |
 
-**Standalone:** Works from your current kube context with no signup required.
+In plugin form (`cub scout ...`) the token from `cub auth login` is inherited
+automatically. In standalone form (`cub-scout ...`) it is picked up from
+`cub`'s local token store.
 
-**Connected:** Run `cub auth login` to enable ConfigHub-backed comparison,
-history, import, and fleet features. In plugin form (`cub scout ...`), the
-token from `cub auth login` is inherited automatically; in standalone form
-(`cub-scout ...`), it is picked up via the `cub` CLI's local token store.
-
-Connected import writes ConfigHub records, not cluster manifests.
+**Important:** connected import writes ConfigHub records, not cluster
+manifests. cub-scout never modifies the cluster.
 
 ---
 
@@ -331,14 +411,19 @@ If you prefer CLI-only, omit `--map`.
 ## Why People Reach For It
 
 GitOps stacks are powerful, but the day-two questions are still painful:
-- a Deployment exists, but what actually owns it?
-- Argo or Flux says "synced", but is the cluster converged?
-- which events explain the failure right now?
-- is this resource governed, orphaned, or manually changed?
 
-cub-scout gives you those answers through one read-only observation layer
-instead of making you stitch them together by hand with `kubectl`, controller
-CRDs, labels, and UI tabs.
+- A Deployment exists — but what actually owns it?
+- Argo or Flux says "Synced" — but is the cluster actually converged?
+- Which events explain *this* failure, right now?
+- Is this resource governed, orphaned, or manually changed?
+- Did someone hot-patch prod, or did the renderer produce this?
+
+cub-scout answers these through **one read-only observation layer** instead
+of making you stitch them together by hand with `kubectl`, controller CRDs,
+labels, annotations, and UI tabs across Argo, Flux, and Helm.
+
+It is built to be the tool you can keep running on a cluster you don't fully
+trust yet — including production.
 
 ---
 
@@ -350,14 +435,14 @@ For Claude, Codex, and other AI agents:
 - for AI tool setup, see [docs/howto/using-cub-scout-from-ai-tool.md](docs/howto/using-cub-scout-from-ai-tool.md)
 
 What `cub-scout mcp serve` is:
-- a read-only MCP server over stdio
-- backed by the existing CLI JSON surfaces
-- strongest as a troubleshooting and exploration layer
+- a read-only **Model Context Protocol (MCP)** server over stdio
+- backed by the existing CLI JSON surfaces — same answers, agent-shaped
+- strongest as a troubleshooting and exploration layer for AI agents
 
 What it is not:
-- not a Kubernetes write tool
-- not a multi-gateway router
-- not the full ConfigHub authority layer
+- not a Kubernetes write tool — every tool call goes through the read-only CLI
+- not a multi-gateway router — it speaks one protocol, MCP
+- not the ConfigHub authority layer — that role belongs to `cub`
 
 ---
 
@@ -393,11 +478,23 @@ go build ./cmd/cub-scout
 
 ## Principles
 
-- **Read-only by default**: cluster observation uses `Get`, `List`, and `Watch`
-- **Deterministic**: same inputs, same outputs; no AI/ML inside core ownership logic
-- **Parse, don't guess**: ownership comes from real labels, annotations, owner refs, and controller facts
-- **Complement GitOps**: cub-scout helps you understand Flux, ArgoCD, Helm, and ConfigHub state; it does not try to replace them
-- **Graceful degradation**: works without ConfigHub, without internet, and many flows work without a live cluster
+- **Read-only, by design** — cluster observation uses only `Get`, `List`, and
+  `Watch`. cub-scout has no `apply`, no `delete`, no admission webhook, no
+  cluster-mutating code path. Run it against production without an
+  approval ticket.
+- **Deterministic** — same inputs, same outputs. No AI/ML inference inside the
+  core ownership logic. Ownership decisions are reproducible and explainable.
+- **Parse, don't guess** — ownership comes from real labels, annotations,
+  owner references, and controller facts. We refuse to invent provenance.
+- **Complement GitOps, don't replace it** — cub-scout helps you understand
+  Flux, ArgoCD, Helm, Crossplane, and ConfigHub state. It is not another
+  reconciler.
+- **Graceful degradation** — works without ConfigHub, without internet, and
+  many flows work without a live cluster (debug bundles, manifest scans,
+  Git-path import preview).
+- **Evidence, not authority** — cub-scout is the read-only **witness**.
+  ConfigHub (driven by `cub`) is the **authority** for intended state. The two
+  never overlap on writes.
 
 For more on the security and operating model, see [SECURITY.md](SECURITY.md).
 

--- a/docs/howto/using-cub-scout-from-ai-tool.md
+++ b/docs/howto/using-cub-scout-from-ai-tool.md
@@ -79,7 +79,7 @@ Important rules:
 
 - explicit mode selection should win over auto-detection
 - any host detection should be advisory only
-- JSON and MCP outputs should stay structurally stable across presentation modes
+- JSON and MCP (Model Context Protocol) outputs should stay structurally stable across presentation modes
 - text and markdown outputs can adapt more for readability and handoff quality
 
 Useful concepts:

--- a/skills/cub-scout/SKILL.md
+++ b/skills/cub-scout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cub-scout
-description: Use when working in the cub-scout repo or when answering what cub-scout can do versus ConfigHub/cub. Covers cub-scout's read-only observation role, connected comparison workflows, MCP surfaces, Git preview boundaries, and how to verify current command truth before claiming capability.
+description: Use when working in the cub-scout repo or when answering what cub-scout can do versus ConfigHub/cub. Covers cub-scout's read-only observation role, connected comparison workflows, Model Context Protocol (MCP) surfaces, Git preview boundaries, and how to verify current command truth before claiming capability.
 ---
 
 # cub-scout
@@ -10,7 +10,7 @@ Start here when the task is about:
 - what `cub scout` does today
 - how `cub scout` differs from `cub`
 - whether a workflow is standalone, connected, or ConfigHub/cub
-- AI/MCP usage of `doctor`, `explain`, `trace`, `map`, `scan`
+- AI / Model Context Protocol (MCP) usage of `doctor`, `explain`, `trace`, `map`, `scan`
 - Git preview versus render/import boundaries
 
 ## Read first
@@ -29,7 +29,14 @@ If the user is asking you to *use* cub-scout against a real cluster (not work on
 
 ## Product value in one breath
 
-`cub scout` is the preferred documented form for the read-only Kubernetes and GitOps observer. In this repo, use `./cub-scout ...` for exact local commands.
+**cub scout observes and explains; it never decides.** It is the read-only
+Kubernetes and GitOps observer — it surfaces evidence about ownership,
+health, and drift, but it never mutates the cluster and never makes
+authority calls about what *should* be true. ConfigHub (driven by `cub`) is
+the authority; cub-scout is the witness.
+
+`cub scout` is the preferred documented form. In this repo, use
+`./cub-scout ...` for exact local commands.
 
 ## Tool boundaries
 
@@ -37,7 +44,7 @@ If the user is asking you to *use* cub-scout against a real cluster (not work on
 
 - `doctor`, `explain`, `trace`, `map`, `scan`
 - connected comparison such as `compare three-way`
-- MCP serving through `mcp serve`
+- Model Context Protocol (MCP) serving through `mcp serve`
 - local Git structure preview through `import --git-path` and `parse-repo`
 
 ### Use `cub` for


### PR DESCRIPTION
## Summary

Sharpens the user-facing cub-scout docs in response to a Gemini-generated wiki review (codewiki.google) that exposed several places where downstream readers (and AI summarizers) were hallucinating product framing. Specifically:

- The wiki rendered "MCP" as "Multi-Cloud Platform" because we never spelled out "Model Context Protocol" on first use anywhere user-facing.
- The wiki conflated `cub-scout` and `cub` responsibilities because the boundary lived only in `CLAUDE.md` / internal principles docs.
- The wiki buried the trust/read-only story as a bullet point instead of leading with it.

## Changes

- **Lead with the trust thesis.** "cub-scout observes and explains; it never decides." now lands in the opening paragraph of [README.md](README.md), [AI-README-FIRST.md](AI-README-FIRST.md), [CLI-GUIDE.md](CLI-GUIDE.md), and [skills/cub-scout/SKILL.md](skills/cub-scout/SKILL.md).
- **Make the cub-scout vs cub boundary visible to users**, not just internal docs — new comparison table in README ("Observe and explain" vs "Act and govern").
- **Add "What cub-scout does, at a glance"** verb table (diagnose / explain / trace / map / scan / compare / serve) in README, anchored to actual commands.
- **Rewrite Standalone vs Connected** to lead with what becomes possible (DRY/WET/LIVE, change history, fleet queries, import preview) rather than a feature checklist.
- **Clarify "cub plugin"** — what it is, when to use plugin form, parity guarantees.
- **Spell out "Model Context Protocol (MCP)"** on first use across all five user-facing docs.
- **Strengthen Principles** with explicit evidence/witness/authority triad.
- **Add personas** ("Who reaches for cub-scout?" — SREs, platform engineers, AI agents) up front.

No code changes; no command surface changes; no schema changes.

## Test plan

- [x] `go run ./scripts/check-cli-docs` — passes
- [x] `bash scripts/check-cli-guide-parity.sh` — passes
- [x] `bash scripts/check-doc-freshness.sh` — passes
- [x] `go test ./scripts/ci/...` — passes (covers `readme_scan_docs_test`)
- [ ] Manual eyeball of README on GitHub for table rendering
- [ ] (Optional) Re-run codewiki.google or a similar summarizer to confirm the new opener no longer hallucinates "Multi-Cloud Platform"

🤖 Generated with [Claude Code](https://claude.com/claude-code)