### PR TITLE
feat: attribution layer C2 — per-field binding source

### DIFF
--- a/cmd/cub-scout/compare_bindings.go
+++ b/cmd/cub-scout/compare_bindings.go
@@ -49,9 +49,57 @@ type IncomingBinding struct {
 	WhereResource string `json:"whereResource,omitempty"`
 
 	// BindingsCount is the number of explicit binding expressions on the
-	// link (extracted from Link.Bindings). The detailed per-field
-	// breakdown is C2 territory.
+	// link (extracted from Link.Bindings). See Bindings below for the
+	// per-field breakdown when expanded.
 	BindingsCount int `json:"bindingsCount,omitempty"`
+
+	// Bindings is the per-field expansion of Link.Bindings — C2 of the
+	// attribution layer. Each entry pairs a downstream path on this unit
+	// with the upstream path on the producer unit that feeds it. Best-
+	// effort: parsed from the JSON shape ConfigHub returns; unknown shapes
+	// fall back to an empty list while BindingsCount still reflects the
+	// raw count.
+	Bindings []FieldBinding `json:"bindings,omitempty"`
+}
+
+// FieldBinding captures one entry from a Link's Bindings list — the
+// extraction of a value from an upstream unit's path into a downstream unit's
+// path. Optional TransformExpr captures any Go template / CEL expression
+// applied between source and target.
+type FieldBinding struct {
+	// DownstreamPath is the canonical field-path within the downstream unit
+	// where the bound value lands (e.g., ".spec.replicas").
+	DownstreamPath string `json:"downstreamPath,omitempty"`
+
+	// UpstreamPath is the canonical field-path within the upstream unit
+	// that supplies the value.
+	UpstreamPath string `json:"upstreamPath,omitempty"`
+
+	// TransformExpr is the optional transform expression (Go template, CEL,
+	// or similar) applied between source and target.
+	TransformExpr string `json:"transformExpr,omitempty"`
+}
+
+// FieldBindingSource references the specific Link + binding entry that
+// produced a given field mismatch's value. Surfaced on compareFieldMismatch
+// when the field name maps to a known canonical path and a matching binding
+// is found in IncomingBindings.
+type FieldBindingSource struct {
+	// LinkID is the unique identifier of the Link entity.
+	LinkID string `json:"linkId,omitempty"`
+
+	// LinkSlug is the Link's URL-safe identifier.
+	LinkSlug string `json:"linkSlug,omitempty"`
+
+	// UpstreamUnitID is the producer unit feeding this field.
+	UpstreamUnitID string `json:"upstreamUnitId,omitempty"`
+
+	// UpstreamPath is the path within the upstream unit that supplies
+	// the value.
+	UpstreamPath string `json:"upstreamPath,omitempty"`
+
+	// TransformExpr is the optional transform applied (Go template, CEL).
+	TransformExpr string `json:"transformExpr,omitempty"`
 }
 
 // linkRunner is the abstraction over `cub link` shell invocations used by the
@@ -122,9 +170,105 @@ func parseLinkListJSON(raw []byte) []IncomingBinding {
 			WhereResource: strings.TrimSpace(r.WhereResource),
 		}
 		entry.BindingsCount = countBindings(r.Bindings)
+		entry.Bindings = expandBindings(r.Bindings)
 		out = append(out, entry)
 	}
 	return out
