### PR TITLE
[codex] add v2.2.1 release notes

### DIFF
--- a/docs/releases/v2.2.1.md
+++ b/docs/releases/v2.2.1.md
@@ -1,0 +1,131 @@
+# v2.2.1 Release Notes — Connected JSON Compatibility Hardening
+
+> **Status:** Draft release notes. This file describes what the `v2.2.1`
+> tag will ship when cut from `main`.
+>
+> **Previous release:** [`v2.2.0`](v2.2.0.md) — cub-scout becomes
+> categorically read-only.
+
+**Theme:** *make connected cub-scout more tolerant of equivalent `cub`
+JSON envelopes.* This is a patch release with one runtime change: connected
+paths that shell out to `cub` now accept a wider set of equivalent payload
+shapes instead of assuming one rigid nested form.
+
+There are **no new commands**, **no removed flags**, and **no changes to
+cub-scout's own JSON contracts** in this release.
+
+---
+
+## What's In This Patch
+
+### Tolerant `cub` JSON parsing for connected flows
+
+`cub-scout` now centralizes several `cub` JSON decoders behind a shared
+tolerant parser layer in `cmd/cub-scout/cub_json.go`.
+
+The new parser accepts common envelope variants such as:
+
+- nested vs flat object shapes
+- PascalCase vs camelCase field names
+- numeric fields represented as JSON numbers or numeric strings
+
+That hardening is now used by connected code paths that depend on `cub`
+JSON, including:
+
+- `compare three-way` metadata decoding
+- ConfigHub-backed `map` and fleet lookups
+- connected `history` item extraction
+- connected target selection during `import`
+- connected context and worker lookup in `status`
+
+### Why this matters
+
+Before this patch, several connected features decoded `cub` responses with
+strict ad hoc structs. Equivalent payloads could fail if field casing or
+wrapper shape varied.
+
+This release makes those consumers more resilient without changing the
+user-facing command surface.
+
+---
+
+## Behavior
+
+### What changes
+
+- connected parsing is more tolerant when `cub` returns equivalent JSON in
+  a different envelope
+- several previously duplicated decoders now share one parser layer
+
+### What does not change
+
+- standalone `doctor`, `explain`, `trace`, `scan`, and `map` behavior
+- cub-scout CLI flags, exit codes, and command names
+- cub-scout-produced JSON and MCP output contracts
+- the read-only evidence / judge / authority boundary from `v2.2.0`
+
+---
+
+## Validation
+
+The merge to `main` completed with green CI on commit `6afecc9` on
+2026-05-17.
+
+Focused parser coverage was added for:
+
+- nested and flat unit list payloads
+- PascalCase and camelCase context/target/worker payloads
+- numeric-string revision fields in connected compare metadata
+
+Release workflow validation remains the standard:
+
+```bash
+git checkout v2.2.1
+go build ./cmd/cub-scout
+go test ./...
+./cub-scout version
+./cub-scout compare three-way --help
+./cub-scout map --help
+```
+
+---
+
+## Upgrade / Install
+
+### Plugin form
+
+```bash
+cub plugin install confighub/cub-scout
+cub scout version    # should print v2.2.1
+```
+
+### Standalone
+
+```bash
+# Homebrew
+brew upgrade confighub/tap/cub-scout
+
+# krew
+kubectl krew upgrade cub-scout
+
+# direct download
+curl -L https://github.com/confighub/cub-scout/releases/download/v2.2.1/cub-scout_v2.2.1_darwin_arm64.tar.gz | tar xz
+./cub-scout version
+```
+
+---
+
+## Linked
+
+- [#433](https://github.com/confighub/cub-scout/pull/433) — tolerate `cub`
+  JSON envelope variants across connected consumers
+- [`v2.2.0`](v2.2.0.md) — previous release, which made cub-scout
+  categorically read-only
+
+---
+
+## Credits
+
+This patch keeps the `v2.2.0` read-only boundary intact while making the
+connected evidence paths less brittle. It is a compatibility hardening
+release, not a product-surface expansion.


### PR DESCRIPTION
## What changed

Adds `docs/releases/v2.2.1.md` to document the patch-release story for the single post-`v2.2.0` runtime change now on `main`.

## Why

The repo's release checklist expects in-repo release notes at `docs/releases/vX.Y.Z.md`, and `main` is now in a clean patch-release shape:

- latest release: `v2.2.0`
- one runtime commit after that: `fix: tolerate cub json envelope variants (#433)`
- green `main` CI on the merge commit

## Scope

This PR is docs-only. It intentionally does not widen into roadmap or product-surface changes.

## Validation

- Verified `main` is exactly one runtime commit ahead of `v2.2.0`
- Verified CI succeeded for merge commit `6afecc9`
- No local tests run for this docs-only PR
