### PR TITLE
[codex] tolerate cub json envelope variants

### DIFF
--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -364,37 +364,26 @@ func decodeCompareUnitMetadataFromGetJSON(raw string) (compareUnitMetadata, erro
 		return compareUnitMetadata{}, fmt.Errorf("empty unit get output")
 	}
 
-	var payload struct {
-		Space struct {
-			Slug    string `json:"Slug"`
-			SpaceID string `json:"SpaceID"`
-		} `json:"Space"`
-		Unit struct {
-			Slug                   string `json:"Slug"`
-			UnitID                 string `json:"UnitID"`
-			SpaceID                string `json:"SpaceID"`
-			HeadRevisionNum        int    `json:"HeadRevisionNum"`
-			LiveRevisionNum        int    `json:"LiveRevisionNum"`
-			LastAppliedRevisionNum int    `json:"LastAppliedRevisionNum"`
-		} `json:"Unit"`
-	}
+	var payload interface{}
 	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
 		return compareUnitMetadata{}, fmt.Errorf("parse unit get json: %w", err)
 	}
-
-	spaceID := strings.TrimSpace(payload.Space.SpaceID)
-	if spaceID == "" {
-		spaceID = strings.TrimSpace(payload.Unit.SpaceID)
+	items := cubExtractItems(payload)
+	if len(items) == 0 {
+		return compareUnitMetadata{}, fmt.Errorf("unit get output missing object payload")
 	}
 
+	ref := mcpUnitRefFromItem(items[0])
+	state, _ := mcpExtractUnitRevisionState(items[0])
+
 	return compareUnitMetadata{
-		UnitSlug:            strings.TrimSpace(payload.Unit.Slug),
-		UnitID:              strings.TrimSpace(payload.Unit.UnitID),
-		SpaceName:           strings.TrimSpace(payload.Space.Slug),
-		SpaceID:             spaceID,
-		HeadRevisionNum:     payload.Unit.HeadRevisionNum,
-		LiveRevisionNum:     payload.Unit.LiveRevisionNum,
-		LastAppliedRevision: payload.Unit.LastAppliedRevisionNum,
+		UnitSlug:            ref.UnitSlug,
+		UnitID:              ref.UnitID,
+		SpaceName:           ref.SpaceSlug,
+		SpaceID:             ref.SpaceID,
+		HeadRevisionNum:     state.HeadRevision,
+		LiveRevisionNum:     state.LiveRevision,
+		LastAppliedRevision: state.LastAppliedRevision,
 	}, nil
 }
 

