### PR TITLE
feat: attribution layer C1 — incoming binding introspection

### DIFF
--- a/cmd/cub-scout/compare_bindings.go
+++ b/cmd/cub-scout/compare_bindings.go
@@ -1,0 +1,205 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// IncomingBinding describes a ConfigHub Link whose downstream unit is the
+// resource's owning unit. Each entry represents "this unit's config is
+// influenced by upstream unit X via update type Y" — the variant-management
+// directed graph cub-scout surfaces as evidence (C1 of the attribution layer,
+// issue #435).
+//
+// Fields are a curated subset of the Link entity (see `cub link explain`).
+// The classifier intentionally does not expand the full Bindings list at C1;
+// per-field binding attribution is C2.
+type IncomingBinding struct {
+	// LinkID is the unique identifier for the link.
+	LinkID string `json:"linkId,omitempty"`
+
+	// Slug is the URL-safe identifier — useful for `cub link get <slug>`.
+	Slug string `json:"slug,omitempty"`
+
+	// DisplayName is the human-friendly name when set.
+	DisplayName string `json:"displayName,omitempty"`
+
+	// UpdateType is the operation performed by the link: NeedsProvides,
+	// UpgradeUnits, MergeUnits, Insert, Upsert, or future Transform.
+	UpdateType string `json:"updateType,omitempty"`
+
+	// ToUnitID identifies the upstream (producer) Unit.
+	ToUnitID string `json:"toUnitId,omitempty"`
+
+	// ToSpaceID identifies the upstream Unit's space.
+	ToSpaceID string `json:"toSpaceId,omitempty"`
+
+	// AutoUpdate is true when the link auto-propagates upstream changes
+	// to the downstream unit.
+	AutoUpdate bool `json:"autoUpdate,omitempty"`
+
+	// WhereResource is the optional filter selecting which upstream
+	// resources are eligible for propagation.
+	WhereResource string `json:"whereResource,omitempty"`
+
+	// BindingsCount is the number of explicit binding expressions on the
+	// link (extracted from Link.Bindings). The detailed per-field
+	// breakdown is C2 territory.
+	BindingsCount int `json:"bindingsCount,omitempty"`
+}
+
+// linkRunner is the abstraction over `cub link` shell invocations used by the
+// incoming-binding collector. Production wires this to exec.CommandContext;
+// tests inject a fake that returns prefab JSON.
+type linkRunner func(ctx context.Context, args ...string) ([]byte, error)
+
+var compareLinkRunner linkRunner = func(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "cub", args...).Output()
+}
+
+// collectIncomingBindings queries `cub link list` for all links whose
+// FromUnitID matches the given downstream unit. Each matching link is
+// returned as an IncomingBinding for surfacing on compareResourceResult.
+//
+// Best-effort: returns nil on any auth failure, parse error, or empty result
+// — bindings are enrichment evidence, not a hard dependency. Returning nil
+// matches the rest of the connected enrichment pattern (attribution,
+// gitSource).
+func collectIncomingBindings(ctx context.Context, unitID, space string) []IncomingBinding {
+	if strings.TrimSpace(unitID) == "" {
+		return nil
+	}
+	space = strings.TrimSpace(space)
+	if space == "" {
+		space = "*"
+	}
+	where := fmt.Sprintf("FromUnitID = '%s'", strings.ReplaceAll(unitID, "'", ""))
+	out, err := compareLinkRunner(ctx, "link", "list", "--space", space, "--where", where, "-o", "json", "--quiet")
+	if err != nil || len(out) == 0 {
+		return nil
+	}
+	return parseLinkListJSON(out)
+}
+
+// parseLinkListJSON decodes the JSON array `cub link list -o json` returns
+// into IncomingBinding values. Unknown fields are ignored; unparseable input
+// yields nil so callers can treat the result as "no bindings observed."
+func parseLinkListJSON(raw []byte) []IncomingBinding {
+	type rawLink struct {
+		LinkID        string          `json:"LinkID"`
+		Slug          string          `json:"Slug"`
+		DisplayName   string          `json:"DisplayName"`
+		UpdateType    string          `json:"UpdateType"`
+		ToUnitID      string          `json:"ToUnitID"`
+		ToSpaceID     string          `json:"ToSpaceID"`
+		AutoUpdate    bool            `json:"AutoUpdate"`
+		WhereResource string          `json:"WhereResource"`
+		Bindings      json.RawMessage `json:"Bindings"`
+	}
+	var rows []rawLink
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]IncomingBinding, 0, len(rows))
+	for _, r := range rows {
+		entry := IncomingBinding{
+			LinkID:        strings.TrimSpace(r.LinkID),
+			Slug:          strings.TrimSpace(r.Slug),
+			DisplayName:   strings.TrimSpace(r.DisplayName),
+			UpdateType:    strings.TrimSpace(r.UpdateType),
+			ToUnitID:      strings.TrimSpace(r.ToUnitID),
+			ToSpaceID:     strings.TrimSpace(r.ToSpaceID),
+			AutoUpdate:    r.AutoUpdate,
+			WhereResource: strings.TrimSpace(r.WhereResource),
+		}
+		entry.BindingsCount = countBindings(r.Bindings)
+		out = append(out, entry)
+	}
+	return out
+}
+
+// countBindings returns the number of binding entries on a Link without
+// expanding their structure. The Bindings field is a list of arbitrary
+// shape per ConfigHub schema; for C1 we only need the count.
+func countBindings(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	// Try a list of objects; many BindingList shapes serialize that way.
+	var asArray []json.RawMessage
+	if err := json.Unmarshal(raw, &asArray); err == nil {
+		return len(asArray)
+	}
+	// Some shapes wrap entries in an object — try that and sum the entries.
+	var asObject map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &asObject); err == nil {
+		return len(asObject)
+	}
+	return 0
+}
+
+func renderIncomingBindingsASCII(b *strings.Builder, bindings []IncomingBinding) {
+	if len(bindings) == 0 {
+		return
+	}
+	b.WriteString("\nIncoming Bindings (ConfigHub)\n")
+	for _, link := range bindings {
+		display := link.DisplayName
+		if display == "" {
+			display = link.Slug
+		}
+		if display == "" {
+			display = link.LinkID
+		}
+		line := fmt.Sprintf("  - %s [%s]", display, link.UpdateType)
+		if link.ToUnitID != "" {
+			line += fmt.Sprintf(" <- unit:%s", link.ToUnitID)
+		}
+		if link.AutoUpdate {
+			line += " auto-update"
+		}
+		if link.BindingsCount > 0 {
+			line += fmt.Sprintf(" bindings=%d", link.BindingsCount)
+		}
+		b.WriteString(line + "\n")
+	}
+}
+
+func renderIncomingBindingsMarkdown(b *strings.Builder, bindings []IncomingBinding) {
+	if len(bindings) == 0 {
+		return
+	}
+	b.WriteString("\n### Incoming Bindings (ConfigHub)\n\n")
+	b.WriteString("| Link | Update Type | Upstream Unit | Auto | Bindings |\n")
+	b.WriteString("|---|---|---|---|---:|\n")
+	for _, link := range bindings {
+		display := link.DisplayName
+		if display == "" {
+			display = link.Slug
+		}
+		if display == "" {
+			display = link.LinkID
+		}
+		auto := "no"
+		if link.AutoUpdate {
+			auto = "yes"
+		}
+		b.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %s | %d |\n",
+			display,
+			link.UpdateType,
+			link.ToUnitID,
+			auto,
+			link.BindingsCount,
+		))
+	}
+	b.WriteString("\n")
+}