+}
+
+// expandBindings parses Link.Bindings into structured FieldBinding entries.
+// ConfigHub's Bindings field shape is evolving; this function handles two
+// common JSON layouts and falls back to nil on unrecognized shapes:
+//
+//   1. Array of objects: [{downstreamPath, upstreamPath, transformExpr}]
+//   2. Object keyed by downstream path: {".spec.x": {upstreamPath, ...}}
+//
+// Unknown shapes return nil — BindingsCount still reflects the raw count so
+// callers can detect "bindings exist but we couldn't expand them."
+func expandBindings(raw json.RawMessage) []FieldBinding {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	// Shape 1: array of objects.
+	type bindingObj struct {
+		DownstreamPath string `json:"downstreamPath"`
+		UpstreamPath   string `json:"upstreamPath"`
+		TransformExpr  string `json:"transformExpr"`
+		// Some schemas use Target/Source naming. Captured as fallback.
+		Target    string `json:"target"`
+		Source    string `json:"source"`
+		Transform string `json:"transform"`
+	}
+	var asArray []bindingObj
+	if err := json.Unmarshal(raw, &asArray); err == nil && len(asArray) > 0 {
+		out := make([]FieldBinding, 0, len(asArray))
+		for _, b := range asArray {
+			fb := FieldBinding{
+				DownstreamPath: firstNonEmptyBindingStr(b.DownstreamPath, b.Target),
+				UpstreamPath:   firstNonEmptyBindingStr(b.UpstreamPath, b.Source),
+				TransformExpr:  firstNonEmptyBindingStr(b.TransformExpr, b.Transform),
+			}
+			if fb.DownstreamPath != "" || fb.UpstreamPath != "" || fb.TransformExpr != "" {
+				out = append(out, fb)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+
+	// Shape 2: object keyed by downstream path.
+	var asObject map[string]bindingObj
+	if err := json.Unmarshal(raw, &asObject); err == nil && len(asObject) > 0 {
+		out := make([]FieldBinding, 0, len(asObject))
+		for downstream, b := range asObject {
+			fb := FieldBinding{
+				DownstreamPath: downstream,
+				UpstreamPath:   firstNonEmptyBindingStr(b.UpstreamPath, b.Source),
+				TransformExpr:  firstNonEmptyBindingStr(b.TransformExpr, b.Transform),
+			}
+			out = append(out, fb)
+		}
+		return out
+	}
+
+	return nil
+}
+
+func firstNonEmptyBindingStr(values ...string) string {
+	for _, v := range values {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// LookupFieldBindingSource searches incomingBindings for a binding whose
+// DownstreamPath matches the given canonical path. Returns the first match
+// (deterministic by IncomingBindings iteration order). The caller is
+// expected to map a compareFieldMismatch.Field name to its canonical path
+// before calling (see compareFieldToPath).
+func LookupFieldBindingSource(downstreamPath string, incomingBindings []IncomingBinding) *FieldBindingSource {
+	downstreamPath = strings.TrimSpace(downstreamPath)
+	if downstreamPath == "" || len(incomingBindings) == 0 {
+		return nil
+	}
+	for _, link := range incomingBindings {
+		for _, b := range link.Bindings {
+			if b.DownstreamPath == downstreamPath {
+				return &FieldBindingSource{
+					LinkID:         link.LinkID,
+					LinkSlug:       link.Slug,
+					UpstreamUnitID: link.ToUnitID,
+					UpstreamPath:   b.UpstreamPath,
+					TransformExpr:  b.TransformExpr,
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // countBindings returns the number of binding entries on a Link without

--- a/cmd/cub-scout/compare_bindings_c2_test.go
+++ b/cmd/cub-scout/compare_bindings_c2_test.go
@@ -1,0 +1,199 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandBindings_ArrayShape(t *testing.T) {
+	raw := []byte(`[
+		{"downstreamPath": ".spec.replicas", "upstreamPath": ".spec.scale.value"},
+		{"downstreamPath": ".spec.template.spec.containers[0].image", "upstreamPath": ".spec.image", "transformExpr": "{{ . | trim }}"}
+	]`)
+
+	got := expandBindings(raw)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 bindings; got %d", len(got))
+	}
+	if got[0].DownstreamPath != ".spec.replicas" || got[0].UpstreamPath != ".spec.scale.value" {
+		t.Errorf("entry 0: %+v", got[0])
+	}
+	if got[1].TransformExpr != "{{ . | trim }}" {
+		t.Errorf("entry 1 transform: %+v", got[1])
+	}
+}
+
+func TestExpandBindings_ObjectShape(t *testing.T) {
+	raw := []byte(`{
+		".spec.replicas": {"upstreamPath": ".spec.scale.value"},
+		".spec.image":    {"upstreamPath": ".spec.image", "transformExpr": "lower"}
+	}`)
+
+	got := expandBindings(raw)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 bindings; got %d", len(got))
+	}
+	// Order isn't guaranteed for maps; check both entries are present.
+	var seenReplicas, seenImage bool
+	for _, b := range got {
+		switch b.DownstreamPath {
+		case ".spec.replicas":
+			seenReplicas = true
+			if b.UpstreamPath != ".spec.scale.value" {
+				t.Errorf("replicas upstream wrong: %+v", b)
+			}
+		case ".spec.image":
+			seenImage = true
+			if b.TransformExpr != "lower" {
+				t.Errorf("image transform wrong: %+v", b)
+			}
+		}
+	}
+	if !seenReplicas || !seenImage {
+		t.Errorf("missing entries; got %+v", got)
+	}
+}
+
+func TestExpandBindings_TargetSourceAliases(t *testing.T) {
+	// Schema variant using target/source/transform naming.
+	raw := []byte(`[
+		{"target": ".spec.replicas", "source": ".spec.scale.value", "transform": "to_int"}
+	]`)
+	got := expandBindings(raw)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 binding; got %d", len(got))
+	}
+	if got[0].DownstreamPath != ".spec.replicas" || got[0].UpstreamPath != ".spec.scale.value" {
+		t.Errorf("alias normalization failed: %+v", got[0])
+	}
+	if got[0].TransformExpr != "to_int" {
+		t.Errorf("transform alias failed: %+v", got[0])
+	}
+}
+
+func TestExpandBindings_EmptyAndUnknownShapes(t *testing.T) {
+	if got := expandBindings(nil); got != nil {
+		t.Errorf("nil input → nil; got %v", got)
+	}
+	if got := expandBindings([]byte(`[]`)); got != nil {
+		t.Errorf("empty array → nil; got %v", got)
+	}
+	if got := expandBindings([]byte(`"just a string"`)); got != nil {
+		t.Errorf("string scalar → nil; got %v", got)
+	}
+}
+
+func TestLookupFieldBindingSource(t *testing.T) {
+	bindings := []IncomingBinding{
+		{
+			LinkID:   "L1",
+			Slug:     "image-binding",
+			ToUnitID: "upstream-A",
+			Bindings: []FieldBinding{
+				{DownstreamPath: ".spec.replicas", UpstreamPath: ".spec.scale.value"},
+			},
+		},
+		{
+			LinkID:   "L2",
+			Slug:     "image-from-app",
+			ToUnitID: "upstream-B",
+			Bindings: []FieldBinding{
+				{DownstreamPath: ".spec.template.spec.containers[0].image", UpstreamPath: ".spec.image", TransformExpr: "trim"},
+			},
+		},
+	}
+
+	t.Run("match by path", func(t *testing.T) {
+		got := LookupFieldBindingSource(".spec.replicas", bindings)
+		if got == nil {
+			t.Fatal("expected non-nil")
+		}
+		if got.LinkID != "L1" || got.UpstreamUnitID != "upstream-A" {
+			t.Errorf("wrong match: %+v", got)
+		}
+		if got.UpstreamPath != ".spec.scale.value" {
+			t.Errorf("upstream path: %+v", got)
+		}
+	})
+
+	t.Run("transform carried through", func(t *testing.T) {
+		got := LookupFieldBindingSource(".spec.template.spec.containers[0].image", bindings)
+		if got == nil || got.TransformExpr != "trim" {
+			t.Errorf("transform not carried: %+v", got)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		if got := LookupFieldBindingSource(".spec.unused", bindings); got != nil {
+			t.Errorf("expected nil; got %+v", got)
+		}
+	})
+
+	t.Run("empty inputs", func(t *testing.T) {
+		if got := LookupFieldBindingSource("", bindings); got != nil {
+			t.Errorf("empty path → nil; got %+v", got)
+		}
+		if got := LookupFieldBindingSource(".spec.replicas", nil); got != nil {
+			t.Errorf("nil bindings → nil; got %+v", got)
+		}
+	})
+}
+
+func TestParseLinkListJSON_ExpandsBindings(t *testing.T) {
+	// End-to-end: list JSON → parsed IncomingBindings with expanded
+	// FieldBinding entries.
+	raw := []byte(`[
+		{
+			"LinkID": "L1",
+			"Slug": "replicas-from-scale",
+			"UpdateType": "NeedsProvides",
+			"ToUnitID": "upstream-A",
+			"Bindings": [
+				{"downstreamPath": ".spec.replicas", "upstreamPath": ".spec.scale.value"}
+			]
+		}
+	]`)
+
+	got := parseLinkListJSON(raw)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 link; got %d", len(got))
+	}
+	if got[0].BindingsCount != 1 {
+		t.Errorf("count = %d, want 1", got[0].BindingsCount)
+	}
+	if len(got[0].Bindings) != 1 {
+		t.Fatalf("expanded bindings = %d, want 1", len(got[0].Bindings))
+	}
+	if got[0].Bindings[0].DownstreamPath != ".spec.replicas" {
+		t.Errorf("wrong downstream: %+v", got[0].Bindings[0])
+	}
+}
+
+func TestRenderASCII_IncludesBindingSourceLine(t *testing.T) {
+	result := compareResourceResult{
+		Resource: "Deployment/api",
+		Mode:     "dry-wet-live",
+		Connected: true,
+		Mismatches: []compareFieldMismatch{
+			{
+				Field: "replicas",
+				Dry:   "3",
+				Wet:   "3",
+				Live:  "1",
+				BindingSource: &FieldBindingSource{
+					LinkID:         "L1",
+					LinkSlug:       "replicas-from-scale",
+					UpstreamUnitID: "upstream-A",
+					UpstreamPath:   ".spec.scale.value",
+				},
+			},
+		},
+	}
+	out := renderCompareResourceASCII(result)
+	if !strings.Contains(out, "<- bound from unit:upstream-A path:.spec.scale.value via link:replicas-from-scale") {
+		t.Errorf("expected binding line; got:\n%s", out)
+	}
+}

--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -105,6 +105,12 @@ type compareFieldMismatch struct {
 	// this field's value, copied from the resource-level GitSource at A2.
 	// Per-field anchors (different paths/lines per field) are stage B.
 	GitSource *agent.GitSourceAnchor `json:"gitSource,omitempty"`
+
+	// BindingSource identifies the ConfigHub Link binding that produces
+	// this field's value (C2 of the attribution layer). Set when the field
+	// name maps to a known canonical path and an incoming binding's
+	// downstream path matches.
+	BindingSource *FieldBindingSource `json:"bindingSource,omitempty"`
 }
 
 type compareResourceRef struct {
@@ -784,6 +790,9 @@ func finalizeCompareResourceResult(result compareResourceResult) compareResource
 // finalizeCompareResourceResultWithBindings is finalizeCompareResourceResult
 // plus C1 binding enrichment. Called from buildCompareResourceResult where
 // ctx is available; falls through cleanly when the live unit is unknown.
+// C2: after IncomingBindings is populated, walks each mismatch and attaches
+// the matching FieldBindingSource when the field maps to a known canonical
+// path.
 func finalizeCompareResourceResultWithBindings(ctx context.Context, result compareResourceResult) compareResourceResult {
 	result = finalizeCompareResourceResult(result)
 	if !result.Connected {
@@ -793,8 +802,22 @@ func finalizeCompareResourceResultWithBindings(ctx context.Context, result compa
 	if unitID == "" {
 		return result
 	}
-	if bindings := collectIncomingBindings(ctx, unitID, result.Live.SpaceName); len(bindings) > 0 {
-		result.IncomingBindings = bindings
+	bindings := collectIncomingBindings(ctx, unitID, result.Live.SpaceName)
+	if len(bindings) == 0 {
+		return result
+	}
+	result.IncomingBindings = bindings
+
+	// C2: walk mismatches and attach FieldBindingSource for fields whose
+	// canonical paths match an incoming binding's downstream path.
+	for i := range result.Mismatches {
+		path, ok := compareFieldToPath[result.Mismatches[i].Field]
+		if !ok {
+			continue
+		}
+		if src := LookupFieldBindingSource(path, bindings); src != nil {
+			result.Mismatches[i].BindingSource = src
+		}
 	}
 	return result
 }
@@ -1002,6 +1025,22 @@ func renderCompareResourceASCII(result compareResourceResult) string {
 		for _, mismatch := range result.Mismatches {
 			b.WriteString(fmt.Sprintf("  - %s: DRY=%s | WET=%s | LIVE=%s\n",
 				mismatch.Field, mismatch.Dry, mismatch.Wet, mismatch.Live))
+			if bs := mismatch.BindingSource; bs != nil {
+				bindLine := "      <- bound from"
+				if bs.UpstreamUnitID != "" {
+					bindLine += fmt.Sprintf(" unit:%s", bs.UpstreamUnitID)
+				}
+				if bs.UpstreamPath != "" {
+					bindLine += fmt.Sprintf(" path:%s", bs.UpstreamPath)
+				}
+				if bs.LinkSlug != "" {
+					bindLine += fmt.Sprintf(" via link:%s", bs.LinkSlug)
+				}
+				if bs.TransformExpr != "" {
+					bindLine += fmt.Sprintf(" transform:%s", bs.TransformExpr)
+				}
+				b.WriteString(bindLine + "\n")
+			}
 		}
 	}
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -392,7 +392,65 @@ When `compare three-way` (or `compare` per-resource) runs in connected mode agai
 | `whereResource` | string | Filter selecting which upstream resources are eligible for propagation. |
 | `bindingsCount` | int | Number of explicit binding expressions on the link. The per-field expansion of `Bindings` is C2. |
 
-Best-effort: omitted when no live unit is known, when `cub link list` fails, or when the result is empty. C2 will extend this with per-field binding attribution on each `compareFieldMismatch`.
+Best-effort: omitted when no live unit is known, when `cub link list` fails, or when the result is empty.
+
+### Field-level binding source (C2)
+
+When an incoming binding's `downstreamPath` matches a `compareFieldMismatch`'s canonical path, the mismatch is annotated with a `bindingSource` pointing at the specific Link + binding that supplies the value. This answers the variant-management punch-line question: "this field's value came from upstream unit X at path Y via link Z."
+
+```json
+{
+  "mismatches": [
+    {
+      "field": "replicas",
+      "dry": "3",
+      "wet": "3",
+      "live": "1",
+      "cause": "manual-edit",
+      "managerHint": "kubectl-edit",
+      "bindingSource": {
+        "linkId": "01HFK...A1",
+        "linkSlug": "replicas-from-scale",
+        "upstreamUnitId": "01HFK...XY",
+        "upstreamPath": ".spec.scale.value",
+        "transformExpr": "to_int"
+      }
+    }
+  ],
+  "incomingBindings": [
+    {
+      "linkId": "01HFK...A1",
+      "slug": "replicas-from-scale",
+      "updateType": "NeedsProvides",
+      "toUnitId": "01HFK...XY",
+      "bindingsCount": 1,
+      "bindings": [
+        {"downstreamPath": ".spec.replicas", "upstreamPath": ".spec.scale.value", "transformExpr": "to_int"}
+      ]
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bindingSource.linkId` | string | Link entity ID. |
+| `bindingSource.linkSlug` | string | Link slug (useful for `cub link get`). |
+| `bindingSource.upstreamUnitId` | string | Producer unit ID supplying the value. |
+| `bindingSource.upstreamPath` | string | Canonical path within the upstream unit. |
+| `bindingSource.transformExpr` | string | Optional transform expression (Go template, CEL, etc.). |
+
+In ASCII output, the binding source renders as an indented annotation under the field's diff line:
+
+```
+Diff Highlights
+  - replicas: DRY=3 | WET=3 | LIVE=1
+      <- bound from unit:01HFK...XY path:.spec.scale.value via link:replicas-from-scale
+```
+
+Best-effort: omitted when the field name has no canonical-path mapping (e.g., `images` which spans containers) or when no incoming binding's `downstreamPath` matches.
+
+`incomingBindings[].bindings` carries the same per-field expansion at the resource level — `BindingsCount` (C1) remains the raw count even when expansion produces an empty list (unrecognized binding JSON shape).
 
 Source: `cmd/cub-scout/compare_bindings.go`
 


### PR DESCRIPTION
## Summary

C2 of the attribution layer (#435), building on C1 (#438).

Each `compareFieldMismatch` gains a `bindingSource` pointer to the specific ConfigHub Link + binding entry that supplies the field's value — answering the variant-management punch-line question: "this field's value came from upstream unit X at path Y via link Z."

## How it works

1. C1 already collects incoming Links via `cub link list -o json`. C2 extends the parser to expand each Link's `Bindings` JSON into structured `FieldBinding` entries.
2. The parser handles two common shapes — array of objects and object-keyed-by-downstream-path — plus `target/source/transform` name aliases. Unrecognized shapes leave the expanded list empty while `BindingsCount` still reflects the raw count.
3. After mismatches are detected, the finalizer walks each one, maps the field name to its canonical path via `compareFieldToPath`, and runs `LookupFieldBindingSource` to find any incoming binding whose `downstreamPath` matches.
4. The first match is attached as `mismatch.BindingSource` (`linkId`, `linkSlug`, `upstreamUnitId`, `upstreamPath`, `transformExpr`).
5. ASCII output adds an indented annotation under the diff line:

```
Diff Highlights
  - replicas: DRY=3 | WET=3 | LIVE=1
      <- bound from unit:01HFK...XY path:.spec.scale.value via link:replicas-from-scale
```

## What landed

- `cmd/cub-scout/compare_bindings.go` — `FieldBinding` + `FieldBindingSource` types; `expandBindings` (handles array + object shapes + target/source aliases); `LookupFieldBindingSource`; `IncomingBinding.Bindings` field
- `cmd/cub-scout/compare_resource.go` — `compareFieldMismatch.BindingSource`; finalizer walks mismatches and attaches matches; ASCII renderer emits the bound-from annotation
- `cmd/cub-scout/compare_bindings_c2_test.go` — coverage for both JSON shapes, target/source aliases, lookup-by-path, transform pass-through, edge cases
- `docs/reference/json-contracts.md` — new "Field-level binding source (C2)" section

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/cub-scout/...` green (C1 tests still pass + new C2 tests)

## Closes

Closes #435 in part (C2). Stage B (Helm/Kustomize back-resolution) remains.
