### PR TITLE
feat: attribution layer — mutation cause + git source (A1/A1.5/A2)

### DIFF
--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -45,10 +45,17 @@ type compareSideSummary struct {
 	LabelCount             int      `json:"labelCount,omitempty"`
 	AnnotationCount        int      `json:"annotationCount,omitempty"`
 
-	// Attribution carries the mutation-source classification computed from
-	// metadata.managedFields. Only populated on the live side (Source == "cluster");
-	// dry/wet sides do not have managedFields data.
+	// Attribution carries the resource-level mutation-source classification
+	// computed from metadata.managedFields. Only populated on the live side
+	// (Source == "cluster"); dry/wet sides do not have managedFields data.
 	Attribution *agent.FieldMutationAttribution `json:"attribution,omitempty"`
+
+	// AttributionByPath carries per-field-path mutation-source classification
+	// keyed by canonical field-path strings (e.g., ".spec.replicas"). Populated
+	// when managedFields entries include decodable FieldsV1 data. Used by the
+	// mismatch detector to give per-field cause/managerHint, falling back to
+	// Attribution above when a field doesn't map to a known path.
+	AttributionByPath map[string]agent.FieldMutationAttribution `json:"attributionByPath,omitempty"`
 }
 
 type compareResourceResult struct {
@@ -639,10 +646,14 @@ func summarizeCompareLiveObject(obj *unstructured.Unstructured) compareSideSumma
 
 	// Compute mutation-source attribution from metadata.managedFields, using
 	// the owner detected from labels/annotations as the co-signal. See
-	// pkg/agent/field_ownership.go.
+	// pkg/agent/field_ownership.go. AttributeFieldsByManagedFields also
+	// returns per-field-path classifications when FieldsV1 data is present.
 	owner := agent.DetectOwnership(obj)
-	attribution := agent.AttributeFieldMutation(obj, owner)
-	out.Attribution = &attribution
+	resourceAttr, byPath := agent.AttributeFieldsByManagedFields(obj, owner)
+	out.Attribution = &resourceAttr
+	if len(byPath) > 0 {
+		out.AttributionByPath = byPath
+	}
 
 	return out
 }
@@ -814,13 +825,47 @@ func detectCompareFieldMismatches(dry, wet *compareSideSummary, live compareSide
 			Wet:   displayCompareFieldValue(wetValue),
 			Live:  displayCompareFieldValue(liveValue),
 		}
-		if live.Attribution != nil {
+		// Prefer per-field-path attribution (A1.5); fall back to the
+		// resource-level rollup (A1) when no per-path entry is available
+		// (e.g., for fields like "images" that don't map to a single path,
+		// or when FieldsV1 data is missing from managedFields).
+		if attr, ok := lookupFieldAttribution(field.Name, live); ok {
+			mismatch.Cause = attr.Cause
+			mismatch.ManagerHint = attr.ManagerHint
+		} else if live.Attribution != nil {
 			mismatch.Cause = live.Attribution.Cause
 			mismatch.ManagerHint = live.Attribution.ManagerHint
 		}
 		out = append(out, mismatch)
 	}
 	return out
+}
+
+// compareFieldToPath maps a compareFieldMismatch.Field name to the canonical
+// metadata.managedFields path string used by sigs.k8s.io/structured-merge-diff/v4
+// fieldpath.Path.String. Fields without a single canonical path (e.g., "images"
+// which spreads across container list items) are intentionally absent from
+// this map and fall back to resource-level attribution.
+var compareFieldToPath = map[string]string{
+	"apiVersion": ".apiVersion",
+	"kind":       ".kind",
+	"namespace":  ".metadata.namespace",
+	"replicas":   ".spec.replicas",
+}
+
+func lookupFieldAttribution(fieldName string, live compareSideSummary) (agent.FieldMutationAttribution, bool) {
+	if len(live.AttributionByPath) == 0 {
+		return agent.FieldMutationAttribution{}, false
+	}
+	path, ok := compareFieldToPath[fieldName]
+	if !ok {
+		return agent.FieldMutationAttribution{}, false
+	}
+	attr, ok := live.AttributionByPath[path]
+	if !ok || attr.Cause == "" {
+		return agent.FieldMutationAttribution{}, false
+	}
+	return attr, true
 }
 
 func compareFieldHasDivergence(values ...string) bool {

--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -56,6 +56,14 @@ type compareSideSummary struct {
 	// mismatch detector to give per-field cause/managerHint, falling back to
 	// Attribution above when a field doesn't map to a known path.
 	AttributionByPath map[string]agent.FieldMutationAttribution `json:"attributionByPath,omitempty"`
+
+	// GitSource is the source-control anchor (repo URL, revision, path) the
+	// GitOps controller is reconciling from. Resolved at A2 via the existing
+	// Argo / Flux tracers; nil when no GitOps owner is detected, when tracer
+	// CLIs are unavailable, or when the chain root carries no useful data.
+	// Stage B will refine to per-field anchors (file path + line) via
+	// rendering-aware back-resolution.
+	GitSource *agent.GitSourceAnchor `json:"gitSource,omitempty"`
 }
 
 type compareResourceResult struct {
@@ -85,6 +93,11 @@ type compareFieldMismatch struct {
 	// ManagerHint is a representative manager string for transparency — see
 	// agent.FieldMutationAttribution.ManagerHint.
 	ManagerHint string `json:"managerHint,omitempty"`
+
+	// GitSource is the source-control anchor (repo URL, revision, path) for
+	// this field's value, copied from the resource-level GitSource at A2.
+	// Per-field anchors (different paths/lines per field) are stage B.
+	GitSource *agent.GitSourceAnchor `json:"gitSource,omitempty"`
 }
 
 type compareResourceRef struct {
@@ -583,6 +596,9 @@ func loadCompareLiveSnapshot(ctx context.Context, kind, name, namespace string) 
 	}
 
 	summary := summarizeCompareLiveObject(obj)
+	if anchor := agent.CollectGitSourceAnchor(ctx, obj); anchor != nil {
+		summary.GitSource = anchor
+	}
 	if summary.UnitSlug != "" {
 		return summary, nil
 	}
@@ -836,9 +852,42 @@ func detectCompareFieldMismatches(dry, wet *compareSideSummary, live compareSide
 			mismatch.Cause = live.Attribution.Cause
 			mismatch.ManagerHint = live.Attribution.ManagerHint
 		}
+		// Carry the resource-level git source onto every field mismatch (A2).
+		// Per-field anchors are stage B.
+		if live.GitSource != nil {
+			mismatch.GitSource = live.GitSource
+		}
 		out = append(out, mismatch)
 	}
 	return out
+}
+
+func renderGitSourceASCII(gs *agent.GitSourceAnchor) string {
+	parts := make([]string, 0, 3)
+	if gs.RepoURL != "" {
+		parts = append(parts, gs.RepoURL)
+	}
+	if gs.Revision != "" {
+		parts = append(parts, "@"+gs.Revision)
+	}
+	if gs.Path != "" {
+		parts = append(parts, "path="+gs.Path)
+	}
+	return strings.Join(parts, " ")
+}
+
+func renderGitSourceMarkdown(gs *agent.GitSourceAnchor) string {
+	parts := make([]string, 0, 3)
+	if gs.RepoURL != "" {
+		parts = append(parts, "`"+gs.RepoURL+"`")
+	}
+	if gs.Revision != "" {
+		parts = append(parts, "@`"+gs.Revision+"`")
+	}
+	if gs.Path != "" {
+		parts = append(parts, "path=`"+gs.Path+"`")
+	}
+	return strings.Join(parts, " ")
 }
 
 // compareFieldToPath maps a compareFieldMismatch.Field name to the canonical
@@ -920,6 +969,10 @@ func renderCompareResourceASCII(result compareResourceResult) string {
 			}
 			b.WriteString("\n")
 		}
+		if gs := result.Live.GitSource; gs != nil && !gs.IsEmpty() {
+			b.WriteString(fmt.Sprintf("Git source: %s", renderGitSourceASCII(gs)))
+			b.WriteString("\n")
+		}
 		b.WriteString("\nDiff Highlights\n")
 		for _, mismatch := range result.Mismatches {
 			b.WriteString(fmt.Sprintf("  - %s: DRY=%s | WET=%s | LIVE=%s\n",
@@ -967,6 +1020,9 @@ func renderCompareResourceMarkdown(result compareResourceResult) string {
 				b.WriteString(fmt.Sprintf(" (manager: `%s`)", attr.ManagerHint))
 			}
 			b.WriteString("\n\n")
+		}
+		if gs := result.Live.GitSource; gs != nil && !gs.IsEmpty() {
+			b.WriteString(fmt.Sprintf("Git source: %s\n\n", renderGitSourceMarkdown(gs)))
 		}
 		b.WriteString("| Field | DRY | WET | LIVE |\n")
 		b.WriteString("|---|---|---|---|\n")

--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/confighub/cub-scout/pkg/hub"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +44,11 @@ type compareSideSummary struct {
 	Images                 []string `json:"images,omitempty"`
 	LabelCount             int      `json:"labelCount,omitempty"`
 	AnnotationCount        int      `json:"annotationCount,omitempty"`
+
+	// Attribution carries the mutation-source classification computed from
+	// metadata.managedFields. Only populated on the live side (Source == "cluster");
+	// dry/wet sides do not have managedFields data.
+	Attribution *agent.FieldMutationAttribution `json:"attribution,omitempty"`
 }
 
 type compareResourceResult struct {
@@ -62,6 +68,16 @@ type compareFieldMismatch struct {
 	Dry   string `json:"dry"`
 	Wet   string `json:"wet"`
 	Live  string `json:"live"`
+
+	// Cause classifies the mutation source for this field mismatch. At A1
+	// the same value is set for every mismatch on a resource (resource-level
+	// classification from managedFields + ownership co-signal). A1.5 will
+	// refine to per-field-path resolution.
+	Cause agent.FieldMutationCause `json:"cause,omitempty"`
+
+	// ManagerHint is a representative manager string for transparency — see
+	// agent.FieldMutationAttribution.ManagerHint.
+	ManagerHint string `json:"managerHint,omitempty"`
 }
 
 type compareResourceRef struct {
@@ -620,6 +636,14 @@ func summarizeCompareLiveObject(obj *unstructured.Unstructured) compareSideSumma
 	if replicas, ok, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas"); ok {
 		out.Replicas = &replicas
 	}
+
+	// Compute mutation-source attribution from metadata.managedFields, using
+	// the owner detected from labels/annotations as the co-signal. See
+	// pkg/agent/field_ownership.go.
+	owner := agent.DetectOwnership(obj)
+	attribution := agent.AttributeFieldMutation(obj, owner)
+	out.Attribution = &attribution
+
 	return out
 }
 
@@ -784,12 +808,17 @@ func detectCompareFieldMismatches(dry, wet *compareSideSummary, live compareSide
 		if !compareFieldHasDivergence(dryValue, wetValue, liveValue) {
 			continue
 		}
-		out = append(out, compareFieldMismatch{
+		mismatch := compareFieldMismatch{
 			Field: field.Name,
 			Dry:   displayCompareFieldValue(dryValue),
 			Wet:   displayCompareFieldValue(wetValue),
 			Live:  displayCompareFieldValue(liveValue),
-		})
+		}
+		if live.Attribution != nil {
+			mismatch.Cause = live.Attribution.Cause
+			mismatch.ManagerHint = live.Attribution.ManagerHint
+		}
+		out = append(out, mismatch)
 	}
 	return out
 }
