### PR TITLE
docs: restructure description around verb groups + attribution layer

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -21,28 +21,43 @@ Use these for different AI scenarios:
 - `docs/ai/cub-scout-tasks.md` — task skill for *using* cub scout to investigate a real cluster
 - `docs/howto/using-cub-scout-from-ai-tool.md` — demo/operator flows
 
+## Capability Map at a Glance
+
+cub-scout commands fall into seven groups. Each group's **inputs** column tells you whether a command needs only a cluster (standalone), needs a local git checkout, or needs ConfigHub auth (connected). See [README.md § Capability Map](README.md#capability-map) for the full per-command table — this section is the navigation aid.
+
+| Group | What it answers | Notable commands |
+|---|---|---|
+| **Observe** | What's running, who owns it | `doctor`, `map`, `trace`, `tree`, `scan`, `graph`, `snapshot`, `watch`, `status` |
+| **Diagnose** | What's wrong, what to do next | `explain`, `debug`, `suggest-remedy`, `patterns`, `gitops status` |
+| **Compare** | Intended vs actual | `compare`, `compare drift`, `compare three-way`, `compare source-truth` |
+| **Attribute** | Where each field's value came from | per-field `cause`/`managerHint`/`gitSource`/`bindingSource` on `compare` + `explain` |
+| **Ingest** | How to bring config into ConfigHub | `import --git-path`, `import parse-repo`, `import argocd`, `import cluster-aggregator`, `import apply`, `app` |
+| **Govern** | Connected history, fleet, views | `history`, `impact`, `fleet outliers`, `summary`, `views`, `audit`, `bundle`, `catalog` |
+| **Integrate** | Setup + AI gateway | `setup`, `quickstart`, `mcp serve`, `context-pack`, `version` |
+
+When a user asks "can cub scout do X?", first locate X in this map, then verify the exact flag surface with local `--help` (see [Quick Reality Checks](#quick-reality-checks)).
+
 ## Tool Boundaries
 
 ### `cub scout` / `cub-scout`
 
-**`cub scout` observes and explains; it never decides.** It is the
-read-only Kubernetes and GitOps observer — it surfaces evidence, never
-mutates the cluster, and never makes authority calls about what *should* be
-true.
+**`cub scout` observes and explains; it never decides.** It is the read-only Kubernetes and GitOps observer — it surfaces evidence, never mutates the cluster, and never makes authority calls about what *should* be true.
 
-`cub scout` is the preferred documented form. In this repo, local command
-examples still use `./cub-scout ...`.
+`cub scout` is the preferred documented form. In this repo, local command examples still use `./cub-scout ...`.
 
 Use it for:
-- `doctor`, `explain`, `trace`, `map`, `scan`
-- connected comparison such as `compare three-way`
-- local Git structure discovery with `import --git-path` and `parse-repo`
+- Observe: `doctor`, `map`, `trace`, `tree`, `scan`, `graph`, `snapshot`, `watch`, `status`
+- Diagnose: `explain`, `debug`, `suggest-remedy`, `patterns`, `gitops status`
+- Compare: `compare three-way`, `compare source-truth`, `compare drift`, `compare` (resource mode)
+- Attribute (read-only enrichment surfacing on `compare` + `explain` JSON)
+- Local Git structure discovery with `import --git-path` and `import parse-repo`
 - Model Context Protocol (MCP) serving via `mcp serve`
 
 Important:
 - `cub scout` is cluster read-only by default
 - connected imports write inventory/state to ConfigHub, not cluster manifests
 - `import --git-path` is a structure/import-preview path, not a manifest renderer
+- attribution evidence (`cause`, `managerHint`, `gitSource`, `bindingSource`) is enrichment of existing read-only evidence; it never implies a write
 
 ### `cub`
 
@@ -52,6 +67,7 @@ Use it for:
 - spaces, units, targets, workers, and ConfigHub state
 - `cub gitops discover`
 - `cub gitops import`
+- `cub link list / get` (the data feed for cub-scout's connected attribution layer)
 
 Current local CLI truth:
 - `cub gitops discover --space <space> <target-slug>`
@@ -69,64 +85,59 @@ Do not claim that `cub scout` can do SDK/renderer work locally unless the curren
 
 ## Current High-Signal Shipped Capabilities
 
-As of 2026-05-08, these areas are fully or materially shipped:
+As of 2026-05-21, these areas are fully or materially shipped:
 
-- **Source-truth contract** (`#393`, council-prescribed)
+- **Attribution layer** (`#435` — A1, A1.5, A2, B, C1, C2)
+  - `cause` + `managerHint` on every field mismatch — classifies controller-drift vs manual-edit via K8s `managedFields` co-signaled with detected owner
+  - Verified manager-string enumeration (`pkg/agent/manager_strings.go`) covers Argo CD, Flux (kustomize/helm/source), Helm direct, Crossplane (composite/composed/claim/MRD/refs), kro (applyset/parent/labeller), `kubectl-*` — strings not in the enumeration return `unknown`
+  - Per-field-path resolution via `FieldsV1` decoding (`pkg/agent/field_ownership_paths.go`)
+  - `gitSource{repoUrl, revision, path}` resource-level anchor via existing Argo/Flux tracers
+  - `gitSource{file, line}` raw-YAML back-resolution via `--source-path <local-checkout>` flag (`pkg/agent/source_back_resolution.go`)
+  - Connected `incomingBindings[]` from `cub link list` — surfaces upstream units feeding this unit
+  - Connected per-field `bindingSource` — answers "this field's value came from upstream unit X at path Y via link Z"
+  - Documented in `docs/reference/json-contracts.md` § Field Mutation Attribution Contract
+  - Example: `examples/drift/mutation-cause-attribution/`
+- **Source-truth contract** (`#393`)
   - `compare source-truth <kind>/<name> -n <ns> --strategy <s>` emits the structured JSON Pilot's acceptance kernel consumes
-  - 4 strategies: `confighub-oci-argo`, `confighub-oci-flux`, `git-argo`, `git-flux`
-  - Strategy-relative correctness + missing-proof rule enforced in tests, not just intent
+  - 4 strategies today: `confighub-oci-argo`, `confighub-oci-flux`, `git-argo`, `git-flux`
+  - Strategy-relative correctness + missing-proof rule enforced in tests
   - 6-fixture producer suite with byte-equal goldens at `test/fixtures/source-truth/`
 - **Architectural triad locked**
   - cub-scout = read-only evidence provider
   - Pilot = acceptance judge
   - ConfigHub = authority and workflow engine
   - cub-scout never mutates, repairs, approves, or infers authority
+  - `suggest-remedy` (was `remedy`) is categorically read-only — describes but never applies; the executor was removed in `#428`
 - **kstatus migration complete** (`#394`)
   - All readiness derivation flows through `sigs.k8s.io/cli-utils/pkg/kstatus`
-  - Same library Argo CD and Flux use upstream — operator expectations match
-  - Stalled / generation-lagging workloads correctly report `Ready=false`
+  - Same library Argo CD and Flux use upstream
 - **Views integration** (`#391`)
-  - `cub-scout views resolve <uuid-or-url>` — accepts both bare UUIDs and View Explorer URLs
-  - `cub-scout views open <uuid-or-url>` — browser handoff helper
-  - `cub-scout compare three-way --view <uuid-or-url>` — scope a three-way comparison to the cluster resources whose ConfigHub units match a View's filter (#408, shipped 2026-05-09)
-  - URL-as-positional convention for ConfigHub primitives — paste from browser address bar
-  - On-prem ConfigHub deployments work (host not pinned)
-  - `cubRunner` subprocess-injection seam in `views.go` — all future `cub`-shelling code in the views layer should use `viewCubRunner` for testability
-- `doctor` / `explain`
-  - `--presentation human|ai|paired`
-  - `--hint-mode default|beginner|operator`
-- Argo truth-and-guidance track
-  - truthful `explain` ownership for ApplicationSet-managed resources
-  - connected three-way disagreement surfacing
-  - phase-aware next-step hints
-- `compare three-way`
-  - connected DRY/WET/LIVE comparison
-  - `--fail-on` conformance exit codes
-  - agreement/convergence summary in CLI + JSON
-- MCP (Model Context Protocol) gateway
-  - `mcp serve` exposes `doctor` as the first standalone troubleshooting tool, including when the problem might be local access uncertainty such as wrong context, stale kubeconfig, or API reachability
-  - standalone tool set: `doctor`, `explain`, `map`, `scan`, `trace`
-  - connected mode adds read-only ConfigHub query tools
-- Secrets track
-  - trace secret evidence
-  - Crossplane `ProviderConfig` secret evidence
-  - `map issues` secret findings
-  - TUI secret panel
-- Git import track
-  - `import --git-path` local preview
-  - ApplicationSet git-generator support in parser
-  - path-centric duplicate-safe proposal identifiers
+  - `views resolve` accepts UUIDs or View Explorer URLs (`#403`)
+  - `compare three-way --view <uuid-or-url>` scopes to a ConfigHub View (`#414`)
+  - `views project --with-reality` composes View columns with source-truth verdicts (`#420`)
+- `doctor` / `explain` with `--presentation human|ai|paired` and `--hint-mode default|beginner|operator`
+- Argo truth-and-guidance track — truthful `explain` ownership for ApplicationSet-managed resources, connected three-way disagreement surfacing, phase-aware next-step hints
+- `compare three-way` — connected DRY/WET/LIVE comparison, `--fail-on` conformance exit codes, agreement/convergence summary in CLI + JSON, `--source-path` raw-YAML back-resolution (`#440`)
+- MCP gateway — `mcp serve` exposes `doctor` / `explain` / `map` / `scan` / `trace` standalone; connected mode adds read-only ConfigHub query tools
+- Secrets track — trace secret evidence, Crossplane `ProviderConfig` secrets, `map issues` findings, TUI secret panel
+- Git import track — `import --git-path` local preview, ApplicationSet git-generator support, path-centric duplicate-safe proposal identifiers
 
 ## Current Open Queue
 
-Verify live state before acting, but the current open follow-ons are (2026-05-09):
+Verify live state before acting. As of 2026-05-21 the open follow-ons are:
 
-- `#391` — Views integration. Scope #1 (`--view` on `compare three-way`) shipped in #414. Remaining: scope #2 (View column projection in TUI Hub view), scope #3 (reality overlay composing View columns with source-truth verdicts — now unblocked).
-- `#409` — source-truth v0.2 cross-surface revision equality. Design pre-baked, plus a [strategy-shape comment](https://github.com/confighub/cub-scout/issues/409#issuecomment-4411862418) with phased Phase 1/2/3 plan. Phase 1 = four existing strategies; Phase 2 = enum expansion; Phase 3 = multi-source Argo. Prerequisite to verify: does `cub unit get -o json` expose the rendered digest per unit revision?
-- `#410` — Triad-compliance audit (HIGH). **Resolved** with option (b): cub-scout keeps the scan + catalogue + suggested-patch; the executor that applied patches has been removed. Implementation in `#428`. The command is renamed `suggest-remedy` (legacy `remedy` accepted as alias). cub-scout is now categorically read-only; no `--dry-run=false` carve-out remains.
-- `#392` — Initiatives compliance overlay; **deferred** until ConfigHub side exposes Initiative as an addressable backend primitive. Design doc at `docs/howto/initiatives-integration-when-ready.md` is ready to consume the day the prerequisite lands.
-- `confighubai/confighub#4356` — cross-repo dependency for the ArgoCDOCI Helm-source shape symptom classifier in `compare source-truth`.
-- `confighub-ai-demo#264` — Pilot consumer-side fixtures (paired with cub-scout #395 + future #409 fixtures).
+- **`#409`** — source-truth v0.2 cross-surface revision equality. Phase 1 (existing four strategies) shipped; Phase 2 (enum expansion to `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`) shipped in `#418`. Phase 3 (multi-source Argo) remains. Verify ConfigHub-side rendered-digest exposure before extending further.
+- **`#391`** — Views integration tail. Scope #1 (`--view` on `compare three-way`) shipped in `#414`. Scope #2 (TUI Hub View column projection) shipped in `#419`/`#420`. Scope #3 (reality overlay) is the active follow-on.
+- **`#392`** — Initiatives compliance overlay; **deferred** until ConfigHub exposes Initiative as a backend primitive. Design doc at `docs/howto/initiatives-integration-when-ready.md`.
+- **Attribution layer next-up** (no separate issues yet; tracked in [README § What's coming next](README.md#whats-coming-next)):
+  - Helm / Kustomize back-resolution to populate `gitSource.file:line` for templated sources
+  - List-key selectors (e.g., `[name="api"]` for container images) in `compareFieldToPath`
+  - Standalone `--source-path` as DRY source for `compare three-way`
+  - `import --git-path --output-dir` to emit proposals to disk
+  - Hierarchy-aware ingest (preserve ApplicationSet / app-of-apps / Flux composition)
+  - Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)
+- `confighubai/confighub#4356` — cross-repo dependency for ArgoCDOCI Helm-source shape symptom classifier.
+- `confighub-ai-demo#264` — Pilot consumer-side fixtures (paired with cub-scout `#395` + future `#409` fixtures).
 
 ## Non-Negotiables
 
@@ -135,7 +146,7 @@ Verify live state before acting, but the current open follow-ons are (2026-05-09
 3. Prefer `./cub-scout` in local repo workflows.
 4. Keep cluster read-only behavior separate from ConfigHub writes.
 5. Treat `cub scout` and `cub gitops import` as complementary, not interchangeable.
-6. Preserve deterministic facts over optimistic guidance.
+6. Preserve deterministic facts over optimistic guidance — when attribution can't classify confidently, return `unknown` rather than guessing.
 
 ## Quick Reality Checks
 
@@ -147,8 +158,10 @@ Use these before answering capability or workflow questions:
 ./cub-scout doctor --help
 ./cub-scout explain --help
 ./cub-scout compare three-way --help
+./cub-scout compare source-truth --help
 ./cub-scout import --help
-./cub-scout parse-repo --help
+./cub-scout views --help
+./cub-scout mcp serve --help
 ```
 
 When the question crosses into ConfigHub or renderer workflows:
@@ -157,6 +170,8 @@ When the question crosses into ConfigHub or renderer workflows:
 cub version
 cub gitops --help
 cub gitops import --help
+cub link --help
+cub link list --help
 ```
 
 ## Best Next Read Based On Intent
@@ -164,4 +179,5 @@ cub gitops import --help
 - implementing or reviewing code: `HANDOVER.md`
 - checking exact flags or stable command surfaces: `docs/reference/commands.md` and `docs/reference/cli-contract.md`
 - checking JSON outputs or MCP-adjacent facts: `docs/reference/json-contracts.md`
+- attribution layer (cause / managerHint / gitSource / bindingSource): `docs/reference/json-contracts.md` § Field Mutation Attribution Contract, plus `examples/drift/mutation-cause-attribution/`
 - capability-assistant or demo flow: `docs/howto/using-cub-scout-from-ai-tool.md`

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,6 +1,6 @@
 # cub-scout Handover for the Next AI Coder
 
-Last updated: 2026-05-09
+Last updated: 2026-05-21
 
 ## Current repo state
 
@@ -14,6 +14,27 @@ Last updated: 2026-05-09
   - `docs/reference/cli-reference.md` = A-Z command catalog
   - `docs/reference/commands.md` = detailed usage and examples
   - `docs/reference/cli-contract.md` = stable flags, exit codes, and schemas
+
+## May 2026 completions — session 2026-05-21 (attribution layer)
+
+The full attribution layer (`#435`) shipped in four squash-merged PRs. Every `compareFieldMismatch` now carries `cause`, `managerHint`, `gitSource`, and (when connected) `bindingSource` — answering "which controller, or which human, last touched this field, what's it sourced from in git, and which ConfigHub Link supplies it?" all in one read-only evidence record.
+
+| PR | Stages | Subject |
+|----|--------|---------|
+| [#437](https://github.com/confighub/cub-scout/pull/437) | A1 + A1.5 + A2 | `managedFields` classifier (`controller-drift` / `manual-edit` / `unknown`) co-signaled with detected owner; verified manager-string enumeration (Argo CD / Flux kustomize+helm+source / Helm direct / Crossplane composite+composed+claim+MRD+refs / kro applyset+parent+labeller / `kubectl-*`); per-field-path resolution via `FieldsV1` decoding (`sigs.k8s.io/structured-merge-diff/v4/fieldpath`); resource-level git anchor (`repoUrl` / `revision` / `path`) via existing Argo/Flux tracers. |
+| [#438](https://github.com/confighub/cub-scout/pull/438) | C1 | Incoming-binding introspection via `cub link list -o json`; `compareLinkRunner` injection seam; `IncomingBinding` + ASCII/Markdown rendering. |
+| [#439](https://github.com/confighub/cub-scout/pull/439) | C2 | Per-field `bindingSource` on each mismatch; `expandBindings` handles array + object Bindings JSON shapes plus `target/source/transform` aliases; ASCII renders `<- bound from unit:... path:... via link:...` under the diff line. |
+| [#440](https://github.com/confighub/cub-scout/pull/440) | Stage B | Raw-YAML `gitSource.file:line` back-resolution via opt-in `--source-path <local-checkout>`; `BackResolveGitSource` walks YAML/YML files with `gopkg.in/yaml.v3` line tracking, matches by `kind`/`name`/`namespace`, navigates dotted canonical paths. Helm/Kustomize templating explicitly deferred. |
+
+### Key design decisions locked in this track
+
+- **Verified manager-string enumeration, not guessed**: every string in `pkg/agent/manager_strings.go` has an upstream citation. Unknown strings fall through to `unknown` rather than misclassifying — same `parse, don't guess` rule used by ownership detection.
+- **Owner co-signal disambiguates kubectl-client-side-apply**: Argo CD's CSA migration default and `kubectl apply --client-side` write the same manager string. The classifier reads `pkg/agent/ownership.go` first so Argo-owned resources resolve as `controller-drift` while non-Argo resources resolve as `manual-edit`.
+- **Crossplane composed children use prefix match**: `apiextensions.crossplane.io/composed-<hash>` varies per XR. Match is `strings.HasPrefix`, not exact.
+- **Per-field rollup degrades cleanly to resource-level**: when `FieldsV1` is missing (older K8s or stripped), classification is resource-level (A1). When present, per-field (A1.5). Fields like `images` that span multiple container list items intentionally fall back to resource-level pending list-key selector support.
+- **`cub link list` runner seam**: `compareLinkRunner` function variable lets tests inject prefab JSON, matching the `viewCubRunner` pattern in `views.go` (#414).
+- **A2 anchor and B file:line are decoupled**: A2 surfaces `repoUrl`/`revision`/`path` automatically (tracer-driven). Stage B `file:line` is opt-in via `--source-path` to avoid surprising filesystem walks on the standard `compare three-way` run.
+- **Doc + example land with the code**: `docs/reference/json-contracts.md` § Field Mutation Attribution Contract carries the full contract; `examples/drift/mutation-cause-attribution/` carries the operator-facing narrative with `controller-drift.json` + `manual-edit.json` fixtures.
 
 ## May 2026 completions — session 2026-05-09
 
@@ -109,20 +130,25 @@ Key deliverables now in place:
 
 ## Open issues
 
-Current tracked follow-ons (verified 2026-05-09):
+Current tracked follow-ons (verified 2026-05-21):
 
-- **#391 (two scopes remain)** — Views integration. Scope #1 (`--view` on `compare three-way`) shipped in #414. Remaining:
-  2. View column projection in TUI Hub view
-  3. Reality overlay composing View columns with #393 source-truth verdicts (depends on scope #1 — now unblocked)
-- **#409** — source-truth v0.2 cross-surface revision equality. Design pre-baked in the issue body, plus a [strategy-shape comment](https://github.com/confighub/cub-scout/issues/409#issuecomment-4411862418) with the full per-strategy data shape table, runtime-anchor extractability per strategy (notably: Helm runtime anchor is **already extractable** via `helm.sh/chart` labels in `pkg/agent/ownership.go`), the multi-source Argo gap, and a concrete Phase 1/2/3 implementation plan. Phase 1 = existing four strategies; Phase 2 = enum expansion (`helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`); Phase 3 = multi-source Argo. Verify ConfigHub-side rendered-digest exposure before starting Phase 1. `confighubai/confighub#4356` interacts with `confighub-oci-argo` equality.
-- **#410 / #428** — Triad-compliance audit (HIGH severity). **Resolved with option (b)** in #428: cub-scout keeps the scan + catalogue + suggested-patch JSON; the executor that applied patches has been deleted. Command renamed `suggest-remedy` (legacy `remedy` is an alias). The previous `--dry-run`, `--force`, `--audit`, `--audit-file` flags were removed; cub-scout no longer has a non-dry-run path. Lower-severity findings on `import apply` wording and a hint-command lint rule remain open in #410.
+- **`#435` attribution-layer next-up (no separate issues yet, tracked in `README.md` § What's coming next):**
+  - Helm / Kustomize back-resolution to extend stage B's `gitSource.file:line` from raw YAML to templated sources
+  - List-key selectors in `compareFieldToPath` (e.g., `.spec.template.spec.containers[name="api"].image`) so per-field classification covers container images and other list-keyed fields
+  - Standalone `--source-path` as a DRY source for `compare three-way` — would let raw-YAML repos run the same three-way view without ConfigHub
+  - `import --git-path --output-dir` to emit proposed unit YAMLs to disk for PR review (one bundle, two workflows — disk PR + Installer `--merge-external-source`)
+  - Hierarchy-aware ingest preserving ApplicationSet / app-of-apps / Flux Kustomization composition in import proposals
+  - Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)
+- **#391** — Views integration. Scopes #1 (`--view` on `compare three-way`, `#414`) and #2 (TUI Hub View column projection, `#419`/`#420`) shipped. Scope #3 (reality overlay composing View columns with `#393` source-truth verdicts) is the active follow-on.
+- **#409** — source-truth v0.2 cross-surface revision equality. Phase 1 (existing four strategies) shipped; Phase 2 (enum expansion to `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`) shipped in `#418`. Phase 3 (multi-source Argo) remains.
+- **#410 / #428** — Triad-compliance audit. Major item resolved: cub-scout is categorically read-only (`suggest-remedy` describes but never applies). Lower-severity findings on `import apply` wording and a hint-command lint rule remain open in #410.
 - **#392** — Initiatives compliance overlay. **Still deferred.** ConfigHub side has no backend primitive yet. Design doc at [`docs/howto/initiatives-integration-when-ready.md`](docs/howto/initiatives-integration-when-ready.md) holds the integration spec.
 - **confighubai/confighub#4356** — cross-repo dependency for ArgoCDOCI Helm-source shape. Blocks accurate `confighub-oci-argo` symptom classification in `compare source-truth`.
 - **confighub-ai-demo#264** — Pilot consumer-side fixtures pairing with cub-scout #395 + future #409 fixtures.
 
 ## Current checkpoint
 
-`go test ./...` is green as of 2026-05-09 with all 37 packages passing. Main CI is green. GitHub Actions workflows now run on Node 24 (PRs #412, #413).
+`go test ./...` is green as of 2026-05-21 across every package touched by the attribution-layer work. The only failure on a clean main checkout is the pre-existing `test/unit/demo_worker_lifecycle_script_test.go` — unrelated to attribution work, fails on a `git stash`-clean tree too. Main CI is green. GitHub Actions workflows now run on Node 24 (PRs #412, #413).
 
 The practical state heading into the `cub scout` plugin switchover is:
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,23 @@ Press `?` inside the TUI for shortcuts.
 
 ![cub-scout map dashboard](docs/images/map-dashboard.png)
 
+### Scan Variants
+
+`scan` is the fastest way to audit a cluster or manifest set for known risk patterns. The built-in scanner covers **46 patterns**, and the broader [confighub-scan](https://github.com/confighubai/confighub-scan) catalog tracks **3,513 risk patterns** for deeper policy and detection work.
+
+Common entrypoints:
+
+- `cub-scout scan --state`
+- `cub-scout scan --kyverno`
+- `cub-scout scan --lifecycle-hazards`
+- `cub-scout scan --timing-bombs`
+- `cub-scout scan --dangling`
+- `cub-scout scan --file manifest.yaml`
+- `cub-scout scan --json`
+- `cub-scout scan --normalized-json`
+
+Detailed scanner behavior and output shape: [docs/reference/commands.md#scan](docs/reference/commands.md#scan) and [docs/reference/json-contracts.md](docs/reference/json-contracts.md).
+
 ---
 
 ## AI integration

--- a/README.md
+++ b/README.md
@@ -1,108 +1,143 @@
-# cub-scout — explore and map GitOps clusters
+# cub-scout — observe and explain Kubernetes + GitOps
 
 **Read-only. Deterministic. Offline-capable. Optional `cub` plugin.**
 
-cub-scout is an open-source observer for Kubernetes and GitOps.
-**It observes and explains; it never decides.** It diagnoses, explains,
-traces, maps, and scans Kubernetes resources and their GitOps origins — but
-never modifies cluster state and never makes authority calls about what
-*should* be true. It is safe to run against production.
+cub-scout is an open-source observer for Kubernetes and GitOps. It diagnoses, explains, traces, maps, scans, **compares** intended vs running state, and **attributes** every field back to its source — but it never modifies cluster state and never makes authority calls about what *should* be true. Safe to run against production.
 
 It helps you answer:
 - what owns this resource, really?
-- where did it come from in Git?
-- what is broken right now, and what should I do next?
+- where did each field's value come from — controller, git file, ConfigHub binding, or someone editing manually?
+- what's broken right now, and what should I do next?
 - how does **intended** (governed) state compare to **live** (cluster) state?
 
-It works standalone with your current kube context, or connected to
-[ConfigHub](https://confighub.com) for governed comparison, change history,
-import, fleet queries, and AI-friendly read-only workflows.
+It works **standalone** with your current kube context, or **connected** to [ConfigHub](https://confighub.com) for governed comparison, history, import, fleet queries, and AI-friendly read-only workflows.
 
 ### Who reaches for cub-scout?
 
-- **SREs and on-call** — when a workload is unhealthy and you need to know
-  *why* and *who owns it* in seconds, not by clicking through Argo or Flux UIs.
-- **Platform engineers** — when you inherit a cluster and need a
-  trustworthy ownership map across Flux, ArgoCD, Helm, Crossplane, ConfigHub,
-  and naked YAML.
-- **AI agents and automation** — when you need stable, deterministic JSON or
-  a Model Context Protocol (MCP) gateway for read-only cluster facts.
+- **SREs and on-call** — when a workload is unhealthy and you need to know *why* and *who owns it* in seconds, not by clicking across Argo or Flux UIs.
+- **Platform engineers** — when you inherit a cluster and need a trustworthy ownership map across Flux, ArgoCD, Helm, Crossplane, kro, ConfigHub, and naked YAML.
+- **AI agents and automation** — when you need stable, deterministic JSON or a Model Context Protocol (MCP) gateway for read-only cluster facts.
 
 ### `cub-scout` vs `cub`: the boundary
-
-cub-scout and [`cub`](https://confighub.com) are designed to be complementary,
-not interchangeable:
 
 | | `cub-scout` | `cub` |
 |---|---|---|
 | Role | **Observe and explain** | **Act and govern** |
 | Cluster state | Read-only | Read + reconcile via workers |
 | ConfigHub state | Read-only queries | Authoring, import, promotion |
-| Best for | Diagnosis, ownership, drift, audit, AI tools | Intended-state authoring, GitOps pipelines |
+| Best for | Diagnosis, ownership, drift, attribution, AI tools | Intended-state authoring, GitOps pipelines |
 
-cub-scout is the **read-only witness**. ConfigHub (driven by `cub`) is the
-**authority**. The two ship as separate binaries and never overlap on writes.
-
-> **New in v2.0:** cub-scout also runs as a `cub` plugin (`cub scout ...`)
-> with inherited auth. Standalone `cub-scout` is unchanged. See
-> [How To Run It](#how-to-run-it) and the
-> [migration guide](docs/releases/v2.0.0-migration-guide.md).
-
-**New here?** Start with the [Fast Path](#fast-path-2-minutes), then use:
-- [CLI Guide](CLI-GUIDE.md) for the workflow-first tour
-- [docs/reference/cli-reference.md](docs/reference/cli-reference.md) for the full command catalog
-- [docs/reference/commands.md](docs/reference/commands.md) for detailed usage examples
-- [docs/reference/cli-contract.md](docs/reference/cli-contract.md) for stable flags and schemas
-
-Please send feedback by [opening an issue](https://github.com/confighub/cub-scout/issues)
-or joining [Discord](https://discord-auth.confighub.net/discord/join) via ConfigHub signup.
+cub-scout is the **read-only witness**. ConfigHub (driven by `cub`) is the **authority**. The two ship as separate binaries and never overlap on writes.
 
 ---
 
-## What cub-scout does, at a glance
+## Capability Map
 
-| Capability | Command | What you get |
+cub-scout's commands fall into seven groups. Each command's **Inputs** column tells you exactly what it needs — cluster only (standalone), cluster + a local git checkout (standalone + `--source-path` / `--git-path`), or cluster + ConfigHub auth (connected).
+
+### Observe — see what's running
+
+| Command | What you get | Inputs |
 |---|---|---|
-| **Diagnose** cluster health | `doctor` | One-screen summary of ownership, health, drift, and risk, with concrete next steps. |
-| **Explain** any resource | `explain` | Plain-English ownership and lineage for one resource — auto-detects Flux, ArgoCD, Helm, Crossplane, or native. |
-| **Trace** workloads to Git | `trace` | The full ownership chain from a Kubernetes object back to its Git source, ApplicationSet, or OCI registry. |
-| **Map** the cluster interactively | `map` | TUI for browsing ownership, health, and dependencies across a cluster. |
-| **Scan** for risk | `scan` | Audits live clusters or manifest files against 46 built-in risk patterns. Optionally delegates to the separate [confighub-scan](https://github.com/confighubai/confighub-scan) tool for its broader catalog. |
-| **Compare** intent vs reality | `compare three-way` | Three-way diff between **DRY** (what ConfigHub *intends* to deploy), **WET** (what the renderer *produced*), and **LIVE** (what is *running* in the cluster). Surfaces drift the Kubernetes API alone cannot. *Connected only.* |
-| **Serve** as an AI gateway | `mcp serve` | Read-only Model Context Protocol (MCP) server over stdio for Claude, Codex, and other agents. |
+| `doctor` | One-screen cluster health summary with concrete next steps | cluster |
+| `map` (TUI / `list` / `hooks` / `orphans` / `meaning`) | Ownership inventory, lifecycle hooks, orphan detection, meaning-first grouping | cluster |
+| `trace` | Full ownership chain from K8s object → Application/Kustomization → Git source / OCI digest | cluster |
+| `tree` | Runtime, ownership, git, and composition hierarchies | cluster |
+| `scan` | Audit live cluster or manifest files against 46 built-in risk patterns | cluster *or* file |
+| `graph export` | Resource graph as DOT/JSON | cluster |
+| `snapshot` | Dump cluster state as GSF JSON | cluster |
+| `watch` | Stream observation events to webhook/file sinks | cluster |
+| `status` | Connection mode and cluster context info | cluster |
 
-All commands emit deterministic JSON via `--format json` for scripts and
-agents. Same input, same output — no AI/ML inference inside the core
-ownership logic.
+### Diagnose — interpret what you observe
+
+| Command | What you get | Inputs |
+|---|---|---|
+| `explain` | Plain-English ownership and lineage for one resource, with phase-aware next-step hints | cluster |
+| `debug` | Guided GitOps debugging wizard | cluster |
+| `suggest-remedy` | Read-only description of a remediation that *would* resolve a finding — never applies it | cluster |
+| `patterns` (`detect` / `explain` / `list`) | Pattern-engine catalogue + matched findings | cluster *or* file |
+| `gitops status` | GitOps pipeline health across Flux + Argo controllers | cluster |
+
+### Compare — intended vs actual
+
+| Command | What you get | Inputs |
+|---|---|---|
+| `compare` (resource mode) | Single-resource DRY/WET/LIVE picture when connected; LIVE-only when standalone | cluster (+ConfigHub for DRY/WET) |
+| `compare drift` | Desired (file) vs live drift detection | cluster + file |
+| `compare three-way` | Scope-wide DRY/WET/LIVE with agreement summary and conformance verdict | cluster + ConfigHub |
+| `compare source-truth` | Strategy-relative `PASS` / `WATCH` / `ASK` / `BLOCK` evidence Pilot consumes (#393) | cluster + ConfigHub |
+
+Today, `compare three-way` and `compare source-truth` require ConfigHub. A standalone "git as DRY" mode is in the [next-up](#whats-coming-next) list.
+
+### Attribute — where each value came from
+
+cub-scout's **attribution layer** (#435) annotates every field mismatch with provenance evidence:
+
+| Signal | Surfaces on | Inputs |
+|---|---|---|
+| `cause` + `managerHint` (controller-drift / manual-edit / unknown) — from K8s `managedFields` | `compare` + `explain` | cluster |
+| `gitSource.{repoUrl, revision, path}` — from Argo Application / Flux GitRepository spec | `compare` + `explain` | cluster (needs `argocd` / `flux` CLI for tracer) |
+| `gitSource.file` + `gitSource.line` — raw-YAML back-resolution | `compare` | cluster + `--source-path <local-checkout>` |
+| `incomingBindings[]` — ConfigHub Links influencing this unit | `compare` | cluster + ConfigHub |
+| `bindingSource` — per-field upstream unit + binding path | `compare` | cluster + ConfigHub |
+
+The verified manager-string enumeration covers Argo CD, Flux (kustomize / helm / source controllers), Helm direct, Crossplane (composite / composed / claim / MRD / refs), kro (applyset / parent / labeller), and `kubectl-*` interactive paths — strings not in the enumeration fall through to `unknown` rather than being guessed.
+
+### Ingest — import config into ConfigHub
+
+| Command | What you get | Inputs |
+|---|---|---|
+| `import --git-path` | Local Git-structure preview, no upload | git checkout |
+| `import parse-repo` | Repo structure JSON for downstream tools | git checkout |
+| `import argocd` | Import one ArgoCD Application's units | cluster + ConfigHub |
+| `import cluster-aggregator` | Aggregate import proposals across many controllers | cluster + ConfigHub |
+| `import apply` | Apply an import proposal JSON to ConfigHub | ConfigHub |
+| `app` | Manage ConfigHub Apps | ConfigHub |
+
+Today standalone `import --git-path` is preview-only. A `--output-dir` mode that emits proposed unit YAMLs to disk for review/PR/upload is in the [next-up](#whats-coming-next) list.
+
+### Govern — connected fleet and history
+
+| Command | What you get | Inputs |
+|---|---|---|
+| `history` | Connected ChangeSet timeline for one resource | ConfigHub |
+| `impact` | Connected blast-radius preview for one unit | ConfigHub |
+| `fleet outliers` | Cluster divergence report across many clusters | ConfigHub |
+| `summary` (`list` / `slack`) | Connected summary storage + Slack delivery | ConfigHub |
+| `views` (`resolve` / `open` / `project`) | Resolve, open, and project ConfigHub Views (#391) | ConfigHub |
+| `audit list` | Break-glass accept/reject audit trail | ConfigHub |
+| `bundle` / `catalog` | Inspect, replay, diff, and summarize debug bundles + manage catalogs | bundle artifact |
+
+### Integrate — AI, setup, and infrastructure
+
+| Command | What you get | Inputs |
+|---|---|---|
+| `setup connect` | Import or create a kubeconfig context | none |
+| `setup completion` | Shell completion script | none |
+| `quickstart demo` | Fixture-backed first-run tour | none |
+| `mcp serve` | Read-only Model Context Protocol (MCP) server over stdio for Claude, Codex, agents | cluster (any subset of the above based on the tool invoked) |
+| `context-pack` | Deterministic AI context JSON export | cluster |
+| `version` | Build/version info | none |
+
+All commands emit deterministic JSON via `--format json` for scripts and agents. Same input, same output — no AI/ML inference in the ownership logic.
 
 ---
 
 ## Fast Path (2 Minutes)
 
-**No ConfigHub signup required.** cub-scout reads from your current kube
-context and works fully offline.
+**No ConfigHub signup required.** cub-scout reads your current kube context and works fully offline.
 
 ```bash
-# Install (Homebrew — see Install section below for other options)
 brew install confighub/tap/cub-scout
 
-# Triage flow: doctor → explain → trace
 cub-scout doctor                                  # cluster health summary
-cub-scout explain deploy/frontend -n boutique     # who owns this resource?
-cub-scout trace   deploy/frontend -n boutique     # where did it come from?
+cub-scout explain deploy/api -n prod              # who owns this resource?
+cub-scout trace   deploy/api -n prod              # where did it come from?
 cub-scout map                                     # interactive TUI
 ```
 
-If `cub-scout: command not found` but you have `cub` installed, try
-`cub scout doctor` instead — see [How To Run It](#how-to-run-it) for the
-plugin form.
-
-What you get in the first two minutes:
-- ownership detection across Flux, ArgoCD, Helm, Crossplane, ConfigHub, and native resources
-- one-command health summary with next steps
-- trace from workload to Git source (Application, ApplicationSet, GitRepository, OCI registry)
-- recent Kubernetes events surfaced in `explain` and `trace`
-- deterministic JSON for scripts, AI agents, and MCP clients
+If `cub-scout: command not found` but you have `cub` installed, try `cub scout doctor` instead — see [How to invoke](#how-to-invoke).
 
 ---
 
@@ -129,139 +164,45 @@ docker run ghcr.io/confighub/cub-scout:latest version
 kubectl krew install cub-scout
 ```
 
-If you want the `kubectl` plugin wrapper too:
-
-```bash
-make build-kubectl-plugin
-kubectl cub-scout map list --json
-```
-
-See [docs/howto/plugin-install.md](docs/howto/plugin-install.md) for pinned
-version install, direct-URL install, offline install, and plugin-mode
-troubleshooting.
+`make build-kubectl-plugin` also produces a `kubectl cub-scout ...` wrapper. See [docs/howto/plugin-install.md](docs/howto/plugin-install.md) for pinned-version, direct-URL, and offline installs.
 
 ---
 
-## How To Run It
+## How to invoke
 
-Same binary, three ways to invoke it. Commands, flags, JSON, exit codes, and
-MCP tool names are identical across all three; only the invocation prefix
-differs.
-
-### 1. Standalone — "if you can kubectl, you can cub-scout"
-
-No ConfigHub signup required. Reads from your current kube context.
+Same binary, three invocation forms — commands, flags, JSON, exit codes, and MCP tool names are identical across all three; only the prefix differs:
 
 ```bash
-brew install confighub/tap/cub-scout
-cub-scout doctor
-cub-scout explain deploy/api -n prod
-cub-scout trace deploy/api -n prod
+cub-scout doctor          # 1. Standalone — installed directly
+cub scout    doctor       # 2. cub plugin — after `cub plugin install confighub/cub-scout`
+kubectl cub-scout doctor  # 3. kubectl plugin — from `make build-kubectl-plugin`
 ```
 
-### 2. Connected — ConfigHub-backed comparison, history, import
-
-Adds governed read paths once you've authenticated with `cub`. cub-scout
-still never modifies the cluster — `import` writes records into ConfigHub,
-not manifests into your cluster.
-
-```bash
-cub auth login
-cub-scout compare three-way --scope namespace/prod
-cub-scout history deploy/api -n prod
-cub-scout import --dry-run -n prod
-```
-
-### 3. Plugin mode (new in v2.0) — `cub scout ...`
-
-A **`cub` plugin** is an installable extension to the `cub` CLI that lets you
-invoke another tool as a `cub` subcommand. cub-scout was the first tool we
-shipped this way: after `cub plugin install confighub/cub-scout`, the plugin
-form `cub scout ...` runs the same binary as standalone `cub-scout ...` but
-inherits `cub`'s authentication, context, and ConfigHub session
-automatically — no separate login step.
-
-Use plugin form when:
-- you already have `cub` installed and authenticated (one auth surface)
-- you are invoking cub-scout from AI tools (MCP tool descriptions and `nextSteps`
-  hints render `cub scout ...`, so agent output stays consistent)
-
-Otherwise, standalone form is the path of least resistance: `brew install`
-and you're done.
-
-```bash
-cub plugin install confighub/cub-scout
-cub scout doctor
-cub scout compare three-way --scope cluster
-cub scout mcp serve
-```
-
-Under the hood, `cub` exec's the plugin binary with `CUB_PLUGIN=1`,
-`CUB_TOKEN`, and `CUB_CONTEXT` set. The plugin form inherits auth without a
-separate login step and never recursively shells out to `cub auth get-token`.
-
-Standalone and plugin forms are held to byte-equivalence by a release-gate
-test (`TestPluginParity_StandaloneMatchesPlugin`).
+Plugin form (`cub scout ...`) inherits `cub`'s auth automatically — useful when you also use ConfigHub. Standalone form is the path of least resistance and the default for AI/MCP scenarios. Parity is enforced by a release-gate test (`TestPluginParity_StandaloneMatchesPlugin`).
 
 ---
 
-## Choose Your Goal
+## Standalone vs Connected
 
-Each example below uses standalone form (`cub-scout ...`). If you installed
-the plugin (`cub plugin install confighub/cub-scout`), substitute `cub scout`
-for `cub-scout` in any command — behavior is identical.
+cub-scout works fully offline. Connected mode is optional but unlocks the questions a live cluster alone cannot answer.
 
-### Standalone Value Now
+**Standalone (no signup):** ownership detection, tracing, health diagnosis, drift hints, risk scanning, JSON, MCP gateway, attribution via `managedFields` + Argo/Flux tracer + (with `--source-path`) raw-YAML file:line resolution.
 
-```bash
-cub-scout quickstart --yes
-cub-scout doctor
-cub-scout explain deploy/api -n prod
-cub-scout trace deploy/api -n prod
-cub-scout scan
-```
+**Connected (`cub auth login`):** adds the historical and cross-cluster context the Kubernetes API doesn't have:
 
-Use this path when you want immediate cluster visibility without signing into
-anything else.
+- **DRY vs WET vs LIVE** — compare what ConfigHub *intended*, what the renderer *produced*, and what's actually *running*. Catches drift the live cluster can't tell you about.
+- **Per-field binding source** — answer "this field's value came from upstream unit X at path Y via link Z."
+- **Change history** — `kubectl events` only goes so far; `history` walks the ConfigHub governed timeline.
+- **Fleet queries** — "is this version running everywhere it should?" across many clusters.
+- **Import preview** — propose how a live workload should be modeled in ConfigHub before writing anything.
 
-### Connected Value Now
-
-```bash
-cub auth login
-cub-scout status
-cub-scout compare three-way --scope namespace/prod
-cub-scout history deploy/api -n prod
-cub-scout impact payments-api
-cub-scout import --dry-run -n prod
-```
-
-Use this path when you want ConfigHub-backed history, comparison, import, and
-fleet workflows. In plugin form, `cub auth login` is all you need — the
-plugin inherits the token automatically, no separate cub-scout auth step.
-
-### AI And Automation
-
-```bash
-cub scout mcp serve                                 # or: cub-scout mcp serve
-cub scout doctor --format json
-cub scout explain deploy/api -n prod --format json
-cub scout compare three-way --scope namespace/prod --format json
-cub scout context-pack --format json --max-bytes 16384
-```
-
-Use this path when you want stable read-only JSON or an MCP gateway for
-Claude, Codex, or other agent tooling. The plugin form is preferred here
-because MCP tool descriptions, structured `nextSteps` hints, and canonical
-trust URLs all render the `cub scout ...` invocation form so downstream
-agents see a consistent command shape.
+**Important:** connected import writes ConfigHub records, not cluster manifests. cub-scout never modifies the cluster.
 
 ---
 
 ## Signature Example
 
-`trace` is the headline feature: it answers "what created this?" without making
-you manually jump across Deployments, Applications, Helm releases, labels,
-annotations, and controller state.
+`trace` is the headline feature — it answers "what created this?" without making you stitch Deployments, Applications, Helm releases, labels, annotations, and controller state by hand:
 
 ```text
 $ cub-scout trace deploy/frontend -n boutique
@@ -279,175 +220,54 @@ Next:
   cub-scout explain deploy/frontend -n boutique
 ```
 
-For more detailed examples, see [docs/reference/commands.md#trace](docs/reference/commands.md#trace).
+For more, see [docs/reference/commands.md#trace](docs/reference/commands.md#trace).
 
 ---
 
-## Choose Your Interface
+## Interfaces
 
 | Interface | Best for | Start here |
-|-----------|----------|------------|
-| TUI | Interactive exploration and keyboard-driven debugging | `cub-scout map` |
-| CLI | One-off troubleshooting, shell use, pipelines | `doctor`, `explain`, `trace` |
+|---|---|---|
+| TUI | Interactive exploration, keyboard-driven debugging | `cub-scout map` |
+| CLI | One-off triage, shell use, pipelines | `doctor`, `explain`, `trace` |
 | JSON | Automation, AI, MCP, downstream tooling | `--format json` or `--json` |
 
-Press `?` inside the TUI for shortcuts and panel navigation.
-
-**Ownership at a glance:**
+Press `?` inside the TUI for shortcuts.
 
 ![cub-scout map dashboard](docs/images/map-dashboard.png)
 
-### Scan Variants
-
-`scan` is the fastest way to audit a cluster or manifest set for known risk patterns.
-The built-in scanner covers **46 patterns**, and the broader
-[confighub-scan](https://github.com/confighubai/confighub-scan) catalog tracks
-**3,513 risk patterns** for deeper policy and detection work.
-
-Common entrypoints:
-
-- `cub-scout scan --state`
-- `cub-scout scan --kyverno`
-- `cub-scout scan --lifecycle-hazards`
-- `cub-scout scan --timing-bombs`
-- `cub-scout scan --dangling`
-- `cub-scout scan --file manifest.yaml`
-- `cub-scout scan --json`
-- `cub-scout scan --normalized-json`
-
-```bash
-cub-scout scan --state
-cub-scout scan --kyverno
-cub-scout scan --lifecycle-hazards
-cub-scout scan --timing-bombs
-cub-scout scan --dangling
-cub-scout scan --file manifest.yaml
-cub-scout scan --json
-cub-scout scan --normalized-json
-```
-
-For detailed scanner behavior and output shape, use
-[docs/reference/commands.md#scan](docs/reference/commands.md#scan) and
-[docs/reference/json-contracts.md](docs/reference/json-contracts.md).
-
 ---
 
-## Standalone vs Connected
-
-cub-scout works fully offline. Connected mode is optional but unlocks the
-questions a live cluster alone cannot answer.
-
-**Standalone (no signup):** Works from your current kube context. You get
-ownership detection, ownership tracing, health diagnosis, drift hints,
-risk scanning, JSON, and an MCP gateway — everything you need to triage
-*right now* on the cluster in front of you.
-
-**Connected (`cub auth login`):** Adds the historical and cross-cluster
-context that the Kubernetes API does not have. Specifically:
-
-- **DRY vs WET vs LIVE** — compare what ConfigHub *intended* to deploy
-  (DRY), what the renderer *produced* (WET), and what is actually
-  *running* (LIVE). Catches drift the live cluster can't tell you about.
-- **Change history** — ask "when did this change, who changed it, and
-  why?" against ConfigHub's governed timeline, not just `kubectl events`.
-- **Fleet queries** — answer "is this version running everywhere it
-  should?" across many clusters at once.
-- **Import preview** — propose how a live workload should be modeled in
-  ConfigHub before writing anything.
-
-The capability axis is orthogonal to the [invocation form](#how-to-run-it):
-every row below works identically in `cub-scout ...` standalone and `cub
-scout ...` plugin form. Parity is enforced by a release-gate test
-(`TestPluginParity_StandaloneMatchesPlugin`).
-
-| Capability | Standalone | Connected |
-|------------|:----------:|:---------:|
-| Map cluster resources | ✓ | ✓ |
-| Explain ownership and lineage | ✓ | ✓ |
-| Trace to Git source | ✓ | ✓ |
-| Scan for risk issues | ✓ | ✓ |
-| Deterministic JSON output | ✓ | ✓ |
-| Model Context Protocol (MCP) gateway | ✓ | ✓ |
-| DRY vs WET vs LIVE comparison | — | ✓ |
-| Connected change history | — | ✓ |
-| Fleet-level queries | — | ✓ |
-| Import workloads into ConfigHub | — | ✓ |
-
-In plugin form (`cub scout ...`) the token from `cub auth login` is inherited
-automatically. In standalone form (`cub-scout ...`) it is picked up from
-`cub`'s local token store.
-
-**Important:** connected import writes ConfigHub records, not cluster
-manifests. cub-scout never modifies the cluster.
-
----
-
-## Quick Connect
-
-Use `setup connect` when you want "just connect and go" with minimal kubeconfig
-setup:
-
-```bash
-# Import an existing kubeconfig context and launch the TUI
-cub-scout setup connect --from-kubeconfig ./artem.yaml --from-context ske-vcl-pro --map
-
-# Or connect directly to an API endpoint with a token
-cub-scout setup connect https://api.example.com:6443 \
-  --token "$K8S_BEARER_TOKEN" \
-  --context prod \
-  --map
-```
-
-If you prefer CLI-only, omit `--map`.
-
----
-
-## Why People Reach For It
-
-GitOps stacks are powerful, but the day-two questions are still painful:
-
-- A Deployment exists — but what actually owns it?
-- Argo or Flux says "Synced" — but is the cluster actually converged?
-- Which events explain *this* failure, right now?
-- Is this resource governed, orphaned, or manually changed?
-- Did someone hot-patch prod, or did the renderer produce this?
-
-cub-scout answers these through **one read-only observation layer** instead
-of making you stitch them together by hand with `kubectl`, controller CRDs,
-labels, annotations, and UI tabs across Argo, Flux, and Helm.
-
-It is built to be the tool you can keep running on a cluster you don't fully
-trust yet — including production.
-
----
-
-## AI First-Read
+## AI integration
 
 For Claude, Codex, and other AI agents:
 - start with [AI-README-FIRST.md](AI-README-FIRST.md)
 - then load [skills/cub-scout/SKILL.md](skills/cub-scout/SKILL.md) if repo-local skills are supported
 - for AI tool setup, see [docs/howto/using-cub-scout-from-ai-tool.md](docs/howto/using-cub-scout-from-ai-tool.md)
 
-What `cub-scout mcp serve` is:
-- a read-only **Model Context Protocol (MCP)** server over stdio
-- backed by the existing CLI JSON surfaces — same answers, agent-shaped
-- strongest as a troubleshooting and exploration layer for AI agents
+`cub-scout mcp serve` is a read-only MCP server over stdio backed by the same CLI JSON surfaces — same answers, agent-shaped. It's not a Kubernetes write tool, not a multi-gateway router, and not the ConfigHub authority layer (that role belongs to `cub`).
 
-What it is not:
-- not a Kubernetes write tool — every tool call goes through the read-only CLI
-- not a multi-gateway router — it speaks one protocol, MCP
-- not the ConfigHub authority layer — that role belongs to `cub`
+---
+
+## What's coming next
+
+Honest gaps in the current capability map, with the leverage on filling them:
+
+- **Standalone `compare three-way --git-path` / `--source-path` as DRY source** — would let raw-YAML repos run the same three-way view without ConfigHub. Stage B back-resolution (#440) already lays the parsing groundwork.
+- **`compare source-truth` strategy expansion** — [#409](https://github.com/confighub/cub-scout/issues/409) Phase 2 adds `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`; Phase 3 adds multi-source Argo. Moves the strategy count from 4 to 9.
+- **`import --git-path --output-dir`** — emit proposed unit YAMLs to disk for PR review, then upload via Installer's `--merge-external-source` once connected. One bundle, two workflows.
+- **Hierarchy-aware ingest** — preserve ApplicationSet / app-of-apps / Flux Kustomization composition in import proposals so imported ConfigHub state is navigable, not flat.
+- **Helm / Kustomize back-resolution** — extends stage B (#440) from raw YAML to templated sources for per-field `file:line` provenance.
+- **Additional manager-string writers** — Tekton, Argo Workflows, Cluster API, OIDC-based CD systems — gated on whether the variant-management story demands them.
 
 ---
 
 ## Documentation Map
 
-Start here based on what you need:
-
 | Need | Doc |
-|------|-----|
+|---|---|
 | Workflow-first CLI tour | [CLI-GUIDE.md](CLI-GUIDE.md) |
-| Full command catalog | [docs/reference/cli-reference.md](docs/reference/cli-reference.md) |
+| Full command catalog (A–Z) | [docs/reference/cli-reference.md](docs/reference/cli-reference.md) |
 | Command usage and examples | [docs/reference/commands.md](docs/reference/commands.md) |
 | Stable flags and schemas | [docs/reference/cli-contract.md](docs/reference/cli-contract.md) |
 | JSON fields and output model | [docs/reference/json-contracts.md](docs/reference/json-contracts.md) |
@@ -472,33 +292,20 @@ go build ./cmd/cub-scout
 
 ## Principles
 
-- **Read-only, by design** — cluster observation uses only `Get`, `List`, and
-  `Watch`. cub-scout has no `apply`, no `delete`, no admission webhook, no
-  cluster-mutating code path. Even `suggest-remedy` is read-only — it
-  describes a fix that *would* resolve a finding; it does not run it. Apply
-  via ConfigHub or kubectl, governed. Run cub-scout against production
-  without an approval ticket.
-- **Deterministic** — same inputs, same outputs. No AI/ML inference inside the
-  core ownership logic. Ownership decisions are reproducible and explainable.
-- **Parse, don't guess** — ownership comes from real labels, annotations,
-  owner references, and controller facts. We refuse to invent provenance.
-- **Complement GitOps, don't replace it** — cub-scout helps you understand
-  Flux, ArgoCD, Helm, Crossplane, and ConfigHub state. It is not another
-  reconciler.
-- **Graceful degradation** — works without ConfigHub, without internet, and
-  many flows work without a live cluster (debug bundles, manifest scans,
-  Git-path import preview).
-- **Evidence, not authority** — cub-scout is the read-only **witness**.
-  ConfigHub (driven by `cub`) is the **authority** for intended state. The two
-  never overlap on writes.
+- **Read-only, by design** — observation uses only `Get`, `List`, `Watch`. No `apply`, no `delete`, no admission webhook. Even `suggest-remedy` only *describes* a fix — it does not run it.
+- **Deterministic** — same inputs, same outputs. No AI/ML inference in the ownership logic.
+- **Parse, don't guess** — ownership and attribution come from real labels, annotations, owner references, controller facts, and verified manager-string enumerations. Unknown is preferred over wrong.
+- **Complement GitOps, don't replace it** — cub-scout helps you understand Flux, ArgoCD, Helm, Crossplane, kro, and ConfigHub state. It's not another reconciler.
+- **Graceful degradation** — works without ConfigHub, without internet, and many flows work without a live cluster (debug bundles, manifest scans, Git-path import preview).
+- **Evidence, not authority** — cub-scout is the read-only witness. ConfigHub (via `cub`) is the authority for intended state.
 
-For more on the security and operating model, see [SECURITY.md](SECURITY.md).
+For more on the security model, see [SECURITY.md](SECURITY.md).
 
 ---
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 - **Found a bug?** [Open an issue](https://github.com/confighub/cub-scout/issues)
 - **Have an idea?** Start a discussion

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -23,7 +23,7 @@ Source of truth:
 | `audit` | Break-glass audit trail tools | [Command Reference](commands.md#audit-list) | [Connect and compare](../../examples/connect-and-compare/) |
 | `bundle` | Inspect, replay, diff, and summarize debug bundles | [Command Reference](commands.md#bundle-inspect-v015) | [Artifact workflows](../../examples/workflows/) |
 | `catalog` | Manage bundle catalogs | [Command Reference](commands.md#catalog-list-v015) | [Artifact workflows](../../examples/workflows/) |
-| `compare` | Compare Git, bundle, live, or connected intent/render/live state | [Command Reference](commands.md#compare) | [Connect and compare](../../examples/connect-and-compare/) |
+| `compare` | Compare Git, bundle, live, or connected intent/render/live state; in connected mode each field mismatch carries attribution evidence (`cause`, `managerHint`, `gitSource`, `bindingSource`) | [Command Reference](commands.md#compare) | [Connect and compare](../../examples/connect-and-compare/) |
 | `context-pack` | Export deterministic AI context JSON | [How-to](../howto/context-pack-v2.md) | [AI integration](../../examples/ai-integration/) |
 | `debug` | Guided GitOps debugging wizard | [Command Reference](commands.md#debug) | [Platform example](../../examples/platform-example/) |
 | `doctor` | One-command cluster health summary | [Command Reference](commands.md#doctor) | [Connect and compare](../../examples/connect-and-compare/) |
@@ -60,7 +60,7 @@ Source of truth:
 | `audit list` | Break-glass accept/reject audit trail | [Command Reference](commands.md#audit-list) | [Connect and compare](../../examples/connect-and-compare/) |
 | `compare drift` | Desired vs live drift detection | [Command Reference](commands.md#compare-drift) | [Drift examples](../../examples/drift/) |
 | `compare source-truth` | Read-only source-truth evidence for Pilot acceptance (#393) | [Command Reference](commands.md#compare-source-truth) | - |
-| `compare three-way` | Connected DRY/WET/LIVE comparison | [Command Reference](commands.md#compare-three-way) | [Connect and compare](../../examples/connect-and-compare/) |
+| `compare three-way` | Connected DRY/WET/LIVE comparison; `--source-path <local-checkout>` opts into stage-B `gitSource.file:line` back-resolution for raw-YAML sources | [Command Reference](commands.md#compare-three-way) | [Connect and compare](../../examples/connect-and-compare/) |
 | `fleet outliers` | Cluster divergence report | [Command Reference](commands.md#fleet-outliers) | [Fleet import](../../examples/fleet-import/) |
 | `gitops status` | GitOps pipeline health | [Command Reference](commands.md#gitops-v014) | [Connected summary storage](../../examples/connected-summary-storage/) |
 | `import apply` | Apply an import proposal JSON | [Command Reference](commands.md#import-apply) | [Import from live](../../examples/import-from-live/) |

--- a/skills/cub-scout/SKILL.md
+++ b/skills/cub-scout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cub-scout
-description: Use when working in the cub-scout repo or when answering what cub-scout can do versus ConfigHub/cub. Covers cub-scout's read-only observation role, connected comparison workflows, Model Context Protocol (MCP) surfaces, Git preview boundaries, and how to verify current command truth before claiming capability.
+description: Use when working in the cub-scout repo or when answering what cub-scout can do versus ConfigHub/cub. Covers cub-scout's read-only observation role, connected comparison workflows, attribution layer (mutation cause + git source + ConfigHub binding source), Model Context Protocol (MCP) surfaces, Git preview boundaries, and how to verify current command truth before claiming capability.
 ---
 
 # cub-scout
@@ -11,6 +11,7 @@ Start here when the task is about:
 - how `cub scout` differs from `cub`
 - whether a workflow is standalone, connected, or ConfigHub/cub
 - AI / Model Context Protocol (MCP) usage of `doctor`, `explain`, `trace`, `map`, `scan`
+- attribution evidence on field mismatches (`cause`, `managerHint`, `gitSource`, `bindingSource`)
 - Git preview versus render/import boundaries
 
 ## Read first
@@ -21,31 +22,40 @@ Start here when the task is about:
 4. `docs/reference/cli-contract.md`
 5. `docs/reference/json-contracts.md`
 
-For capability-triage and demo conversations such as "can cub scout do X?" or
-"should I use cub scout or kubectl here?", also read
-`references/capability-assistant.md`.
+For capability-triage and demo conversations such as "can cub scout do X?" or "should I use cub scout or kubectl here?", also read `references/capability-assistant.md`.
 
 If the user is asking you to *use* cub-scout against a real cluster (not work on the repo), load `docs/ai/cub-scout-tasks.md` instead — that file is task-oriented with concrete command flows for operator scenarios.
 
 ## Product value in one breath
 
-**cub scout observes and explains; it never decides.** It is the read-only
-Kubernetes and GitOps observer — it surfaces evidence about ownership,
-health, and drift, but it never mutates the cluster and never makes
-authority calls about what *should* be true. ConfigHub (driven by `cub`) is
-the authority; cub-scout is the witness.
+**cub scout observes and explains; it never decides.** It is the read-only Kubernetes and GitOps observer — it surfaces evidence about ownership, health, drift, and provenance, but it never mutates the cluster and never makes authority calls about what *should* be true. ConfigHub (driven by `cub`) is the authority; cub-scout is the witness.
 
-`cub scout` is the preferred documented form. In this repo, use
-`./cub-scout ...` for exact local commands.
+`cub scout` is the preferred documented form. In this repo, use `./cub-scout ...` for exact local commands.
+
+## Capability groups (the verb map)
+
+cub-scout commands fall into seven groups; see `README.md` § Capability Map for the full per-command table. The lens:
+
+- **Observe** — `doctor`, `map`, `trace`, `tree`, `scan`, `graph`, `snapshot`, `watch`, `status` (cluster only)
+- **Diagnose** — `explain`, `debug`, `suggest-remedy`, `patterns`, `gitops status` (cluster only)
+- **Compare** — `compare`, `compare drift` (standalone); `compare three-way`, `compare source-truth` (connected)
+- **Attribute** — `cause`/`managerHint`/`gitSource`/`bindingSource` surfacing on `compare` + `explain` output (mix of standalone + connected)
+- **Ingest** — `import --git-path` (preview); `import argocd`, `import cluster-aggregator`, `import apply`, `app` (connected)
+- **Govern** — `history`, `impact`, `fleet outliers`, `summary`, `views`, `audit`, `bundle`, `catalog` (connected)
+- **Integrate** — `setup`, `quickstart`, `mcp serve`, `context-pack`, `version`
+
+Standalone vs connected is preserved per-command — never blur the two.
 
 ## Tool boundaries
 
 ### Use `cub scout` for
 
-- `doctor`, `explain`, `trace`, `map`, `scan`
-- connected comparison such as `compare three-way`
+- Observe: `doctor`, `explain`, `trace`, `map`, `scan`
+- Diagnose: `explain`, `patterns`, `suggest-remedy`
+- Compare: `compare three-way`, `compare source-truth`, `compare drift`
+- Attribute: read provenance fields on the JSON output of `compare` and `explain`
 - Model Context Protocol (MCP) serving through `mcp serve`
-- local Git structure preview through `import --git-path` and `parse-repo`
+- Local Git structure preview through `import --git-path` and `import parse-repo`
 
 ### Use `cub` for
 
@@ -53,28 +63,32 @@ the authority; cub-scout is the witness.
 - spaces, units, targets, workers
 - `cub gitops discover`
 - `cub gitops import`
+- `cub link list / get` (the data feed for cub-scout's connected attribution layer)
 
 ### Do not blur these
 
 - `cub scout import --git-path` is a local structure/import-preview flow
 - `cub gitops import` is target + render-target based
 - SDK renderers are implementation detail for `cub`, not an implied `cub scout` feature
+- Attribution evidence on `compare`/`explain` JSON is read-only enrichment — never implies a write
 
 ## High-signal shipped capabilities
 
-- `doctor` / `explain` with `--presentation` and `--hint-mode`
-- truthful Argo ownership and phase-aware hints
-- connected `compare three-way` with conformance + agreement summary
-- secret evidence across trace, Crossplane, map issues, and TUI trace
-- MCP standalone tools with `doctor` as the first troubleshooting tool, including cluster-access uncertainty such as wrong context, stale kubeconfig, or API reachability
-- Git preview with ApplicationSet git-generator support
+- **Attribution layer** (`#435`): `cause` + `managerHint` (managedFields-based controller-drift vs manual-edit), `gitSource{repoUrl, revision, path, file, line}` (Argo/Flux tracer + opt-in `--source-path` for raw-YAML back-resolution), `incomingBindings[]` + `bindingSource` (connected, via `cub link list`). Documented in `docs/reference/json-contracts.md` § Field Mutation Attribution Contract.
+- **Source-truth contract** (`#393`, `#418`): `compare source-truth` with Phase 1 + Phase 2 strategies (9 total: `confighub-oci-argo`, `confighub-oci-flux`, `git-argo`, `git-flux`, `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`).
+- **Views integration** (`#391`): `views resolve`, `views open`, `views project --with-reality`, `compare three-way --view`.
+- **`doctor` / `explain`**: `--presentation` and `--hint-mode` for AI-friendly output.
+- **Argo truth-and-guidance**: truthful ownership for ApplicationSet-managed resources, three-way disagreement, phase-aware hints.
+- **`compare three-way`**: connected DRY/WET/LIVE, `--fail-on` conformance exit codes, agreement summary, `--source-path` opt-in for stage-B back-resolution.
+- **MCP gateway** (`mcp serve`): `doctor` as the first standalone troubleshooting tool, including for local access uncertainty (wrong context, stale kubeconfig, API reachability).
+- **Secret evidence** across trace, Crossplane, `map issues`, and TUI.
+- **Git preview** with ApplicationSet git-generator support.
 
 ## Queue source
 
 Do not rely on this file for current milestone state.
 
-Use `HANDOVER.md` plus live GitHub issues for the active queue so the skill does
-not become a second source of truth.
+Use `HANDOVER.md` plus live GitHub issues for the active queue so the skill does not become a second source of truth.
 
 ## Verification rule
 
@@ -87,7 +101,9 @@ Verify from local help before claiming capability:
 ./cub-scout doctor --help
 ./cub-scout explain --help
 ./cub-scout compare three-way --help
+./cub-scout compare source-truth --help
 ./cub-scout import --help
+./cub-scout views --help
 ./cub-scout mcp serve --help
 ```
 
@@ -96,6 +112,8 @@ When the workflow crosses into ConfigHub:
 ```bash
 cub gitops --help
 cub gitops import --help
+cub link --help
+cub link list --help
 ```
 
 ## Safety rule
@@ -103,3 +121,4 @@ cub gitops import --help
 - `cub-scout` is cluster read-only by default
 - connected import writes inventory/state to ConfigHub, not cluster manifests
 - prefer preview or dry-run paths first
+- attribution evidence is enrichment, never mutation


### PR DESCRIPTION
## Summary

Restructure how cub-scout is described across the five user-and-AI-facing docs around **seven verb groups** — Observe / Diagnose / Compare / Attribute / Ingest / Govern / Integrate — with the **standalone vs connected** distinction preserved per command via an explicit Inputs column.

The **Attribute** group lands as a first-class capability area, covering the attribution layer that shipped this cycle (#435: A1+A1.5+A2 in #437, C1 in #438, C2 in #439, stage B in #440): `cause`/`managerHint`, `gitSource` (`repoUrl`/`revision`/`path`/`file`/`line`), `incomingBindings`, `bindingSource`.

## Files

| File | Change |
|---|---|
| `README.md` | Restructured around the seven groups. Single capability map replaces the two redundant tables. "How to invoke" condensed. Scan Variants block moved to scan docs. Drops 514 → ~370 lines while *gaining* the attribution surface. |
| `AI-README-FIRST.md` | "Current High-Signal Shipped Capabilities" refreshed to 2026-05-21 with the attribution layer and views #2 + source-truth Phase 2. New "Capability Map at a Glance" navigation aid for AI agents. |
| `HANDOVER.md` | New "May 2026 completions — session 2026-05-21 (attribution layer)" section covers the four PRs + key design decisions (manager-string co-signal, Crossplane prefix match, runner seam, A2 vs B coupling). Open queue prunes resolved scopes (views #1/#2, source-truth Phase 1/2) and adds explicit next-up items. |
| `skills/cub-scout/SKILL.md` | Adds the verb-group lens; refreshes high-signal shipped capabilities; calls out the connected attribution dependency on `cub link list`. |
| `docs/reference/cli-reference.md` | `--source-path` note on `compare three-way` row; attribution-evidence note on `compare` row. |

## Standalone vs connected, per command

Every command in the README capability map has an **Inputs** column stating exactly what it needs:
- `cluster` — standalone, works from current kube context only
- `+git` or `+--source-path` — needs a local git checkout
- `+ConfigHub` — needs `cub auth login`

So the standalone/connected distinction is preserved per command, not buried in a separate section that gets stale.

## What's coming next

The README and HANDOVER both surface honest gaps with leverage notes — these are not promises, they're the most-leveraged next moves on each axis:

- Standalone `compare three-way --source-path` as DRY source (raw-YAML repos without ConfigHub)
- `compare source-truth` strategy expansion Phase 3 (multi-source Argo)
- `import --git-path --output-dir` to emit proposals to disk
- Hierarchy-aware ingest (preserve ApplicationSet / app-of-apps / Flux composition)
- Helm/Kustomize back-resolution for stage B's `gitSource.file:line`
- Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-CD)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green for all packages (same pre-existing demo-worker lifecycle failure unrelated to docs)
- [x] `go run ./scripts/check-cli-docs` passes — docs cross-references intact
- [x] All five files reviewed for confidential context — none present (per `feedback_public_github_confidentiality`)