--- a/cmd/cub-scout/compare_bindings_test.go
+++ b/cmd/cub-scout/compare_bindings_test.go
@@ -1,0 +1,198 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseLinkListJSON(t *testing.T) {
+	raw := []byte(`[
+		{
+			"LinkID": "link-1",
+			"Slug": "image-from-app",
+			"DisplayName": "Image From App",
+			"UpdateType": "NeedsProvides",
+			"FromUnitID": "unit-downstream",
+			"ToUnitID": "unit-upstream-image",
+			"ToSpaceID": "space-A",
+			"AutoUpdate": true,
+			"WhereResource": "kind=Deployment",
+			"Bindings": [{"foo":"bar"},{"x":"y"},{"a":"b"}]
+		},
+		{
+			"LinkID": "link-2",
+			"Slug": "upgrade",
+			"UpdateType": "UpgradeUnits",
+			"FromUnitID": "unit-downstream",
+			"ToUnitID": "unit-upstream-base",
+			"AutoUpdate": false,
+			"Bindings": {}
+		}
+	]`)
+
+	got := parseLinkListJSON(raw)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+
+	if got[0].LinkID != "link-1" || got[0].Slug != "image-from-app" {
+		t.Errorf("entry 0 mismatch: %+v", got[0])
+	}
+	if got[0].UpdateType != "NeedsProvides" || got[0].ToUnitID != "unit-upstream-image" {
+		t.Errorf("entry 0 type/upstream mismatch: %+v", got[0])
+	}
+	if !got[0].AutoUpdate {
+		t.Errorf("entry 0 AutoUpdate should be true; got %+v", got[0])
+	}
+	if got[0].BindingsCount != 3 {
+		t.Errorf("entry 0 BindingsCount = %d, want 3", got[0].BindingsCount)
+	}
+	if got[0].WhereResource != "kind=Deployment" {
+		t.Errorf("entry 0 WhereResource = %q", got[0].WhereResource)
+	}
+
+	if got[1].LinkID != "link-2" || got[1].UpdateType != "UpgradeUnits" {
+		t.Errorf("entry 1 mismatch: %+v", got[1])
+	}
+	if got[1].AutoUpdate {
+		t.Errorf("entry 1 AutoUpdate should be false; got %+v", got[1])
+	}
+	// Empty {} bindings object → count zero
+	if got[1].BindingsCount != 0 {
+		t.Errorf("entry 1 BindingsCount = %d, want 0", got[1].BindingsCount)
+	}
+}
+
+func TestParseLinkListJSON_EmptyAndInvalid(t *testing.T) {
+	if got := parseLinkListJSON([]byte(`[]`)); got != nil {
+		t.Errorf("empty array → expected nil, got %v", got)
+	}
+	if got := parseLinkListJSON([]byte(`not json`)); got != nil {
+		t.Errorf("invalid JSON → expected nil, got %v", got)
+	}
+	if got := parseLinkListJSON(nil); got != nil {
+		t.Errorf("nil input → expected nil, got %v", got)
+	}
+}
+
+func TestCollectIncomingBindings_RoundTrip(t *testing.T) {
+	// Inject a stub runner that records args and returns canned JSON.
+	var capturedArgs []string
+	saved := compareLinkRunner
+	defer func() { compareLinkRunner = saved }()
+	compareLinkRunner = func(ctx context.Context, args ...string) ([]byte, error) {
+		capturedArgs = args
+		return []byte(`[{"LinkID":"L","Slug":"s","UpdateType":"Upsert","ToUnitID":"upstream"}]`), nil
+	}
+
+	got := collectIncomingBindings(context.Background(), "unit-A", "space-X")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 binding; got %d", len(got))
+	}
+	if got[0].UpdateType != "Upsert" || got[0].ToUnitID != "upstream" {
+		t.Errorf("bad binding decode: %+v", got[0])
+	}
+
+	// Verify the cub command shape — link list with FromUnitID filter.
+	joined := strings.Join(capturedArgs, " ")
+	for _, expect := range []string{"link", "list", "--space", "space-X", "--where", "FromUnitID = 'unit-A'", "-o", "json", "--quiet"} {
+		if !strings.Contains(joined, expect) {
+			t.Errorf("expected %q in args; got %q", expect, joined)
+		}
+	}
+}
+
+func TestCollectIncomingBindings_EmptyUnitID(t *testing.T) {
+	// Empty unitID short-circuits to nil without calling the runner.
+	called := false
+	saved := compareLinkRunner
+	defer func() { compareLinkRunner = saved }()
+	compareLinkRunner = func(ctx context.Context, args ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	}
+
+	got := collectIncomingBindings(context.Background(), "", "space-X")
+	if got != nil {
+		t.Errorf("expected nil; got %v", got)
+	}
+	if called {
+		t.Errorf("runner should not have been invoked for empty unitID")
+	}
+}
+
+func TestCollectIncomingBindings_DefaultSpaceWildcard(t *testing.T) {
+	// Empty space defaults to "*" so cross-space links are reachable.
+	var capturedArgs []string
+	saved := compareLinkRunner
+	defer func() { compareLinkRunner = saved }()
+	compareLinkRunner = func(ctx context.Context, args ...string) ([]byte, error) {
+		capturedArgs = args
+		return []byte(`[]`), nil
+	}
+
+	_ = collectIncomingBindings(context.Background(), "unit-A", "")
+	joined := strings.Join(capturedArgs, " ")
+	if !strings.Contains(joined, "--space *") {
+		t.Errorf("expected default --space *; got %q", joined)
+	}
+}
+
+func TestCollectIncomingBindings_RunnerErrorReturnsNil(t *testing.T) {
+	saved := compareLinkRunner
+	defer func() { compareLinkRunner = saved }()
+	compareLinkRunner = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, errors.New("auth failed")
+	}
+
+	got := collectIncomingBindings(context.Background(), "unit-A", "space-X")
+	if got != nil {
+		t.Errorf("expected nil on runner error; got %v", got)
+	}
+}
+
+func TestRenderIncomingBindingsASCII(t *testing.T) {
+	var b strings.Builder
+	renderIncomingBindingsASCII(&b, []IncomingBinding{
+		{LinkID: "L1", Slug: "image-from-app", DisplayName: "Image From App", UpdateType: "NeedsProvides", ToUnitID: "u1", AutoUpdate: true, BindingsCount: 3},
+		{LinkID: "L2", Slug: "upgrade", UpdateType: "UpgradeUnits", ToUnitID: "u2"},
+	})
+
+	out := b.String()
+	if !strings.Contains(out, "Incoming Bindings (ConfigHub)") {
+		t.Errorf("missing header: %q", out)
+	}
+	if !strings.Contains(out, "Image From App [NeedsProvides] <- unit:u1 auto-update bindings=3") {
+		t.Errorf("entry 1 wrong: %q", out)
+	}
+	if !strings.Contains(out, "upgrade [UpgradeUnits] <- unit:u2") {
+		t.Errorf("entry 2 wrong: %q", out)
+	}
+}
+
+func TestRenderIncomingBindingsASCII_Empty(t *testing.T) {
+	var b strings.Builder
+	renderIncomingBindingsASCII(&b, nil)
+	if b.Len() != 0 {
+		t.Errorf("empty bindings should produce empty output; got %q", b.String())
+	}
+}
+
+func TestRenderIncomingBindingsMarkdown(t *testing.T) {
+	var b strings.Builder
+	renderIncomingBindingsMarkdown(&b, []IncomingBinding{
+		{LinkID: "L1", Slug: "image-from-app", UpdateType: "NeedsProvides", ToUnitID: "u1", AutoUpdate: true, BindingsCount: 3},
+	})
+	out := b.String()
+	if !strings.Contains(out, "### Incoming Bindings (ConfigHub)") {
+		t.Errorf("missing header: %q", out)
+	}
+	if !strings.Contains(out, "| `image-from-app` | `NeedsProvides` | `u1` | yes | 3 |") {
+		t.Errorf("row wrong: %q", out)
+	}
+}