@@ -839,6 +868,13 @@ func renderCompareResourceASCII(result compareResourceResult) string {
 	}
 	renderCompareASCIISection(&b, "LIVE (cluster)", result.Live)
 	if len(result.Mismatches) > 0 {
+		if attr := result.Live.Attribution; attr != nil && attr.Cause != "" {
+			b.WriteString(fmt.Sprintf("\nDrift cause: %s", attr.Cause))
+			if attr.ManagerHint != "" {
+				b.WriteString(fmt.Sprintf(" (manager: %s)", attr.ManagerHint))
+			}
+			b.WriteString("\n")
+		}
 		b.WriteString("\nDiff Highlights\n")
 		for _, mismatch := range result.Mismatches {
 			b.WriteString(fmt.Sprintf("  - %s: DRY=%s | WET=%s | LIVE=%s\n",
@@ -880,6 +916,13 @@ func renderCompareResourceMarkdown(result compareResourceResult) string {
 	renderCompareMarkdownSection(&b, "LIVE (cluster)", result.Live)
 	if len(result.Mismatches) > 0 {
 		b.WriteString("\n### Mismatches\n\n")
+		if attr := result.Live.Attribution; attr != nil && attr.Cause != "" {
+			b.WriteString(fmt.Sprintf("Drift cause: `%s`", attr.Cause))
+			if attr.ManagerHint != "" {
+				b.WriteString(fmt.Sprintf(" (manager: `%s`)", attr.ManagerHint))
+			}
+			b.WriteString("\n\n")
+		}
 		b.WriteString("| Field | DRY | WET | LIVE |\n")
 		b.WriteString("|---|---|---|---|\n")
 		for _, mismatch := range result.Mismatches {

--- a/cmd/cub-scout/compare_three_way.go
+++ b/cmd/cub-scout/compare_three_way.go
@@ -913,6 +913,13 @@ func renderThreeWayASCII(report threeWayReport) string {
 			entry.Severity,
 			len(entry.Result.Mismatches),
 		))
+		if attr := entry.Result.Live.Attribution; attr != nil && attr.Cause != "" && len(entry.Result.Mismatches) > 0 {
+			driftLine := fmt.Sprintf("  drift-cause: %s", attr.Cause)
+			if attr.ManagerHint != "" {
+				driftLine += fmt.Sprintf(" (manager: %s)", attr.ManagerHint)
+			}
+			b.WriteString(driftLine + "\n")
+		}
 		if len(entry.Causes) > 0 {
 			b.WriteString("  causes: " + strings.Join(entry.Causes, ", ") + "\n")
 		}

--- a/cmd/cub-scout/explain.go
+++ b/cmd/cub-scout/explain.go
@@ -70,6 +70,16 @@ type ExplainSummary struct {
 
 	// NextSteps contains structured action-typed hints for AI/MCP clients.
 	NextSteps []StructuredHint `json:"nextSteps,omitempty"`
+
+	// MutationCause classifies the source of recent field mutations on the
+	// live resource (controller-drift / manual-edit / unknown), derived from
+	// metadata.managedFields with the detected owner as co-signal. See
+	// pkg/agent.AttributeFieldMutation.
+	MutationCause agent.FieldMutationCause `json:"mutationCause,omitempty"`
+
+	// MutationManager is a representative manager string for transparency
+	// (see pkg/agent.FieldMutationAttribution.ManagerHint).
+	MutationManager string `json:"mutationManager,omitempty"`
 }
 
 type explainTraceApplicationFunc func(ctx context.Context, appName string) (*agent.TraceResult, error)
@@ -671,6 +681,13 @@ func renderExplainText(summary ExplainSummary, mode PresentationMode, explicitMo
 	fmt.Fprintf(&b, "  %s %s\n", label("Health"), StatusColor(summary.Health))
 	fmt.Fprintf(&b, "  %s %s\n", label("Risks"), summary.Risks)
 	fmt.Fprintf(&b, "  %s %s\n", label("Drift"), colorExplainDrift(summary.Drift))
+	if summary.MutationCause != "" {
+		mutationLine := string(summary.MutationCause)
+		if summary.MutationManager != "" {
+			mutationLine += fmt.Sprintf(" (manager: %s)", summary.MutationManager)
+		}
+		fmt.Fprintf(&b, "  %s %s\n", label("Mutation cause"), colorExplainMutationCause(summary.MutationCause, mutationLine))
+	}
 	if len(summary.Notes) > 0 {
 		fmt.Fprintf(&b, "  %s\n", label("Notes"))
 		for _, note := range summary.Notes {
@@ -743,6 +760,20 @@ func colorExplainDrift(drift string) string {
 	}
 }
 
+// colorExplainMutationCause colors the mutation cause line. Manual edits are
+// the actionable case, so they get amber emphasis; controller drift is
+// expected steady-state coloring.
+func colorExplainMutationCause(cause agent.FieldMutationCause, text string) string {
+	switch cause {
+	case agent.CauseManualEdit:
+		return Yellow(text)
+	case agent.CauseControllerDrift:
+		return text
+	default:
+		return text
+	}
+}
+
 func renderExplainMarkdown(summary ExplainSummary, mode PresentationMode, explicitMode bool, hintCtx HintContext) string {
 	var b strings.Builder
 
@@ -763,6 +794,13 @@ func renderExplainMarkdown(summary ExplainSummary, mode PresentationMode, explic
 	fmt.Fprintf(&b, "- **Health:** %s\n", summary.Health)
 	fmt.Fprintf(&b, "- **Risks:** %s\n", summary.Risks)
 	fmt.Fprintf(&b, "- **Drift:** %s\n", summary.Drift)
+	if summary.MutationCause != "" {
+		mutationLine := fmt.Sprintf("`%s`", summary.MutationCause)
+		if summary.MutationManager != "" {
+			mutationLine += fmt.Sprintf(" (manager: `%s`)", summary.MutationManager)
+		}
+		fmt.Fprintf(&b, "- **Mutation cause:** %s\n", mutationLine)
+	}
 	if len(summary.Notes) > 0 {
 		fmt.Fprintf(&b, "- **Notes:**\n")
 		for _, note := range summary.Notes {

--- a/cmd/cub-scout/observe.go
+++ b/cmd/cub-scout/observe.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/confighub/cub-scout/pkg/agent"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -151,7 +153,45 @@ func ObserveResourceContext(ctx context.Context, req ObserveResourceContextReque
 		summary.ThreeWay = threeWay
 	}
 
+	// Attribute the cause of any recent field mutations from metadata.managedFields.
+	// Best-effort — silently skipped on fetch failure, so explain still works
+	// without cluster access. Per the parse-don't-guess rule, missing or
+	// unrecognized signals yield CauseUnknown rather than misclassification.
+	if attr, ok := fetchResourceAttribution(ctx, ns, kind, name); ok && attr.Cause != "" {
+		summary.MutationCause = attr.Cause
+		summary.MutationManager = attr.ManagerHint
+	}
+
 	return summary, nil
+}
+
+// fetchResourceAttribution loads the live resource and computes mutation-source
+// attribution from metadata.managedFields. Returns false on any fetch or
+// classification failure — attribution is purely additive evidence and must
+// not block explain output.
+func fetchResourceAttribution(ctx context.Context, namespace, kind, name string) (agent.FieldMutationAttribution, bool) {
+	cfg, err := buildConfig()
+	if err != nil {
+		return agent.FieldMutationAttribution{}, false
+	}
+
+	gvr := kindToGVR(kind)
+	if gvr.Resource == "" {
+		return agent.FieldMutationAttribution{}, false
+	}
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return agent.FieldMutationAttribution{}, false
+	}
+
+	obj, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		return agent.FieldMutationAttribution{}, false
+	}
+
+	owner := agent.DetectOwnership(obj)
+	return agent.AttributeFieldMutation(obj, owner), true
 }
 
 // fetchResourceEvents fetches recent events for a resource.

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -316,7 +316,47 @@ The per-field-path map is also exposed under `live.attributionByPath`, keyed by 
 
 The classifier matches against a verified enumeration of upstream field-manager strings — sources documented in `pkg/agent/manager_strings.go`. Strings not in the enumeration fall through to `unknown` rather than being guessed. Recognized sources include Argo CD, Flux (kustomize / helm / source controllers), Helm direct, Crossplane (composite / composed / claim / MRD / reference resolver), kro (applyset / applyset-parent / labeller), and `kubectl-*` interactive paths.
 
-Source: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`
+### Git source anchor (A2)
+
+When `compare three-way` runs against a resource managed by Argo CD or Flux (including ConfigHub-delivered-via-GitOps), the resource-level git source anchor is collected via the existing tracers (`pkg/agent/argo_trace.go`, `pkg/agent/flux_trace.go`) and surfaced on both the live side and each field mismatch.
+
+```json
+{
+  "live": {
+    "gitSource": {
+      "repoUrl": "https://github.com/org/platform-config",
+      "revision": "abc123def456",
+      "path": "apps/prod/payments"
+    }
+  },
+  "mismatches": [
+    {
+      "field": "replicas",
+      "dry": "3",
+      "wet": "3",
+      "live": "1",
+      "cause": "manual-edit",
+      "managerHint": "kubectl-edit",
+      "gitSource": {
+        "repoUrl": "https://github.com/org/platform-config",
+        "revision": "abc123def456",
+        "path": "apps/prod/payments"
+      }
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gitSource.repoUrl` | string | Source repository URL (`spec.url` for Flux GitRepository / `spec.source.repoURL` for Argo Application). |
+| `gitSource.revision` | string | Observed commit SHA, tag, or OCI digest. |
+| `gitSource.path` | string | Subdirectory within the repo (`spec.path` for Flux Kustomization / `spec.source.path` for Argo). |
+| `gitSource.line` | int | Reserved for stage B (rendering-aware back-resolution); always `0` at A2. |
+
+At A2 the anchor is resource-level — every field mismatch carries the same anchor. Stage B (Helm/Kustomize back-resolution) will refine to per-field anchors with file path + line resolution. Best-effort: omitted when no GitOps owner is detected, when the tracer CLI is unavailable, or when the chain root carries no useful data.
+
+Source: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`, `pkg/agent/git_source_anchor.go`
 
 ## MCP Structured Content Contract
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -282,7 +282,9 @@ When `compare three-way` and `explain` are run in connected mode (and the live c
 | `cause` | string enum | `controller-drift`, `manual-edit`, or `unknown`. Omitted when classification yields no signal. |
 | `managerHint` | string | Representative manager string from `metadata.managedFields` for transparency. Omitted when no manager string was identified. |
 
-At A1, `cause` and `managerHint` are resource-level and therefore the same for every mismatch on one resource. A1.5 will refine to per-field-path resolution.
+When the live K8s resource has decodable `FieldsV1` data in `metadata.managedFields`, `cause` and `managerHint` are resolved **per-field-path** (A1.5) — each field mismatch gets the classification specific to its path. When `FieldsV1` is absent or the field name doesn't map to a single canonical path (e.g., `images` which spans container list items), the classifier falls back to the resource-level rollup (A1).
+
+The per-field-path map is also exposed under `live.attributionByPath`, keyed by canonical path strings as rendered by `sigs.k8s.io/structured-merge-diff/v4/fieldpath.Path.String` (for example `.spec.replicas` or `.spec.template.spec.containers[name="api"].image`).
 
 ### Cause values
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -256,6 +256,66 @@ When `compare three-way --format json` is used, the JSON output includes `summar
 
 Source: `cmd/cub-scout/three_way.go`, `cmd/cub-scout/compare_three_way.go`
 
+## Field Mutation Attribution Contract
+
+When `compare three-way` and `explain` are run in connected mode (and the live cluster is reachable), each field mismatch is annotated with a `cause` classifying the mutation source — controller drift vs manual edit — derived from K8s `metadata.managedFields` co-signaled with the resource owner detected from labels and annotations. This is the first stage of the attribution layer; see `pkg/agent/field_ownership.go`.
+
+### compareFieldMismatch additions (compare three-way / compare three-way per-resource)
+
+```json
+{
+  "mismatches": [
+    {
+      "field": "replicas",
+      "dry": "3",
+      "wet": "3",
+      "live": "1",
+      "cause": "manual-edit",
+      "managerHint": "kubectl-edit"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cause` | string enum | `controller-drift`, `manual-edit`, or `unknown`. Omitted when classification yields no signal. |
+| `managerHint` | string | Representative manager string from `metadata.managedFields` for transparency. Omitted when no manager string was identified. |
+
+At A1, `cause` and `managerHint` are resource-level and therefore the same for every mismatch on one resource. A1.5 will refine to per-field-path resolution.
+
+### Cause values
+
+| Value | Meaning |
+|-------|---------|
+| `controller-drift` | The resource's expected GitOps/orchestration controller (per `pkg/agent/ownership.go`) is reconciling fields. A mismatch with desired state is likely transient. |
+| `manual-edit` | A `kubectl-*` or other interactive tool has written fields. Includes the mixed case where both a controller and an interactive tool have managed fields. |
+| `unknown` | The cause cannot be confidently determined — `managedFields` missing/empty, or only unrecognized manager strings present. Omitted from JSON output. |
+
+### ExplainSummary additions (explain --format json)
+
+```json
+{
+  "resource": "Deployment/api",
+  "namespace": "prod",
+  "owner": "ArgoCD",
+  "drift": "Detected by ConfigHub",
+  "mutationCause": "manual-edit",
+  "mutationManager": "kubectl-edit"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mutationCause` | string enum | Same enum as `cause` above. Best-effort; omitted on fetch failure or when no signal is present. |
+| `mutationManager` | string | Representative manager string for transparency. |
+
+### Verified manager strings
+
+The classifier matches against a verified enumeration of upstream field-manager strings — sources documented in `pkg/agent/manager_strings.go`. Strings not in the enumeration fall through to `unknown` rather than being guessed. Recognized sources include Argo CD, Flux (kustomize / helm / source controllers), Helm direct, Crossplane (composite / composed / claim / MRD / reference resolver), kro (applyset / applyset-parent / labeller), and `kubectl-*` interactive paths.
+
+Source: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`
+
 ## MCP Structured Content Contract
 
 When MCP tools return JSON-backed data, the gateway keeps the raw JSON string in `content[0].text`.

--- a/examples/drift/README.md
+++ b/examples/drift/README.md
@@ -57,6 +57,7 @@ Summary: 3 findings │ 2 warning │ 1 critical │ 3 affected objects
 | [env-var-drift/](env-var-drift/) | `LOG_LEVEL` changed | Warning | Running with wrong config |
 | [image-policy-drift/](image-policy-drift/) | `imagePullPolicy` changed | Warning | Silently running stale images |
 | [resource-drift/](resource-drift/) | `requests.cpu` exceeds limits | Critical | Next pod restart will fail |
+| [mutation-cause-attribution/](mutation-cause-attribution/) | Cause classification | n/a | Distinguish controller-drift vs `kubectl edit` |
 
 ## Quick Start
 

--- a/examples/drift/mutation-cause-attribution/README.md
+++ b/examples/drift/mutation-cause-attribution/README.md
@@ -101,9 +101,33 @@ The per-path map is exposed in `compare three-way` JSON output as `live.attribut
 
 Fields not yet mapped to canonical paths inherit the resource-level conclusion. A future expansion (A1.x or later) will introduce richer mappings for complex multi-path fields like container images.
 
+## Git Source Anchor (A2)
+
+When the resource is GitOps-managed (Argo CD or Flux, including ConfigHub-delivered-via-GitOps), `compare three-way` pairs the mutation cause with a **git source anchor** showing where the field's desired value came from in source control:
+
+```json
+"gitSource": {
+  "repoUrl": "https://github.com/org/platform-config",
+  "revision": "abc123def456",
+  "path": "apps/prod/payments"
+}
+```
+
+In ASCII output this renders as a `Git source:` line above the diff highlights:
+
+```
+Drift cause: manual-edit (manager: kubectl-edit)
+Git source: https://github.com/org/platform-config @abc123def456 path=apps/prod/payments
+
+Diff Highlights
+  - replicas: DRY=3 | WET=3 | LIVE=1
+```
+
+The anchor is resource-level at A2 — every field mismatch carries the same `gitSource`. **Line numbers and per-field file resolution** (mapping a specific field back to the line in `apps/prod/payments/deployment.yaml` where it's set) require rendering-aware back-resolution and are part of stage B.
+
 ## References
 
 - Parent issue: [confighub/cub-scout#435](https://github.com/confighub/cub-scout/issues/435) — Attribution layer
 - A1: [confighub/cub-scout#436](https://github.com/confighub/cub-scout/issues/436) — managedFields classification
-- Implementation: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`
+- Implementation: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`, `pkg/agent/field_ownership_paths.go`, `pkg/agent/git_source_anchor.go`
 - JSON contract: `docs/reference/json-contracts.md` § Field Mutation Attribution Contract

--- a/examples/drift/mutation-cause-attribution/README.md
+++ b/examples/drift/mutation-cause-attribution/README.md
@@ -86,11 +86,20 @@ The classifier uses the resource owner (detected by labels and annotations like 
 - Argo-owned resource + `kubectl-client-side-apply` → `controller-drift` (Argo CSA migration)
 - Native resource + `kubectl-client-side-apply` → `manual-edit` (`kubectl apply`)
 
-## What This Doesn't Tell You (Yet)
+## Per-Field-Path Attribution (A1.5)
 
-At A1, the classification is **resource-level** — the same `cause` is reported for every field mismatch on one resource. If only one field was edited by hand and the rest are controller-managed, A1 still surfaces the resource-level conclusion (mixed → `manual-edit`).
+When the live resource's `metadata.managedFields` includes decodable `FieldsV1` data, the classifier resolves the cause **per individual field path** — not just at the resource level.
 
-Per-field-path resolution (decoding `FieldsV1` to attribute each field to its specific writer) is the next stage, A1.5.
+This matters when, for example, Argo CD owns `.spec.template.spec.containers` but someone edited `.spec.replicas`:
+
+| Field | Cause | Manager hint |
+|-------|-------|--------------|
+| `.spec.replicas` | `manual-edit` | `kubectl-edit` |
+| `.spec.template.spec.containers` | `controller-drift` | `argocd-controller` |
+
+The per-path map is exposed in `compare three-way` JSON output as `live.attributionByPath`, keyed by canonical field-path strings (e.g., `.spec.replicas`). Each `compareFieldMismatch.cause` picks up the per-path classification when the field name maps to a known path, falling back to the resource-level rollup otherwise (e.g., for `images` which spans multiple container list items).
+
+Fields not yet mapped to canonical paths inherit the resource-level conclusion. A future expansion (A1.x or later) will introduce richer mappings for complex multi-path fields like container images.
 
 ## References
 

--- a/examples/drift/mutation-cause-attribution/README.md
+++ b/examples/drift/mutation-cause-attribution/README.md
@@ -1,0 +1,100 @@
+# Mutation Cause Attribution
+
+When `compare three-way` or `explain` detects that a live resource diverges from its desired state, the **mutation cause** classifies *why* — controller still reconciling vs someone bypassing the GitOps loop.
+
+## The Problem
+
+Two ways live state can diverge from desired:
+
+```
+desired (Git/ConfigHub)              live (cluster)
+─────────────────────                ──────────────
+replicas: 3              ──→  ✗      replicas: 1
+```
+
+- Maybe the **controller is mid-sync** — Argo CD just pushed the desired state and the replica count will converge in a few seconds.
+- Maybe **someone ran `kubectl edit`** — bypassing GitOps. The controller will eventually overwrite, but in the meantime live state is wrong and the change isn't tracked anywhere.
+
+Both look identical in a plain field diff. The difference matters because they need different responses: wait for one, investigate the other.
+
+## How cub-scout Distinguishes Them
+
+Kubernetes records *who last wrote each field* in `metadata.managedFields`. cub-scout reads this list and co-signals it against the resource owner detected from labels (see `pkg/agent/ownership.go`).
+
+```
+metadata:
+  managedFields:
+  - manager: argocd-application-controller   ← Argo CD writing
+    operation: Apply
+  - manager: kubectl-edit                    ← Someone editing manually
+    operation: Update
+```
+
+- Manager string matches the **expected owner's** known controller → `controller-drift`
+- Only `kubectl-*` managers (or bare `kubectl` for SSA) → `manual-edit`
+- Both present → `manual-edit` (operator on top of controller — surface the manual involvement)
+- Neither → `unknown` (parse-don't-guess; never misclassify)
+
+The verified manager-string enumeration lives in `pkg/agent/manager_strings.go` with citations to upstream sources for Argo CD, Flux (kustomize/helm/source controllers), Helm direct, Crossplane (composite/composed/claim/MRD/refs), kro, and `kubectl-*`.
+
+## Scenario A: Controller Reconciling
+
+An Argo CD-managed Deployment has `replicas: 1` in the cluster but ConfigHub says `replicas: 3`. The controller will sync — wait.
+
+See [`controller-drift.json`](controller-drift.json) for the annotated `compare three-way` output. The key field:
+
+```json
+"cause": "controller-drift",
+"managerHint": "argocd-application-controller"
+```
+
+In `explain`:
+
+```
+  Drift          Detected by ConfigHub
+  Mutation cause controller-drift (manager: argocd-application-controller)
+```
+
+**Next step:** wait for reconciliation; re-run `compare three-way` after a sync.
+
+## Scenario B: Manual Edit on a GitOps Resource
+
+Same resource, but this time a `kubectl edit` happened on top of Argo CD. The mismatch is *not* transient — Argo will fight back, but until then live state is wrong and the manual change is lost when Argo wins.
+
+See [`manual-edit.json`](manual-edit.json). The key field:
+
+```json
+"cause": "manual-edit",
+"managerHint": "kubectl-edit"
+```
+
+In `explain`:
+
+```
+  Drift          Detected by ConfigHub
+  Mutation cause manual-edit (manager: kubectl-edit)
+```
+
+**Next step:** investigate who edited, port the change back to Git/ConfigHub if intentional, revert in the cluster.
+
+## Co-signal: `kubectl-client-side-apply` is Ambiguous
+
+Argo CD's CSA migration default and `kubectl apply --client-side` both write `kubectl-client-side-apply`. The string alone cannot disambiguate.
+
+The classifier uses the resource owner (detected by labels and annotations like `argocd.argoproj.io/tracking-id`) as a co-signal:
+
+- Argo-owned resource + `kubectl-client-side-apply` → `controller-drift` (Argo CSA migration)
+- Native resource + `kubectl-client-side-apply` → `manual-edit` (`kubectl apply`)
+
+## What This Doesn't Tell You (Yet)
+
+At A1, the classification is **resource-level** — the same `cause` is reported for every field mismatch on one resource. If only one field was edited by hand and the rest are controller-managed, A1 still surfaces the resource-level conclusion (mixed → `manual-edit`).
+
+Per-field-path resolution (decoding `FieldsV1` to attribute each field to its specific writer) is the next stage, A1.5.
+
+## References
+
+- Parent issue: [confighub/cub-scout#435](https://github.com/confighub/cub-scout/issues/435) — Attribution layer
+- A1: [confighub/cub-scout#436](https://github.com/confighub/cub-scout/issues/436) — managedFields classification
+- Implementation: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`
+- JSON contract: `docs/reference/json-contracts.md` § Field Mutation Attribution Contract

--- a/examples/drift/mutation-cause-attribution/controller-drift.json
+++ b/examples/drift/mutation-cause-attribution/controller-drift.json
@@ -1,0 +1,47 @@
+{
+  "resource": "Deployment/api",
+  "namespace": "prod",
+  "mode": "dry-wet-live",
+  "connected": true,
+  "dry": {
+    "source": "confighub-dry",
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod",
+    "replicas": 3
+  },
+  "wet": {
+    "source": "confighub-wet",
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod",
+    "replicas": 3
+  },
+  "live": {
+    "source": "cluster",
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod",
+    "replicas": 1,
+    "attribution": {
+      "cause": "controller-drift",
+      "managerHint": "argocd-application-controller",
+      "managers": [
+        "argocd-application-controller"
+      ]
+    }
+  },
+  "mismatches": [
+    {
+      "field": "replicas",
+      "dry": "3",
+      "wet": "3",
+      "live": "1",
+      "cause": "controller-drift",
+      "managerHint": "argocd-application-controller"
+    }
+  ]
+}

--- a/examples/drift/mutation-cause-attribution/manual-edit.json
+++ b/examples/drift/mutation-cause-attribution/manual-edit.json
@@ -1,0 +1,48 @@
+{
+  "resource": "Deployment/api",
+  "namespace": "prod",
+  "mode": "dry-wet-live",
+  "connected": true,
+  "dry": {
+    "source": "confighub-dry",
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod",
+    "replicas": 3
+  },
+  "wet": {
+    "source": "confighub-wet",
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod",
+    "replicas": 3
+  },
+  "live": {
+    "source": "cluster",
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "name": "api",
+    "namespace": "prod",
+    "replicas": 1,
+    "attribution": {
+      "cause": "manual-edit",
+      "managerHint": "kubectl-edit",
+      "managers": [
+        "argocd-application-controller",
+        "kubectl-edit"
+      ]
+    }
+  },
+  "mismatches": [
+    {
+      "field": "replicas",
+      "dry": "3",
+      "wet": "3",
+      "live": "1",
+      "cause": "manual-edit",
+      "managerHint": "kubectl-edit"
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
+	sigs.k8s.io/cli-utils v0.37.2
+	sigs.k8s.io/structured-merge-diff/v4 v4.6.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -70,8 +72,6 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
-	sigs.k8s.io/cli-utils v0.37.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,6 @@ github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNE
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -105,7 +104,6 @@ github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/agent/field_ownership.go
+++ b/pkg/agent/field_ownership.go
@@ -1,0 +1,142 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// FieldMutationCause classifies the cause of a field mutation observed on a
+// live K8s resource, based on metadata.managedFields and the expected owner.
+type FieldMutationCause string
+
+const (
+	// CauseControllerDrift indicates the resource's expected GitOps or
+	// orchestration controller is reconciling fields. A mismatch with the
+	// desired state is likely transient.
+	CauseControllerDrift FieldMutationCause = "controller-drift"
+
+	// CauseManualEdit indicates an interactive tool (kubectl-*) has written
+	// fields on the resource. Also reported when both a controller and an
+	// interactive tool have managed fields on the resource — the operator
+	// edited on top of controller reconciliation.
+	CauseManualEdit FieldMutationCause = "manual-edit"
+
+	// CauseUnknown indicates the cause cannot be confidently determined,
+	// either because managedFields is missing/empty or because the manager
+	// strings present are not in the verified enumeration. Returning
+	// unknown is preferred over guessing.
+	CauseUnknown FieldMutationCause = "unknown"
+)
+
+// FieldMutationAttribution is the result of classifying a field mutation.
+type FieldMutationAttribution struct {
+	// Cause is the classified cause of the mutation.
+	Cause FieldMutationCause `json:"cause"`
+
+	// ManagerHint is a representative manager string for transparency. For
+	// CauseControllerDrift it is the matched controller manager. For
+	// CauseManualEdit it is the matched interactive manager (which is the
+	// cause-changing signal even when mixed with a controller string). For
+	// CauseUnknown it is the first unrecognized manager string if any.
+	ManagerHint string `json:"managerHint,omitempty"`
+
+	// Managers is the de-duplicated list of all manager strings observed on
+	// the resource, in first-seen order. Provided for full transparency for
+	// operators and downstream tooling that want the raw signal.
+	Managers []string `json:"managers,omitempty"`
+}
+
+// AttributeFieldMutation classifies the cause of field mutations on a live
+// K8s resource by reading metadata.managedFields and applying the
+// expected-owner co-signal:
+//
+//   - Any managedFields entry whose manager matches the expected owner's
+//     known controller string → CauseControllerDrift.
+//   - Otherwise, any entry whose manager is a known interactive (kubectl-*)
+//     string → CauseManualEdit.
+//   - If both are seen → CauseManualEdit (operator edited on top of
+//     controller reconciliation; surface the manual involvement).
+//   - Otherwise → CauseUnknown.
+//
+// Missing or empty managedFields returns CauseUnknown. Manager strings not in
+// the verified enumeration in manager_strings.go fall through to CauseUnknown
+// — the function never guesses.
+//
+// expectedOwner is typically obtained via DetectOwnership on the same resource.
+func AttributeFieldMutation(resource *unstructured.Unstructured, expectedOwner Ownership) FieldMutationAttribution {
+	if resource == nil {
+		return FieldMutationAttribution{Cause: CauseUnknown}
+	}
+
+	entries := resource.GetManagedFields()
+	if len(entries) == 0 {
+		return FieldMutationAttribution{Cause: CauseUnknown}
+	}
+
+	var (
+		sawController   bool
+		sawInteractive  bool
+		controllerHint  string
+		interactiveHint string
+		managers        []string
+	)
+	seen := make(map[string]struct{})
+
+	for _, e := range entries {
+		m := e.Manager
+		if m == "" {
+			continue
+		}
+		if _, dup := seen[m]; !dup {
+			seen[m] = struct{}{}
+			managers = append(managers, m)
+		}
+
+		if IsControllerManagerFor(m, expectedOwner.Type, expectedOwner.SubType) {
+			sawController = true
+			if controllerHint == "" {
+				controllerHint = m
+			}
+			continue
+		}
+		if IsInteractiveManager(m) {
+			sawInteractive = true
+			if interactiveHint == "" {
+				interactiveHint = m
+			}
+		}
+	}
+
+	switch {
+	case sawController && sawInteractive:
+		return FieldMutationAttribution{
+			Cause:       CauseManualEdit,
+			ManagerHint: interactiveHint,
+			Managers:    managers,
+		}
+	case sawController:
+		return FieldMutationAttribution{
+			Cause:       CauseControllerDrift,
+			ManagerHint: controllerHint,
+			Managers:    managers,
+		}
+	case sawInteractive:
+		return FieldMutationAttribution{
+			Cause:       CauseManualEdit,
+			ManagerHint: interactiveHint,
+			Managers:    managers,
+		}
+	default:
+		hint := ""
+		if len(managers) > 0 {
+			hint = managers[0]
+		}
+		return FieldMutationAttribution{
+			Cause:       CauseUnknown,
+			ManagerHint: hint,
+			Managers:    managers,
+		}
+	}
+}

--- a/pkg/agent/field_ownership_paths.go
+++ b/pkg/agent/field_ownership_paths.go
@@ -1,0 +1,112 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"bytes"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+)
+
+// AttributeFieldsByManagedFields extends AttributeFieldMutation by computing
+// per-field-path classifications when the K8s metadata.managedFields entries
+// carry FieldsV1 data. Returns both the per-path map and the resource-level
+// rollup (the latter matching AttributeFieldMutation).
+//
+// Keys in the returned map are canonical field-path strings as rendered by
+// sigs.k8s.io/structured-merge-diff/v4/fieldpath.Path.String — for example
+// ".spec.replicas" or ".spec.template.spec.containers[name=\"app\"].image".
+//
+// Per-path classification follows the same co-signal rule as the
+// resource-level classifier:
+//   - Any manager owning this path matches the expected owner's known
+//     controller string → CauseControllerDrift.
+//   - Only kubectl-*/bare kubectl owners on this path → CauseManualEdit.
+//   - Both → CauseManualEdit (operator edited on top of controller).
+//   - Otherwise → CauseUnknown.
+//
+// FieldsV1 entries that fail to decode are skipped silently; they do not
+// produce a classification of their own (graceful degradation).
+func AttributeFieldsByManagedFields(resource *unstructured.Unstructured, expectedOwner Ownership) (FieldMutationAttribution, map[string]FieldMutationAttribution) {
+	resourceLevel := AttributeFieldMutation(resource, expectedOwner)
+	if resource == nil {
+		return resourceLevel, nil
+	}
+	entries := resource.GetManagedFields()
+	if len(entries) == 0 {
+		return resourceLevel, nil
+	}
+
+	type pathAccum struct {
+		sawController   bool
+		sawInteractive  bool
+		controllerHint  string
+		interactiveHint string
+	}
+	byPath := make(map[string]*pathAccum)
+
+	for _, e := range entries {
+		m := e.Manager
+		if m == "" || e.FieldsV1 == nil || len(e.FieldsV1.Raw) == 0 {
+			continue
+		}
+		set := &fieldpath.Set{}
+		if err := set.FromJSON(bytes.NewReader(e.FieldsV1.Raw)); err != nil {
+			continue
+		}
+
+		isController := IsControllerManagerFor(m, expectedOwner.Type, expectedOwner.SubType)
+		isInteractive := !isController && IsInteractiveManager(m)
+		if !isController && !isInteractive {
+			continue
+		}
+
+		set.Iterate(func(p fieldpath.Path) {
+			key := p.String()
+			acc, ok := byPath[key]
+			if !ok {
+				acc = &pathAccum{}
+				byPath[key] = acc
+			}
+			if isController {
+				acc.sawController = true
+				if acc.controllerHint == "" {
+					acc.controllerHint = m
+				}
+			} else if isInteractive {
+				acc.sawInteractive = true
+				if acc.interactiveHint == "" {
+					acc.interactiveHint = m
+				}
+			}
+		})
+	}
+
+	if len(byPath) == 0 {
+		return resourceLevel, nil
+	}
+
+	out := make(map[string]FieldMutationAttribution, len(byPath))
+	for path, acc := range byPath {
+		switch {
+		case acc.sawController && acc.sawInteractive:
+			out[path] = FieldMutationAttribution{
+				Cause:       CauseManualEdit,
+				ManagerHint: acc.interactiveHint,
+			}
+		case acc.sawController:
+			out[path] = FieldMutationAttribution{
+				Cause:       CauseControllerDrift,
+				ManagerHint: acc.controllerHint,
+			}
+		case acc.sawInteractive:
+			out[path] = FieldMutationAttribution{
+				Cause:       CauseManualEdit,
+				ManagerHint: acc.interactiveHint,
+			}
+		}
+	}
+	return resourceLevel, out
+}

--- a/pkg/agent/field_ownership_paths_test.go
+++ b/pkg/agent/field_ownership_paths_test.go
@@ -1,0 +1,186 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeResourceWithFieldsV1(entries ...metav1.ManagedFieldsEntry) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	u.SetManagedFields(entries)
+	return u
+}
+
+func fieldsV1(rawJSON string) *metav1.FieldsV1 {
+	return &metav1.FieldsV1{Raw: []byte(rawJSON)}
+}
+
+func TestAttributeFieldsByManagedFields_PerPathClassification(t *testing.T) {
+	// Argo owns .spec.template.spec.containers; kubectl-edit owns .spec.replicas.
+	// Per-path classification should split these.
+	argoEntry := metav1.ManagedFieldsEntry{
+		Manager:    ManagerArgoCD,
+		Operation:  metav1.ManagedFieldsOperationApply,
+		FieldsType: "FieldsV1",
+		FieldsV1: fieldsV1(`{
+			"f:spec":{
+				"f:template":{
+					"f:spec":{
+						"f:containers":{}
+					}
+				}
+			}
+		}`),
+	}
+	editEntry := metav1.ManagedFieldsEntry{
+		Manager:    ManagerKubectlEdit,
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		FieldsType: "FieldsV1",
+		FieldsV1:   fieldsV1(`{"f:spec":{"f:replicas":{}}}`),
+	}
+	resource := makeResourceWithFieldsV1(argoEntry, editEntry)
+	owner := Ownership{Type: OwnerArgo, SubType: "application"}
+
+	_, byPath := AttributeFieldsByManagedFields(resource, owner)
+	if len(byPath) == 0 {
+		t.Fatalf("expected per-path map to be populated; got empty")
+	}
+
+	// .spec.replicas should be classified as manual-edit (kubectl-edit owns it).
+	replicasAttr, ok := byPath[".spec.replicas"]
+	if !ok {
+		t.Errorf("missing .spec.replicas in byPath; keys = %v", keys(byPath))
+	} else {
+		if replicasAttr.Cause != CauseManualEdit {
+			t.Errorf(".spec.replicas Cause = %q, want %q", replicasAttr.Cause, CauseManualEdit)
+		}
+		if replicasAttr.ManagerHint != ManagerKubectlEdit {
+			t.Errorf(".spec.replicas ManagerHint = %q, want %q", replicasAttr.ManagerHint, ManagerKubectlEdit)
+		}
+	}
+
+	// .spec.template.spec.containers should be classified as controller-drift (Argo owns it).
+	containersAttr, ok := byPath[".spec.template.spec.containers"]
+	if !ok {
+		t.Errorf("missing .spec.template.spec.containers in byPath; keys = %v", keys(byPath))
+	} else {
+		if containersAttr.Cause != CauseControllerDrift {
+			t.Errorf(".spec.template.spec.containers Cause = %q, want %q", containersAttr.Cause, CauseControllerDrift)
+		}
+		if containersAttr.ManagerHint != ManagerArgoCD {
+			t.Errorf(".spec.template.spec.containers ManagerHint = %q, want %q", containersAttr.ManagerHint, ManagerArgoCD)
+		}
+	}
+}
+
+func TestAttributeFieldsByManagedFields_MixedOnSamePath(t *testing.T) {
+	// Two managers both touch .spec.replicas — Argo via Apply, kubectl-edit via
+	// Update. Per the algorithm, the mixed case resolves to manual-edit because
+	// human involvement is the cause-changing signal.
+	argoEntry := metav1.ManagedFieldsEntry{
+		Manager:    ManagerArgoCD,
+		Operation:  metav1.ManagedFieldsOperationApply,
+		FieldsType: "FieldsV1",
+		FieldsV1:   fieldsV1(`{"f:spec":{"f:replicas":{}}}`),
+	}
+	editEntry := metav1.ManagedFieldsEntry{
+		Manager:    ManagerKubectlEdit,
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		FieldsType: "FieldsV1",
+		FieldsV1:   fieldsV1(`{"f:spec":{"f:replicas":{}}}`),
+	}
+	resource := makeResourceWithFieldsV1(argoEntry, editEntry)
+	owner := Ownership{Type: OwnerArgo, SubType: "application"}
+
+	_, byPath := AttributeFieldsByManagedFields(resource, owner)
+	replicasAttr, ok := byPath[".spec.replicas"]
+	if !ok {
+		t.Fatalf("missing .spec.replicas; keys = %v", keys(byPath))
+	}
+	if replicasAttr.Cause != CauseManualEdit {
+		t.Errorf("Cause = %q, want %q (mixed must resolve to manual-edit)", replicasAttr.Cause, CauseManualEdit)
+	}
+	if replicasAttr.ManagerHint != ManagerKubectlEdit {
+		t.Errorf("ManagerHint = %q, want %q", replicasAttr.ManagerHint, ManagerKubectlEdit)
+	}
+}
+
+func TestAttributeFieldsByManagedFields_ResourceLevelAlsoReturned(t *testing.T) {
+	resource := makeResource(ManagerArgoCD)
+	owner := Ownership{Type: OwnerArgo, SubType: "application"}
+
+	resourceLevel, _ := AttributeFieldsByManagedFields(resource, owner)
+	if resourceLevel.Cause != CauseControllerDrift {
+		t.Errorf("resourceLevel.Cause = %q, want %q", resourceLevel.Cause, CauseControllerDrift)
+	}
+	if resourceLevel.ManagerHint != ManagerArgoCD {
+		t.Errorf("resourceLevel.ManagerHint = %q, want %q", resourceLevel.ManagerHint, ManagerArgoCD)
+	}
+}
+
+func TestAttributeFieldsByManagedFields_NoFieldsV1ReturnsEmptyMap(t *testing.T) {
+	// makeResource builds entries with no FieldsV1 — per-path map must be nil
+	// or empty, while the resource-level rollup still works.
+	resource := makeResource(ManagerArgoCD, ManagerKubectlEdit)
+	owner := Ownership{Type: OwnerArgo, SubType: "application"}
+
+	resourceLevel, byPath := AttributeFieldsByManagedFields(resource, owner)
+	if resourceLevel.Cause != CauseManualEdit {
+		t.Errorf("resourceLevel.Cause = %q, want %q", resourceLevel.Cause, CauseManualEdit)
+	}
+	if len(byPath) != 0 {
+		t.Errorf("byPath = %v, want nil/empty when FieldsV1 missing", byPath)
+	}
+}
+
+func TestAttributeFieldsByManagedFields_NilAndEmpty(t *testing.T) {
+	t.Run("nil resource", func(t *testing.T) {
+		resourceLevel, byPath := AttributeFieldsByManagedFields(nil, Ownership{Type: OwnerArgo})
+		if resourceLevel.Cause != CauseUnknown {
+			t.Errorf("resourceLevel.Cause = %q, want %q", resourceLevel.Cause, CauseUnknown)
+		}
+		if byPath != nil {
+			t.Errorf("byPath = %v, want nil", byPath)
+		}
+	})
+
+	t.Run("no managedFields", func(t *testing.T) {
+		u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		resourceLevel, byPath := AttributeFieldsByManagedFields(u, Ownership{Type: OwnerArgo})
+		if resourceLevel.Cause != CauseUnknown {
+			t.Errorf("resourceLevel.Cause = %q, want %q", resourceLevel.Cause, CauseUnknown)
+		}
+		if byPath != nil {
+			t.Errorf("byPath = %v, want nil", byPath)
+		}
+	})
+
+}
+
+func TestAttributeFieldsByManagedFields_UnknownManagerSkipped(t *testing.T) {
+	// Unknown manager strings should not produce per-path entries — parse don't guess.
+	unknown := metav1.ManagedFieldsEntry{
+		Manager:    "some-unknown-tool",
+		Operation:  metav1.ManagedFieldsOperationApply,
+		FieldsType: "FieldsV1",
+		FieldsV1:   fieldsV1(`{"f:spec":{"f:replicas":{}}}`),
+	}
+	resource := makeResourceWithFieldsV1(unknown)
+	_, byPath := AttributeFieldsByManagedFields(resource, Ownership{Type: OwnerArgo, SubType: "application"})
+	if len(byPath) != 0 {
+		t.Errorf("byPath = %v, want empty for unknown manager", byPath)
+	}
+}
+
+func keys(m map[string]FieldMutationAttribution) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/agent/field_ownership_test.go
+++ b/pkg/agent/field_ownership_test.go
@@ -1,0 +1,325 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeResource(managers ...string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	entries := make([]metav1.ManagedFieldsEntry, 0, len(managers))
+	for _, m := range managers {
+		entries = append(entries, metav1.ManagedFieldsEntry{Manager: m, Operation: metav1.ManagedFieldsOperationApply})
+	}
+	u.SetManagedFields(entries)
+	return u
+}
+
+func TestAttributeFieldMutation_Argo(t *testing.T) {
+	owner := Ownership{Type: OwnerArgo, SubType: "application"}
+
+	t.Run("argocd-controller only", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerArgoCD), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+		if got.ManagerHint != ManagerArgoCD {
+			t.Errorf("ManagerHint = %q, want %q", got.ManagerHint, ManagerArgoCD)
+		}
+	})
+
+	t.Run("CSA migration default counts as controller", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerKubectlCSA), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q (Argo CSA migration must be controller-drift)", got.Cause, CauseControllerDrift)
+		}
+		if got.ManagerHint != ManagerKubectlCSA {
+			t.Errorf("ManagerHint = %q, want %q", got.ManagerHint, ManagerKubectlCSA)
+		}
+	})
+
+	t.Run("controller + kubectl edit is manual-edit with kubectl hint", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerArgoCD, ManagerKubectlEdit), owner)
+		if got.Cause != CauseManualEdit {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseManualEdit)
+		}
+		if got.ManagerHint != ManagerKubectlEdit {
+			t.Errorf("ManagerHint = %q, want %q (mixed case must surface interactive)", got.ManagerHint, ManagerKubectlEdit)
+		}
+		wantManagers := []string{ManagerArgoCD, ManagerKubectlEdit}
+		if !reflect.DeepEqual(got.Managers, wantManagers) {
+			t.Errorf("Managers = %v, want %v", got.Managers, wantManagers)
+		}
+	})
+}
+
+func TestAttributeFieldMutation_Native(t *testing.T) {
+	owner := Ownership{Type: OwnerKubernetes}
+
+	t.Run("CSA on native is manual-edit", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerKubectlCSA), owner)
+		if got.Cause != CauseManualEdit {
+			t.Errorf("Cause = %q, want %q (CSA on non-Argo must be manual)", got.Cause, CauseManualEdit)
+		}
+		if got.ManagerHint != ManagerKubectlCSA {
+			t.Errorf("ManagerHint = %q, want %q", got.ManagerHint, ManagerKubectlCSA)
+		}
+	})
+
+	t.Run("kubectl-edit is manual-edit", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerKubectlEdit), owner)
+		if got.Cause != CauseManualEdit {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseManualEdit)
+		}
+	})
+
+	t.Run("bare kubectl SSA is manual-edit", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerKubectlSSA), owner)
+		if got.Cause != CauseManualEdit {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseManualEdit)
+		}
+	})
+}
+
+func TestAttributeFieldMutation_Flux(t *testing.T) {
+	t.Run("kustomization with kustomize-controller", func(t *testing.T) {
+		owner := Ownership{Type: OwnerFlux, SubType: "kustomization"}
+		got := AttributeFieldMutation(makeResource(ManagerFluxKustomize), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+	})
+
+	t.Run("helmrelease with helm-controller", func(t *testing.T) {
+		owner := Ownership{Type: OwnerFlux, SubType: "helmrelease"}
+		got := AttributeFieldMutation(makeResource(ManagerFluxHelm), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+	})
+
+	t.Run("helmrelease with wrong controller subtype is unknown", func(t *testing.T) {
+		owner := Ownership{Type: OwnerFlux, SubType: "helmrelease"}
+		got := AttributeFieldMutation(makeResource(ManagerFluxKustomize), owner)
+		if got.Cause != CauseUnknown {
+			t.Errorf("Cause = %q, want %q (kustomize-controller does not manage HelmReleases)", got.Cause, CauseUnknown)
+		}
+	})
+
+	t.Run("helmrelease with kustomize-controller + kubectl edit", func(t *testing.T) {
+		owner := Ownership{Type: OwnerFlux, SubType: "helmrelease"}
+		got := AttributeFieldMutation(makeResource(ManagerFluxKustomize, ManagerKubectlEdit), owner)
+		// Kustomize-controller is not the expected controller for a
+		// HelmRelease, but kubectl-edit is still interactive — manual-edit.
+		if got.Cause != CauseManualEdit {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseManualEdit)
+		}
+	})
+}
+
+func TestAttributeFieldMutation_HelmDirect(t *testing.T) {
+	owner := Ownership{Type: OwnerHelm, SubType: "release"}
+	got := AttributeFieldMutation(makeResource(ManagerHelm), owner)
+	if got.Cause != CauseControllerDrift {
+		t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+	}
+	if got.ManagerHint != ManagerHelm {
+		t.Errorf("ManagerHint = %q, want %q", got.ManagerHint, ManagerHelm)
+	}
+}
+
+func TestAttributeFieldMutation_Crossplane(t *testing.T) {
+	t.Run("composite XR", func(t *testing.T) {
+		owner := Ownership{Type: OwnerCrossplane, SubType: "composite"}
+		got := AttributeFieldMutation(makeResource(ManagerCrossplaneComposite), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+	})
+
+	t.Run("composed children prefix match", func(t *testing.T) {
+		owner := Ownership{Type: OwnerCrossplane, SubType: "managed-resource"}
+		got := AttributeFieldMutation(makeResource("apiextensions.crossplane.io/composed-9f8e7d6c5b4a"), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q (prefix match for composed children must work)", got.Cause, CauseControllerDrift)
+		}
+		if got.ManagerHint != "apiextensions.crossplane.io/composed-9f8e7d6c5b4a" {
+			t.Errorf("ManagerHint = %q, want full string with hash", got.ManagerHint)
+		}
+	})
+
+	t.Run("claim", func(t *testing.T) {
+		owner := Ownership{Type: OwnerCrossplane, SubType: "claim"}
+		got := AttributeFieldMutation(makeResource(ManagerCrossplaneClaim), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+	})
+
+	t.Run("provider via ref resolver", func(t *testing.T) {
+		owner := Ownership{Type: OwnerCrossplane, SubType: "managed-resource"}
+		got := AttributeFieldMutation(makeResource(ManagerCrossplaneRefResolver), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+	})
+}
+
+func TestAttributeFieldMutation_Kro(t *testing.T) {
+	owner := Ownership{Type: OwnerKro, SubType: "instance"}
+	got := AttributeFieldMutation(makeResource(ManagerKroApplyset), owner)
+	if got.Cause != CauseControllerDrift {
+		t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+	}
+}
+
+func TestAttributeFieldMutation_ConfigHub(t *testing.T) {
+	owner := Ownership{Type: OwnerConfigHub, SubType: "unit"}
+
+	t.Run("delivered via Argo", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerArgoCD), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+	})
+
+	t.Run("delivered via Flux kustomize", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerFluxKustomize), owner)
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+	})
+
+	t.Run("unrelated controller is not controller-drift", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerCrossplaneClaim), owner)
+		if got.Cause != CauseUnknown {
+			t.Errorf("Cause = %q, want %q (Crossplane manager doesn't deliver ConfigHub units)", got.Cause, CauseUnknown)
+		}
+	})
+}
+
+func TestAttributeFieldMutation_EdgeCases(t *testing.T) {
+	t.Run("nil resource", func(t *testing.T) {
+		got := AttributeFieldMutation(nil, Ownership{Type: OwnerArgo})
+		if got.Cause != CauseUnknown {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseUnknown)
+		}
+		if got.ManagerHint != "" {
+			t.Errorf("ManagerHint = %q, want empty", got.ManagerHint)
+		}
+		if len(got.Managers) != 0 {
+			t.Errorf("Managers = %v, want empty", got.Managers)
+		}
+	})
+
+	t.Run("no managedFields", func(t *testing.T) {
+		u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		got := AttributeFieldMutation(u, Ownership{Type: OwnerArgo})
+		if got.Cause != CauseUnknown {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseUnknown)
+		}
+	})
+
+	t.Run("only unknown manager string", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource("some-unrecognized-tool"), Ownership{Type: OwnerArgo})
+		if got.Cause != CauseUnknown {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseUnknown)
+		}
+		if got.ManagerHint != "some-unrecognized-tool" {
+			t.Errorf("ManagerHint = %q, want %q (unrecognized hint surfaced for transparency)", got.ManagerHint, "some-unrecognized-tool")
+		}
+	})
+
+	t.Run("empty manager entry skipped", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource("", ManagerArgoCD), Ownership{Type: OwnerArgo})
+		if got.Cause != CauseControllerDrift {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseControllerDrift)
+		}
+		// Empty string must not appear in Managers.
+		for _, m := range got.Managers {
+			if m == "" {
+				t.Errorf("Managers contains empty string: %v", got.Managers)
+			}
+		}
+	})
+
+	t.Run("duplicate managers deduplicated", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerArgoCD, ManagerArgoCD, ManagerArgoCD), Ownership{Type: OwnerArgo})
+		if len(got.Managers) != 1 {
+			t.Errorf("Managers = %v, want exactly 1 entry after dedup", got.Managers)
+		}
+	})
+
+	t.Run("unknown owner with controller-looking string", func(t *testing.T) {
+		// ArgoCD-controller string but ownership detection returned unknown.
+		// The classifier shouldn't treat the string as controller-drift
+		// without the expected-owner signal.
+		got := AttributeFieldMutation(makeResource(ManagerArgoCD), Ownership{Type: OwnerUnknown})
+		if got.Cause != CauseUnknown {
+			t.Errorf("Cause = %q, want %q (cannot assume controller without owner signal)", got.Cause, CauseUnknown)
+		}
+	})
+
+	t.Run("custom owner with no manager mapping", func(t *testing.T) {
+		got := AttributeFieldMutation(makeResource(ManagerArgoCD), Ownership{Type: OwnerCustom})
+		// No manager string is registered for OwnerCustom; the only thing the
+		// classifier can do is fall through. argocd-controller is not in the
+		// interactive set, so it goes to unknown.
+		if got.Cause != CauseUnknown {
+			t.Errorf("Cause = %q, want %q", got.Cause, CauseUnknown)
+		}
+	})
+}
+
+// TestAttributeFieldMutation_ManagerHintPrefersInteractiveWhenMixed locks in
+// the mixed-case behavior: when both a controller and an interactive manager
+// are present, the hint points at the interactive string because that's the
+// cause-changing signal.
+func TestAttributeFieldMutation_ManagerHintPrefersInteractiveWhenMixed(t *testing.T) {
+	cases := []struct {
+		name    string
+		owner   Ownership
+		mgrs    []string
+		wantCause FieldMutationCause
+		wantHint  string
+	}{
+		{
+			name:      "argo + kubectl-edit",
+			owner:     Ownership{Type: OwnerArgo, SubType: "application"},
+			mgrs:      []string{ManagerArgoCD, ManagerKubectlEdit},
+			wantCause: CauseManualEdit,
+			wantHint:  ManagerKubectlEdit,
+		},
+		{
+			name:      "flux kustomize + kubectl-patch",
+			owner:     Ownership{Type: OwnerFlux, SubType: "kustomization"},
+			mgrs:      []string{ManagerFluxKustomize, ManagerKubectlPatch},
+			wantCause: CauseManualEdit,
+			wantHint:  ManagerKubectlPatch,
+		},
+		{
+			name:      "helm direct + kubectl-replace",
+			owner:     Ownership{Type: OwnerHelm, SubType: "release"},
+			mgrs:      []string{ManagerHelm, ManagerKubectlReplace},
+			wantCause: CauseManualEdit,
+			wantHint:  ManagerKubectlReplace,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AttributeFieldMutation(makeResource(tc.mgrs...), tc.owner)
+			if got.Cause != tc.wantCause {
+				t.Errorf("Cause = %q, want %q", got.Cause, tc.wantCause)
+			}
+			if got.ManagerHint != tc.wantHint {
+				t.Errorf("ManagerHint = %q, want %q", got.ManagerHint, tc.wantHint)
+			}
+		})
+	}
+}

