### PR TITLE
feat: attribution layer stage B — raw-YAML gitSource file:line back-resolution

### DIFF
--- a/cmd/cub-scout/combined.go
+++ b/cmd/cub-scout/combined.go
@@ -116,6 +116,7 @@ func init() {
 	combinedCmd.Flags().BoolVar(&combinedSuggest, "suggest", false, "Generate App model proposal")
 	combinedCmd.Flags().BoolVar(&combinedApply, "apply", false, "Create App and Deployments in ConfigHub")
 	combinedCmd.Flags().BoolVar(&combinedDryRun, "dry-run", false, "Show what would be created without making changes")
+	combinedCmd.Flags().StringVar(&compareSourcePath, "source-path", "", "Local git checkout to back-resolve gitSource.file:line for each field mismatch (stage B; raw YAML only)")
 
 	rootCmd.AddCommand(combinedCmd)
 }

--- a/cmd/cub-scout/compare_back_resolution_test.go
+++ b/cmd/cub-scout/compare_back_resolution_test.go
@@ -1,0 +1,134 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func writeBackResolveTestFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestBackResolveFieldGitSource_NoSourcePath(t *testing.T) {
+	// Defaults: compareSourcePath is empty → nil return regardless of inputs.
+	prev := compareSourcePath
+	compareSourcePath = ""
+	defer func() { compareSourcePath = prev }()
+
+	got := backResolveFieldGitSource(compareSideSummary{
+		Kind:      "Deployment",
+		Name:      "api",
+		Namespace: "prod",
+		GitSource: &agent.GitSourceAnchor{RepoURL: "https://github.com/o/r"},
+	}, "replicas")
+	if got != nil {
+		t.Errorf("expected nil when --source-path unset; got %+v", got)
+	}
+}
+
+func TestBackResolveFieldGitSource_HappyPath(t *testing.T) {
+	root := t.TempDir()
+	writeBackResolveTestFile(t, root, "apps/prod/api/deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+spec:
+  replicas: 4
+`)
+
+	prev := compareSourcePath
+	compareSourcePath = root
+	defer func() { compareSourcePath = prev }()
+
+	live := compareSideSummary{
+		Kind:      "Deployment",
+		Name:      "api",
+		Namespace: "prod",
+		GitSource: &agent.GitSourceAnchor{
+			RepoURL:  "https://github.com/o/r",
+			Revision: "abc123",
+			Path:     "apps/prod/api",
+		},
+	}
+
+	got := backResolveFieldGitSource(live, "replicas")
+	if got == nil {
+		t.Fatal("expected non-nil anchor")
+	}
+	if got.File != "deployment.yaml" {
+		t.Errorf("File = %q (expected file relative to GitSource.Path)", got.File)
+	}
+	if got.Line != 7 {
+		t.Errorf("Line = %d, want 7", got.Line)
+	}
+	// Resource-level anchor preserved.
+	if got.RepoURL != "https://github.com/o/r" || got.Revision != "abc123" || got.Path != "apps/prod/api" {
+		t.Errorf("clone lost resource-level fields: %+v", got)
+	}
+}
+
+func TestBackResolveFieldGitSource_UnmappedFieldFallsThrough(t *testing.T) {
+	root := t.TempDir()
+	writeBackResolveTestFile(t, root, "deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+spec:
+  replicas: 3
+`)
+
+	prev := compareSourcePath
+	compareSourcePath = root
+	defer func() { compareSourcePath = prev }()
+
+	// "images" has no canonical-path mapping → expected nil.
+	got := backResolveFieldGitSource(compareSideSummary{
+		Kind:      "Deployment",
+		Name:      "api",
+		Namespace: "prod",
+		GitSource: &agent.GitSourceAnchor{},
+	}, "images")
+	if got != nil {
+		t.Errorf("expected nil for unmapped field; got %+v", got)
+	}
+}
+
+func TestBackResolveFieldGitSource_FieldAbsentFallsThrough(t *testing.T) {
+	root := t.TempDir()
+	writeBackResolveTestFile(t, root, "deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+spec: {}
+`)
+	prev := compareSourcePath
+	compareSourcePath = root
+	defer func() { compareSourcePath = prev }()
+
+	// .spec.replicas isn't present → BackResolveGitSource returns false → nil.
+	got := backResolveFieldGitSource(compareSideSummary{
+		Kind:      "Deployment",
+		Name:      "api",
+		Namespace: "prod",
+		GitSource: &agent.GitSourceAnchor{},
+	}, "replicas")
+	if got != nil {
+		t.Errorf("expected nil when field absent from source; got %+v", got)
+	}
+}

--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
+	"path/filepath"
 	"sigs.k8s.io/yaml"
 )
 
@@ -149,6 +150,11 @@ var (
 	compareDefaultSpaceFn         = detectCompareSpace
 	runCompareCubCommand          = runCompareCubCommandImpl
 )
+
+// compareSourcePath holds the value of --source-path (stage B back-resolution).
+// Read by detectCompareFieldMismatches when populating per-mismatch
+// gitSource.file:line. Empty means no back-resolution is attempted.
+var compareSourcePath string
 
 func runCombinedResourceCompare(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
@@ -901,17 +907,56 @@ func detectCompareFieldMismatches(dry, wet *compareSideSummary, live compareSide
 			mismatch.ManagerHint = live.Attribution.ManagerHint
 		}
 		// Carry the resource-level git source onto every field mismatch (A2).
-		// Per-field anchors are stage B.
+		// At stage B, attempt to back-resolve a per-field File:Line when a
+		// local source checkout is provided via --source-path. A successful
+		// back-resolution clones the GitSource and sets the new File:Line
+		// so the resource-level anchor is preserved while each mismatch
+		// carries its own per-field provenance.
 		if live.GitSource != nil {
 			mismatch.GitSource = live.GitSource
+			if strings.TrimSpace(compareSourcePath) != "" {
+				if anchor := backResolveFieldGitSource(live, field.Name); anchor != nil {
+					mismatch.GitSource = anchor
+				}
+			}
 		}
 		out = append(out, mismatch)
 	}
 	return out
 }
 
+// backResolveFieldGitSource clones live.GitSource and populates File/Line
+// for the given field name when:
+//   - compareSourcePath is set
+//   - the field name has a canonical-path mapping (compareFieldToPath)
+//   - agent.BackResolveGitSource finds a matching document and field
+//
+// Returns nil when any precondition fails, so callers can fall back to the
+// shared resource-level pointer.
+func backResolveFieldGitSource(live compareSideSummary, fieldName string) *agent.GitSourceAnchor {
+	if strings.TrimSpace(compareSourcePath) == "" || live.GitSource == nil {
+		return nil
+	}
+	canonicalPath, ok := compareFieldToPath[fieldName]
+	if !ok {
+		return nil
+	}
+	root := strings.TrimSpace(compareSourcePath)
+	if subdir := strings.TrimSpace(live.GitSource.Path); subdir != "" {
+		root = filepath.Join(root, subdir)
+	}
+	hit, ok := agent.BackResolveGitSource(root, live.Kind, live.Name, live.Namespace, canonicalPath)
+	if !ok {
+		return nil
+	}
+	clone := *live.GitSource
+	clone.File = hit.File
+	clone.Line = hit.Line
+	return &clone
+}
+
 func renderGitSourceASCII(gs *agent.GitSourceAnchor) string {
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 5)
 	if gs.RepoURL != "" {
 		parts = append(parts, gs.RepoURL)
 	}
@@ -921,11 +966,18 @@ func renderGitSourceASCII(gs *agent.GitSourceAnchor) string {
 	if gs.Path != "" {
 		parts = append(parts, "path="+gs.Path)
 	}
+	if gs.File != "" {
+		fileRef := "file=" + gs.File
+		if gs.Line > 0 {
+			fileRef = fmt.Sprintf("file=%s:%d", gs.File, gs.Line)
+		}
+		parts = append(parts, fileRef)
+	}
 	return strings.Join(parts, " ")
 }
 
 func renderGitSourceMarkdown(gs *agent.GitSourceAnchor) string {
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 5)
 	if gs.RepoURL != "" {
 		parts = append(parts, "`"+gs.RepoURL+"`")
 	}
@@ -934,6 +986,13 @@ func renderGitSourceMarkdown(gs *agent.GitSourceAnchor) string {
 	}
 	if gs.Path != "" {
 		parts = append(parts, "path=`"+gs.Path+"`")
+	}
+	if gs.File != "" {
+		fileRef := "file=`" + gs.File + "`"
+		if gs.Line > 0 {
+			fileRef = fmt.Sprintf("file=`%s:%d`", gs.File, gs.Line)
+		}
+		parts = append(parts, fileRef)
 	}
 	return strings.Join(parts, " ")
 }

--- a/cmd/cub-scout/compare_three_way.go
+++ b/cmd/cub-scout/compare_three_way.go
@@ -146,6 +146,7 @@ func init() {
 	compareThreeWayCmd.Flags().StringVar(&compareThreeWayFormat, "format", "ascii", "Output format: ascii, json, md")
 	compareThreeWayCmd.Flags().BoolVar(&compareThreeWayJSON, "json", false, "Output as JSON (shorthand for --format json)")
 	compareThreeWayCmd.Flags().StringVar(&compareThreeWayFailOn, "fail-on", "", "Exit non-zero if max severity >= level (info, warning)")
+	compareThreeWayCmd.Flags().StringVar(&compareSourcePath, "source-path", "", "Local git checkout to back-resolve gitSource.file:line for each field mismatch (stage B; raw YAML only)")
 }
 
 func runCompareThreeWay(cmd *cobra.Command, args []string) error {

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -354,7 +354,21 @@ When `compare three-way` runs against a resource managed by Argo CD or Flux (inc
 | `gitSource.path` | string | Subdirectory within the repo (`spec.path` for Flux Kustomization / `spec.source.path` for Argo). |
 | `gitSource.line` | int | Reserved for stage B (rendering-aware back-resolution); always `0` at A2. |
 
-At A2 the anchor is resource-level — every field mismatch carries the same anchor. Stage B (Helm/Kustomize back-resolution) will refine to per-field anchors with file path + line resolution. Best-effort: omitted when no GitOps owner is detected, when the tracer CLI is unavailable, or when the chain root carries no useful data.
+At A2 the anchor is resource-level — every field mismatch carries the same anchor. Stage B refines to per-field anchors with file path + line resolution when `--source-path <local-checkout>` is passed: cub-scout walks YAML manifests under `<local-checkout>/<gitSource.path>`, finds the document matching the resource's kind/name/namespace, and records the line where the field's canonical path (e.g., `.spec.replicas`) is set.
+
+```json
+"gitSource": {
+  "repoUrl": "https://github.com/org/platform-config",
+  "revision": "abc123def456",
+  "path": "apps/prod/payments",
+  "file": "deployment.yaml",
+  "line": 9
+}
+```
+
+Stage B handles **raw YAML** manifests only — Helm/Kustomize template back-resolution requires rendering-aware mapping that is out of scope. For Helm/Kustomize sources, `file` and `line` remain empty while the resource-level anchor (`repoUrl`, `revision`, `path`) is still populated.
+
+Best-effort: omitted when no GitOps owner is detected, when the tracer CLI is unavailable, when no `--source-path` is provided, or when the chain root carries no useful data.
 
 Source: `pkg/agent/manager_strings.go`, `pkg/agent/field_ownership.go`, `pkg/agent/git_source_anchor.go`
 

--- a/pkg/agent/git_source_anchor.go
+++ b/pkg/agent/git_source_anchor.go
@@ -36,9 +36,15 @@ type GitSourceAnchor struct {
 	// Application this is spec.source.path.
 	Path string `json:"path,omitempty"`
 
-	// Line is the line number within the manifest file where the field was
-	// set. Reserved for stage B (rendering-aware back-resolution); always
-	// zero in A2.
+	// File is the relative path (within Path) of the specific manifest file
+	// that defines the resource. Populated by stage B back-resolution when
+	// a local checkout is provided via --git-source-path. Empty otherwise.
+	File string `json:"file,omitempty"`
+
+	// Line is the line number within File where the field was set.
+	// Populated by stage B back-resolution. Zero when File is empty or
+	// when the field path could not be resolved to a single line (e.g.,
+	// rendered Helm/Kustomize output).
 	Line int `json:"line,omitempty"`
 }
 
@@ -50,6 +56,7 @@ func (g *GitSourceAnchor) IsEmpty() bool {
 	return strings.TrimSpace(g.RepoURL) == "" &&
 		strings.TrimSpace(g.Revision) == "" &&
 		strings.TrimSpace(g.Path) == "" &&
+		strings.TrimSpace(g.File) == "" &&
 		g.Line == 0
 }
 

--- a/pkg/agent/source_back_resolution.go
+++ b/pkg/agent/source_back_resolution.go
@@ -1,0 +1,226 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BackResolveResult identifies the source file and line where a resource's
+// field is defined in a local git checkout. Stage B of the attribution
+// layer.
+type BackResolveResult struct {
+	// File is the path relative to the search root.
+	File string
+
+	// Line is the 1-based line number in File where the field is set.
+	Line int
+}
+
+// BackResolveGitSource walks the YAML/YML manifest files under rootDir,
+// finds the multi-doc YAML document matching (kind, name, namespace), and
+// returns the file + line for the requested canonical field path.
+//
+// fieldPath uses the canonical-path string form ".a.b.c"; only top-level
+// and dotted nested keys are supported at stage B. List-key selectors
+// like `[name="foo"]` (for container images, etc.) are deferred to a
+// later refinement of this function.
+//
+// Returns (nil, false) when:
+//   - rootDir is empty or unreadable
+//   - no manifest file contains a matching document
+//   - the document does contain the path but it lives in a non-locatable form
+//     (e.g., rendered Helm output where the value came from values.yaml)
+//
+// Helm/Kustomize templated sources are explicitly out of scope at stage B;
+// callers should treat absence of a result as "we can show repo+revision
+// from A2 but not a file:line."
+func BackResolveGitSource(rootDir, kind, name, namespace, fieldPath string) (*BackResolveResult, bool) {
+	rootDir = strings.TrimSpace(rootDir)
+	if rootDir == "" {
+		return nil, false
+	}
+	info, err := os.Stat(rootDir)
+	if err != nil || !info.IsDir() {
+		return nil, false
+	}
+
+	pathParts := splitCanonicalPath(fieldPath)
+	if len(pathParts) == 0 {
+		return nil, false
+	}
+
+	var hit *BackResolveResult
+	_ = filepath.Walk(rootDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		if !isYAMLFile(p) {
+			return nil
+		}
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		decoder := yaml.NewDecoder(strings.NewReader(string(raw)))
+		for {
+			var node yaml.Node
+			if err := decoder.Decode(&node); err != nil {
+				break
+			}
+			if !documentMatches(&node, kind, name, namespace) {
+				continue
+			}
+			if line, ok := findFieldLine(&node, pathParts); ok {
+				rel, relErr := filepath.Rel(rootDir, p)
+				if relErr != nil {
+					rel = p
+				}
+				hit = &BackResolveResult{File: rel, Line: line}
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+
+	if hit == nil {
+		return nil, false
+	}
+	return hit, true
+}
+
+// splitCanonicalPath splits a canonical field-path string like ".spec.replicas"
+// into ["spec", "replicas"]. Leading dot is stripped; empty input yields nil.
+func splitCanonicalPath(path string) []string {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, ".")
+	if path == "" {
+		return nil
+	}
+	parts := strings.Split(path, ".")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isYAMLFile(p string) bool {
+	ext := strings.ToLower(filepath.Ext(p))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// documentMatches returns true when the YAML document at the given node
+// represents a K8s object matching the given kind/name/namespace. A blank
+// namespace argument matches any namespace (useful for cluster-scoped
+// resources whose namespace metadata is absent).
+func documentMatches(node *yaml.Node, kind, name, namespace string) bool {
+	mapping := documentMapping(node)
+	if mapping == nil {
+		return false
+	}
+	if v := mappingScalarValue(mapping, "kind"); v != kind {
+		return false
+	}
+	metadata := mappingChildMapping(mapping, "metadata")
+	if metadata == nil {
+		return false
+	}
+	if v := mappingScalarValue(metadata, "name"); v != name {
+		return false
+	}
+	if namespace != "" {
+		if v := mappingScalarValue(metadata, "namespace"); v != namespace {
+			return false
+		}
+	}
+	return true
+}
+
+// findFieldLine navigates the mapping nodes for the given canonical path
+// parts and returns the 1-based line number where the leaf is set. Returns
+// (0, false) when any segment is not a mapping or the leaf key is absent.
+func findFieldLine(node *yaml.Node, parts []string) (int, bool) {
+	mapping := documentMapping(node)
+	if mapping == nil {
+		return 0, false
+	}
+	current := mapping
+	for i, key := range parts {
+		valueNode := mappingValue(current, key)
+		if valueNode == nil {
+			return 0, false
+		}
+		if i == len(parts)-1 {
+			// Leaf — return the line of the value node (where the actual
+			// value appears in the file).
+			return valueNode.Line, true
+		}
+		if valueNode.Kind != yaml.MappingNode {
+			return 0, false
+		}
+		current = valueNode
+	}
+	return 0, false
+}
+
+// documentMapping unwraps a yaml document node down to its mapping.
+func documentMapping(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			return nil
+		}
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	return node
+}
+
+// mappingValue returns the value node for a given key in a mapping, or nil.
+func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		k := mapping.Content[i]
+		if k.Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// mappingChildMapping returns the value as a mapping node if it's a mapping.
+func mappingChildMapping(mapping *yaml.Node, key string) *yaml.Node {
+	v := mappingValue(mapping, key)
+	if v == nil || v.Kind != yaml.MappingNode {
+		return nil
+	}
+	return v
+}
+
+// mappingScalarValue returns the scalar string value at key, or "" if absent.
+func mappingScalarValue(mapping *yaml.Node, key string) string {
+	v := mappingValue(mapping, key)
+	if v == nil || v.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return v.Value
+}

--- a/pkg/agent/source_back_resolution_test.go
+++ b/pkg/agent/source_back_resolution_test.go
@@ -1,0 +1,221 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func TestSplitCanonicalPath(t *testing.T) {
+	tests := map[string][]string{
+		".spec.replicas":      {"spec", "replicas"},
+		"spec.replicas":       {"spec", "replicas"},
+		".apiVersion":         {"apiVersion"},
+		"":                    nil,
+		".":                   nil,
+		"  .  ":               nil,
+		".metadata.namespace": {"metadata", "namespace"},
+		".a..b":               {"a", "b"},
+	}
+	for in, want := range tests {
+		t.Run(in, func(t *testing.T) {
+			got := splitCanonicalPath(in)
+			if len(got) != len(want) {
+				t.Fatalf("splitCanonicalPath(%q) = %v, want %v", in, got, want)
+			}
+			for i, w := range want {
+				if got[i] != w {
+					t.Errorf("split[%d] = %q, want %q", i, got[i], w)
+				}
+			}
+		})
+	}
+}
+
+func TestBackResolveGitSource_RawYAML(t *testing.T) {
+	root := t.TempDir()
+	// Manifest under apps/prod/api/deployment.yaml.
+	yaml := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+  labels:
+    app: api
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: api
+        image: ghcr.io/example/api:v1
+`
+	writeFile(t, root, "apps/prod/api/deployment.yaml", yaml)
+
+	t.Run("locate spec.replicas line", func(t *testing.T) {
+		got, ok := BackResolveGitSource(root, "Deployment", "api", "prod", ".spec.replicas")
+		if !ok {
+			t.Fatal("expected hit")
+		}
+		if got.File != filepath.Join("apps", "prod", "api", "deployment.yaml") {
+			t.Errorf("File = %q", got.File)
+		}
+		// The value `3` lives on the same line as `replicas:` — line 9 in the YAML above.
+		if got.Line != 9 {
+			t.Errorf("Line = %d, want 9", got.Line)
+		}
+	})
+
+	t.Run("locate metadata.namespace", func(t *testing.T) {
+		got, ok := BackResolveGitSource(root, "Deployment", "api", "prod", ".metadata.namespace")
+		if !ok {
+			t.Fatal("expected hit")
+		}
+		if got.Line != 5 {
+			t.Errorf("Line = %d, want 5", got.Line)
+		}
+	})
+
+	t.Run("missing field returns false", func(t *testing.T) {
+		_, ok := BackResolveGitSource(root, "Deployment", "api", "prod", ".spec.notARealField")
+		if ok {
+			t.Error("expected no hit for missing field")
+		}
+	})
+
+	t.Run("wrong resource returns false", func(t *testing.T) {
+		_, ok := BackResolveGitSource(root, "Deployment", "wrong-name", "prod", ".spec.replicas")
+		if ok {
+			t.Error("expected no hit for wrong name")
+		}
+	})
+
+	t.Run("wrong namespace returns false", func(t *testing.T) {
+		_, ok := BackResolveGitSource(root, "Deployment", "api", "wrong-ns", ".spec.replicas")
+		if ok {
+			t.Error("expected no hit for wrong namespace")
+		}
+	})
+
+	t.Run("blank namespace matches any", func(t *testing.T) {
+		_, ok := BackResolveGitSource(root, "Deployment", "api", "", ".spec.replicas")
+		if !ok {
+			t.Error("blank namespace should match")
+		}
+	})
+}
+
+func TestBackResolveGitSource_MultiDocFile(t *testing.T) {
+	root := t.TempDir()
+	multiDoc := `apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: prod
+spec:
+  ports:
+  - port: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+spec:
+  replicas: 5
+`
+	writeFile(t, root, "manifests.yaml", multiDoc)
+
+	got, ok := BackResolveGitSource(root, "Deployment", "api", "prod", ".spec.replicas")
+	if !ok {
+		t.Fatal("expected hit on second doc")
+	}
+	if got.Line != 16 {
+		t.Errorf("Line = %d, want 16 (replicas in second doc)", got.Line)
+	}
+}
+
+func TestBackResolveGitSource_MultiFileSearch(t *testing.T) {
+	root := t.TempDir()
+	// Decoy: another resource in a different file.
+	writeFile(t, root, "decoy.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api
+  namespace: prod
+data:
+  k: v
+`)
+	// Actual target.
+	writeFile(t, root, "nested/deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+spec:
+  replicas: 7
+`)
+
+	got, ok := BackResolveGitSource(root, "Deployment", "api", "prod", ".spec.replicas")
+	if !ok {
+		t.Fatal("expected hit in nested file")
+	}
+	if got.File != filepath.Join("nested", "deployment.yaml") {
+		t.Errorf("File = %q", got.File)
+	}
+}
+
+func TestBackResolveGitSource_InvalidInputs(t *testing.T) {
+	t.Run("empty root", func(t *testing.T) {
+		if _, ok := BackResolveGitSource("", "Deployment", "api", "prod", ".spec.replicas"); ok {
+			t.Error("empty root should return false")
+		}
+	})
+
+	t.Run("non-directory root", func(t *testing.T) {
+		root := t.TempDir()
+		file := writeFile(t, root, "not-a-dir.yaml", "foo: bar")
+		if _, ok := BackResolveGitSource(file, "Deployment", "api", "prod", ".spec.replicas"); ok {
+			t.Error("file path as root should return false")
+		}
+	})
+
+	t.Run("empty field path", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "d.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n  namespace: y\n")
+		if _, ok := BackResolveGitSource(root, "ConfigMap", "x", "y", ""); ok {
+			t.Error("empty field path should return false")
+		}
+	})
+
+	t.Run("no matching docs", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "d.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n  namespace: y\n")
+		if _, ok := BackResolveGitSource(root, "Deployment", "x", "y", ".spec.replicas"); ok {
+			t.Error("no matching docs should return false")
+		}
+	})
+
+	t.Run("ignores non-yaml extensions", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "readme.txt", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n  namespace: y\n")
+		if _, ok := BackResolveGitSource(root, "ConfigMap", "x", "y", ".kind"); ok {
+			t.Error("non-yaml files should be skipped")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Stage B of the attribution layer (#435), building on A2 (#437).

Adds a `--source-path <local-checkout>` flag to `compare` and `compare three-way`. When set, cub-scout walks YAML/YML manifests under `<source-path>/<gitSource.path>`, finds the document matching `(kind, name, namespace)`, and records the line where each mismatch's canonical field path is set. Each `compareFieldMismatch.gitSource` is cloned with the per-field `file` + `line` populated, preserving the resource-level `repoUrl`/`revision`/`path` from A2.

## What landed

- `pkg/agent/git_source_anchor.go` — `GitSourceAnchor` gains `File` (relative to `Path`); `Line` becomes load-bearing
- `pkg/agent/source_back_resolution.go` + tests — `BackResolveGitSource(rootDir, kind, name, namespace, fieldPath)`; multi-doc YAML; line tracking via `gopkg.in/yaml.v3`; raw-YAML scope explicitly documented
- `cmd/cub-scout/compare_resource.go` — `compareSourcePath` global var; `--source-path` flag on both `compare` and `compare three-way`; `backResolveFieldGitSource` clones the resource-level anchor per field; ASCII/Markdown renderers surface `file=apps/prod/api/deployment.yaml:9`
- `cmd/cub-scout/compare_back_resolution_test.go` — wiring tests covering happy path, unmapped fields, missing fields, unset `--source-path`
- `docs/reference/json-contracts.md` — extends the Git source anchor section with the new `file`/`line` shape + stage B scope notes

## Scope (deliberate)

- **In scope**: raw YAML / YML files in a local checkout, multi-doc files, top-level + nested mapping paths
- **Out of scope (deferred)**: Helm template back-resolution, Kustomize patch lineage, list-key selectors like `[name="foo"]` for container images. `file` and `line` remain empty for those cases while the resource-level anchor still applies.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/agent/...` green (`TestBackResolveGitSource_*`, `TestSplitCanonicalPath`)
- [x] `go test ./cmd/cub-scout/...` green (`TestBackResolveFieldGitSource_*`)

## Closes

Closes #435 (final remaining stage). The attribution layer parent is now complete through A1, A1.5, A2, B, C1, C2.