--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -76,6 +76,13 @@ type compareResourceResult struct {
 	Live       compareSideSummary     `json:"live"`
 	Mismatches []compareFieldMismatch `json:"mismatches,omitempty"`
 	Notes      []string               `json:"notes,omitempty"`
+
+	// IncomingBindings lists ConfigHub Links whose downstream (consumer) unit
+	// is this resource's unit — i.e., where its config data is influenced
+	// from. Populated only in connected mode when the live unit slug is
+	// known and the `cub link list` call succeeds (C1 of the attribution
+	// layer, issue #435). Per-field binding attribution is C2.
+	IncomingBindings []IncomingBinding `json:"incomingBindings,omitempty"`
 }
 
 type compareFieldMismatch struct {
@@ -239,7 +246,7 @@ func buildCompareResourceResult(ctx context.Context, resourceArg, namespace stri
 				if dryWet.Wet == nil {
 					notes = append(notes, "WET snapshot unavailable for linked unit.")
 				}
-				return finalizeCompareResourceResult(compareResourceResult{
+				return finalizeCompareResourceResultWithBindings(ctx, compareResourceResult{
 					Resource:  kind + "/" + name,
 					Namespace: ns,
 					Mode:      mode,
@@ -255,7 +262,7 @@ func buildCompareResourceResult(ctx context.Context, resourceArg, namespace stri
 		notes = append(notes, "Connect to ConfigHub to unlock DRY/WET/LIVE expected-state comparison.")
 	}
 
-	return finalizeCompareResourceResult(compareResourceResult{
+	return finalizeCompareResourceResultWithBindings(ctx, compareResourceResult{
 		Resource:  kind + "/" + name,
 		Namespace: ns,
 		Mode:      mode,
@@ -774,6 +781,24 @@ func finalizeCompareResourceResult(result compareResourceResult) compareResource
 	return result
 }
 
+// finalizeCompareResourceResultWithBindings is finalizeCompareResourceResult
+// plus C1 binding enrichment. Called from buildCompareResourceResult where
+// ctx is available; falls through cleanly when the live unit is unknown.
+func finalizeCompareResourceResultWithBindings(ctx context.Context, result compareResourceResult) compareResourceResult {
+	result = finalizeCompareResourceResult(result)
+	if !result.Connected {
+		return result
+	}
+	unitID := strings.TrimSpace(result.Live.UnitID)
+	if unitID == "" {
+		return result
+	}
+	if bindings := collectIncomingBindings(ctx, unitID, result.Live.SpaceName); len(bindings) > 0 {
+		result.IncomingBindings = bindings
+	}
+	return result
+}
+
 func detectCompareFieldMismatches(dry, wet *compareSideSummary, live compareSideSummary) []compareFieldMismatch {
 	type compareFieldDescriptor struct {
 		Name    string
@@ -980,6 +1005,8 @@ func renderCompareResourceASCII(result compareResourceResult) string {
 		}
 	}
 
+	renderIncomingBindingsASCII(&b, result.IncomingBindings)
+
 	if len(result.Notes) > 0 {
 		b.WriteString("\nNotes:\n")
 		for _, note := range result.Notes {
@@ -1036,6 +1063,8 @@ func renderCompareResourceMarkdown(result compareResourceResult) string {
 		}
 		b.WriteString("\n")
 	}
+
+	renderIncomingBindingsMarkdown(&b, result.IncomingBindings)
 
 	if len(result.Notes) > 0 {
 		b.WriteString("\n### Notes\n\n")

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -358,6 +358,44 @@ At A2 the anchor is resource-level — every field mismatch carries the same anc
 
 Source: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`, `pkg/agent/git_source_anchor.go`
 
+### Incoming bindings (C1)
+
+When `compare three-way` (or `compare` per-resource) runs in connected mode against a resource whose live unit slug is known, cub-scout queries `cub link list` for incoming Links (where `FromUnitID = <this-unit-id>`) and surfaces them under `incomingBindings`. Each entry describes one ConfigHub Link influencing this unit's config data — the variant-management directed graph as read-only evidence.
+
+```json
+{
+  "incomingBindings": [
+    {
+      "linkId": "01HFK...A1",
+      "slug": "image-from-app",
+      "displayName": "Image From App",
+      "updateType": "NeedsProvides",
+      "toUnitId": "01HFK...XY",
+      "toSpaceId": "01HFK...SP",
+      "autoUpdate": true,
+      "whereResource": "kind=Deployment",
+      "bindingsCount": 3
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `linkId` | string | Unique identifier for the Link entity. |
+| `slug` | string | URL-safe identifier (useful for `cub link get <slug>` follow-up). |
+| `displayName` | string | Human-friendly name when set. |
+| `updateType` | string | Operation kind: `NeedsProvides`, `UpgradeUnits`, `MergeUnits`, `Insert`, `Upsert` (and future `Transform`). |
+| `toUnitId` | string | Upstream (producer) unit ID. |
+| `toSpaceId` | string | Upstream unit's space ID. |
+| `autoUpdate` | bool | True when the link auto-propagates upstream changes downstream. |
+| `whereResource` | string | Filter selecting which upstream resources are eligible for propagation. |
+| `bindingsCount` | int | Number of explicit binding expressions on the link. The per-field expansion of `Bindings` is C2. |
+
+Best-effort: omitted when no live unit is known, when `cub link list` fails, or when the result is empty. C2 will extend this with per-field binding attribution on each `compareFieldMismatch`.
+
+Source: `cmd/cub-scout/compare_bindings.go`
+
 ## MCP Structured Content Contract
 
 When MCP tools return JSON-backed data, the gateway keeps the raw JSON string in `content[0].text`.


### PR DESCRIPTION
## Summary

C1 of the attribution layer (#435): surface ConfigHub Links influencing a resource's owning unit as read-only evidence on `compareResourceResult`.

cub-scout shells to `cub link list --where "FromUnitID = <unit-id>" -o json` and decodes the resulting array into `IncomingBinding` entries describing upstream units this unit consumes config from. Each entry captures `linkId`, `slug`, `displayName`, `updateType` (NeedsProvides / UpgradeUnits / MergeUnits / Insert / Upsert / Transform), `toUnitId`, `toSpaceId`, `autoUpdate`, `whereResource`, and a `bindingsCount` summary. Per-field expansion of `Bindings` is C2.

ASCII + Markdown renderers surface a new "Incoming Bindings (ConfigHub)" section after the Diff Highlights. JSON contract documented under `docs/reference/json-contracts.md` § Field Mutation Attribution Contract → Incoming bindings.

## What landed

- `cmd/cub-scout/compare_bindings.go` — `IncomingBinding` type, `collectIncomingBindings`, `parseLinkListJSON`, ASCII + Markdown renderers
- `cmd/cub-scout/compare_bindings_test.go` — JSON decode, runner round-trip via injected `compareLinkRunner` seam, empty/invalid/error edge cases, renderer output
- `cmd/cub-scout/compare_resource.go` — `compareResourceResult.IncomingBindings` field + `finalizeCompareResourceResultWithBindings` that pulls bindings post-finalize when connected and a live unit ID is known
- `docs/reference/json-contracts.md` — new "Incoming bindings (C1)" section under Field Mutation Attribution Contract

Stays inside the read-only triad lock — bindings are evidence enrichment, not authority or mutation.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/cub-scout/...` green
- [x] 9 new C1 subtests covering JSON parsing, runner shape, default-space wildcard, error handling, and renderer output

## Closes

Closes #435 in part (C1). C2 (per-field binding attribution) and Stage B (Helm/Kustomize back-resolution) remain.