--- a/pkg/agent/git_source_anchor.go
+++ b/pkg/agent/git_source_anchor.go
@@ -1,0 +1,129 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// GitSourceAnchor identifies where a field's value originated in source
+// control. It pairs with FieldMutationAttribution to answer two halves of
+// the same question:
+//
+//   - FieldMutationAttribution: which writer last set this field on the cluster
+//   - GitSourceAnchor: which git source the controller is reconciling from
+//
+// At A2 the anchor is resolved at the resource level — every field on a
+// given resource shares the same anchor. Stage B will refine to per-field
+// anchors via rendering-aware back-resolution (Helm value paths, Kustomize
+// patch lineage).
+type GitSourceAnchor struct {
+	// RepoURL is the source repository URL observed by the GitOps controller.
+	// For Flux GitRepository this is spec.url; for Argo Application this is
+	// spec.source.repoURL (or spec.sources[0].repoURL).
+	RepoURL string `json:"repoUrl,omitempty"`
+
+	// Revision is the observed commit SHA, tag, or OCI digest. May be empty
+	// when the controller has not yet observed a revision.
+	Revision string `json:"revision,omitempty"`
+
+	// Path is the subdirectory within the repository used by the controller,
+	// when known. For Flux Kustomization this is spec.path; for Argo
+	// Application this is spec.source.path.
+	Path string `json:"path,omitempty"`
+
+	// Line is the line number within the manifest file where the field was
+	// set. Reserved for stage B (rendering-aware back-resolution); always
+	// zero in A2.
+	Line int `json:"line,omitempty"`
+}
+
+// IsEmpty reports whether the anchor carries no useful information.
+func (g *GitSourceAnchor) IsEmpty() bool {
+	if g == nil {
+		return true
+	}
+	return strings.TrimSpace(g.RepoURL) == "" &&
+		strings.TrimSpace(g.Revision) == "" &&
+		strings.TrimSpace(g.Path) == "" &&
+		g.Line == 0
+}
+
+// CollectGitSourceAnchor traces the resource via the appropriate GitOps
+// tracer and returns the source anchor at the root of the ownership chain
+// (the GitRepository / OCIRepository / Argo Application source). Returns
+// nil for any of:
+//
+//   - resource is nil
+//   - resource has no recognized GitOps owner (Argo / Flux / ConfigHub-via-GitOps)
+//   - the required tracer CLI is not available
+//   - tracing fails or produces an empty chain
+//   - the chain root carries no URL, Revision, or Path
+//
+// Best-effort by design: A2 is an enrichment of evidence, not a hard
+// dependency. Callers should treat nil as "no anchor available" rather
+// than an error condition.
+func CollectGitSourceAnchor(ctx context.Context, obj *unstructured.Unstructured) *GitSourceAnchor {
+	if obj == nil {
+		return nil
+	}
+	owner := DetectOwnership(obj)
+	switch owner.Type {
+	case OwnerArgo, OwnerConfigHub:
+		// ConfigHub-managed resources are delivered by Argo (preferred) or
+		// Flux. Try Argo first; fall through to Flux if the Argo tracer
+		// finds nothing. Treating ConfigHub-via-Flux as a fallback keeps
+		// the common case (ConfigHub-via-Argo) on the fast path.
+		if anchor := collectArgoGitSource(ctx, obj); anchor != nil {
+			return anchor
+		}
+		if owner.Type == OwnerConfigHub {
+			return collectFluxGitSource(ctx, obj)
+		}
+		return nil
+	case OwnerFlux:
+		return collectFluxGitSource(ctx, obj)
+	default:
+		return nil
+	}
+}
+
+func collectArgoGitSource(ctx context.Context, obj *unstructured.Unstructured) *GitSourceAnchor {
+	tr := NewArgoTracer()
+	if !tr.Available() {
+		return nil
+	}
+	res, err := tr.Trace(ctx, obj.GetKind(), obj.GetName(), obj.GetNamespace())
+	if err != nil || res == nil || len(res.Chain) == 0 {
+		return nil
+	}
+	return anchorFromChainRoot(res.Chain[0])
+}
+
+func collectFluxGitSource(ctx context.Context, obj *unstructured.Unstructured) *GitSourceAnchor {
+	tr := NewFluxTracer()
+	if !tr.Available() {
+		return nil
+	}
+	res, err := tr.Trace(ctx, obj.GetKind(), obj.GetName(), obj.GetNamespace())
+	if err != nil || res == nil || len(res.Chain) == 0 {
+		return nil
+	}
+	return anchorFromChainRoot(res.Chain[0])
+}
+
+func anchorFromChainRoot(root ChainLink) *GitSourceAnchor {
+	anchor := &GitSourceAnchor{
+		RepoURL:  strings.TrimSpace(root.URL),
+		Revision: strings.TrimSpace(root.Revision),
+		Path:     strings.TrimSpace(root.Path),
+	}
+	if anchor.IsEmpty() {
+		return nil
+	}
+	return anchor
+}

