### PR TITLE
release: v2.1.0 prep — release notes + sim-driven README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,10 @@ not interchangeable:
 cub-scout is the **read-only witness**. ConfigHub (driven by `cub`) is the
 **authority**. The two ship as separate binaries and never overlap on writes.
 
-**New in v2.0:** cub-scout also ships as one of our first `cub` plugins. Run
-`cub plugin install confighub/cub-scout` and invoke it as `cub scout ...`
-with inherited auth from `cub` — same binary, same JSON, same MCP tools.
-Standalone `cub-scout` is unchanged and fully supported. See
-[Three Invocation Forms](#three-invocation-forms) and the
-[migration guide](docs/releases/v2.0.0-migration-guide.md).
+> **New in v2.0:** cub-scout also runs as a `cub` plugin (`cub scout ...`)
+> with inherited auth. Standalone `cub-scout` is unchanged. See
+> [How To Run It](#how-to-run-it) and the
+> [migration guide](docs/releases/v2.0.0-migration-guide.md).
 
 **New here?** Start with the [Fast Path](#fast-path-2-minutes), then use:
 - [CLI Guide](CLI-GUIDE.md) for the workflow-first tour
@@ -69,8 +67,8 @@ or joining [Discord](https://discord-auth.confighub.net/discord/join) via Config
 | **Explain** any resource | `explain` | Plain-English ownership and lineage for one resource — auto-detects Flux, ArgoCD, Helm, Crossplane, or native. |
 | **Trace** workloads to Git | `trace` | The full ownership chain from a Kubernetes object back to its Git source, ApplicationSet, or OCI registry. |
 | **Map** the cluster interactively | `map` | TUI for browsing ownership, health, and dependencies across a cluster. |
-| **Scan** for risk | `scan` | Audits live clusters or manifest files against 46 built-in risk patterns (and 3,513 in the [confighub-scan](https://github.com/confighubai/confighub-scan) catalog). |
-| **Compare** intent vs reality | `compare three-way` | DRY (intended) vs WET (rendered) vs LIVE (cluster) — shows drift no live API can. *Connected only.* |
+| **Scan** for risk | `scan` | Audits live clusters or manifest files against 46 built-in risk patterns. Optionally delegates to the separate [confighub-scan](https://github.com/confighubai/confighub-scan) tool for its broader catalog. |
+| **Compare** intent vs reality | `compare three-way` | Three-way diff between **DRY** (what ConfigHub *intends* to deploy), **WET** (what the renderer *produced*), and **LIVE** (what is *running* in the cluster). Surfaces drift the Kubernetes API alone cannot. *Connected only.* |
 | **Serve** as an AI gateway | `mcp serve` | Read-only Model Context Protocol (MCP) server over stdio for Claude, Codex, and other agents. |
 
 All commands emit deterministic JSON via `--format json` for scripts and
@@ -81,33 +79,29 @@ ownership logic.
 
 ## Fast Path (2 Minutes)
 
+**No ConfigHub signup required.** cub-scout reads from your current kube
+context and works fully offline.
+
 ```bash
-# Standalone: works with any kube context, no signup
+# Install (Homebrew — see Install section below for other options)
 brew install confighub/tap/cub-scout
-cub-scout quickstart
-cub-scout doctor
-cub-scout explain deploy/app -n ns
-cub-scout trace deploy/app -n ns
-cub-scout map
+
+# Triage flow: doctor → explain → trace
+cub-scout doctor                                  # cluster health summary
+cub-scout explain deploy/frontend -n boutique     # who owns this resource?
+cub-scout trace   deploy/frontend -n boutique     # where did it come from?
+cub-scout map                                     # interactive TUI
 ```
 
-Or, if you already use `cub`:
-
-```bash
-# Plugin form: inherits cub's auth and context
-cub plugin install confighub/cub-scout
-cub scout quickstart
-cub scout doctor
-cub scout explain deploy/app -n ns
-cub scout trace deploy/app -n ns
-cub scout map
-```
+If `cub-scout: command not found` but you have `cub` installed, try
+`cub scout doctor` instead — see [How To Run It](#how-to-run-it) for the
+plugin form.
 
 What you get in the first two minutes:
-- ownership detection across Flux, ArgoCD, Helm, ConfigHub, and native resources
+- ownership detection across Flux, ArgoCD, Helm, Crossplane, ConfigHub, and native resources
 - one-command health summary with next steps
-- trace from workload to Git source
-- recent Kubernetes events in `explain` and `trace`
+- trace from workload to Git source (Application, ApplicationSet, GitRepository, OCI registry)
+- recent Kubernetes events surfaced in `explain` and `trace`
 - deterministic JSON for scripts, AI agents, and MCP clients
 
 ---
@@ -148,12 +142,11 @@ troubleshooting.
 
 ---
 
-## Three Invocation Forms
+## How To Run It
 
-The same binary, three ways to run it. Pick whichever fits your environment.
-Commands, flags, JSON contracts, exit codes, and MCP tool names are identical
-across forms — only the invocation prefix differs. Feature parity is enforced
-by a release-gate test (`TestPluginParity_StandaloneMatchesPlugin`).
+Same binary, three ways to invoke it. Commands, flags, JSON, exit codes, and
+MCP tool names are identical across all three; only the invocation prefix
+differs.
 
 ### 1. Standalone — "if you can kubectl, you can cub-scout"
 
@@ -168,7 +161,9 @@ cub-scout trace deploy/api -n prod
 
 ### 2. Connected — ConfigHub-backed comparison, history, import
 
-Adds governed read paths once you've authenticated once with `cub`.
+Adds governed read paths once you've authenticated with `cub`. cub-scout
+still never modifies the cluster — `import` writes records into ConfigHub,
+not manifests into your cluster.
 
 ```bash
 cub auth login
@@ -187,11 +182,12 @@ inherits `cub`'s authentication, context, and ConfigHub session
 automatically — no separate login step.
 
 Use plugin form when:
-- you already have `cub` installed and authenticated
-- you want a single auth surface instead of two
-- you want to invoke cub-scout from AI tools — MCP tool descriptions,
-  structured `nextSteps` hints, and trust URLs all canonicalize to
-  `cub scout ...` so downstream agents see one consistent command shape
+- you already have `cub` installed and authenticated (one auth surface)
+- you are invoking cub-scout from AI tools (MCP tool descriptions and `nextSteps`
+  hints render `cub scout ...`, so agent output stays consistent)
+
+Otherwise, standalone form is the path of least resistance: `brew install`
+and you're done.
 
 ```bash
 cub plugin install confighub/cub-scout
@@ -204,9 +200,8 @@ Under the hood, `cub` exec's the plugin binary with `CUB_PLUGIN=1`,
 `CUB_TOKEN`, and `CUB_CONTEXT` set. The plugin form inherits auth without a
 separate login step and never recursively shells out to `cub auth get-token`.
 
-**Same binary, same JSON, same MCP tools.** Standalone and plugin forms are
-held to byte-equivalence by the `TestPluginParity_StandaloneMatchesPlugin`
-release-gate test.
+Standalone and plugin forms are held to byte-equivalence by a release-gate
+test (`TestPluginParity_StandaloneMatchesPlugin`).
 
 ---
 
@@ -214,8 +209,7 @@ release-gate test.
 
 Each example below uses standalone form (`cub-scout ...`). If you installed
 the plugin (`cub plugin install confighub/cub-scout`), substitute `cub scout`
-for `cub-scout` in any command — behavior is identical and the MCP/JSON
-outputs are byte-for-byte equivalent under the release-gate parity test.
+for `cub-scout` in any command — behavior is identical.
 
 ### Standalone Value Now
 
@@ -361,7 +355,7 @@ context that the Kubernetes API does not have. Specifically:
 - **Import preview** — propose how a live workload should be modeled in
   ConfigHub before writing anything.
 
-The capability axis is orthogonal to the [invocation form](#three-invocation-forms):
+The capability axis is orthogonal to the [invocation form](#how-to-run-it):
 every row below works identically in `cub-scout ...` standalone and `cub
 scout ...` plugin form. Parity is enforced by a release-gate test
 (`TestPluginParity_StandaloneMatchesPlugin`).
@@ -478,10 +472,12 @@ go build ./cmd/cub-scout
 
 ## Principles
 
-- **Read-only, by design** — cluster observation uses only `Get`, `List`, and
-  `Watch`. cub-scout has no `apply`, no `delete`, no admission webhook, no
-  cluster-mutating code path. Run it against production without an
-  approval ticket.
+- **Read-only by default** — observation, comparison, tracing, scanning, and
+  MCP all use only `Get`, `List`, and `Watch`. The one mutating command,
+  `remedy`, defaults to `--dry-run=true` and only applies fixes when you
+  explicitly pass `--dry-run=false` against a chosen risk finding. The
+  default `cub-scout doctor / explain / trace / map / scan / mcp serve`
+  flow is safe to run against production without an approval ticket.
 - **Deterministic** — same inputs, same outputs. No AI/ML inference inside the
   core ownership logic. Ownership decisions are reproducible and explainable.
 - **Parse, don't guess** — ownership comes from real labels, annotations,

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,0 +1,252 @@
+# v2.1.0 Release Notes — Views, Source-Truth v0.2, and kstatus
+
+> **Previous release:** [`v2.0.0`](v2.0.0.md) — `cub-scout` becomes `cub scout` plugin.
+
+**Theme:** *cub-scout becomes the read-only evidence layer for ConfigHub
+acceptance.* This release ships the **views** integration, **source-truth
+v0.2** evidence contract, and the **kstatus** readiness migration — making
+cub-scout's output safe for Pilot's acceptance kernel to consume directly.
+
+---
+
+## Highlights
+
+- **Views integration.** Resolve and project ConfigHub Views directly from
+  cub-scout: `views resolve`, `views open`, `views project --with-reality`,
+  and `compare three-way --view`.
+- **Source-truth evidence contract v0.2.** A structured, strategy-relative
+  JSON contract that downstream judges (Pilot) can consume without
+  guessing. Four strategies cover the common Flux/Argo × Git/OCI matrix.
+- **kstatus alignment.** Workload readiness now flows through
+  `sigs.k8s.io/cli-utils/pkg/kstatus` — the same library Argo CD and Flux
+  use upstream. Stalled or generation-lagging workloads correctly report
+  `Ready=false` instead of being silently classified as healthy.
+- **`compare source-truth` exposed as an MCP tool.** AI agents can now ask
+  for source-truth verdicts through the structured tool surface, not just
+  the CLI.
+
+---
+
+## What's New
+
+### Views integration ([#391](https://github.com/confighub/cub-scout/issues/391))
+
+cub-scout now treats ConfigHub Views as first-class scoping primitives:
+
+```bash
+# Accept a UUID or paste a View Explorer URL — both work
+cub-scout views resolve <uuid-or-url>
+cub-scout views open    <uuid-or-url>
+cub-scout views project <uuid-or-url> --with-reality
+
+# Scope a three-way comparison to a View's filter
+cub-scout compare three-way --view <uuid-or-url> --scope namespace/prod
+```
+
+Highlights:
+
+- **URL-as-positional** — paste from your browser address bar instead of
+  copying out UUIDs.
+- **On-prem ConfigHub deployments** — the host is not pinned, so any
+  ConfigHub deployment is supported.
+- **Reality overlay** — `views project --with-reality` composes a View's
+  ConfigHub-side projection with cub-scout's live cluster observations.
+
+Shipped in [#403](https://github.com/confighub/cub-scout/pull/403)
+(resolver), [#406](https://github.com/confighub/cub-scout/pull/406) (open),
+[#414](https://github.com/confighub/cub-scout/pull/414) (`--view` flag), and
+[#420](https://github.com/confighub/cub-scout/pull/420) (`--with-reality`).
+
+### Source-truth evidence contract ([#393](https://github.com/confighub/cub-scout/issues/393), [#409](https://github.com/confighub/cub-scout/issues/409))
+
+A structured, deterministic JSON contract for "what does cub-scout's
+read-only evidence say about this resource, relative to a chosen delivery
+strategy?":
+
+```bash
+cub-scout compare source-truth deploy/api -n prod \
+  --strategy git-flux \
+  --format json
+```
+
+Four strategies cover the common matrix:
+
+| Strategy | Source | Delivery |
+|---|---|---|
+| `git-flux` | Git repository | Flux Kustomization / HelmRelease |
+| `git-argo` | Git repository | Argo Application / ApplicationSet |
+| `confighub-oci-flux` | ConfigHub OCI | Flux Kustomization / HelmRelease |
+| `confighub-oci-argo` | ConfigHub OCI | Argo Application / ApplicationSet |
+
+Strategy-relative correctness and the missing-proof rule are enforced in
+tests, not just intent. A 6-fixture producer suite at
+`test/fixtures/source-truth/` keeps the JSON contract byte-stable.
+
+`compare source-truth` is also exposed as an MCP tool
+([#407](https://github.com/confighub/cub-scout/pull/407)) so AI agents can
+get structured verdicts directly.
+
+Phase 2 ([#418](https://github.com/confighub/cub-scout/pull/418)) expanded
+the strategy enum; Phase 3
+([#417](https://github.com/confighub/cub-scout/pull/417)) closed the
+multi-source Argo gap; Phase 1
+([#416](https://github.com/confighub/cub-scout/pull/416)) shipped the
+cross-surface revision equality for `git-*` strategies.
+
+### kstatus migration ([#394](https://github.com/confighub/cub-scout/issues/394))
+
+All readiness derivation flows through `sigs.k8s.io/cli-utils/pkg/kstatus`,
+the same library Argo CD and Flux use upstream. Operator expectations now
+match: stalled workloads, generation-lagging Deployments, and
+not-yet-reconciled controllers correctly report `Ready=false` instead of
+being silently classified as healthy.
+
+**Behavior change:** if you have automation that depended on the old,
+divergent readiness logic, some workloads that previously reported
+`Ready=true` may now correctly report `Ready=false`. This brings cub-scout
+in line with what Argo and Flux already say about the same resources.
+
+### Architectural triad locked
+
+- **cub-scout** — read-only evidence provider (this release)
+- **Pilot** — acceptance judge (separate product)
+- **ConfigHub** — authority and workflow engine (`cub`)
+
+cub-scout never mutates, repairs, approves, or infers authority. The
+"observes and explains; it never decides" thesis now lands in the opening
+paragraph of `README.md`, `AI-README-FIRST.md`, `CLI-GUIDE.md`, and
+`skills/cub-scout/SKILL.md`.
+
+---
+
+## Changed
+
+- **Workload readiness** — see kstatus migration above. JSON output for
+  `Ready` may flip from `true` to `false` for stalled or generation-lagging
+  workloads. This is a correctness fix, not a regression.
+- **Flux trace** classifies "Last reconciled" status as healthy
+  ([#387](https://github.com/confighub/cub-scout/pull/387)).
+- **`compare three-way` accepts `--view`** to scope comparisons by ConfigHub
+  View ([#408](https://github.com/confighub/cub-scout/issues/408)).
+- **MCP tool surface** adds `compare_source_truth`
+  ([#407](https://github.com/confighub/cub-scout/pull/407)).
+
+---
+
+## Fixed
+
+- `tree` patterns no longer panic when context is not seeded by Cobra
+  `Execute` ([#390](https://github.com/confighub/cub-scout/pull/390)).
+- CLI parity script reads the canonical CLI reference instead of
+  `CLI-GUIDE.md` ([#399](https://github.com/confighub/cub-scout/pull/399)).
+- `cub context get --json` is used for server URL discovery instead of the
+  removed `cub info` (commit `c438347`).
+
+---
+
+## Infrastructure
+
+- **GoReleaser** migrated `brews` → `homebrew_casks`
+  ([#389](https://github.com/confighub/cub-scout/issues/389)) for the
+  homebrew-tap publish step. Existing `brew install confighub/tap/cub-scout`
+  continues to work.
+- **GitHub Actions** upgraded to Node 24
+  ([#385](https://github.com/confighub/cub-scout/issues/385)).
+- **Test stability** — `TestDemoWorkerLifecycleScript_StartStop` startup
+  grace bumped ([#388](https://github.com/confighub/cub-scout/issues/388)).
+- **Lint debt** in `main` cleared
+  ([#384](https://github.com/confighub/cub-scout/issues/384)).
+
+---
+
+## Documentation
+
+The user-facing docs were rewritten around three load-bearing claims:
+
+1. **"cub-scout observes and explains; it never decides."** Lands in the
+   opening of every cold-start path (README, AI-README-FIRST, CLI-GUIDE,
+   SKILL.md).
+2. **`cub-scout` vs `cub` boundary** is now an explicit table in the README
+   — observe vs govern, read-only vs reconcile, witness vs authority.
+3. **Model Context Protocol (MCP)** is spelled out on first use everywhere,
+   so downstream AI summarizers no longer hallucinate "Multi-Cloud
+   Platform."
+
+The README's "What cub-scout does, at a glance" verb table maps each
+capability to its command. DRY/WET/LIVE is now defined inline at first use.
+
+---
+
+## Upgrade / Install
+
+### Plugin form
+
+```bash
+cub plugin install confighub/cub-scout
+cub scout version    # should print v2.1.0
+cub scout doctor
+```
+
+### Standalone
+
+```bash
+# Homebrew
+brew upgrade confighub/tap/cub-scout
+
+# krew
+kubectl krew upgrade cub-scout
+
+# direct download
+curl -L https://github.com/confighub/cub-scout/releases/download/v2.1.0/cub-scout_v2.1.0_darwin_arm64.tar.gz | tar xz
+./cub-scout doctor
+```
+
+---
+
+## Verification
+
+```bash
+git checkout v2.1.0
+go build ./cmd/cub-scout
+go test ./...
+./cub-scout version
+./cub-scout doctor --help
+./cub-scout views --help
+./cub-scout compare source-truth --help
+```
+
+Full test suite must be green. The plugin parity test
+(`TestPluginParity_StandaloneMatchesPlugin`) and source-truth fixture
+producer suite are the new release-gate invariants for this line.
+
+---
+
+## Known Limitations
+
+- **`remedy` is the one mutating command** and remains gated behind
+  `--dry-run=true` by default. Discussion ticket
+  [#410](https://github.com/confighub/cub-scout/issues/410) is open to
+  decide whether `remedy` should be removed, renamed, or hidden behind a
+  separate flag in a future release. The default `cub-scout doctor /
+  explain / trace / map / scan / mcp serve` flow is unchanged and remains
+  read-only.
+- **Initiatives compliance overlay** ([#392](https://github.com/confighub/cub-scout/issues/392))
+  remains deferred until ConfigHub exposes Initiative as an addressable
+  backend primitive. Design doc at
+  `docs/howto/initiatives-integration-when-ready.md` is ready to consume
+  the day the prerequisite lands.
+- **Windows plugin form** is still not supported (cub plugin dispatch uses
+  `syscall.Exec`). Standalone `cub-scout` on Windows is unaffected.
+
+---
+
+## Credits
+
+This release closes the source-truth v0.2 line
+([#393](https://github.com/confighub/cub-scout/issues/393),
+[#409](https://github.com/confighub/cub-scout/issues/409)), the views
+integration ([#391](https://github.com/confighub/cub-scout/issues/391)),
+and the kstatus migration
+([#394](https://github.com/confighub/cub-scout/issues/394)) tracked across
+the v2.1 milestone. The triad lock (evidence / judge / authority) is now
+the documented architecture, not just an internal principle.


### PR DESCRIPTION
## Summary

Prepares the v2.1.0 release. Adds the release notes file and applies a round of README tightening based on simulated new-user feedback (SRE on-call, platform engineer evaluating, AI agent cold-start).

## Release notes (docs/releases/v2.1.0.md)

Theme: **cub-scout becomes the read-only evidence layer for ConfigHub acceptance.** Highlights:

- **Views integration** (#391) — `views resolve`, `views open`, `views project --with-reality`, `compare three-way --view`
- **Source-truth v0.2** (#393, #409) — four-strategy evidence contract, exposed as MCP tool (#407)
- **kstatus migration** (#394) — readiness now matches what Argo/Flux say upstream
- **Architectural triad locked** — evidence (cub-scout) / judge (Pilot) / authority (ConfigHub)

This is a **minor** bump because we added new commands, a new flag, a new MCP tool, and a new strategy enum. No removals.

## README fixes from sim feedback

| Sim flag | Fix |
|---|---|
| DRY/WET/LIVE used 280 lines before being defined | Inline definition in the at-a-glance table |
| `scan` row blurred cub-scout's 46 patterns with confighub-scan's separate 3,513 catalog | Honest split: 46 built-in + optional delegation to the separate tool |
| Fast Path command was `deploy/app -n ns` (placeholder) | Concrete `deploy/frontend -n boutique` matching the SRE's actual situation |
| No recovery hint when `cub-scout: command not found` | Added inline pointer to plugin form |
| "Three Invocation Forms" reads ceremonial | Renamed to "How To Run It" |
| Plugin-form value bullets read marketing-y | Trimmed to 2 honest reasons |
| Parity test mentioned 3× (defensive) | Kept one mention; removed the others |
| `import` claim ambiguous w.r.t. read-only thesis | Disclaimer next to the *first* import mention, not 200 lines later |
| Principles claimed "no apply, no delete" but `cub-scout remedy --dry-run=false` mutates | Softened to acknowledge `remedy`; #410 tracks the resolution |
| v2.0 plugin callout front-loaded in the incident path | Demoted to a one-line blockquote below the fold |

Plus a few link/anchor fixups from the rename.

## Verification

- [x] `go build ./cmd/cub-scout`
- [x] `go test ./...` — all green
- [x] `scripts/check-cli-docs` — passes
- [x] `scripts/check-cli-guide-parity.sh` — passes
- [x] `scripts/check-doc-freshness.sh` — passes
- [ ] Manual: re-skim README rendered on GitHub before tagging

## Next steps after merge

1. Tag `v2.1.0` on `main` (triggers `.github/workflows/release.yaml` → goreleaser)
2. Verify the release publishes binaries + Homebrew cask + ghcr image
3. Smoke test `brew upgrade confighub/tap/cub-scout` and `cub plugin install confighub/cub-scout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)