### PR TITLE
fix(#450): compare source-truth help lists all 9 strategies + drift test

### DIFF
--- a/cmd/cub-scout/source_truth.go
+++ b/cmd/cub-scout/source_truth.go
@@ -45,7 +45,7 @@ var (
 
 var sourceTruthCmd = &cobra.Command{
 	Use:   "source-truth <kind>/<name> | <kind> <name>",
-	Short: "Read-only source-truth evidence for a single workload (v0.1)",
+	Short: "Read-only source-truth evidence for a single workload",
 	Long: `source-truth emits read-only evidence about a single workload's intended,
 controller-observed, and runtime state. Output is the structured JSON
 contract Pilot's acceptance kernel consumes (#393).
@@ -54,20 +54,38 @@ cub-scout is the *evidence provider*; Pilot is the acceptance judge.
 This command never mutates, repairs, approves, or infers authority.
 
 Strategy is required input — cub-scout never infers the delivery path.
-v0.1 strategies:
+Strategies (Phase 1 + Phase 2 per #418):
 
-  confighub-oci-argo   ConfigHub -> OCI -> Argo CD -> Kubernetes
-  confighub-oci-flux   ConfigHub -> OCI -> Flux    -> Kubernetes
-  git-argo             Git      -> Argo CD -> Kubernetes
-  git-flux             Git      -> Flux    -> Kubernetes
+  confighub-oci-argo   ConfigHub -> OCI -> Argo CD          -> Kubernetes (unit revision anchor)
+  confighub-oci-flux   ConfigHub -> OCI -> Flux             -> Kubernetes (unit revision anchor)
+  git-argo             Git       -> Argo CD                 -> Kubernetes (Git SHA anchor)
+  git-flux             Git       -> Flux                    -> Kubernetes (Git SHA anchor)
+  helm-argo            Helm chart -> Argo CD                -> Kubernetes (chart version anchor)
+  helm-flux            Helm chart -> Flux HelmRelease       -> Kubernetes (chart version anchor)
+  kustomize-flux       Git source -> Flux Kustomization     -> Kubernetes (Git SHA + overlay)
+  oci-argo             OCI (non-ConfigHub) -> Argo CD       -> Kubernetes (OCI digest anchor)
+  oci-flux             OCI (non-ConfigHub) -> Flux OCIRepo  -> Kubernetes (OCI digest anchor)
 
 Examples:
   cub-scout compare source-truth deploy/rag-server -n demo --strategy confighub-oci-flux
   cub scout compare source-truth Deployment rag-server -n demo --strategy git-argo
+  cub-scout compare source-truth statefulset/db -n prod --strategy helm-flux
 
-v0.1 supports Deployment, StatefulSet, DaemonSet. Other kinds emit ASK.`,
+Supports Deployment, StatefulSet, DaemonSet. Other kinds emit ASK.`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runSourceTruth,
+}
+
+// sourceTruthStrategyFlagHelp builds the --strategy flag help string from the
+// canonical enum in pkg/agent so help text never drifts from code. Adding a
+// new strategy to agent.AllStrategies() automatically extends the help.
+func sourceTruthStrategyFlagHelp() string {
+	all := agent.AllStrategies()
+	values := make([]string, 0, len(all))
+	for _, s := range all {
+		values = append(values, string(s))
+	}
+	return fmt.Sprintf("Declared delivery path. Required. One of: %s", strings.Join(values, ", "))
 }
 
 func init() {
@@ -75,8 +93,8 @@ func init() {
 	// way comparison" framing. Keeps the top-level command surface lean.
 	combinedCmd.AddCommand(sourceTruthCmd)
 	sourceTruthCmd.Flags().StringVarP(&sourceTruthNamespace, "namespace", "n", "", "Namespace of the resource (required for namespaced kinds)")
-	sourceTruthCmd.Flags().StringVar(&sourceTruthStrategy, "strategy", "", "Declared delivery path. Required. One of: confighub-oci-argo, confighub-oci-flux, git-argo, git-flux")
-	sourceTruthCmd.Flags().StringVar(&sourceTruthFormat, "format", "json", "Output format. v0.1 supports: json")
+	sourceTruthCmd.Flags().StringVar(&sourceTruthStrategy, "strategy", "", sourceTruthStrategyFlagHelp())
+	sourceTruthCmd.Flags().StringVar(&sourceTruthFormat, "format", "json", "Output format: json")
 }
 
 func runSourceTruth(cmd *cobra.Command, args []string) error {

--- a/cmd/cub-scout/source_truth_help_test.go
+++ b/cmd/cub-scout/source_truth_help_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+// TestSourceTruthHelpListsAllStrategies prevents the help text from drifting
+// out of sync with the strategy enum in pkg/agent. Every value returned by
+// agent.AllStrategies() must appear in both the long help text and the
+// --strategy flag description.
+//
+// This test is the drift-resistance gate referenced in #450: when the enum
+// expanded from 4 strategies to 9 in #418 (Phase 2), the help text was not
+// updated, leaving operators reading stale guidance. Adding a new strategy
+// in code now requires the help to mention it, or this test fails.
+func TestSourceTruthHelpListsAllStrategies(t *testing.T) {
+	all := agent.AllStrategies()
+	if len(all) == 0 {
+		t.Fatal("agent.AllStrategies() returned no strategies — fixture broken")
+	}
+
+	long := sourceTruthCmd.Long
+	flag := sourceTruthCmd.Flags().Lookup("strategy")
+	if flag == nil {
+		t.Fatal("--strategy flag not registered")
+	}
+
+	for _, s := range all {
+		strategy := string(s)
+		if !strings.Contains(long, strategy) {
+			t.Errorf("source-truth Long help does not mention strategy %q — update the Long block in source_truth.go to list the new strategy", strategy)
+		}
+		if !strings.Contains(flag.Usage, strategy) {
+			t.Errorf("--strategy flag help does not mention %q — sourceTruthStrategyFlagHelp() builds this dynamically; check that agent.AllStrategies() includes it", strategy)
+		}
+	}
+}
+
+// TestSourceTruthFlagHelpDynamic verifies the flag-help builder produces
+// the same set of strategies as agent.AllStrategies(), in order. Decoupling
+// catches the case where someone replaces the dynamic builder with a
+// hand-maintained string that then drifts.
+func TestSourceTruthFlagHelpDynamic(t *testing.T) {
+	help := sourceTruthStrategyFlagHelp()
+	all := agent.AllStrategies()
+	for _, s := range all {
+		if !strings.Contains(help, string(s)) {
+			t.Errorf("sourceTruthStrategyFlagHelp() does not contain %q; help text was: %s", string(s), help)
+		}
+	}
+	// The phrase "Required" anchors the help text against drift in the
+	// surrounding prose.
+	if !strings.Contains(help, "Required") {
+		t.Errorf("sourceTruthStrategyFlagHelp() missing the Required marker; got: %s", help)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #450. The Phase 2 expansion in #418 grew the source-truth strategy enum from 4 to 9 strategies (adding `helm-argo`, `helm-flux`, `kustomize-flux`, `oci-argo`, `oci-flux`), but the CLI help in `source_truth.go` still listed only the original four. Operators reading `cub-scout compare source-truth --help` got stale guidance.

## What landed

- **`cmd/cub-scout/source_truth.go`** — updated `Long` help to enumerate all 9 strategies with one-line "delivery path → equality anchor" descriptions matching the table already in `docs/reference/commands.md`. Dropped the "v0.1" qualifier. Added a `sourceTruthStrategyFlagHelp()` helper that builds the `--strategy` flag description **dynamically from `agent.AllStrategies()`** so the flag help can never drift from the enum again.
- **`cmd/cub-scout/source_truth_help_test.go`** (new) — two drift-resistance tests:
  - `TestSourceTruthHelpListsAllStrategies` — scans both the `Long` block and the `--strategy` flag usage for every value returned by `agent.AllStrategies()`. Adding a new strategy without updating the `Long` block now fails this test.
  - `TestSourceTruthFlagHelpDynamic` — verifies the dynamic builder produces an entry for every strategy + the `Required` anchor phrase. Catches the case where someone replaces the dynamic builder with a hand-maintained string that then drifts.

## What's not touched

- `docs/reference/commands.md` already had the correct 9-strategy table (~L1283-L1291) — no doc drift there.
- `docs/releases/v2.1.0.md` references "Four strategies" but that's accurate history for the v0.1 ship; not updated.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/cub-scout/ -run 'TestSourceTruth(Help|FlagHelp)'` passes
- [x] Full `go test ./cmd/cub-scout/` passes (no regressions)
- [x] `./cub-scout compare source-truth --help` shows all 9 strategies (verified locally via test)

## Closes

Closes #450.