### PR TITLE
release: v2.2.0 prep — categorically read-only

### DIFF
--- a/docs/releases/v2.2.0.md
+++ b/docs/releases/v2.2.0.md
@@ -1,0 +1,201 @@
+# v2.2.0 Release Notes — cub-scout becomes categorically read-only
+
+> **Previous release:** [`v2.1.0`](v2.1.0.md) — Views, source-truth v0.2, kstatus alignment.
+
+**Theme:** *cub-scout becomes the read-only evidence layer, with no carve-outs.* This release closes the last triad violation: the `remedy` command, which previously executed `kubectl apply / patch / delete` via `executor.Execute`, is now read-only. cub-scout describes a suggested patch; ConfigHub Pilot or an operator decides whether and how to apply it.
+
+After this release, the README's principles claim — *"no `apply`, no `delete`, no admission webhook, no cluster-mutating code path"* — is **literally true** with no asterisk.
+
+---
+
+## Breaking changes
+
+This release renames a public command and removes flags. **Anyone using
+`cub-scout remedy --dry-run=false` to apply fixes will need to update
+their workflow.**
+
+### Renamed: `remedy` → `suggest-remedy`
+
+The command is now [`cub-scout suggest-remedy`](../reference/commands.md#suggest-remedy).
+The verb `remedy` is retained as a Cobra alias for transition, so
+`cub-scout remedy CCVE-2025-0687 -n production` still resolves — but the
+behavior is now strictly read-only.
+
+### Removed flags
+
+`--dry-run`, `--force`, `--audit`, `--audit-file`, and `--timeout` have been
+removed from the command. cub-scout no longer has a non-dry-run path, so
+these flags became meaningless. Passing them now produces:
+
+```
+Error: unknown flag: --dry-run
+```
+
+This is intentional: scripts that depended on the mutation behavior should
+fail loudly, not silently downgrade.
+
+### Removed JSON fields
+
+The JSON output shape changed:
+
+- `RemedyOutput` → `SuggestRemedyOutput`
+- `dryRun` field removed (always read-only now)
+- `result` field removed (no apply, no result)
+- `fixed` / `failed` summary counts removed; new fields: `total`, `describable`, `skipped`
+
+If you parse this JSON, update to the new shape. The producer-side schema is the load-bearing artifact for [Pilot Risk Capability](https://github.com/confighubai/confighub-ai-demo/issues/353) consumption — formal documentation in `docs/reference/json-contracts.md` is a follow-up.
+
+### Removed TUI keybinding
+
+The `F` "apply fix" key in `cub-scout map` is gone. The `f` key now shows the suggested remedy as JSON instead of running a dry-run preview that you could then escalate.
+
+---
+
+## What's New
+
+### `suggest-remedy` — read-only successor
+
+```bash
+# Describe the suggested fix for a specific finding
+cub-scout suggest-remedy CCVE-2025-0687 -n production
+
+# Describe suggestions for all auto-suggestable findings (the JSON
+# contract Pilot consumes)
+cub-scout suggest-remedy --all -n production --json
+
+# Scan a manifest file and report suggestions
+cub-scout suggest-remedy --file manifest.yaml
+
+# List auto-suggestable risk-issue categories
+cub-scout suggest-remedy --list
+```
+
+Output describes the patch that *would* resolve the finding — kubectl
+command, current state, expected change — but cub-scout never applies
+it. Apply via ConfigHub or kubectl, governed.
+
+### Architectural triad now categorical
+
+Before this release the README and SECURITY had to hedge: the `remedy`
+command was a documented exception to "read-only by default." After this
+release, the hedge is gone. Every command in cub-scout uses only `Get` /
+`List` / `Watch` against the cluster.
+
+| | `cub-scout` | `Pilot` | `ConfigHub` |
+|---|---|---|---|
+| Role | Evidence | Judge | Authority |
+| Cluster mutation | None | None | Via worker, governed |
+| Owns the apply? | No | No | Yes |
+
+---
+
+## What's Not Changing
+
+- **Other CLI commands.** `doctor`, `explain`, `trace`, `map`, `scan`,
+  `compare`, `import`, `views`, `mcp` are all unchanged.
+- **JSON contracts for everything else.** No schema changes outside of
+  `suggest-remedy`.
+- **MCP tool set.** The MCP gateway exposes the same tools as v2.1.0.
+- **Plugin parity.** `cub scout suggest-remedy` and standalone
+  `cub-scout suggest-remedy` are byte-equivalent under
+  `TestPluginParity_StandaloneMatchesPlugin`.
+
+---
+
+## Fixed / Infrastructure
+
+- **CI unbreaking:** [#430](https://github.com/confighub/cub-scout/pull/430)
+  — pinned `golangci-lint` to `v1.64.8` and `golangci-lint-action` to `@v6`
+  because v2.x of the lint binary requires a `.golangci.yml` schema
+  migration. Main CI was red from 2026-05-09 12:01 UTC until this pin
+  landed; v2.1.0 still released cleanly because [release.yaml](../../.github/workflows/release.yaml)
+  doesn't run golangci-lint. Migrating `.golangci.yml` to v2 schema is a
+  separate follow-up.
+
+---
+
+## Migration
+
+If you only use cub-scout for diagnosis (`doctor`, `explain`, `trace`,
+`map`, `scan`, `compare`, `mcp`), this release is a transparent upgrade.
+
+If you use the `remedy` command:
+
+| Before | After |
+|---|---|
+| `cub-scout remedy CCVE-2025-0687 -n prod` | `cub-scout suggest-remedy CCVE-2025-0687 -n prod` (or keep `remedy` — alias works) |
+| `cub-scout remedy --all --dry-run -n prod` | `cub-scout suggest-remedy --all -n prod` |
+| `cub-scout remedy --all --dry-run=false --force -n prod` | **No longer applies fixes.** Pipe the JSON to ConfigHub Pilot, or apply via kubectl directly. |
+| Parsing the `dryRun` field in JSON | Field gone. The output is always read-only. |
+| Parsing `result.success` per finding | Field gone. cub-scout no longer reports apply outcomes — there are no applies. |
+| TUI `F` to apply fix | Key removed. `f` now shows the suggested remedy as JSON. |
+
+For automated remediation flows, the recommended path is to consume
+`cub-scout suggest-remedy --all --json` and feed the suggestions to
+ConfigHub Pilot's [Risk Capability](https://github.com/confighubai/confighub-ai-demo/issues/353),
+which judges and proposes governed remediation through ConfigHub.
+
+---
+
+## Upgrade / Install
+
+### Plugin form
+
+```bash
+cub plugin install confighub/cub-scout
+cub scout version    # should print v2.2.0
+cub scout suggest-remedy --list
+```
+
+### Standalone
+
+```bash
+# Homebrew
+brew upgrade confighub/tap/cub-scout
+
+# krew
+kubectl krew upgrade cub-scout
+
+# direct download
+curl -L https://github.com/confighub/cub-scout/releases/download/v2.2.0/cub-scout_v2.2.0_darwin_arm64.tar.gz | tar xz
+./cub-scout suggest-remedy --list
+```
+
+---
+
+## Verification
+
+```bash
+git checkout v2.2.0
+go build ./cmd/cub-scout
+go test ./...
+./cub-scout version
+./cub-scout suggest-remedy --help        # canonical name
+./cub-scout remedy --help                # alias resolves to same Long
+./cub-scout --help | grep -E "remedy|suggest-remedy"  # only suggest-remedy listed
+```
+
+Full test suite must be green. Plugin parity test
+(`TestPluginParity_StandaloneMatchesPlugin`) covers the rename.
+
+---
+
+## Linked
+
+- [#410](https://github.com/confighub/cub-scout/issues/410) — triad-compliance audit (HIGH severity portion **resolved**; `import apply` wording and hint-command lint rule remain open as lower-severity follow-ups)
+- [#428](https://github.com/confighub/cub-scout/issues/428) — option (b) implementation issue
+- [#429](https://github.com/confighub/cub-scout/pull/429) — this release's headline PR
+- [#430](https://github.com/confighub/cub-scout/pull/430) — CI pin to unblock main
+- [confighub/cub-scout#393](https://github.com/confighub/cub-scout/issues/393) — council ruling locking the triad
+- [confighubai/confighub-ai-demo#353](https://github.com/confighubai/confighub-ai-demo/issues/353) — Pilot Risk Capability that consumes the suggested-patch JSON contract this release ships
+
+---
+
+## Credits
+
+This release closes the architectural triad in code, not just intent. The
+trust thesis from [v2.0.0](v2.0.0.md) ("cub-scout observes and explains;
+it never decides"), the source-truth contract from [v2.1.0](v2.1.0.md),
+and the executor removal in this release together make cub-scout the
+read-only evidence layer that ConfigHub Pilot can consume without
+worrying about cub-scout-side mutation.


### PR DESCRIPTION
## Summary

Release notes for **v2.2.0**. Theme: *cub-scout becomes categorically read-only.*

The option (b) work in [#429](https://github.com/confighub/cub-scout/pull/429) closes the last triad violation (the `remedy` command's `executor.Execute` path). After this release the README's principles claim — *"no `apply`, no `delete`, no admission webhook, no cluster-mutating code path"* — is **literally true** with no asterisk.

## Headline changes (all in v2.2.0 since v2.1.0)

| | |
|---|---|
| **Renamed** | `remedy` → `suggest-remedy` (legacy `remedy` retained as Cobra alias) |
| **Removed flags** | `--dry-run`, `--force`, `--audit`, `--audit-file`, `--timeout` |
| **Removed JSON fields** | `dryRun`, `result.*`, `summary.fixed`, `summary.failed`. Output renamed `RemedyOutput` → `SuggestRemedyOutput`. |
| **Removed TUI keybinding** | `F` apply-fix gone; `f` now shows suggested remedy as JSON |
| **Doc revert** | README Principles + SECURITY.md drop the v2.1.0 softening; "no apply, no delete" is now literal |
| **CI infrastructure** | golangci-lint pinned to v1.64.8 + action @v6 via [#430](https://github.com/confighub/cub-scout/pull/430) — v2-schema migration is a follow-up |

This is **breaking** for anyone using `cub-scout remedy --dry-run=false` to apply fixes — they'll hit `unknown flag` errors. That's intentional, so the change is visible and not silently downgraded.

The migration table in the notes covers each breaking case with a before/after.

## Recommended path for automated remediation

`cub-scout suggest-remedy --all --json` → ConfigHub Pilot's [Risk Capability](https://github.com/confighubai/confighub-ai-demo/issues/353) → governed remediation through ConfigHub.

## Verification

- [x] `go build ./...` clean
- [x] `go test ./...` green (37 packages)
- [x] `scripts/check-cli-docs` passes
- [x] `scripts/check-cli-guide-parity.sh` passes
- [x] `scripts/check-doc-freshness.sh` passes

## Next steps after merge

1. Tag `v2.2.0` on `main` (triggers [release.yaml](.github/workflows/release.yaml) → goreleaser)
2. Verify the release publishes binaries + Homebrew cask + ghcr image
3. Smoke test: `brew upgrade confighub/tap/cub-scout` and `cub plugin install confighub/cub-scout`

## Linked

- [#410](https://github.com/confighub/cub-scout/issues/410) — triad audit (HIGH portion resolved)
- [#428](https://github.com/confighub/cub-scout/issues/428) — implementation tracking
- [#429](https://github.com/confighub/cub-scout/pull/429) — headline PR (merged)
- [#430](https://github.com/confighub/cub-scout/pull/430) — CI pin (merged)
- [confighub-ai-demo#353](https://github.com/confighubai/confighub-ai-demo/issues/353) — Pilot Risk Capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)