--- a/cmd/cub-scout/cub_json.go
+++ b/cmd/cub-scout/cub_json.go
@@ -1,0 +1,183 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// cubUnitListEntry captures the small set of unit list fields that multiple
+// connected features depend on. The parser is intentionally tolerant because
+// the cub JSON envelope has evolved over time.
+type cubUnitListEntry struct {
+	UnitSlug        string
+	UnitID          string
+	SpaceSlug       string
+	SpaceID         string
+	TargetSlug      string
+	HeadRevisionNum int
+	LiveRevisionNum int
+	Raw             map[string]interface{}
+}
+
+func parseCubUnitListJSON(raw []byte) ([]cubUnitListEntry, error) {
+	payload, err := parseCubJSONPayload(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	items := cubExtractItems(payload)
+	out := make([]cubUnitListEntry, 0, len(items))
+	for _, item := range items {
+		ref := mcpUnitRefFromItem(item)
+		state, _ := mcpExtractUnitRevisionState(item)
+
+		unitObj := mcpNestedMap(item, "Unit", "unit")
+		if unitObj == nil {
+			unitObj = item
+		}
+
+		targetSlug := mcpFirstString(unitObj, "TargetSlug", "targetSlug", "Target", "target")
+		if targetSlug == "" {
+			if targetObj := mcpNestedMap(item, "Target", "target"); targetObj != nil {
+				targetSlug = mcpFirstString(targetObj, "Slug", "slug", "Name", "name")
+			}
+		}
+
+		out = append(out, cubUnitListEntry{
+			UnitSlug:        ref.UnitSlug,
+			UnitID:          ref.UnitID,
+			SpaceSlug:       ref.SpaceSlug,
+			SpaceID:         ref.SpaceID,
+			TargetSlug:      targetSlug,
+			HeadRevisionNum: state.HeadRevision,
+			LiveRevisionNum: state.LiveRevision,
+			Raw:             item,
+		})
+	}
+	return out, nil
+}
+
+func parseCubTargetListJSON(raw []byte) ([]cubTargetRef, error) {
+	payload, err := parseCubJSONPayload(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	items := cubExtractItems(payload)
+	out := make([]cubTargetRef, 0, len(items))
+	for _, item := range items {
+		targetObj := mcpNestedMap(item, "Target", "target")
+		if targetObj == nil {
+			targetObj = item
+		}
+
+		slug := mcpFirstString(targetObj, "Slug", "slug", "Name", "name")
+		if slug == "" {
+			continue
+		}
+
+		out = append(out, cubTargetRef{
+			Slug:         slug,
+			ProviderType: mcpFirstString(targetObj, "ProviderType", "providerType"),
+			Toolchain:    mcpFirstString(targetObj, "ToolchainType", "toolchainType"),
+		})
+	}
+	return out, nil
+}
+
+func parseCubWorkerListJSON(raw []byte) ([]WorkerListItem, error) {
+	payload, err := parseCubJSONPayload(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	items := cubExtractItems(payload)
+	out := make([]WorkerListItem, 0, len(items))
+	for _, item := range items {
+		workerObj := mcpNestedMap(item, "Worker", "worker")
+		if workerObj == nil {
+			workerObj = item
+		}
+
+		out = append(out, WorkerListItem{
+			Name:      mcpFirstString(workerObj, "Slug", "slug", "Name", "name"),
+			Cluster:   mcpFirstString(workerObj, "Cluster", "cluster", "BridgeHandle", "bridgeHandle"),
+			Condition: mcpFirstString(workerObj, "Condition", "condition", "Status", "status"),
+		})
+	}
+	return out, nil
+}
+
+func parseCubContextJSON(raw []byte) (*statusCubContext, error) {
+	payload, err := parseCubJSONPayload(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	item, ok := payload.(map[string]interface{})
+	if !ok {
+		items := cubExtractItems(payload)
+		if len(items) == 0 {
+			return nil, fmt.Errorf("unexpected cub context payload")
+		}
+		item = items[0]
+	}
+
+	ctx := &statusCubContext{
+		Name: mcpFirstString(item, "Name", "name"),
+	}
+
+	if coord := mcpNestedMap(item, "Coordinate", "coordinate"); coord != nil {
+		ctx.Coordinate.ServerURL = mcpFirstString(coord, "ServerURL", "serverURL")
+		ctx.Coordinate.OrganizationID = mcpFirstString(coord, "OrganizationID", "organizationID")
+	}
+	if settings := mcpNestedMap(item, "Settings", "settings"); settings != nil {
+		ctx.Settings.DefaultSpace = mcpFirstString(settings, "DefaultSpace", "defaultSpace")
+	}
+
+	if ctx.Name == "" && ctx.Coordinate.ServerURL == "" && ctx.Settings.DefaultSpace == "" {
+		return nil, fmt.Errorf("missing expected cub context fields")
+	}
+	return ctx, nil
+}
+
+func parseCubJSONPayload(raw []byte) (interface{}, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, fmt.Errorf("empty cub JSON output")
+	}
+
+	var payload interface{}
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func cubExtractItems(payload interface{}) []map[string]interface{} {
+	switch typed := payload.(type) {
+	case []interface{}:
+		return historyArrayToObjects(typed)
+	case map[string]interface{}:
+		for _, key := range []string{
+			"items", "Items",
+			"data", "Data",
+			"results", "Results",
+			"units", "Units",
+			"targets", "Targets",
+			"workers", "Workers",
+			"changesets", "ChangeSets",
+		} {
+			if arr, ok := typed[key].([]interface{}); ok {
+				return historyArrayToObjects(arr)
+			}
+		}
+		return []map[string]interface{}{typed}
+	default:
+		return nil
+	}
+}

--- a/cmd/cub-scout/cub_json_test.go
+++ b/cmd/cub-scout/cub_json_test.go
@@ -1,0 +1,121 @@
+package main
+
+import "testing"
+
+func TestParseCubUnitListJSON_AcceptsNestedAndFlatShapes(t *testing.T) {
+	raw := []byte(`{
+		"items": [
+			{
+				"Space": {"Slug": "prod", "SpaceID": "sp-1"},
+				"Unit": {
+					"Slug": "payments-api",
+					"UnitID": "u-1",
+					"HeadRevisionNum": 9,
+					"LiveRevisionNum": 7,
+					"TargetSlug": "cluster-a"
+				}
+			},
+			{
+				"space": {"slug": "staging", "spaceId": "sp-2"},
+				"unit": {
+					"slug": "payments-worker",
+					"unitId": "u-2",
+					"headRevisionNum": "5",
+					"liveRevisionNum": "5"
+				},
+				"target": {"slug": "cluster-b"}
+			}
+		]
+	}`)
+
+	got, err := parseCubUnitListJSON(raw)
+	if err != nil {
+		t.Fatalf("parseCubUnitListJSON() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].UnitSlug != "payments-api" || got[0].TargetSlug != "cluster-a" || got[0].HeadRevisionNum != 9 || got[0].LiveRevisionNum != 7 {
+		t.Fatalf("first entry = %+v, want slug/target/revisions populated", got[0])
+	}
+	if got[1].UnitSlug != "payments-worker" || got[1].TargetSlug != "cluster-b" || got[1].SpaceSlug != "staging" {
+		t.Fatalf("second entry = %+v, want camelCase fields populated", got[1])
+	}
+}
+
+func TestParseCubTargetListJSON_AcceptsNestedAndFlatShapes(t *testing.T) {
+	raw := []byte(`{
+		"Targets": [
+			{"Target": {"Slug": "k8s-prod", "ProviderType": "Kubernetes", "ToolchainType": "Kubernetes/YAML"}},
+			{"target": {"slug": "argo-renderer", "providerType": "ArgoCDRenderer", "toolchainType": "Kubernetes/YAML"}}
+		]
+	}`)
+
+	got, err := parseCubTargetListJSON(raw)
+	if err != nil {
+		t.Fatalf("parseCubTargetListJSON() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Slug != "k8s-prod" || got[1].Slug != "argo-renderer" {
+		t.Fatalf("got = %+v, want both target slugs", got)
+	}
+}
+
+func TestParseCubContextJSON_AcceptsCamelAndPascalCase(t *testing.T) {
+	raw := []byte(`{
+		"name": "alexis@example.com",
+		"coordinate": {"serverURL": "https://hub.example.com", "organizationID": "org-1"},
+		"settings": {"defaultSpace": "payments"}
+	}`)
+
+	ctx, err := parseCubContextJSON(raw)
+	if err != nil {
+		t.Fatalf("parseCubContextJSON() error = %v", err)
+	}
+	if ctx.Name != "alexis@example.com" || ctx.Coordinate.ServerURL != "https://hub.example.com" || ctx.Settings.DefaultSpace != "payments" {
+		t.Fatalf("ctx = %+v, want parsed context fields", ctx)
+	}
+}
+
+func TestDecodeCompareUnitMetadataFromGetJSON_AcceptsCamelCase(t *testing.T) {
+	raw := `{
+		"space": {"slug": "prod", "spaceId": "sp-123"},
+		"unit": {
+			"slug": "checkout",
+			"unitId": "u-123",
+			"headRevisionNum": "9",
+			"liveRevisionNum": 7,
+			"lastAppliedRevisionNum": "8",
+			"data": "YXBpVmVyc2lvbjogdjEK"
+		}
+	}`
+
+	got, err := decodeCompareUnitMetadataFromGetJSON(raw)
+	if err != nil {
+		t.Fatalf("decodeCompareUnitMetadataFromGetJSON() error = %v", err)
+	}
+	if got.UnitSlug != "checkout" || got.SpaceName != "prod" || got.HeadRevisionNum != 9 || got.LiveRevisionNum != 7 || got.LastAppliedRevision != 8 {
+		t.Fatalf("got = %+v, want tolerant metadata parse", got)
+	}
+}
+
+func TestParseCubWorkerListJSON_AcceptsNestedWorkerShape(t *testing.T) {
+	raw := []byte(`{
+		"workers": [
+			{"worker": {"slug": "cluster-worker", "cluster": "prod-cluster", "condition": "Connected"}}
+		]
+	}`)
+
+	got, err := parseCubWorkerListJSON(raw)
+	if err != nil {
+		t.Fatalf("parseCubWorkerListJSON() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Name != "cluster-worker" || got[0].Cluster != "prod-cluster" || got[0].Condition != "Connected" {
+		t.Fatalf("got[0] = %+v, want parsed worker fields", got[0])
+	}
+}

--- a/cmd/cub-scout/fleet_outliers.go
+++ b/cmd/cub-scout/fleet_outliers.go
@@ -123,31 +123,22 @@ func loadFleetOutlierUnits() ([]fleetUnitSnapshot, error) {
 		return nil, errFleetOutliersNotConnected
 	}
 
-	var unitList []struct {
-		Unit struct {
-			Slug            string `json:"Slug"`
-			HeadRevisionNum int    `json:"HeadRevisionNum"`
-			TargetSlug      string `json:"TargetSlug"`
-		} `json:"Unit"`
-		Space struct {
-			Slug string `json:"Slug"`
-		} `json:"Space"`
-	}
-	if err := json.Unmarshal(out, &unitList); err != nil {
+	unitList, err := parseCubUnitListJSON(out)
+	if err != nil {
 		return nil, fmt.Errorf("parse unit list: %w", err)
 	}
 
 	units := make([]fleetUnitSnapshot, 0, len(unitList))
 	for _, item := range unitList {
-		cluster := strings.TrimSpace(item.Unit.TargetSlug)
+		cluster := strings.TrimSpace(item.TargetSlug)
 		if cluster == "" {
 			continue
 		}
 		units = append(units, fleetUnitSnapshot{
-			UnitSlug: strings.TrimSpace(item.Unit.Slug),
+			UnitSlug: strings.TrimSpace(item.UnitSlug),
 			Cluster:  cluster,
-			Revision: item.Unit.HeadRevisionNum,
-			Space:    strings.TrimSpace(item.Space.Slug),
+			Revision: item.HeadRevisionNum,
+			Space:    strings.TrimSpace(item.SpaceSlug),
 		})
 	}
 	return units, nil

--- a/cmd/cub-scout/history.go
+++ b/cmd/cub-scout/history.go
@@ -84,10 +84,10 @@ type historyNavigation struct {
 }
 
 var (
-	requireHistoryConnectedFn = requireHistoryConnected
-	fetchHistoryEntriesFn     = fetchHistoryEntries
-	historyNowFn              = time.Now
-	runHistoryCubCommand      = runHistoryCubCommandImpl
+	requireHistoryConnectedFn  = requireHistoryConnected
+	fetchHistoryEntriesFn      = fetchHistoryEntries
+	historyNowFn               = time.Now
+	runHistoryCubCommand       = runHistoryCubCommandImpl
 	resolveHistoryNavigationFn = resolveHistoryNavigation
 )
 
@@ -400,19 +400,7 @@ func buildHistoryEntriesFromChangeSetsWithOptions(raw string, cutoff time.Time, 
 }
 
 func historyExtractItems(payload interface{}) []map[string]interface{} {
-	switch typed := payload.(type) {
-	case []interface{}:
-		return historyArrayToObjects(typed)
-	case map[string]interface{}:
-		for _, key := range []string{"items", "data", "results", "changesets", "ChangeSets"} {
-			if arr, ok := typed[key].([]interface{}); ok {
-				return historyArrayToObjects(arr)
-			}
-		}
-		return []map[string]interface{}{typed}
-	default:
-		return nil
-	}
+	return cubExtractItems(payload)
 }
 
 func historyArrayToObjects(arr []interface{}) []map[string]interface{} {

--- a/cmd/cub-scout/import.go
+++ b/cmd/cub-scout/import.go
@@ -123,8 +123,8 @@ type WorkloadJSON struct {
 
 // SuggestionJSON is the JSON representation of the import suggestion
 type SuggestionJSON struct {
-	App string     `json:"app"`
-	Units    []UnitJSON `json:"units"`
+	App   string     `json:"app"`
+	Units []UnitJSON `json:"units"`
 }
 
 // UnitJSON is the JSON representation of a suggested unit
@@ -1630,28 +1630,7 @@ func loadCubTargets(space string) ([]cubTargetRef, error) {
 	if err != nil {
 		return nil, err
 	}
-	var raw []struct {
-		Target struct {
-			Slug         string `json:"Slug"`
-			ProviderType string `json:"ProviderType"`
-			Toolchain    string `json:"ToolchainType"`
-		} `json:"Target"`
-	}
-	if err := json.Unmarshal(out, &raw); err != nil {
-		return nil, err
-	}
-	targets := make([]cubTargetRef, 0, len(raw))
-	for _, t := range raw {
-		if t.Target.Slug == "" {
-			continue
-		}
-		targets = append(targets, cubTargetRef{
-			Slug:         t.Target.Slug,
-			ProviderType: t.Target.ProviderType,
-			Toolchain:    t.Target.Toolchain,
-		})
-	}
-	return targets, nil
+	return parseCubTargetListJSON(out)
 }
 
 func selectGitOpsTargets(targets []cubTargetRef) (k8sTarget, argoRenderer, fluxRenderer string) {

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -1513,50 +1513,21 @@ func fetchFleetUnits(space, appFilter string) ([]FleetUnit, error) {
 		return nil, fmt.Errorf("failed to fetch units from ConfigHub: %w\n\n  Check that 'cub' CLI is installed and you're authenticated: cub auth login", err)
 	}
 
-	// The cub CLI returns nested structure: [{Space: {}, Unit: {}, UnitStatus: {}}, ...]
-	var response []map[string]interface{}
-	if err := json.Unmarshal(output, &response); err != nil {
+	unitList, err := parseCubUnitListJSON(output)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	var units []FleetUnit
-	for _, item := range response {
-		// Extract from nested Unit object
-		unitObj, ok := item["Unit"].(map[string]interface{})
-		if !ok {
-			continue
-		}
-		spaceObj, _ := item["Space"].(map[string]interface{})
-		statusObj, _ := item["UnitStatus"].(map[string]interface{})
-
-		slug := ""
-		spaceSlug := ""
-		headRev := 0
-		liveRev := 0
+	for _, item := range unitList {
+		slug := item.UnitSlug
+		spaceSlug := item.SpaceSlug
+		headRev := item.HeadRevisionNum
+		liveRev := item.LiveRevisionNum
 		status := ""
-		target := ""
-
-		if s, ok := unitObj["Slug"].(string); ok {
-			slug = s
-		}
-		if spaceObj != nil {
-			if s, ok := spaceObj["Slug"].(string); ok {
-				spaceSlug = s
-			}
-		}
-		if r, ok := unitObj["HeadRevisionNum"].(float64); ok {
-			headRev = int(r)
-		}
-		if r, ok := unitObj["LiveRevisionNum"].(float64); ok {
-			liveRev = int(r)
-		}
-		if statusObj != nil {
-			if s, ok := statusObj["Status"].(string); ok {
-				status = s
-			}
-		}
-		if t, ok := unitObj["Target"].(string); ok {
-			target = t
+		target := item.TargetSlug
+		if statusObj := mcpNestedMap(item.Raw, "UnitStatus", "unitStatus"); statusObj != nil {
+			status = mcpFirstString(statusObj, "Status", "status", "Condition", "condition")
 		}
 
 		// Labels aren't in list output, need to fetch each unit
@@ -1604,18 +1575,24 @@ func fetchUnitLabels(space, slug string) (map[string]string, error) {
 		return nil, err
 	}
 
-	var response map[string]interface{}
-	if err := json.Unmarshal(output, &response); err != nil {
+	payload, err := parseCubJSONPayload(output)
+	if err != nil {
 		return nil, err
 	}
 
 	labels := make(map[string]string)
-	if unitObj, ok := response["Unit"].(map[string]interface{}); ok {
-		if l, ok := unitObj["Labels"].(map[string]interface{}); ok {
-			for k, v := range l {
-				if vs, ok := v.(string); ok {
-					labels[k] = vs
-				}
+	items := cubExtractItems(payload)
+	if len(items) == 0 {
+		return labels, nil
+	}
+	unitObj := mcpNestedMap(items[0], "Unit", "unit")
+	if unitObj == nil {
+		unitObj = items[0]
+	}
+	if l := mcpNestedMap(unitObj, "Labels", "labels"); l != nil {
+		for k, v := range l {
+			if vs, ok := v.(string); ok {
+				labels[k] = vs
 			}
 		}
 	}
@@ -4796,12 +4773,8 @@ func fetchConfigHubUnits() (*cubUnitCache, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ConfigHub authentication required.\n\n  To authenticate: cub auth login\n  To use standalone: cub-scout map (without --hub)")
 	}
-	var ctx struct {
-		Settings struct {
-			DefaultSpace string `json:"defaultSpace"`
-		} `json:"settings"`
-	}
-	if err := json.Unmarshal(ctxOut, &ctx); err != nil {
+	ctx, err := parseCubContextJSON(ctxOut)
+	if err != nil {
 		return nil, err
 	}
 	space := ctx.Settings.DefaultSpace
@@ -4816,18 +4789,8 @@ func fetchConfigHubUnits() (*cubUnitCache, error) {
 		return nil, fmt.Errorf("failed to list units: %w", err)
 	}
 
-	// Parse units (cub CLI returns [{Unit: {...}, Space: {...}}])
-	var unitList []struct {
-		Unit struct {
-			Slug            string `json:"Slug"`
-			HeadRevisionNum int    `json:"HeadRevisionNum"`
-			TargetSlug      string `json:"TargetSlug"`
-		} `json:"Unit"`
-		Space struct {
-			Slug string `json:"Slug"`
-		} `json:"Space"`
-	}
-	if err := json.Unmarshal(listOut, &unitList); err != nil {
+	unitList, err := parseCubUnitListJSON(listOut)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse units: %w", err)
 	}
 
@@ -4838,11 +4801,11 @@ func fetchConfigHubUnits() (*cubUnitCache, error) {
 	}
 
 	for _, u := range unitList {
-		cache.units[u.Unit.Slug] = &cubUnitInfo{
-			Slug:            u.Unit.Slug,
-			HeadRevisionNum: u.Unit.HeadRevisionNum,
-			TargetSlug:      u.Unit.TargetSlug,
-			Space:           u.Space.Slug,
+		cache.units[u.UnitSlug] = &cubUnitInfo{
+			Slug:            u.UnitSlug,
+			HeadRevisionNum: u.HeadRevisionNum,
+			TargetSlug:      u.TargetSlug,
+			Space:           u.SpaceSlug,
 		}
 	}
 

--- a/cmd/cub-scout/status.go
+++ b/cmd/cub-scout/status.go
@@ -196,8 +196,8 @@ func getStatusCubContext() (*statusCubContext, string, error) {
 		return nil, "", err
 	}
 
-	var ctx statusCubContext
-	if err := json.Unmarshal(out, &ctx); err != nil {
+	ctx, err := parseCubContextJSON(out)
+	if err != nil {
 		return nil, "", err
 	}
 
@@ -210,7 +210,7 @@ func getStatusCubContext() (*statusCubContext, string, error) {
 
 	// If context has a name, we're connected
 	if ctx.Name != "" {
-		return &ctx, email, nil
+		return ctx, email, nil
 	}
 
 	return nil, "", fmt.Errorf("no context found")
@@ -247,8 +247,8 @@ func getWorkerForCluster(space, clusterName string) *WorkerInfo {
 		return nil
 	}
 
-	var workers []WorkerListItem
-	if err := json.Unmarshal(out, &workers); err != nil {
+	workers, err := parseCubWorkerListJSON(out)
+	if err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
## What changed

This PR adds a shared tolerant parser layer for `cub` JSON responses used by connected `cub-scout` flows.

It introduces `cmd/cub-scout/cub_json.go` and switches several callers to use it instead of decoding a single rigid envelope shape:

- `compare_resource.go`
- `fleet_outliers.go`
- `history.go`
- `import.go`
- `map.go`
- `status.go`

It also adds focused tests in `cmd/cub-scout/cub_json_test.go` for nested vs flat payloads, PascalCase vs camelCase fields, and numeric-string revision values.

## Why this changed

`cub-scout` depends on a handful of `cub` CLI JSON contracts in connected mode, and several code paths were assuming one exact payload shape. That makes features like compare, map, history, import, and fleet views more fragile if `cub` output evolves.

## Root cause

The parsing logic was duplicated across call sites and tightly coupled to one envelope layout, field casing, and numeric representation.

## User impact

This should make connected `cub-scout` behavior more resilient when `cub` returns equivalent data in slightly different JSON envelopes.

The main goal is graceful compatibility hardening, not a user-visible feature change.

## Validation

Ran targeted parser coverage:

```bash
go test ./cmd/cub-scout -run 'TestParseCub|TestDecodeCompareUnitMetadata' -count=1 -timeout=30s
```