--- a/pkg/agent/git_source_anchor_test.go
+++ b/pkg/agent/git_source_anchor_test.go
@@ -1,0 +1,110 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGitSourceAnchor_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		anchor *GitSourceAnchor
+		want   bool
+	}{
+		{"nil anchor", nil, true},
+		{"all empty", &GitSourceAnchor{}, true},
+		{"whitespace only", &GitSourceAnchor{RepoURL: "  ", Revision: "\t", Path: " "}, true},
+		{"repo only", &GitSourceAnchor{RepoURL: "https://github.com/org/repo"}, false},
+		{"revision only", &GitSourceAnchor{Revision: "abc123"}, false},
+		{"path only", &GitSourceAnchor{Path: "apps/prod"}, false},
+		{"all populated", &GitSourceAnchor{RepoURL: "https://github.com/o/r", Revision: "abc", Path: "apps", Line: 0}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.anchor.IsEmpty()
+			if got != tc.want {
+				t.Errorf("IsEmpty = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAnchorFromChainRoot(t *testing.T) {
+	tests := []struct {
+		name string
+		root ChainLink
+		want *GitSourceAnchor
+	}{
+		{
+			name: "git-repo style root",
+			root: ChainLink{Kind: "GitRepository", URL: "https://github.com/org/repo", Revision: "main@sha1:abc123", Path: "apps/prod"},
+			want: &GitSourceAnchor{RepoURL: "https://github.com/org/repo", Revision: "main@sha1:abc123", Path: "apps/prod"},
+		},
+		{
+			name: "argo source root",
+			root: ChainLink{Kind: "Application", URL: "https://github.com/org/repo", Revision: "abc123", Path: "manifests"},
+			want: &GitSourceAnchor{RepoURL: "https://github.com/org/repo", Revision: "abc123", Path: "manifests"},
+		},
+		{
+			name: "OCI-style root with digest as revision",
+			root: ChainLink{Kind: "OCIRepository", URL: "oci://ghcr.io/org/chart", Revision: "sha256:deadbeef"},
+			want: &GitSourceAnchor{RepoURL: "oci://ghcr.io/org/chart", Revision: "sha256:deadbeef"},
+		},
+		{
+			name: "empty chainlink returns nil",
+			root: ChainLink{Kind: "Whatever"},
+			want: nil,
+		},
+		{
+			name: "whitespace-only fields return nil",
+			root: ChainLink{URL: " ", Revision: " ", Path: " "},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := anchorFromChainRoot(tc.root)
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("anchorFromChainRoot = %v, want %v", got, tc.want)
+			}
+			if got == nil {
+				return
+			}
+			if got.RepoURL != tc.want.RepoURL || got.Revision != tc.want.Revision || got.Path != tc.want.Path {
+				t.Errorf("anchorFromChainRoot = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCollectGitSourceAnchor_BestEffortNil(t *testing.T) {
+	// CollectGitSourceAnchor goes through real ArgoTracer/FluxTracer which
+	// require CLI availability. In a test environment without those CLIs
+	// (or without a real cluster), the function must silently return nil
+	// rather than panic. That's the contract.
+	t.Run("nil resource", func(t *testing.T) {
+		if got := CollectGitSourceAnchor(context.Background(), nil); got != nil {
+			t.Errorf("expected nil for nil resource; got %+v", got)
+		}
+	})
+
+	t.Run("native resource without GitOps owner", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "default",
+				// No owner labels → owner type "k8s" or "unknown" → no tracer dispatch
+			},
+		}}
+		if got := CollectGitSourceAnchor(context.Background(), obj); got != nil {
+			t.Errorf("expected nil for resource without GitOps owner; got %+v", got)
+		}
+	})
+}

--- a/pkg/agent/manager_strings.go
+++ b/pkg/agent/manager_strings.go
@@ -1,0 +1,242 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import "strings"
+
+// K8s metadata.managedFields[].manager string constants, verified against
+// upstream sources. Each constant's doc comment cites the source where the
+// string is defined.
+//
+// The Attribution Layer (issue #435 / A1 issue #436) uses these constants
+// together with ownership detection in ownership.go to classify a field
+// mismatch as controller-drift, manual-edit, or unknown. See
+// IsControllerManagerFor and IsInteractiveManager below.
+//
+// Strings are intentionally locked into named constants so that the
+// verified enumeration is a single source of truth in the code, not free
+// strings spread across call sites.
+
+// --- GitOps / orchestration controller manager strings ---
+
+// ManagerArgoCD is the field-manager used by Argo CD's application-controller
+// for server-side apply. Source: argoproj/argo-cd `common.ArgoCDSSAManager`.
+const ManagerArgoCD = "argocd-controller"
+
+// ManagerFluxKustomize is the field-manager used by the Flux
+// kustomize-controller. Source: fluxcd/kustomize-controller `controllerName`.
+const ManagerFluxKustomize = "kustomize-controller"
+
+// ManagerFluxHelm is the field-manager used by the Flux helm-controller.
+// Source: fluxcd/helm-controller `controllerName`.
+const ManagerFluxHelm = "helm-controller"
+
+// ManagerFluxSource is the field-manager used by the Flux source-controller.
+// Source: fluxcd/source-controller `controllerName`.
+const ManagerFluxSource = "source-controller"
+
+// ManagerHelm is the default field-manager used by the `helm` CLI for
+// install/upgrade SSA patches. Source: helm/helm `kube.ManagedFieldsManager`
+// default (`filepath.Base(os.Args[0])`). Third-party embedders (Flux
+// helm-controller, terraform-provider-helm, etc.) override this with their
+// own identity, so the bare string `helm` denotes a direct helm-binary
+// invocation rather than a controller using the Helm library.
+const ManagerHelm = "helm"
+
+// ManagerCrossplaneComposite is the field-manager used by Crossplane's
+// composite (XR) controller when writing fields on the XR itself. Source:
+// crossplane/crossplane `FieldOwnerXR`.
+const ManagerCrossplaneComposite = "apiextensions.crossplane.io/composite"
+
+// ManagerCrossplaneComposedPrefix is the prefix of the field-manager used by
+// the Crossplane composite controller when writing fields on composed
+// children. The full string is `apiextensions.crossplane.io/composed-<hash>`
+// where the suffix is per-XR. Match this constant by prefix only. Source:
+// crossplane/crossplane `FieldOwnerComposedPrefix` + `ComposedFieldOwnerName`.
+const ManagerCrossplaneComposedPrefix = "apiextensions.crossplane.io/composed"
+
+// ManagerCrossplaneClaim is the field-manager used by the Crossplane claim
+// SSA syncer. Source: crossplane/crossplane claim package `FieldOwnerXR`
+// constant (note: symbol name in upstream is misleading; value is
+// `.../claim`).
+const ManagerCrossplaneClaim = "apiextensions.crossplane.io/claim"
+
+// ManagerCrossplaneMRD is the field-manager used by the Crossplane MRD
+// (managed-resource-definition) reconciler. Source: crossplane/crossplane
+// `FieldOwnerMRD`.
+const ManagerCrossplaneMRD = "apiextensions.crossplane.io/managed"
+
+// ManagerCrossplaneRefResolver is the field-manager used by
+// crossplane-runtime's reference resolver. Used by every provider that links
+// via crossplane-runtime. Source: crossplane/crossplane-runtime
+// `fieldOwnerAPISimpleRefResolver`.
+const ManagerCrossplaneRefResolver = "managed.crossplane.io/api-simple-reference-resolver"
+
+// ManagerKroApplyset is the field-manager used by kro for applyset-managed
+// child resources. Source: kro-run/kro `applyset.FieldManager`.
+const ManagerKroApplyset = "kro.run/applyset"
+
+// ManagerKroApplysetParent is the field-manager used by kro for applyset
+// metadata on the parent instance. Source: kro-run/kro
+// `applyset.FieldManager + "-parent"`.
+const ManagerKroApplysetParent = "kro.run/applyset-parent"
+
+// ManagerKroLabeller is the field-manager used by kro for finalizer/label SSA
+// on instances. Source: kro-run/kro `FieldManagerForLabeler`.
+const ManagerKroLabeller = "kro.run/labeller"
+
+// --- Interactive (kubectl) manager strings ---
+
+// ManagerKubectlSSA is the field-manager used by `kubectl apply --server-side`.
+// Source: kubernetes/kubectl `pkg/cmd/apply/apply.go` `fieldManagerServerSideApply`.
+// The bare string `kubectl` is deliberate (back-compat with pre-SSA-flag kubectl).
+const ManagerKubectlSSA = "kubectl"
+
+// ManagerKubectlCSA is the field-manager used by `kubectl apply` (client-side,
+// the default). Source: kubernetes/kubectl `FieldManagerClientSideApply`.
+// Note: Argo CD's CSA migration uses the same string; the classifier
+// disambiguates via the owner co-signal (see IsControllerManagerFor).
+const ManagerKubectlCSA = "kubectl-client-side-apply"
+
+// ManagerKubectlEdit is the field-manager used by `kubectl edit`.
+// Source: kubernetes/kubectl `pkg/cmd/edit/edit.go`.
+const ManagerKubectlEdit = "kubectl-edit"
+
+// ManagerKubectlPatch is the field-manager used by `kubectl patch`.
+// Source: kubernetes/kubectl `pkg/cmd/patch/patch.go`.
+const ManagerKubectlPatch = "kubectl-patch"
+
+// ManagerKubectlCreate is the field-manager used by `kubectl create`.
+// Source: kubernetes/kubectl `pkg/cmd/create/create.go`.
+const ManagerKubectlCreate = "kubectl-create"
+
+// ManagerKubectlReplace is the field-manager used by `kubectl replace`.
+// Source: kubernetes/kubectl `pkg/cmd/replace/replace.go`.
+const ManagerKubectlReplace = "kubectl-replace"
+
+// ManagerKubectlLastApplied is the field-manager used by kubectl during the
+// CSA-to-SSA migration on the `kubectl.kubernetes.io/last-applied-configuration`
+// annotation. Source: kubernetes/kubectl `fieldManagerLastAppliedAnnotation`.
+const ManagerKubectlLastApplied = "kubectl-last-applied"
+
+// managerMatcher describes how a manager string is matched against an entry
+// from metadata.managedFields. Most matches are exact; Crossplane composed
+// children use a hashed suffix that requires prefix matching.
+type managerMatcher struct {
+	pattern  string
+	isPrefix bool
+}
+
+func (m managerMatcher) matches(manager string) bool {
+	if m.isPrefix {
+		return strings.HasPrefix(manager, m.pattern)
+	}
+	return manager == m.pattern
+}
+
+// controllerManagersForOwner returns the set of manager-string matchers
+// indicating the given owner is reconciling fields. The ownerSubType is
+// honored when present to narrow Flux to the specific controller (kustomize
+// vs helm vs source); when not, all three are accepted.
+func controllerManagersForOwner(ownerType, ownerSubType string) []managerMatcher {
+	switch ownerType {
+	case OwnerArgo:
+		return []managerMatcher{
+			{pattern: ManagerArgoCD},
+			{pattern: ManagerKubectlCSA}, // Argo CSA migration default
+		}
+	case OwnerFlux:
+		switch ownerSubType {
+		case "kustomization":
+			return []managerMatcher{{pattern: ManagerFluxKustomize}}
+		case "helmrelease":
+			return []managerMatcher{{pattern: ManagerFluxHelm}}
+		case "source", "gitrepository", "ocirepository", "helmrepository", "bucket":
+			return []managerMatcher{{pattern: ManagerFluxSource}}
+		default:
+			return []managerMatcher{
+				{pattern: ManagerFluxKustomize},
+				{pattern: ManagerFluxHelm},
+				{pattern: ManagerFluxSource},
+			}
+		}
+	case OwnerHelm:
+		return []managerMatcher{{pattern: ManagerHelm}}
+	case OwnerCrossplane:
+		return []managerMatcher{
+			{pattern: ManagerCrossplaneComposite},
+			{pattern: ManagerCrossplaneComposedPrefix, isPrefix: true},
+			{pattern: ManagerCrossplaneClaim},
+			{pattern: ManagerCrossplaneMRD},
+			{pattern: ManagerCrossplaneRefResolver},
+		}
+	case OwnerKro:
+		return []managerMatcher{
+			{pattern: ManagerKroApplyset},
+			{pattern: ManagerKroApplysetParent},
+			{pattern: ManagerKroLabeller},
+		}
+	case OwnerConfigHub:
+		// ConfigHub units are delivered by Argo or Flux controllers; accept
+		// either's strings as controller-drift evidence.
+		return []managerMatcher{
+			{pattern: ManagerArgoCD},
+			{pattern: ManagerKubectlCSA},
+			{pattern: ManagerFluxKustomize},
+			{pattern: ManagerFluxHelm},
+		}
+	default:
+		return nil
+	}
+}
+
+// interactiveManagers is the set of kubectl/CLI manager strings that indicate
+// a manual edit when not accompanied by a controller co-signal.
+var interactiveManagers = []managerMatcher{
+	{pattern: ManagerKubectlSSA},
+	{pattern: ManagerKubectlCSA},
+	{pattern: ManagerKubectlEdit},
+	{pattern: ManagerKubectlPatch},
+	{pattern: ManagerKubectlCreate},
+	{pattern: ManagerKubectlReplace},
+	{pattern: ManagerKubectlLastApplied},
+}
+
+// IsControllerManagerFor returns true when the manager string indicates the
+// GitOps/orchestration controller expected for the given owner is reconciling
+// fields. The (ownerType, ownerSubType) co-signal handles overlapping strings:
+// for example, `kubectl-client-side-apply` is Argo CD's CSA migration default,
+// so an Argo-owned resource with that manager is controller-drift, not
+// manual-edit.
+//
+// Returns false when:
+//   - the owner type is unknown or unrecognized
+//   - the manager string does not match any known controller pattern for the owner
+func IsControllerManagerFor(manager, ownerType, ownerSubType string) bool {
+	if manager == "" {
+		return false
+	}
+	for _, m := range controllerManagersForOwner(ownerType, ownerSubType) {
+		if m.matches(manager) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsInteractiveManager returns true for manager strings that indicate a
+// kubectl/CLI write. Callers classifying a field mismatch should check
+// IsControllerManagerFor first when the resource has a known GitOps owner —
+// see the package doc for the classifier co-signal rule.
+func IsInteractiveManager(manager string) bool {
+	if manager == "" {
+		return false
+	}
+	for _, m := range interactiveManagers {
+		if m.matches(manager) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/agent/manager_strings_test.go
+++ b/pkg/agent/manager_strings_test.go
@@ -1,0 +1,148 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import "testing"
+
+func TestIsControllerManagerFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		manager      string
+		ownerType    string
+		ownerSubType string
+		want         bool
+	}{
+		// Argo CD — both the SSA-default and CSA-migration default count as
+		// controller-drift when the owner is Argo.
+		{"argo ssa", ManagerArgoCD, OwnerArgo, "application", true},
+		{"argo csa migration", ManagerKubectlCSA, OwnerArgo, "application", true},
+
+		// Flux — narrows by subtype.
+		{"flux kustomize for kustomization", ManagerFluxKustomize, OwnerFlux, "kustomization", true},
+		{"flux helm for helmrelease", ManagerFluxHelm, OwnerFlux, "helmrelease", true},
+		{"flux source for gitrepository", ManagerFluxSource, OwnerFlux, "gitrepository", true},
+		{"flux source for ocirepository", ManagerFluxSource, OwnerFlux, "ocirepository", true},
+		{"flux source for bucket", ManagerFluxSource, OwnerFlux, "bucket", true},
+		{"flux kustomize wrong subtype", ManagerFluxKustomize, OwnerFlux, "helmrelease", false},
+		{"flux helm wrong subtype", ManagerFluxHelm, OwnerFlux, "kustomization", false},
+		// Unknown Flux subtype accepts any Flux controller.
+		{"flux unknown subtype accepts kustomize", ManagerFluxKustomize, OwnerFlux, "", true},
+		{"flux unknown subtype accepts helm", ManagerFluxHelm, OwnerFlux, "", true},
+		{"flux unknown subtype accepts source", ManagerFluxSource, OwnerFlux, "", true},
+
+		// Helm direct.
+		{"helm direct", ManagerHelm, OwnerHelm, "release", true},
+		{"helm direct does not match flux helm controller", ManagerFluxHelm, OwnerHelm, "release", false},
+
+		// Crossplane — exact for most, prefix for composed children.
+		{"crossplane composite", ManagerCrossplaneComposite, OwnerCrossplane, "composite", true},
+		{"crossplane composed prefix exact", ManagerCrossplaneComposedPrefix, OwnerCrossplane, "managed-resource", true},
+		{"crossplane composed with hash suffix", "apiextensions.crossplane.io/composed-abcd1234ef567890", OwnerCrossplane, "managed-resource", true},
+		{"crossplane composed with another hash", "apiextensions.crossplane.io/composed-deadbeef", OwnerCrossplane, "composite", true},
+		{"crossplane claim", ManagerCrossplaneClaim, OwnerCrossplane, "claim", true},
+		{"crossplane mrd", ManagerCrossplaneMRD, OwnerCrossplane, "managed-resource", true},
+		{"crossplane ref resolver", ManagerCrossplaneRefResolver, OwnerCrossplane, "managed-resource", true},
+		{"crossplane unrelated string", "apiextensions.crossplane.io/something-else", OwnerCrossplane, "claim", false},
+
+		// kro.
+		{"kro applyset", ManagerKroApplyset, OwnerKro, "instance", true},
+		{"kro applyset-parent", ManagerKroApplysetParent, OwnerKro, "instance", true},
+		{"kro labeller", ManagerKroLabeller, OwnerKro, "instance", true},
+		{"kro unrelated string", "kro.run/other", OwnerKro, "instance", false},
+
+		// ConfigHub units are delivered by GitOps controllers; accept either's strings.
+		{"confighub via argo", ManagerArgoCD, OwnerConfigHub, "unit", true},
+		{"confighub via argo csa migration", ManagerKubectlCSA, OwnerConfigHub, "unit", true},
+		{"confighub via flux kustomize", ManagerFluxKustomize, OwnerConfigHub, "unit", true},
+		{"confighub via flux helm", ManagerFluxHelm, OwnerConfigHub, "unit", true},
+		{"confighub does not accept random controller", ManagerCrossplaneClaim, OwnerConfigHub, "unit", false},
+
+		// Co-signal: kubectl-client-side-apply is only a controller string when
+		// the owner is Argo or ConfigHub-delivered-via-Argo. Other owners treat
+		// it as manual via IsInteractiveManager.
+		{"csa for kubernetes-native is not controller", ManagerKubectlCSA, OwnerKubernetes, "", false},
+		{"csa for helm is not controller", ManagerKubectlCSA, OwnerHelm, "release", false},
+		{"csa for crossplane is not controller", ManagerKubectlCSA, OwnerCrossplane, "claim", false},
+		{"csa for unknown owner is not controller", ManagerKubectlCSA, OwnerUnknown, "", false},
+
+		// Empty strings + unknown manager.
+		{"empty manager for argo", "", OwnerArgo, "application", false},
+		{"empty manager for native", "", OwnerKubernetes, "", false},
+		{"unknown manager for argo", "some-random-tool", OwnerArgo, "application", false},
+		{"unknown manager for native", "some-random-tool", OwnerKubernetes, "", false},
+
+		// Unknown owner type returns false for any manager.
+		{"unknown owner with argo string", ManagerArgoCD, OwnerUnknown, "", false},
+		{"empty owner type", ManagerArgoCD, "", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsControllerManagerFor(tc.manager, tc.ownerType, tc.ownerSubType)
+			if got != tc.want {
+				t.Errorf("IsControllerManagerFor(%q, %q, %q) = %v, want %v",
+					tc.manager, tc.ownerType, tc.ownerSubType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsInteractiveManager(t *testing.T) {
+	tests := []struct {
+		name    string
+		manager string
+		want    bool
+	}{
+		{"kubectl ssa bare", ManagerKubectlSSA, true},
+		{"kubectl csa", ManagerKubectlCSA, true},
+		{"kubectl edit", ManagerKubectlEdit, true},
+		{"kubectl patch", ManagerKubectlPatch, true},
+		{"kubectl create", ManagerKubectlCreate, true},
+		{"kubectl replace", ManagerKubectlReplace, true},
+		{"kubectl last-applied", ManagerKubectlLastApplied, true},
+
+		// Controller strings are not interactive.
+		{"argocd-controller is not interactive", ManagerArgoCD, false},
+		{"kustomize-controller is not interactive", ManagerFluxKustomize, false},
+		{"helm-controller is not interactive", ManagerFluxHelm, false},
+		{"source-controller is not interactive", ManagerFluxSource, false},
+		{"helm direct is not interactive", ManagerHelm, false},
+		{"crossplane composite is not interactive", ManagerCrossplaneComposite, false},
+		{"kro applyset is not interactive", ManagerKroApplyset, false},
+
+		// Edge cases.
+		{"empty manager", "", false},
+		{"unknown manager", "some-random-tool", false},
+		{"kubectl-like but unknown", "kubectl-fancy-new-thing", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsInteractiveManager(tc.manager)
+			if got != tc.want {
+				t.Errorf("IsInteractiveManager(%q) = %v, want %v", tc.manager, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestManagerStringCoSignalDisambiguates documents the key co-signal property
+// for the kubectl-client-side-apply string: it appears as a controller string
+// for Argo-owned resources (CSA migration) and as an interactive string for
+// non-Argo owners. The classifier in field_ownership.go relies on this
+// asymmetric behavior; if this test starts failing because both functions
+// agree, the disambiguation is broken.
+func TestManagerStringCoSignalDisambiguates(t *testing.T) {
+	const csa = ManagerKubectlCSA
+
+	if !IsControllerManagerFor(csa, OwnerArgo, "application") {
+		t.Errorf("CSA must be a controller manager for Argo (CSA migration default)")
+	}
+	if !IsInteractiveManager(csa) {
+		t.Errorf("CSA must remain in the interactive set for the classifier's mixed-case rule")
+	}
+	if IsControllerManagerFor(csa, OwnerKubernetes, "") {
+		t.Errorf("CSA must NOT be a controller manager for native resources — that would misclassify kubectl apply as controller-drift")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the first three stages of the attribution layer (#435):

- **A1 (#436)** — `managedFields`-based mutation-source classification (`controller-drift` vs `manual-edit`) using the verified upstream manager-string enumeration in `pkg/agent/manager_strings.go` co-signaled with `pkg/agent/ownership.go`.
- **A1.5** — per-field-path classification by decoding `FieldsV1` via `sigs.k8s.io/structured-merge-diff/v4/fieldpath`. Each `compareFieldMismatch` picks up the path-specific cause when the field name maps to a known canonical path (`.spec.replicas`, etc.), falling back to the resource-level rollup otherwise.
- **A2** — git source anchor on each field mismatch (`repoUrl`, `revision`, `path`) by tracing the resource via the existing `ArgoTracer` / `FluxTracer`. Best-effort; nil when tracer CLIs are unavailable or no GitOps owner is detected. Line numbers and per-field file resolution are explicitly reserved for stage B.

All work stays inside the read-only triad lock from #410/#428 — attribution is enrichment of evidence, not authority or mutation.

## What landed end-to-end

- `pkg/agent/manager_strings.go` + tests — verified constants (Argo CD / Flux / Helm / Crossplane / kro / kubectl), `IsControllerManagerFor`, `IsInteractiveManager`
- `pkg/agent/field_ownership.go` + tests — `AttributeFieldMutation` resource-level classifier
- `pkg/agent/field_ownership_paths.go` + tests — `AttributeFieldsByManagedFields` per-field-path classifier
- `pkg/agent/git_source_anchor.go` + tests — `GitSourceAnchor` type + `CollectGitSourceAnchor` tracer-backed collector
- `cmd/cub-scout/compare_resource.go` — `compareFieldMismatch` extended with `cause`, `managerHint`, `gitSource`; `compareSideSummary` extended with `attribution`, `attributionByPath`, `gitSource`; ASCII + Markdown renderers
- `cmd/cub-scout/compare_three_way.go` — drift-cause line in per-resource ASCII output
- `cmd/cub-scout/explain.go` + `observe.go` — `mutationCause` / `mutationManager` on `ExplainSummary`; best-effort `fetchResourceAttribution` helper
- `docs/reference/json-contracts.md` — new "Field Mutation Attribution Contract" section documenting `cause`, `managerHint`, `attributionByPath`, `gitSource`
- `examples/drift/mutation-cause-attribution/` — README + `controller-drift.json` + `manual-edit.json` showing both classifications
- `go.mod` — `sigs.k8s.io/structured-merge-diff/v4` promoted from indirect to direct dependency

## What's deliberately deferred

- **Stage B** — Helm/Kustomize back-resolution to populate `gitSource.line` and per-field paths
- **Stage C1** — ConfigHub binding / needs-provides introspection (requires `cub` API surface verification)
- **Stage C2** — field-level ConfigHub provenance ("from upstream unit X via binding Y")
- Additional writers in the manager enumeration: Tekton, Argo Workflows, Cluster API, OIDC-based CD — filed as non-goals, may be follow-up issues if the variant-management story demands them

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/agent/...` — 100+ new subtests across `manager_strings`, `field_ownership`, `field_ownership_paths`, `git_source_anchor`
- [x] `go test ./cmd/cub-scout/...` — existing golden + comparison suites unaffected (all additive `omitempty` JSON fields)
- [x] Full repo `go test ./...` — green except a pre-existing `test/unit/demo_worker_lifecycle_script_test.go` failure that also fails on a clean main checkout (unrelated to this PR)

## Closes

Closes #435, closes #436.
