### PR TITLE
feat(#446): batch 2 — source-truth-pass + no-manual-edits-since predicates

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -24,6 +24,8 @@ var (
 	receiptNamespace string
 	receiptPredicate string
 	receiptAtCommit  string
+	receiptStrategy  string
+	receiptSince     string
 	receiptFormat    string
 	receiptOut       string
 )
@@ -31,6 +33,13 @@ var (
 // Function-variable seam for tests. Production reads from the cluster via
 // the dynamic client; tests swap with a fake returning prefab objects.
 var loadReceiptLiveFn = loadReceiptLive
+
+// collectSourceTruthForReceiptFn is the function-variable seam used by the
+// source-truth-pass predicate path. Production wires it to the live
+// source-truth derivation; tests swap with a fake returning prefab
+// evidence so the receipt CLI integration tests do not require a real
+// ConfigHub or cluster.
+var collectSourceTruthForReceiptFn = collectSourceTruthForReceipt
 
 var receiptCmd = &cobra.Command{
 	Use:   "receipt",
@@ -54,18 +63,27 @@ var receiptVerifyCmd = &cobra.Command{
 	Use:   "verify <subject>",
 	Short: "Build a receipt verifying a property of a Kubernetes resource",
 	Long: `verify produces an in-toto Statement v1 receipt asserting a predicate
-about a live Kubernetes resource. v1 batch 1 supports the applied-matches-spec
-predicate (LIVE matches the controller-resolved git anchor).
+about a live Kubernetes resource.
+
+v1 predicates:
+  applied-matches-spec    LIVE matches the controller-resolved git anchor
+  source-truth-pass       compare source-truth returned PASS under --strategy
+  no-manual-edits-since   no kubectl-* writer touched managedFields after --since
 
 Subject is a positional argument in the form <kind>/<name>.
 
 Predicate auto-detection priority (when --predicate is not passed):
-  1. Argo / Flux / ConfigHub-via-GitOps owner → applied-matches-spec
-  2. Otherwise → INCONCLUSIVE + omission (no auto-detected predicate)
+  1. Argo / Flux / ConfigHub-via-GitOps owner WITH a resolvable git anchor
+     → applied-matches-spec
+  2. --strategy provided → source-truth-pass
+  3. --since provided    → no-manual-edits-since
+  4. Otherwise → INCONCLUSIVE + omission (no auto-detected predicate)
 
 Examples:
   cub-scout receipt verify deploy/api -n prod
   cub-scout receipt verify deploy/api -n prod --at-commit abc123
+  cub-scout receipt verify deploy/api -n prod --strategy git-argo
+  cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
   cub-scout receipt verify deploy/api -n prod --predicate applied-matches-spec --format json --out api.receipt.json
 `,
 	Args: cobra.ExactArgs(1),
@@ -77,8 +95,10 @@ func init() {
 	receiptCmd.AddCommand(receiptVerifyCmd)
 
 	receiptVerifyCmd.Flags().StringVarP(&receiptNamespace, "namespace", "n", "", "Namespace of the resource (required for namespaced kinds)")
-	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 batch 1 supports applied-matches-spec only.")
+	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 supports applied-matches-spec, source-truth-pass, no-manual-edits-since.")
 	receiptVerifyCmd.Flags().StringVar(&receiptAtCommit, "at-commit", "", "Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence.")
+	receiptVerifyCmd.Flags().StringVar(&receiptStrategy, "strategy", "", "Source-truth strategy for source-truth-pass (e.g. git-argo). cub-scout does not infer the strategy.")
+	receiptVerifyCmd.Flags().StringVar(&receiptSince, "since", "", "RFC 3339 cutoff for no-manual-edits-since (e.g. 2026-05-22T00:00:00Z).")
 	receiptVerifyCmd.Flags().StringVar(&receiptFormat, "format", "ascii", "Output format: ascii | json")
 	receiptVerifyCmd.Flags().StringVar(&receiptOut, "out", "", "Write the receipt to this file path (also printed to stdout in the chosen format)")
 }
@@ -87,6 +107,28 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 	format := strings.ToLower(strings.TrimSpace(receiptFormat))
 	if format != "ascii" && format != "json" {
 		return fmt.Errorf("invalid --format %q (valid: ascii, json)", receiptFormat)
+	}
+
+	// Parse --since (RFC 3339). Empty means "not provided".
+	var since time.Time
+	if raw := strings.TrimSpace(receiptSince); raw != "" {
+		parsed, perr := time.Parse(time.RFC3339, raw)
+		if perr != nil {
+			return fmt.Errorf("invalid --since %q (expected RFC 3339, e.g. 2026-05-22T00:00:00Z): %w", raw, perr)
+		}
+		since = parsed
+	}
+
+	// Reject contradictory predicate+signal pairs upfront. cub-scout
+	// won't silently demote an explicit --predicate to "INCONCLUSIVE
+	// because you forgot the matching signal" — the CLI tells the user
+	// to fix it.
+	predicateExplicit := agent.PredicateName(strings.TrimSpace(receiptPredicate))
+	if predicateExplicit == agent.PredicateSourceTruthPass && strings.TrimSpace(receiptStrategy) == "" {
+		return fmt.Errorf("--predicate source-truth-pass requires --strategy (cub-scout does not infer the delivery strategy)")
+	}
+	if predicateExplicit == agent.PredicateNoManualEditsSince && since.IsZero() {
+		return fmt.Errorf("--predicate no-manual-edits-since requires --since <RFC3339 timestamp>")
 	}
 
 	kindRaw, name, ok := parseKindName(args[0])
@@ -128,6 +170,20 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 		GitSource:   gitSource,
 	}
 
+	// source-truth evidence is populated only when the caller signaled
+	// the source-truth-pass predicate (explicitly or via --strategy
+	// auto-detect). The runner refuses to silently derive source-truth
+	// for any receipt — that would attach evidence the consumer may not
+	// have asked for. Source-truth requires connected mode, so this
+	// path is connected-only by definition.
+	if strategy := strings.TrimSpace(receiptStrategy); strategy != "" {
+		stEvidence, stErr := collectSourceTruthForReceiptFn(ctx, kind, name, ns, strategy)
+		if stErr != nil {
+			return fmt.Errorf("collect source-truth evidence: %w", stErr)
+		}
+		evidence.SourceTruth = stEvidence
+	}
+
 	// 3. Build the spec anchor. If --at-commit is set, override the
 	// revision; otherwise use the controller-resolved anchor as both
 	// the spec and the evidence (the anchor-match check is then trivially
@@ -159,10 +215,12 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 			Namespace: ns,
 		},
 		Owner:         owner,
-		PredicateName: agent.PredicateName(strings.TrimSpace(receiptPredicate)),
+		PredicateName: predicateExplicit,
 		Spec:          spec,
 		Evidence:      evidence,
 		Connected:     connected,
+		Strategy:      strings.TrimSpace(receiptStrategy),
+		Since:         since,
 		Verifier: agent.Verifier{
 			Tool:    "cub-scout",
 			Version: BuildTag,
@@ -227,3 +285,39 @@ func loadReceiptLive(ctx context.Context, kind, name, namespace string) (*unstru
 
 // parseKindName lives in navigation_hints.go; we reuse its (kind, name, ok)
 // signature here.
+
+// collectSourceTruthForReceipt runs the same three-surface derivation
+// that `cub-scout compare source-truth` runs and returns the structured
+// evidence body. Read-only by construction: every helper here is a Get
+// against the cluster / ConfigHub / controller tracers; nothing writes.
+//
+// Errors are returned only when the caller's input is bad (unknown
+// strategy, runtime fetch failure with no graceful fallback). Soft
+// failures — missing ConfigHub linkage, controller CLI absent — are
+// converted into nil surfaces and surface through Derive as BLOCK /
+// WATCH / proof_gaps. The receipt orchestrator then mirrors those
+// proof_gaps into omissions[].
+func collectSourceTruthForReceipt(ctx context.Context, kind, name, namespace, strategyStr string) (*agent.SourceTruthEvidence, error) {
+	strategy, ok := agent.ParseStrategy(strategyStr)
+	if !ok {
+		return nil, fmt.Errorf("unknown source-truth strategy %q (valid: %v)", strategyStr, agent.AllStrategies())
+	}
+
+	runtime, runtimeObj, runtimeErr := collectRuntimeSurface(ctx, kind, name, namespace)
+	if runtimeErr != nil {
+		// Runtime unfetchable → BLOCKED evidence (the same shape
+		// `compare source-truth` produces in this case).
+		ev := agent.Derive(strategy, agent.SourceTruthSurfaces{})
+		return &ev, nil
+	}
+
+	chSurface, _ := collectConfigHubSurface(ctx, runtimeObj)
+	ctrlSurface := collectControllerSurface(ctx, strategy, kind, name, namespace)
+
+	ev := agent.Derive(strategy, agent.SourceTruthSurfaces{
+		ConfigHub:  chSurface,
+		Controller: ctrlSurface,
+		Runtime:    runtime,
+	})
+	return &ev, nil
+}

--- a/cmd/cub-scout/receipt_batch2_test.go
+++ b/cmd/cub-scout/receipt_batch2_test.go
@@ -1,0 +1,318 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// withFakeSourceTruth installs a fake source-truth collector and restores
+// the production one on cleanup. Lets the source-truth-pass CLI path run
+// without a real ConfigHub or controller CLI.
+func withFakeSourceTruth(t *testing.T, ev *agent.SourceTruthEvidence) {
+	t.Helper()
+	prev := collectSourceTruthForReceiptFn
+	collectSourceTruthForReceiptFn = func(_ context.Context, _, _, _, _ string) (*agent.SourceTruthEvidence, error) {
+		return ev, nil
+	}
+	t.Cleanup(func() { collectSourceTruthForReceiptFn = prev })
+}
+
+// resetReceiptBatch2Flags zeros out the batch-2 receipt flags (strategy,
+// since) so consecutive tests don't bleed state.
+func resetReceiptBatch2Flags(t *testing.T) {
+	t.Helper()
+	resetReceiptFlags(t)
+	prevStrategy, prevSince := receiptStrategy, receiptSince
+	receiptStrategy = ""
+	receiptSince = ""
+	t.Cleanup(func() {
+		receiptStrategy = prevStrategy
+		receiptSince = prevSince
+	})
+}
+
+func makeLiveWithManagedFieldsForCLI(entries []metav1.ManagedFieldsEntry) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "prod",
+			},
+			"spec": map[string]interface{}{"replicas": int64(3)},
+		},
+	}
+	obj.SetManagedFields(entries)
+	return obj
+}
+
+// --- source-truth-pass path ------------------------------------------
+
+func TestReceiptVerify_SourceTruthPass_HappyPath(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyGitArgo.Human(),
+		Status:           agent.StatusPASS,
+		SourceTruth:      agent.VerdictAGREED,
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--strategy", "git-argo",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --strategy returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateSourceTruthPass) {
+		t.Errorf("predicateName: got %q, want source-truth-pass", stmt.Predicate.PredicateName)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictPASS {
+		t.Errorf("verdict: got %q, want PASS", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.SourceTruth == nil {
+		t.Fatal("source-truth-pass receipt must carry SourceTruth evidence")
+	}
+	if stmt.Predicate.Evidence.SourceTruth.Status != agent.StatusPASS {
+		t.Errorf("SourceTruth.Status: got %q, want PASS", stmt.Predicate.Evidence.SourceTruth.Status)
+	}
+	if err := agent.VerifyStatementFingerprint(stmt); err != nil {
+		t.Errorf("fingerprint integrity check failed: %v", err)
+	}
+}
+
+func TestReceiptVerify_SourceTruthPass_ExplicitPredicateNoStrategy_Errors(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--predicate", "source-truth-pass",
+	})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --predicate source-truth-pass without --strategy")
+	}
+	if !strings.Contains(err.Error(), "--strategy") {
+		t.Errorf("error must point at the missing --strategy flag; got %v", err)
+	}
+}
+
+func TestReceiptVerify_SourceTruthPass_StrategyMismatch_BLOCK(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	// Receipt is invoked with --strategy git-argo, but the evidence
+	// derivation came back with confighub-oci-argo. The predicate must
+	// emit BLOCK + OmissionStrategyMismatch.
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyConfigHubOCIArgo.Human(),
+		Status:           agent.StatusPASS,
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--strategy", "git-argo",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Errorf("strategy mismatch must produce BLOCK; got %q", stmt.Predicate.Verdict)
+	}
+	found := false
+	for _, o := range stmt.Predicate.Omissions {
+		if o.Missing == agent.OmissionStrategyMismatch {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected OmissionStrategyMismatch; got %v", stmt.Predicate.Omissions)
+	}
+}
+
+// --- no-manual-edits-since path --------------------------------------
+
+func TestReceiptVerify_NoManualEditsSince_HappyPath_PASS(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	cutoff := "2026-05-22T00:00:00Z"
+	before := metav1.NewTime(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
+	withFakeReceiptLoader(t, makeLiveWithManagedFieldsForCLI([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &before},
+	}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--since", cutoff,
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --since returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateNoManualEditsSince) {
+		t.Errorf("predicateName: got %q, want no-manual-edits-since", stmt.Predicate.PredicateName)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictPASS {
+		t.Errorf("controller-only managedFields must produce PASS; got %q", stmt.Predicate.Verdict)
+	}
+}
+
+func TestReceiptVerify_NoManualEditsSince_KubectlEdit_BLOCK(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+	withFakeReceiptLoader(t, makeLiveWithManagedFieldsForCLI([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+		{Manager: "kubectl-edit", Operation: metav1.ManagedFieldsOperationUpdate, Time: &after},
+	}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--since", "2026-05-22T00:00:00Z",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --since returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Errorf("kubectl-edit after cutoff must produce BLOCK; got %q", stmt.Predicate.Verdict)
+	}
+}
+
+func TestReceiptVerify_NoManualEditsSince_BadCutoff_Errors(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--since", "yesterday-ish",
+	})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for malformed --since")
+	}
+	if !strings.Contains(err.Error(), "invalid --since") {
+		t.Errorf("error must explain the parse failure; got %v", err)
+	}
+}
+
+func TestReceiptVerify_NoManualEditsSince_ExplicitPredicateNoSince_Errors(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--predicate", "no-manual-edits-since",
+	})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --predicate no-manual-edits-since without --since")
+	}
+	if !strings.Contains(err.Error(), "--since") {
+		t.Errorf("error must point at the missing --since flag; got %v", err)
+	}
+}
+
+// --- auto-detect (CLI surface) ----------------------------------------
+
+func TestReceiptVerify_AutoDetect_StrategyPicksSourceTruthPass(t *testing.T) {
+	// No --predicate. --strategy alone must auto-detect source-truth-pass.
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyGitArgo.Human(),
+		Status:           agent.StatusPASS,
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--strategy", "git-argo",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateSourceTruthPass) {
+		t.Errorf("predicateName: got %q, want source-truth-pass (auto-detect via --strategy)", stmt.Predicate.PredicateName)
+	}
+}
+
+func TestReceiptVerify_AutoDetect_SincePicksNoManualEditsSince(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--since", "2026-05-22T00:00:00Z",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateNoManualEditsSince) {
+		t.Errorf("predicateName: got %q, want no-manual-edits-since (auto-detect via --since)", stmt.Predicate.PredicateName)
+	}
+}

--- a/cmd/cub-scout/receipt_examples_test.go
+++ b/cmd/cub-scout/receipt_examples_test.go
@@ -14,14 +14,15 @@ import (
 )
 
 // TestReceiptExamplesAreFresh re-runs the gen-receipt-examples tool and
-// compares its output to the committed files under
-// examples/receipts/applied-matches-spec. Drift fails the build — the
-// example receipts are a contract surface, not loose docs.
+// compares its output to the committed files under examples/receipts/.
+// Drift fails the build — the example receipts are a contract surface,
+// not loose docs. Both batch 1 (applied-matches-spec) and batch 2
+// (source-truth-pass, no-manual-edits-since) subdirectories are covered.
 //
 // To regenerate after an intentional change to the generator or to a
 // pkg/agent type that changes the wire format:
 //
-//	go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec
+//	go run ./tools/gen-receipt-examples examples/receipts
 func TestReceiptExamplesAreFresh(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("go run via exec is awkward on Windows; the linux/macos CI matrix catches drift")
@@ -37,65 +38,78 @@ func TestReceiptExamplesAreFresh(t *testing.T) {
 		t.Fatalf("regenerate examples: %v\noutput:\n%s", err, out)
 	}
 
-	committedDir := filepath.Join(repoRoot, "examples", "receipts", "applied-matches-spec")
-	committedEntries, err := os.ReadDir(committedDir)
-	if err != nil {
-		t.Fatalf("read committed dir %s: %v", committedDir, err)
+	// Each receipt-predicate subdirectory under examples/receipts/ is a
+	// contract surface. The generator writes the same layout into the
+	// tmp dir; walk both and diff.
+	predicateDirs := []string{
+		"applied-matches-spec",
+		"source-truth-pass",
+		"no-manual-edits-since",
 	}
 
-	var committedJSON []string
-	for _, e := range committedEntries {
-		if strings.HasSuffix(e.Name(), ".json") {
-			committedJSON = append(committedJSON, e.Name())
-		}
-	}
-	if len(committedJSON) == 0 {
-		t.Fatalf("no .json files in %s; the example directory must contain receipts", committedDir)
-	}
+	for _, predicateDir := range predicateDirs {
+		committedDir := filepath.Join(repoRoot, "examples", "receipts", predicateDir)
+		regenDir := filepath.Join(tmp, predicateDir)
 
-	regenEntries, err := os.ReadDir(tmp)
-	if err != nil {
-		t.Fatalf("read tmp output dir: %v", err)
-	}
-	regenSet := map[string]bool{}
-	for _, e := range regenEntries {
-		if strings.HasSuffix(e.Name(), ".json") {
-			regenSet[e.Name()] = true
-		}
-	}
-
-	// Same set of files (no rename / addition / deletion drift).
-	for _, name := range committedJSON {
-		if !regenSet[name] {
-			t.Errorf("committed file %q is no longer produced by the generator; regenerate or update the generator", name)
-		}
-	}
-	for name := range regenSet {
-		found := false
-		for _, c := range committedJSON {
-			if c == name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("generator produces %q but it is not committed; run `go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec`", name)
-		}
-	}
-
-	// Byte-for-byte content match.
-	for _, name := range committedJSON {
-		got, err := os.ReadFile(filepath.Join(tmp, name))
+		committedEntries, err := os.ReadDir(committedDir)
 		if err != nil {
-			continue // file-set mismatch already reported above
-		}
-		want, err := os.ReadFile(filepath.Join(committedDir, name))
-		if err != nil {
-			t.Errorf("read committed %s: %v", name, err)
+			t.Errorf("read committed dir %s: %v", committedDir, err)
 			continue
 		}
-		if !bytes.Equal(got, want) {
-			t.Errorf("committed %s differs from generator output; run `go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec`", name)
+		var committedJSON []string
+		for _, e := range committedEntries {
+			if strings.HasSuffix(e.Name(), ".json") {
+				committedJSON = append(committedJSON, e.Name())
+			}
+		}
+		if len(committedJSON) == 0 {
+			t.Errorf("no .json files in %s; the example directory must contain receipts", committedDir)
+			continue
+		}
+
+		regenEntries, err := os.ReadDir(regenDir)
+		if err != nil {
+			t.Errorf("read regen dir %s: %v", regenDir, err)
+			continue
+		}
+		regenSet := map[string]bool{}
+		for _, e := range regenEntries {
+			if strings.HasSuffix(e.Name(), ".json") {
+				regenSet[e.Name()] = true
+			}
+		}
+
+		for _, name := range committedJSON {
+			if !regenSet[name] {
+				t.Errorf("[%s] committed file %q is no longer produced by the generator; regenerate or update the generator", predicateDir, name)
+			}
+		}
+		for name := range regenSet {
+			found := false
+			for _, c := range committedJSON {
+				if c == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("[%s] generator produces %q but it is not committed; run `go run ./tools/gen-receipt-examples examples/receipts`", predicateDir, name)
+			}
+		}
+
+		for _, name := range committedJSON {
+			got, err := os.ReadFile(filepath.Join(regenDir, name))
+			if err != nil {
+				continue
+			}
+			want, err := os.ReadFile(filepath.Join(committedDir, name))
+			if err != nil {
+				t.Errorf("read committed %s/%s: %v", predicateDir, name, err)
+				continue
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("committed %s/%s differs from generator output; run `go run ./tools/gen-receipt-examples examples/receipts`", predicateDir, name)
+			}
 		}
 	}
 }

--- a/cmd/cub-scout/receipt_render.go
+++ b/cmd/cub-scout/receipt_render.go
@@ -87,6 +87,22 @@ func renderReceiptASCII(stmt agent.Statement) string {
 		}
 	}
 
+	// Source-truth evidence (when present — only the source-truth-pass
+	// path attaches this surface).
+	if pred.Evidence.SourceTruth != nil {
+		st := pred.Evidence.SourceTruth
+		b.WriteString("\nEvidence (source-truth)\n")
+		fmt.Fprintf(&b, "  strategy:    %s\n", st.DeclaredStrategy)
+		fmt.Fprintf(&b, "  status:      %s\n", st.Status)
+		fmt.Fprintf(&b, "  verdict:     %s\n", st.SourceTruth)
+		if st.Outlier != "" {
+			fmt.Fprintf(&b, "  outlier:     %s\n", st.Outlier)
+		}
+		if len(st.ProofGaps) > 0 {
+			fmt.Fprintf(&b, "  proof_gaps:  %s\n", strings.Join(st.ProofGaps, ", "))
+		}
+	}
+
 	// Omissions are critical — they convert silent PASS into honest PASS.
 	if len(pred.Omissions) > 0 {
 		b.WriteString("\nOmissions (deliberate non-claims)\n")

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2460,19 +2460,47 @@ cub-scout receipt verify <kind>/<name> -n <namespace> [flags]
 | Flag | Description |
 |------|-------------|
 | `-n, --namespace` | Namespace of the resource (required for namespaced kinds) |
-| `--predicate` | Predicate to evaluate. v1 batch 1 supports `applied-matches-spec`. Empty triggers auto-detect from owner. |
-| `--at-commit` | Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence. |
+| `--predicate` | Predicate to evaluate. v1 supports `applied-matches-spec`, `source-truth-pass`, `no-manual-edits-since`. Empty triggers auto-detect from owner + signals. |
+| `--at-commit` | Override the spec anchor revision (Git SHA) for `applied-matches-spec`. When empty, the controller-resolved anchor is used as both the spec and the evidence. |
+| `--strategy` | Source-truth strategy for `source-truth-pass` (e.g. `git-argo`, `confighub-oci-flux`, `helm-argo`). cub-scout does not infer the strategy. |
+| `--since` | RFC 3339 cutoff timestamp for `no-manual-edits-since` (e.g. `2026-05-22T00:00:00Z`). |
 | `--format` | Output format: `ascii` (default, one-screen human summary) or `json` (canonical in-toto Statement v1 envelope) |
 | `--out` | Write the receipt to this file path. Always JSON regardless of `--format` — disk is the long-lived artifact. |
+
+v1 predicates:
+
+| Predicate | Required | What it claims |
+|-----------|----------|----------------|
+| `applied-matches-spec` | Argo / Flux / ConfigHub owner + controller-resolved git anchor | LIVE matches the controller-resolved git anchor |
+| `source-truth-pass` | `--strategy <name>` + connected-mode ConfigHub auth | `compare source-truth` under the declared strategy returns PASS (mirrors Status into receipt Verdict) |
+| `no-manual-edits-since` | `--since <RFC3339 timestamp>` | No interactive (`kubectl-*`) writer touched `managedFields` after the cutoff |
+
+Auto-detection priority (when `--predicate` is not passed):
+
+1. Argo / Flux / ConfigHub owner WITH a resolvable git anchor → `applied-matches-spec`
+2. `--strategy` provided → `source-truth-pass`
+3. `--since` provided → `no-manual-edits-since`
+4. Otherwise → INCONCLUSIVE + `auto-detected-predicate` omission
+
+The CLI also rejects contradictory pairs upfront: `--predicate
+source-truth-pass` without `--strategy`, or `--predicate
+no-manual-edits-since` without `--since`, return an error rather than
+silently demoting to INCONCLUSIVE.
 
 Examples:
 
 ```bash
-# Standalone-mode verification — works without ConfigHub auth.
+# applied-matches-spec — standalone-mode verification (no ConfigHub auth required).
 cub-scout receipt verify deploy/api -n prod
 
-# Pin to an explicit revision (e.g., the SHA in a release ticket).
+# applied-matches-spec — pin to an explicit revision (e.g., the SHA in a release ticket).
 cub-scout receipt verify deploy/api -n prod --at-commit abc123def456
+
+# source-truth-pass — declared strategy, connected mode.
+cub-scout receipt verify deploy/api -n prod --strategy git-argo
+
+# no-manual-edits-since — cutoff at midnight UTC today.
+cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
 
 # Write the canonical JSON form to disk for audit attachment.
 cub-scout receipt verify deploy/api -n prod --format json --out api.receipt.json

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -678,30 +678,38 @@ reason string.
 | `BLOCK` | Evidence contradicts the claim |
 | `INCONCLUSIVE` | Evidence is missing or unavailable; always carries one or more `omissions[]` entries explaining what's missing |
 
-### v1 Batch 1 Predicates
+### v1 Predicates
 
-| Predicate | Verdict Logic |
-|-----------|---------------|
-| `applied-matches-spec` | `Spec missing` or `GitSource missing` → INCONCLUSIVE + `OmissionGitSourceAnchor`. `Anchor mismatch (repoUrl/revision/path)` → BLOCK. `Cause = manual-edit` → BLOCK. `Cause = controller-drift` → PASS. `Cause = unknown` or unrecognized → INCONCLUSIVE + `OmissionManagedFields`. |
-
-`source-truth-pass` and `no-manual-edits-since` land in batch 2.
+| Predicate | Required signals | Verdict Logic |
+|-----------|------------------|---------------|
+| `applied-matches-spec` | Controller-resolved `gitSource` on the resource | `Spec missing` or `GitSource missing` → INCONCLUSIVE + `OmissionGitSourceAnchor`. `Anchor mismatch (repoUrl/revision/path)` → BLOCK. `Cause = manual-edit` → BLOCK. `Cause = controller-drift` → PASS. `Cause = unknown` or unrecognized → INCONCLUSIVE + `OmissionManagedFields`. |
+| `source-truth-pass` | `--strategy` (one of nine) + connected-mode ConfigHub auth | `--strategy` empty → INCONCLUSIVE + `OmissionStrategyMissing`. No source-truth evidence body → INCONCLUSIVE + `OmissionSourceTruthEvidence`. Strategy mismatch between caller and evidence → BLOCK + `OmissionStrategyMismatch`. Otherwise: Status PASS → PASS, WATCH → WATCH, BLOCK → BLOCK, ASK → INCONCLUSIVE. Source-truth `proof_gaps[]` are mirrored into `omissions[]` under `source-truth-complete` regardless of verdict. |
+| `no-manual-edits-since` | `--since <RFC3339>` cutoff | `--since` zero → INCONCLUSIVE + `OmissionSinceMissing`. Live nil or no managedFields → INCONCLUSIVE + `OmissionManagedFields`. Any interactive (`kubectl-*`) manager with `Time > since` → BLOCK. Any interactive manager with nil `Time` → INCONCLUSIVE + `OmissionManagedFieldsTime`. Otherwise → PASS. |
 
 ### Auto-Detection Priority
 
-When `--predicate` is not passed, cub-scout picks one based on detected
-ownership AND the resolvability of the git anchor:
+When `--predicate` is not passed, cub-scout picks one from these signals
+in priority order:
 
 1. `OwnerArgo` / `OwnerFlux` / `OwnerConfigHub` **with** a resolved git
    anchor (`evidence.gitSource` non-nil) → `applied-matches-spec`
-2. Same owners **without** a resolved git anchor → `""` (no predicate) +
-   `OmissionAutoDetectedPredicate` — the predicate evaluator could only
-   emit INCONCLUSIVE anyway, so we record the *missing default* rather
-   than masking the auto-detect-declined-here case as a different
-   omission.
-3. Other owners → `""` + `OmissionAutoDetectedPredicate`.
+2. `--strategy` provided → `source-truth-pass`
+3. `--since` provided → `no-manual-edits-since`
+4. Same owners **without** a resolved git anchor, no other signals → `""`
+   (no predicate) + `OmissionAutoDetectedPredicate` — the predicate
+   evaluator could only emit INCONCLUSIVE anyway, so we record the
+   *missing default* rather than masking the auto-detect-declined-here
+   case as a different omission.
+5. Other owners with no signals → `""` + `OmissionAutoDetectedPredicate`.
 
 The result is always an INCONCLUSIVE receipt when auto-detect declines;
 the omission entry names exactly which signal was missing.
+
+Explicit `--predicate` always wins over auto-detect. The CLI also
+rejects contradictory pairs upfront: `--predicate source-truth-pass`
+without `--strategy` errors, and `--predicate no-manual-edits-since`
+without `--since` errors — silently demoting either to INCONCLUSIVE
+would hide the operator's intent from the receipt.
 
 ### Omissions
 
@@ -711,11 +719,17 @@ Each entry explicitly converts a silent PASS into an honest PASS:
 | Omission `missing` | Meaning |
 |--------------------|---------|
 | `confighub-unit-subject` | No ConfigHub unit subject available (standalone mode, or connected mode but no linkage) |
-| `managedFields` | Attribution layer returned `cause:unknown` or an unrecognized cause |
+| `managedFields` | Attribution layer returned `cause:unknown`, or no-manual-edits-since saw no entries on the live object |
+| `managedFields-time` | An interactive `managedFields` entry has nil `Time`; no-manual-edits-since cannot place it on the timeline |
 | `git-source-anchor` | No spec anchor or no controller-resolved git anchor |
-| `auto-detected-predicate` | Owner has no v1 default predicate; `--predicate` must be passed |
+| `auto-detected-predicate` | No signal supported a default predicate; pass `--predicate`, `--strategy`, or `--since` |
+| `strategy` | source-truth-pass invoked without `--strategy`; cub-scout does not infer delivery strategy |
+| `strategy-mismatch` | The receipt's declared strategy disagrees with the strategy recorded in the source-truth evidence body |
+| `source-truth-evidence` | source-truth-pass invoked but no source-truth evidence body was attached |
+| `source-truth-complete` | A proof gap from `compare source-truth` (e.g. `runtime.helm_chart_anchor`); mirrored into `omissions[]` regardless of receipt verdict |
+| `since` | no-manual-edits-since invoked without `--since`; cub-scout does not invent a cutoff |
 | `next-step-allowed-action` | A nextStep with mutating `actionType` was dropped at receipt-emit time |
-| `next-step-allowed-command` | A nextStep with mutating `nextCommand` (apply/edit/patch/delete/sync/create/update/replace/scale/rollout/reconcile) was dropped |
+| `next-step-allowed-command` | A nextStep with mutating `nextCommand` (apply/edit/patch/delete/sync/create/update/replace/scale/rollout/reconcile/annotate/label/set/exec/debug/`helm install`/`helm upgrade`) was dropped |
 
 ### Read-Only Triad Lock
 

--- a/examples/receipts/README.md
+++ b/examples/receipts/README.md
@@ -12,20 +12,42 @@ Wire format: **in-toto Statement v1** envelope (`_type =
 DSSE signing wrapped in Sigstore Bundle v0.3 (purely additive — no
 envelope change).
 
-## v1 Batch 1: `applied-matches-spec`
+## v1 Predicates
 
-See [`applied-matches-spec/`](./applied-matches-spec/) for the four
-canonical example receipts (PASS, BLOCK on manual-edit, BLOCK on anchor
-mismatch, INCONCLUSIVE) and the contract reference.
+| Predicate | Inputs | Verdict semantics |
+|-----------|--------|-------------------|
+| [`applied-matches-spec`](./applied-matches-spec/) | Argo / Flux / ConfigHub owner + controller-resolved git anchor, optional `--at-commit` | LIVE matches the controller-resolved git anchor (PASS on controller-drift cause, BLOCK on manual-edit / anchor mismatch, INCONCLUSIVE on missing anchor) |
+| [`source-truth-pass`](./source-truth-pass/) | Explicit `--strategy <name>` (one of 9 strategies), connected-mode ConfigHub auth | Mirrors `compare source-truth` Status → Verdict (PASS / WATCH / BLOCK / INCONCLUSIVE). Strategy mismatch between caller and evidence → BLOCK + `OmissionStrategyMismatch`. |
+| [`no-manual-edits-since`](./no-manual-edits-since/) | `--since <RFC3339 timestamp>` cutoff | PASS when no interactive (`kubectl-*`) writer touched `metadata.managedFields` after the cutoff; BLOCK on any late interactive write; INCONCLUSIVE on missing managedFields or nil-Time entries. |
+
+Each subdirectory ships canonical example receipts produced
+deterministically by [`tools/gen-receipt-examples`](../../tools/gen-receipt-examples/)
+and validated by `TestReceiptExamplesAreFresh`.
+
+## Auto-Detection Priority
+
+When `--predicate` is not passed, cub-scout picks one from these signals:
+
+1. Argo / Flux / ConfigHub owner WITH a resolvable git anchor →
+   `applied-matches-spec`
+2. `--strategy` provided → `source-truth-pass`
+3. `--since` provided → `no-manual-edits-since`
+4. Otherwise → INCONCLUSIVE + `OmissionAutoDetectedPredicate`
 
 ## Generating Your Own
 
 ```bash
-# Standalone-mode receipt — works without ConfigHub auth.
+# applied-matches-spec — standalone-mode receipt (works without ConfigHub auth).
 ./cub-scout receipt verify deploy/api -n prod
 
-# Pin to an explicit revision (e.g., the SHA in a release ticket).
+# applied-matches-spec — pin to an explicit revision (e.g., the SHA in a release ticket).
 ./cub-scout receipt verify deploy/api -n prod --at-commit abc123def456
+
+# source-truth-pass — connected mode, declared strategy.
+./cub-scout receipt verify deploy/api -n prod --strategy git-argo
+
+# no-manual-edits-since — cutoff before today.
+./cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
 
 # Write the canonical JSON form to disk for audit attachment.
 ./cub-scout receipt verify deploy/api -n prod --format json --out api.receipt.json

--- a/examples/receipts/no-manual-edits-since/README.md
+++ b/examples/receipts/no-manual-edits-since/README.md
@@ -1,0 +1,81 @@
+# Receipt Example: `no-manual-edits-since`
+
+`no-manual-edits-since` verifies that no interactive (`kubectl-*`)
+writer touched `metadata.managedFields` after a given cutoff
+timestamp. It's the receipt-shaped complement to the attribution
+layer's `manual-edit` cause classification — useful for release-gate
+checks like "no operator emergency-edited this Deployment after the
+freeze started."
+
+cub-scout **never invents a cutoff** — you must pass `--since` in
+RFC 3339 form.
+
+## Quick Start
+
+```bash
+# "No manual edits after midnight UTC today."
+./cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
+
+# Write the canonical JSON form to disk for audit attachment.
+./cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z --format json --out api.no-edits.receipt.json
+```
+
+## Verdict Logic
+
+The predicate walks `live.metadata.managedFields` and classifies each
+entry by manager:
+
+- **Controller writer** (e.g. `argocd-controller`, `kustomize-controller`,
+  `helm-controller`) → ignored. We don't claim anything about
+  controller writes; only about interactive ones.
+- **Interactive writer** (any `kubectl-*` manager, plus the verified
+  enumeration in `pkg/agent/manager_strings.go`) → checked against
+  the cutoff:
+  - `e.Time > since` → **BLOCK**. A human bypassed the GitOps loop
+    after the freeze.
+  - `e.Time <= since` → ignored. Old edit, already accounted for.
+  - `e.Time == nil` → **INCONCLUSIVE** + `OmissionManagedFieldsTime`.
+    We cannot place the entry on the timeline and refuse to claim
+    "no manual edits since T" without proof.
+- **Unknown writer** (not in the verified manager-string enumeration)
+  → ignored. Conservative — same `parse, don't guess` rule the
+  attribution layer uses.
+
+If no managedFields exist at all → **INCONCLUSIVE** +
+`OmissionManagedFields`. Old K8s versions, admission-webhook-stripped
+resources, or replayed objects all degrade gracefully rather than
+producing false PASS.
+
+## Caveat: managedFields Is Best-Effort
+
+K8s `managedFields` is the only field-level evidence cub-scout has in
+standalone mode. The predicate inherits its limitations:
+
+- An admission webhook can strip the entries.
+- A `kubectl apply --server-side` with a custom field manager can mask
+  the writer identity.
+- A namespace migration can rewrite the entries with a fresh Time.
+
+In all these cases the predicate emits INCONCLUSIVE rather than
+fabricating a PASS. See `docs/proposals/receipts-way-forward.md` § "field-manager evidence caveat" for the full discussion.
+
+## Example Files
+
+### `pass-controller-only.json` — PASS
+
+`argocd-controller` is the only writer; its Time predates the cutoff.
+No interactive writer present, so verdict: PASS.
+
+### `block-kubectl-edit.json` — BLOCK
+
+Same Deployment, but a `kubectl-edit` entry now appears with Time
+after the cutoff. Verdict: BLOCK. The `nextStep` reason names the
+violating manager and the offending timestamp so the operator can
+investigate in `kubectl get --show-managed-fields`.
+
+## References
+
+- Parent issue: [`confighub/cub-scout#446`](https://github.com/confighub/cub-scout/issues/446) — Receipt capability
+- Manager-string enumeration: `pkg/agent/manager_strings.go`
+- Attribution layer (companion evidence): [`examples/drift/mutation-cause-attribution/`](../../drift/mutation-cause-attribution/)
+- Implementation: `pkg/agent/receipt_predicates.go` `EvaluateNoManualEditsSince`

--- a/examples/receipts/no-manual-edits-since/block-kubectl-edit.json
+++ b/examples/receipts/no-manual-edits-since/block-kubectl-edit.json
@@ -1,0 +1,47 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "no manual edits to Deployment/api in prod since 2026-05-22T00:00:00Z",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "no-manual-edits-since",
+    "verdict": "BLOCK",
+    "evidence": {},
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "interactive writer wrote managedFields after the cutoff (2026-05-22T00:00:00Z): kubectl-edit@2026-05-22T12:00:00Z — investigate the unplanned edit before any apply",
+        "nextCommand": "kubectl get --show-managed-fields",
+        "nextSurface": "kubectl"
+      }
+    ],
+    "fingerprint": "sha256:af4c1c1384823207457e9892ae28d548c924a595e8dcccce51d58b2c1c6c3fc0"
+  }
+}

--- a/examples/receipts/no-manual-edits-since/pass-controller-only.json
+++ b/examples/receipts/no-manual-edits-since/pass-controller-only.json
@@ -1,0 +1,47 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "no manual edits to Deployment/api in prod since 2026-05-22T00:00:00Z",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "no-manual-edits-since",
+    "verdict": "PASS",
+    "evidence": {},
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "no interactive writer touched managedFields after 2026-05-22T00:00:00Z",
+        "nextCommand": "cub-scout explain Deployment/api -n prod",
+        "nextSurface": "cub-scout"
+      }
+    ],
+    "fingerprint": "sha256:07ff1d0c34d17c4ac4140ce913cab45140e4f694535a743bc193da9add589eeb"
+  }
+}

--- a/examples/receipts/source-truth-pass/README.md
+++ b/examples/receipts/source-truth-pass/README.md
@@ -1,0 +1,77 @@
+# Receipt Example: `source-truth-pass`
+
+`source-truth-pass` wraps cub-scout's existing `compare source-truth`
+derivation into a typed, fingerprinted receipt. The predicate verifies
+that the three observed surfaces (ConfigHub / controller / runtime) agree
+under an explicitly-declared delivery strategy.
+
+cub-scout **never infers a strategy** — you must pass `--strategy`. The
+nine v1 strategies (see [source-truth strategies reference](../../../docs/reference/json-contracts.md))
+cover the common Argo / Flux / Helm / OCI / Kustomize combinations.
+
+## Quick Start
+
+```bash
+# Vanilla Git -> Argo -> Kubernetes.
+./cub-scout receipt verify deploy/api -n prod --strategy git-argo
+
+# ConfigHub -> OCI -> Argo -> Kubernetes.
+./cub-scout receipt verify deploy/api -n prod --strategy confighub-oci-argo
+
+# Write the canonical JSON form to disk for audit attachment.
+./cub-scout receipt verify deploy/api -n prod --strategy git-argo --format json --out api.source-truth.receipt.json
+```
+
+## Connected-Mode Required
+
+`source-truth-pass` reads the ConfigHub surface via the `cub` CLI. The
+predicate requires connected mode (`cub auth login` or
+`CONFIGHUB_API_KEY`). Standalone-mode runs decline with an INCONCLUSIVE
+verdict + the source-truth proof gaps mirrored into `omissions[]`.
+
+## Verdict Mapping
+
+The source-truth derivation produces a four-valued **Status** (PASS /
+WATCH / BLOCK / ASK). The receipt maps these directly to receipt-level
+verdicts:
+
+| `compare source-truth` Status | Receipt Verdict |
+|-------------------------------|-----------------|
+| `PASS`  | `PASS` |
+| `WATCH` | `WATCH` |
+| `BLOCK` | `BLOCK` |
+| `ASK`   | `INCONCLUSIVE` (with the evidence's `proof_gaps` mirrored into `omissions[]`) |
+
+The receipt always carries the full `SourceTruthEvidence` body
+(surfaces, proof gaps, outlier, native verdict) in
+`predicate.evidence.sourceTruth` so consumers needing the unflattened
+detail can read it directly.
+
+## Strategy Mismatch Is BLOCK
+
+If the receipt is asked to verify under one strategy but the underlying
+source-truth derivation runs under a different one, the predicate emits
+**BLOCK** with an `OmissionStrategyMismatch` entry. We never silently
+honor the caller's strategy over what the evidence claims to be under
+— that would let a CI gate paper over a real strategy disagreement.
+
+## Example Files
+
+### `pass-agreed.json` — PASS
+
+Vanilla `git-argo` strategy. All three surfaces agree, `Status: PASS`,
+`SourceTruth: AGREED`, no proof gaps. Receipt verdict: PASS.
+
+### `block-mismatch.json` — BLOCK
+
+Same `git-argo` strategy, but the controller's observed revision
+(`feedface...`) doesn't match the runtime's expectations. The
+source-truth derivation emits `Status: BLOCK` with controller as the
+outlier. Receipt verdict: BLOCK.
+
+## References
+
+- Parent issue: [`confighub/cub-scout#446`](https://github.com/confighub/cub-scout/issues/446) — Receipt capability
+- Source-truth contract: [`docs/reference/json-contracts.md`](../../../docs/reference/json-contracts.md) § Source-Truth Evidence Contract
+- Strategy enumeration: `pkg/agent/source_truth.go` `AllStrategies()`
+- Implementation: `pkg/agent/receipt_predicates.go` `EvaluateSourceTruthPass`

--- a/examples/receipts/source-truth-pass/block-mismatch.json
+++ b/examples/receipts/source-truth-pass/block-mismatch.json
@@ -1,0 +1,72 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "source-truth PASS under strategy \"git-argo\" for Deployment/api in prod",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "source-truth-pass",
+    "verdict": "BLOCK",
+    "evidence": {
+      "sourceTruth": {
+        "declared_strategy": "Git -\u003e Argo -\u003e Kubernetes",
+        "status": "BLOCK",
+        "source_truth": "MISMATCH",
+        "outlier": "controller",
+        "surfaces": {
+          "confighub": {
+            "space": "payments",
+            "unit": "api",
+            "revision": "42"
+          },
+          "controller": {
+            "kind": "Argo",
+            "source": "https://github.com/org/platform-config",
+            "revision_or_digest": "feedfacefeedfacefeedfacefeedfacefeedface"
+          },
+          "runtime": {
+            "resource": "Deployment/api in prod",
+            "field": "spec.template.spec.containers[0].image",
+            "value": "ghcr.io/org/api:v2.3.0",
+            "health": "Ready"
+          }
+        }
+      }
+    },
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "source-truth BLOCK; a hard rule failed (strategy mismatch, controller-source resolution failure, etc.) — investigate before acceptance",
+        "nextCommand": "cub-scout compare source-truth --strategy git-argo",
+        "nextSurface": "cub-scout"
+      }
+    ],
+    "fingerprint": "sha256:cf0e510a4e50b08e57431cd5e107f7ca5f184f66d4dd9e8dd582fa848d3ec859"
+  }
+}

--- a/examples/receipts/source-truth-pass/pass-agreed.json
+++ b/examples/receipts/source-truth-pass/pass-agreed.json
@@ -1,0 +1,72 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "source-truth PASS under strategy \"git-argo\" for Deployment/api in prod",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "source-truth-pass",
+    "verdict": "PASS",
+    "evidence": {
+      "sourceTruth": {
+        "declared_strategy": "Git -\u003e Argo -\u003e Kubernetes",
+        "status": "PASS",
+        "source_truth": "AGREED",
+        "outlier": "unknown",
+        "surfaces": {
+          "confighub": {
+            "space": "payments",
+            "unit": "api",
+            "revision": "42"
+          },
+          "controller": {
+            "kind": "Argo",
+            "source": "https://github.com/org/platform-config",
+            "revision_or_digest": "abc123def456abc123def456abc123def456abcd"
+          },
+          "runtime": {
+            "resource": "Deployment/api in prod",
+            "field": "spec.template.spec.containers[0].image",
+            "value": "ghcr.io/org/api:v2.3.0",
+            "health": "Ready"
+          }
+        }
+      }
+    },
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "source-truth PASS under the declared strategy; all three surfaces agree under the strategy-implied authority",
+        "nextCommand": "cub-scout explain Deployment/api -n prod",
+        "nextSurface": "cub-scout"
+      }
+    ],
+    "fingerprint": "sha256:2363cd2b192c8926595d55b7e37330a6343ba375ad9aae0247be86fabdb7cd11"
+  }
+}

--- a/pkg/agent/receipt.go
+++ b/pkg/agent/receipt.go
@@ -243,10 +243,38 @@ type ReceiptNextStep struct {
 // Common omission Missing values, exposed as constants so callers and
 // tests can reference them by name rather than free string.
 const (
-	OmissionConfigHubUnitSubject = "confighub-unit-subject"
-	OmissionManagedFields        = "managedFields"
-	OmissionGitSourceAnchor      = "git-source-anchor"
-	OmissionSourceTruthComplete  = "source-truth-complete"
+	OmissionConfigHubUnitSubject  = "confighub-unit-subject"
+	OmissionManagedFields         = "managedFields"
+	OmissionGitSourceAnchor       = "git-source-anchor"
+	OmissionSourceTruthComplete   = "source-truth-complete"
 	OmissionAutoDetectedPredicate = "auto-detected-predicate"
-	OmissionFieldCoverage        = "field-coverage"
+	OmissionFieldCoverage         = "field-coverage"
+
+	// OmissionStrategyMissing is recorded by the source-truth-pass
+	// predicate when no --strategy was passed. cub-scout never infers a
+	// strategy — the receipt either records the declared strategy or
+	// declines to claim.
+	OmissionStrategyMissing = "strategy"
+
+	// OmissionStrategyMismatch is recorded when the receipt was asked to
+	// verify under a strategy that disagrees with what the source-truth
+	// evidence in the live cluster actually carries.
+	OmissionStrategyMismatch = "strategy-mismatch"
+
+	// OmissionSourceTruthEvidence is recorded by the source-truth-pass
+	// predicate when the evidence body has no source-truth surface to
+	// evaluate.
+	OmissionSourceTruthEvidence = "source-truth-evidence"
+
+	// OmissionSinceMissing is recorded by the no-manual-edits-since
+	// predicate when no --since cutoff was passed. cub-scout will not
+	// invent a cutoff.
+	OmissionSinceMissing = "since"
+
+	// OmissionManagedFieldsTime is recorded by the no-manual-edits-since
+	// predicate when a managedFields entry has no Time stamp. Old K8s
+	// versions or replayed objects can have entries with nil Time;
+	// cub-scout cannot claim "no manual edits since T" if it cannot place
+	// each entry on the timeline.
+	OmissionManagedFieldsTime = "managedFields-time"
 )

--- a/pkg/agent/receipt_build.go
+++ b/pkg/agent/receipt_build.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -66,6 +67,17 @@ type BuildReceiptInput struct {
 	// VerifiedAt is the timestamp. If zero, BuildReceipt uses
 	// time.Now().UTC().
 	VerifiedAt time.Time
+
+	// Strategy is the source-truth strategy the caller declared (via
+	// --strategy). Required for source-truth-pass; signals auto-detect
+	// to pick source-truth-pass when no Argo/Flux/ConfigHub anchor
+	// resolved. cub-scout never infers a strategy.
+	Strategy string
+
+	// Since is the cutoff timestamp for no-manual-edits-since (via
+	// --since). Zero means "not provided"; the predicate then declines
+	// with OmissionSinceMissing.
+	Since time.Time
 }
 
 // BuildReceipt orchestrates: build subjects → resolve predicate →
@@ -117,13 +129,20 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 	}
 
 	// 2. Resolve the predicate. Caller-provided wins; otherwise auto-
-	// detect from owner. Empty after auto-detect → INCONCLUSIVE.
+	// detect from owner + signals (--strategy, --since). Empty after
+	// auto-detect → INCONCLUSIVE.
+	predicateInput := PredicateInput{
+		Scope:     in.Scope,
+		Evidence:  in.Evidence,
+		Spec:      in.Spec,
+		Connected: in.Connected,
+		Strategy:  in.Strategy,
+		Since:     in.Since,
+		Live:      in.Live,
+	}
 	predName := in.PredicateName
 	if predName == "" {
-		detected, detectedOmission := AutoDetectPredicate(
-			PredicateInput{Scope: in.Scope, Evidence: in.Evidence, Spec: in.Spec, Connected: in.Connected},
-			in.Owner,
-		)
+		detected, detectedOmission := AutoDetectPredicate(predicateInput, in.Owner)
 		predName = detected
 		if detectedOmission != nil {
 			omissions = append(omissions, *detectedOmission)
@@ -134,12 +153,11 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 	var result PredicateResult
 	switch predName {
 	case PredicateAppliedMatchesSpec:
-		result = EvaluateAppliedMatchesSpec(PredicateInput{
-			Scope:     in.Scope,
-			Evidence:  in.Evidence,
-			Spec:      in.Spec,
-			Connected: in.Connected,
-		})
+		result = EvaluateAppliedMatchesSpec(predicateInput)
+	case PredicateSourceTruthPass:
+		result = EvaluateSourceTruthPass(predicateInput)
+	case PredicateNoManualEditsSince:
+		result = EvaluateNoManualEditsSince(predicateInput)
 	case "":
 		// Auto-detect failed. The omission entry was already appended
 		// above; the predicate evaluation produces INCONCLUSIVE.
@@ -149,7 +167,7 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 			NextSteps: []ReceiptNextStep{},
 		}
 	default:
-		return Statement{}, fmt.Errorf("build-receipt: predicate %q not implemented in v1 batch 1 (planned in batch 2)", predName)
+		return Statement{}, fmt.Errorf("build-receipt: unknown predicate %q (cub-scout v1 implements %v)", predName, AllPredicates())
 	}
 
 	// 4. Filter nextSteps (defense in depth — predicate evaluators must
@@ -161,7 +179,7 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 	// 5. Derive a default claim if the caller didn't provide one.
 	claim := in.Claim
 	if claim == "" {
-		claim = deriveDefaultClaim(predName, in.Scope, in.Spec)
+		claim = deriveDefaultClaim(predName, in.Scope, in.Spec, in.Strategy, in.Since)
 	}
 
 	// 6. Set timestamp.
@@ -204,13 +222,23 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 
 // deriveDefaultClaim builds a human-readable claim from the predicate
 // and scope when the caller doesn't provide one.
-func deriveDefaultClaim(name PredicateName, scope Scope, spec *SpecAnchor) string {
+func deriveDefaultClaim(name PredicateName, scope Scope, spec *SpecAnchor, strategy string, since time.Time) string {
 	switch name {
 	case PredicateAppliedMatchesSpec:
 		if spec != nil && spec.Anchor.Path != "" {
 			return fmt.Sprintf("applied matches spec at %s", spec.Anchor.Path)
 		}
 		return fmt.Sprintf("applied matches spec for %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
+	case PredicateSourceTruthPass:
+		if strings.TrimSpace(strategy) != "" {
+			return fmt.Sprintf("source-truth PASS under strategy %q for %s/%s in %s", strategy, scope.Kind, scope.Name, scope.Namespace)
+		}
+		return fmt.Sprintf("source-truth PASS for %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
+	case PredicateNoManualEditsSince:
+		if !since.IsZero() {
+			return fmt.Sprintf("no manual edits to %s/%s in %s since %s", scope.Kind, scope.Name, scope.Namespace, since.UTC().Format(time.RFC3339))
+		}
+		return fmt.Sprintf("no manual edits to %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
 	case "":
 		return fmt.Sprintf("no predicate could be auto-detected for %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
 	default:

--- a/pkg/agent/receipt_build_test.go
+++ b/pkg/agent/receipt_build_test.go
@@ -303,16 +303,20 @@ func TestBuildReceipt_NilLive_Errors(t *testing.T) {
 	}
 }
 
-func TestBuildReceipt_UnimplementedPredicate_Errors(t *testing.T) {
+func TestBuildReceipt_UnknownPredicate_Errors(t *testing.T) {
+	// After #446 batch 2 implemented source-truth-pass and
+	// no-manual-edits-since, the unknown-predicate path is reached only
+	// for genuinely-unrecognized names. The error message must enumerate
+	// the implemented predicates so the operator knows what's valid.
 	in := makeReceiptInput(func(in *BuildReceiptInput) {
-		in.PredicateName = PredicateSourceTruthPass // batch 2 work, not implemented
+		in.PredicateName = PredicateName("not-a-real-predicate")
 	})
 	_, err := BuildReceipt(in)
 	if err == nil {
-		t.Error("BuildReceipt with unimplemented predicate must error")
+		t.Fatal("BuildReceipt with unknown predicate must error")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("error must explain unimplementation; got %v", err)
+	if !strings.Contains(err.Error(), "unknown predicate") {
+		t.Errorf("error must explain unknown-predicate; got %v", err)
 	}
 }
 

--- a/pkg/agent/receipt_predicates.go
+++ b/pkg/agent/receipt_predicates.go
@@ -6,6 +6,9 @@ package agent
 import (
 	"fmt"
 	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // PredicateName is the canonical name of a receipt predicate.
@@ -61,6 +64,22 @@ type PredicateInput struct {
 	// evidence is genuinely missing" from "we never had it because
 	// standalone mode".
 	Connected bool
+
+	// Strategy is the explicit source-truth strategy the caller passed
+	// (via --strategy). Required for source-truth-pass; cub-scout never
+	// infers a strategy. Empty means "not provided".
+	Strategy string
+
+	// Since is the cutoff timestamp for the no-manual-edits-since
+	// predicate. A zero value means "not provided" — the predicate then
+	// emits INCONCLUSIVE + OmissionSinceMissing.
+	Since time.Time
+
+	// Live carries the resource the no-manual-edits-since predicate
+	// walks for managedFields entries. Other predicates ignore this
+	// field. Receipts are built from the same Live the orchestrator
+	// already fetched; passing it down avoids a re-read.
+	Live *unstructured.Unstructured
 }
 
 // EvaluateAppliedMatchesSpec runs the `applied-matches-spec` predicate.
@@ -220,14 +239,31 @@ func pathsEquivalent(a, b string) bool {
 // Returns the chosen predicate name (or "" for no auto-detect) plus an
 // omission entry to record when the auto-detect failed.
 func AutoDetectPredicate(in PredicateInput, owner Ownership) (PredicateName, *Omission) {
+	// Priority 1: Argo/Flux/ConfigHub + resolvable anchor → applied-matches-spec.
 	switch owner.Type {
 	case OwnerArgo, OwnerFlux, OwnerConfigHub:
-		// Controller-owned resources can run applied-matches-spec WHEN
-		// a git anchor was resolved. Otherwise the predicate cannot
-		// evaluate honestly and auto-detect must decline.
 		if in.Evidence.GitSource != nil {
 			return PredicateAppliedMatchesSpec, nil
 		}
+	}
+
+	// Priority 2: --strategy provided → source-truth-pass. The predicate
+	// itself enforces the connected-mode gate; auto-detect only needs to
+	// see the strategy signal.
+	if strings.TrimSpace(in.Strategy) != "" {
+		return PredicateSourceTruthPass, nil
+	}
+
+	// Priority 3: --since provided → no-manual-edits-since.
+	if !in.Since.IsZero() {
+		return PredicateNoManualEditsSince, nil
+	}
+
+	// Owner-specific decline reason takes precedence when the owner is one
+	// of the controller types but no anchor resolved — that's a more
+	// actionable hint than the generic "no signal" message.
+	switch owner.Type {
+	case OwnerArgo, OwnerFlux, OwnerConfigHub:
 		return "", &Omission{
 			Missing: OmissionAutoDetectedPredicate,
 			Reason: fmt.Sprintf(
@@ -238,10 +274,266 @@ func AutoDetectPredicate(in PredicateInput, owner Ownership) (PredicateName, *Om
 	default:
 		return "", &Omission{
 			Missing:  OmissionAutoDetectedPredicate,
-			Reason:   fmt.Sprintf("no signal for default predicate (detected owner %q has no v1 default predicate); pass --predicate", owner.Type),
+			Reason:   fmt.Sprintf("no signal for default predicate (detected owner %q has no v1 default predicate); pass --predicate, --strategy, or --since", owner.Type),
 			Severity: "info",
 		}
 	}
+}
+
+// EvaluateSourceTruthPass runs the `source-truth-pass` predicate.
+//
+// Semantics:
+//   - No --strategy passed → INCONCLUSIVE + OmissionStrategyMissing.
+//     cub-scout never infers a delivery strategy; that's the operator's
+//     declared input (`compare source-truth` enforces the same rule).
+//   - No source-truth evidence in the body → INCONCLUSIVE +
+//     OmissionSourceTruthEvidence. The orchestrator should have run
+//     `Derive` and attached the SourceTruthEvidence; if it didn't, the
+//     receipt cannot claim anything about source truth.
+//   - Strategy mismatch between caller and evidence → BLOCK +
+//     OmissionStrategyMismatch. Don't silently honor the caller's strategy
+//     over what the evidence claims to be under.
+//   - Map Status to ReceiptVerdict:
+//     PASS  → VerdictPASS
+//     WATCH → VerdictWATCH
+//     BLOCK → VerdictBLOCK
+//     ASK   → VerdictINCONCLUSIVE (with the evidence's proof_gaps mirrored
+//             into omissions[])
+//
+// Proof gaps in the source-truth evidence are mirrored into the receipt's
+// omissions[] under OmissionSourceTruthComplete so a consumer reading
+// only the receipt knows what the underlying source-truth derivation
+// flagged.
+func EvaluateSourceTruthPass(in PredicateInput) PredicateResult {
+	res := PredicateResult{
+		Omissions: []Omission{},
+		NextSteps: []ReceiptNextStep{},
+	}
+
+	declared := strings.TrimSpace(in.Strategy)
+	if declared == "" {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionStrategyMissing,
+			Reason:   "source-truth-pass requires --strategy; cub-scout does not infer the delivery strategy",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	if in.Evidence.SourceTruth == nil {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthEvidence,
+			Reason:   fmt.Sprintf("no source-truth evidence body attached; run `cub-scout compare source-truth --strategy %s` and feed the result back into the receipt orchestrator", declared),
+			Severity: "warning",
+		})
+		return res
+	}
+
+	// Compare declared strategy with the strategy already captured in the
+	// evidence body. The evidence stores the Human-rendered form
+	// ("Git -> Argo -> Kubernetes"), so we normalize through ParseStrategy
+	// when comparing — accept either the machine name ("git-argo") or the
+	// Human form.
+	evStrategy := in.Evidence.SourceTruth.DeclaredStrategy
+	if !strategyAgrees(declared, evStrategy) {
+		res.Verdict = VerdictBLOCK
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionStrategyMismatch,
+			Reason:   fmt.Sprintf("receipt was asked to verify under strategy %q but source-truth evidence carries %q", declared, evStrategy),
+			Severity: "warning",
+		})
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "rerun the source-truth derivation with the same strategy you want the receipt to claim; do not paper over the disagreement",
+			NextCommand: "cub-scout compare source-truth --strategy " + declared,
+			NextSurface: "cub-scout",
+		})
+		return res
+	}
+
+	// Mirror proof gaps into omissions[] regardless of status.
+	for _, gap := range in.Evidence.SourceTruth.ProofGaps {
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthComplete,
+			Reason:   "source-truth proof gap: " + gap,
+			Severity: "info",
+		})
+	}
+
+	switch in.Evidence.SourceTruth.Status {
+	case StatusPASS:
+		res.Verdict = VerdictPASS
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "source-truth PASS under the declared strategy; all three surfaces agree under the strategy-implied authority",
+			NextCommand: "cub-scout explain " + in.Scope.Kind + "/" + in.Scope.Name + " -n " + in.Scope.Namespace,
+			NextSurface: "cub-scout",
+		})
+	case StatusWATCH:
+		res.Verdict = VerdictWATCH
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "source-truth WATCH; soft proof gap or signal warrants confirmation before acceptance",
+			NextCommand: "cub-scout compare source-truth --strategy " + declared,
+			NextSurface: "cub-scout",
+		})
+	case StatusBLOCK:
+		res.Verdict = VerdictBLOCK
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "source-truth BLOCK; a hard rule failed (strategy mismatch, controller-source resolution failure, etc.) — investigate before acceptance",
+			NextCommand: "cub-scout compare source-truth --strategy " + declared,
+			NextSurface: "cub-scout",
+		})
+	case StatusASK:
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthComplete,
+			Reason:   "source-truth ASK; cub-scout cannot classify deterministically — the evidence's proof_gaps explain what's missing",
+			Severity: "warning",
+		})
+	default:
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthComplete,
+			Reason:   fmt.Sprintf("unrecognized source-truth status %q; cub-scout enumerates PASS / WATCH / BLOCK / ASK", string(in.Evidence.SourceTruth.Status)),
+			Severity: "warning",
+		})
+	}
+	return res
+}
+
+// strategyAgrees returns true if declared (caller's CLI form like
+// "git-argo") names the same strategy as evidence (the Human form like
+// "Git -> Argo -> Kubernetes" recorded by Derive). Either side may be
+// empty after trim.
+func strategyAgrees(declared, evStrategy string) bool {
+	declared = strings.TrimSpace(declared)
+	evStrategy = strings.TrimSpace(evStrategy)
+	if declared == "" || evStrategy == "" {
+		return false
+	}
+	// Same machine form.
+	if declared == evStrategy {
+		return true
+	}
+	// Caller passed the machine form; evidence has the Human form.
+	if parsed, ok := ParseStrategy(declared); ok {
+		if parsed.Human() == evStrategy {
+			return true
+		}
+	}
+	return false
+}
+
+// EvaluateNoManualEditsSince runs the `no-manual-edits-since` predicate.
+//
+// Semantics:
+//   - No --since cutoff → INCONCLUSIVE + OmissionSinceMissing.
+//   - No live object on the input → INCONCLUSIVE + OmissionManagedFields
+//     (defensive — orchestrator should always pass Live).
+//   - No managedFields entries on the object → INCONCLUSIVE +
+//     OmissionManagedFields. Old K8s, stripped admission webhook, etc.
+//   - Any managedFields entry from an interactive manager (kubectl-*)
+//     with Time > since → BLOCK.
+//   - Any managedFields entry from an interactive manager with no Time
+//     → INCONCLUSIVE + OmissionManagedFieldsTime. We cannot place it on
+//     the timeline so we cannot honestly claim "no manual edits since T".
+//   - Otherwise → PASS.
+//
+// Important caveat (from the receipts-way-forward.md design): K8s
+// managedFields evidence is best-effort. If an admission webhook strips
+// the entries, or the resource is migrated across K8s versions, the
+// predicate degrades to INCONCLUSIVE rather than producing false PASS.
+// `parse, don't guess`.
+func EvaluateNoManualEditsSince(in PredicateInput) PredicateResult {
+	res := PredicateResult{
+		Omissions: []Omission{},
+		NextSteps: []ReceiptNextStep{},
+	}
+
+	if in.Since.IsZero() {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSinceMissing,
+			Reason:   "no-manual-edits-since requires --since <RFC3339 timestamp>; cub-scout does not invent a cutoff",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	if in.Live == nil {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionManagedFields,
+			Reason:   "no live object passed to no-manual-edits-since; cub-scout cannot read managedFields without the resource",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	entries := in.Live.GetManagedFields()
+	if len(entries) == 0 {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionManagedFields,
+			Reason:   "live resource has no managedFields entries; no-manual-edits-since cannot establish a baseline without them",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	// Walk entries. Treat any interactive manager with Time > since as a
+	// late manual edit (BLOCK). Treat any interactive manager with nil
+	// Time as a timestamp gap (INCONCLUSIVE).
+	var (
+		violatingManagers []string
+		nilTimeManagers   []string
+	)
+	for _, e := range entries {
+		if !IsInteractiveManager(e.Manager) {
+			continue
+		}
+		if e.Time == nil {
+			nilTimeManagers = append(nilTimeManagers, e.Manager)
+			continue
+		}
+		if e.Time.Time.After(in.Since) {
+			violatingManagers = append(violatingManagers, fmt.Sprintf("%s@%s", e.Manager, e.Time.Time.UTC().Format(time.RFC3339)))
+		}
+	}
+
+	if len(violatingManagers) > 0 {
+		res.Verdict = VerdictBLOCK
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      fmt.Sprintf("interactive writer wrote managedFields after the cutoff (%s): %s — investigate the unplanned edit before any apply", in.Since.UTC().Format(time.RFC3339), strings.Join(violatingManagers, ", ")),
+			NextCommand: "kubectl get --show-managed-fields",
+			NextSurface: "kubectl",
+		})
+		return res
+	}
+
+	if len(nilTimeManagers) > 0 {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionManagedFieldsTime,
+			Reason:   fmt.Sprintf("interactive managedFields entries have nil Time; cannot place them on the timeline: %s", strings.Join(nilTimeManagers, ", ")),
+			Severity: "warning",
+		})
+		return res
+	}
+
+	res.Verdict = VerdictPASS
+	res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+		ActionType:  "read-only",
+		Reason:      fmt.Sprintf("no interactive writer touched managedFields after %s", in.Since.UTC().Format(time.RFC3339)),
+		NextCommand: "cub-scout explain " + in.Scope.Kind + "/" + in.Scope.Name + " -n " + in.Scope.Namespace,
+		NextSurface: "cub-scout",
+	})
+	return res
 }
 
 // FilterNextSteps drops any nextSteps with mutating actionType or

--- a/pkg/agent/receipt_predicates_batch2_test.go
+++ b/pkg/agent/receipt_predicates_batch2_test.go
@@ -1,0 +1,364 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// --- EvaluateSourceTruthPass -----------------------------------------
+
+func TestEvaluateSourceTruthPass_NoStrategy_INCONCLUSIVE(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionStrategyMissing) {
+		t.Errorf("missing-strategy must produce OmissionStrategyMissing; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateSourceTruthPass_NoEvidence_INCONCLUSIVE(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionSourceTruthEvidence) {
+		t.Errorf("missing-evidence must produce OmissionSourceTruthEvidence; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StrategyMismatch_BLOCK(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyConfigHubOCIArgo.Human(),
+				Status:           StatusPASS,
+			},
+		},
+	})
+	if res.Verdict != VerdictBLOCK {
+		t.Fatalf("strategy mismatch must produce BLOCK; got %q", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionStrategyMismatch) {
+		t.Errorf("strategy mismatch must produce OmissionStrategyMismatch; got %v", res.Omissions)
+	}
+	if len(res.NextSteps) == 0 || res.NextSteps[0].ActionType != "read-only" {
+		t.Errorf("strategy mismatch next step must be read-only; got %+v", res.NextSteps)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StrategyAgreesHumanForm_PASS(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				// Evidence stores the Human form; declared can be machine form.
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusPASS,
+				SourceTruth:      VerdictAGREED,
+			},
+		},
+	})
+	if res.Verdict != VerdictPASS {
+		t.Fatalf("PASS status must map to VerdictPASS; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StatusWATCH_VerdictWATCH(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusWATCH,
+				ProofGaps:        []string{"controller.revision_or_digest"},
+			},
+		},
+	})
+	if res.Verdict != VerdictWATCH {
+		t.Errorf("WATCH status must map to VerdictWATCH; got %q", res.Verdict)
+	}
+	// Proof gap should be mirrored as an omission.
+	if !hasOmission(res.Omissions, OmissionSourceTruthComplete) {
+		t.Errorf("WATCH must mirror proof_gaps into OmissionSourceTruthComplete; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StatusBLOCK_VerdictBLOCK(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusBLOCK,
+				SourceTruth:      VerdictMISMATCH,
+			},
+		},
+	})
+	if res.Verdict != VerdictBLOCK {
+		t.Errorf("BLOCK status must map to VerdictBLOCK; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StatusASK_VerdictINCONCLUSIVE(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusASK,
+				SourceTruth:      VerdictUNKNOWN,
+			},
+		},
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Errorf("ASK status must map to VerdictINCONCLUSIVE; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateSourceTruthPass_ProofGapsMirroredOnPASS(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusPASS,
+				ProofGaps:        []string{"runtime.helm_chart_anchor"},
+			},
+		},
+	})
+	if res.Verdict != VerdictPASS {
+		t.Fatalf("PASS status must map to VerdictPASS; got %q", res.Verdict)
+	}
+	// Even on PASS, proof_gaps must be visible — that's the omissions[]
+	// contract.
+	found := false
+	for _, o := range res.Omissions {
+		if o.Missing == OmissionSourceTruthComplete && strings.Contains(o.Reason, "runtime.helm_chart_anchor") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("PASS with proof_gaps must mirror them into omissions; got %v", res.Omissions)
+	}
+}
+
+// --- EvaluateNoManualEditsSince --------------------------------------
+
+func makeLiveWithManagedFields(entries []metav1.ManagedFieldsEntry) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "prod",
+			},
+		},
+	}
+	obj.SetManagedFields(entries)
+	return obj
+}
+
+func TestEvaluateNoManualEditsSince_NoSince_INCONCLUSIVE(t *testing.T) {
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionSinceMissing) {
+		t.Errorf("missing-since must produce OmissionSinceMissing; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_NoLive_INCONCLUSIVE(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live:  nil,
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionManagedFields) {
+		t.Errorf("nil-live must produce OmissionManagedFields; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_NoManagedFields_INCONCLUSIVE(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live:  makeLiveWithManagedFields(nil),
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionManagedFields) {
+		t.Errorf("empty-managedFields must produce OmissionManagedFields; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_OnlyController_PASS(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerArgoCD, Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+		}),
+	})
+	if res.Verdict != VerdictPASS {
+		t.Errorf("only-controller writers after cutoff must produce PASS; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_KubectlEditAfterCutoff_BLOCK(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerArgoCD, Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+			{Manager: ManagerKubectlEdit, Operation: metav1.ManagedFieldsOperationUpdate, Time: &after},
+		}),
+	})
+	if res.Verdict != VerdictBLOCK {
+		t.Errorf("kubectl-edit after cutoff must produce BLOCK; got %q", res.Verdict)
+	}
+	// The BLOCK message must include the violating manager name on the
+	// nextStep reason so an operator can pinpoint the writer.
+	if len(res.NextSteps) == 0 || !strings.Contains(res.NextSteps[0].Reason, ManagerKubectlEdit) {
+		t.Errorf("BLOCK next step must name the violating manager; got %+v", res.NextSteps)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_KubectlEditBeforeCutoff_PASS(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	before := metav1.NewTime(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerKubectlEdit, Operation: metav1.ManagedFieldsOperationUpdate, Time: &before},
+		}),
+	})
+	if res.Verdict != VerdictPASS {
+		t.Errorf("kubectl-edit before cutoff must produce PASS; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_KubectlNilTime_INCONCLUSIVE(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerKubectlEdit, Operation: metav1.ManagedFieldsOperationUpdate, Time: nil},
+		}),
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Errorf("nil Time on interactive writer must produce INCONCLUSIVE; got %q", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionManagedFieldsTime) {
+		t.Errorf("nil Time must produce OmissionManagedFieldsTime; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_ControllerNilTime_StillPASS(t *testing.T) {
+	// A nil-Time controller entry is fine — we don't claim anything about
+	// controller writers, only about interactive ones. PASS as long as
+	// no interactive writer is present.
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerArgoCD, Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+		}),
+	})
+	if res.Verdict != VerdictPASS {
+		t.Errorf("controller-only with nil Time must still PASS; got %q", res.Verdict)
+	}
+}
+
+// --- AutoDetectPredicate (extended for batch 2 signals) --------------
+
+func TestAutoDetectPredicate_StrategyOnly_PicksSourceTruthPass(t *testing.T) {
+	name, om := AutoDetectPredicate(PredicateInput{
+		Strategy: "git-argo",
+	}, Ownership{Type: OwnerUnknown})
+	if name != PredicateSourceTruthPass {
+		t.Errorf("--strategy must auto-detect source-truth-pass; got %q", name)
+	}
+	if om != nil {
+		t.Errorf("--strategy must not produce an omission; got %+v", om)
+	}
+}
+
+func TestAutoDetectPredicate_SinceOnly_PicksNoManualEditsSince(t *testing.T) {
+	name, om := AutoDetectPredicate(PredicateInput{
+		Since: time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC),
+	}, Ownership{Type: OwnerUnknown})
+	if name != PredicateNoManualEditsSince {
+		t.Errorf("--since must auto-detect no-manual-edits-since; got %q", name)
+	}
+	if om != nil {
+		t.Errorf("--since must not produce an omission; got %+v", om)
+	}
+}
+
+func TestAutoDetectPredicate_ArgoAnchorBeatsStrategy(t *testing.T) {
+	// Priority order is locked: Argo + resolvable anchor wins over
+	// --strategy because applied-matches-spec is the more specific claim.
+	name, _ := AutoDetectPredicate(PredicateInput{
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			GitSource: &GitSourceAnchor{
+				RepoURL:  "https://github.com/org/repo",
+				Revision: "abc",
+				Path:     "apps/api",
+			},
+		},
+	}, Ownership{Type: OwnerArgo})
+	if name != PredicateAppliedMatchesSpec {
+		t.Errorf("Argo + anchor must beat --strategy in auto-detect; got %q", name)
+	}
+}
+
+func TestAutoDetectPredicate_StrategyBeatsSince(t *testing.T) {
+	// When both signals are present, --strategy takes precedence per the
+	// locked priority order.
+	name, _ := AutoDetectPredicate(PredicateInput{
+		Strategy: "git-argo",
+		Since:    time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC),
+	}, Ownership{Type: OwnerUnknown})
+	if name != PredicateSourceTruthPass {
+		t.Errorf("--strategy must beat --since in auto-detect; got %q", name)
+	}
+}

--- a/tools/gen-receipt-examples/main.go
+++ b/tools/gen-receipt-examples/main.go
@@ -1,10 +1,11 @@
 // Copyright (C) ConfigHub, Inc.
 // SPDX-License-Identifier: MIT
 
-// gen-receipt-examples emits the four canonical example receipts under
-// examples/receipts/applied-matches-spec/. Run from the repo root:
+// gen-receipt-examples emits the canonical example receipts under
+// examples/receipts/. Run from the repo root pointing at the receipts
+// root (the generator writes one subdirectory per predicate):
 //
-//	go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec
+//	go run ./tools/gen-receipt-examples examples/receipts
 //
 // The generator is deterministic: same input data + same VerifiedAt → same
 // fingerprint. CI re-runs it and diffs against the committed files (see
@@ -19,6 +20,7 @@ import (
 	"time"
 
 	"github.com/confighub/cub-scout/pkg/agent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -135,9 +137,79 @@ func inconclusiveNoAnchor() agent.BuildReceiptInput {
 	return in
 }
 
+// --- batch 2: source-truth-pass examples ----------------------------
+
+func sourceTruthPassInput() agent.BuildReceiptInput {
+	in := baseInput()
+	in.PredicateName = agent.PredicateSourceTruthPass
+	in.Spec = nil // source-truth-pass doesn't use a spec anchor
+	in.Strategy = string(agent.StrategyGitArgo)
+	in.Evidence = agent.Evidence{
+		SourceTruth: &agent.SourceTruthEvidence{
+			DeclaredStrategy: agent.StrategyGitArgo.Human(),
+			Status:           agent.StatusPASS,
+			SourceTruth:      agent.VerdictAGREED,
+			Outlier:          agent.OutlierUnknown,
+			Surfaces: agent.SourceTruthSurfaces{
+				ConfigHub:  &agent.ConfigHubSurface{Space: "payments", Unit: "api", Revision: "42"},
+				Controller: &agent.ControllerSurface{Kind: "Argo", Source: "https://github.com/org/platform-config", RevisionOrDigest: "abc123def456abc123def456abc123def456abcd"},
+				Runtime:    &agent.RuntimeSurface{Resource: "Deployment/api in prod", Field: "spec.template.spec.containers[0].image", Value: "ghcr.io/org/api:v2.3.0", Health: "Ready"},
+			},
+		},
+	}
+	return in
+}
+
+func sourceTruthBlockMismatch() agent.BuildReceiptInput {
+	in := sourceTruthPassInput()
+	in.Evidence.SourceTruth.Status = agent.StatusBLOCK
+	in.Evidence.SourceTruth.SourceTruth = agent.VerdictMISMATCH
+	in.Evidence.SourceTruth.Outlier = agent.OutlierController
+	in.Evidence.SourceTruth.Surfaces.Controller.RevisionOrDigest = "feedfacefeedfacefeedfacefeedfacefeedface"
+	return in
+}
+
+// --- batch 2: no-manual-edits-since examples ------------------------
+
+func noManualEditsSincePass() agent.BuildReceiptInput {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	before := metav1.NewTime(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
+
+	in := baseInput()
+	in.PredicateName = agent.PredicateNoManualEditsSince
+	in.Spec = nil
+	in.Strategy = ""
+	in.Since = cutoff
+	in.Evidence = agent.Evidence{}
+
+	// Live carries the managedFields the predicate walks. The base Live
+	// is a bare Deployment; rebuild with a single Argo controller entry
+	// dated before the cutoff so the predicate emits PASS.
+	live := makeArgoLive()
+	live.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &before},
+	})
+	in.Live = live
+	return in
+}
+
+func noManualEditsSinceBlock() agent.BuildReceiptInput {
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+
+	in := noManualEditsSincePass()
+	live := makeArgoLive()
+	live.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+		{Manager: "kubectl-edit", Operation: metav1.ManagedFieldsOperationUpdate, Time: &after},
+	})
+	in.Live = live
+	return in
+}
+
 type example struct {
-	name string
-	in   agent.BuildReceiptInput
+	predicateDir string // subdirectory under outDir, e.g. "applied-matches-spec"
+	name         string // filename within that subdirectory
+	in           agent.BuildReceiptInput
 }
 
 func main() {
@@ -152,24 +224,36 @@ func main() {
 	}
 
 	examples := []example{
-		{"pass-controller-drift.json", passCase()},
-		{"block-manual-edit.json", blockManualEdit()},
-		{"block-anchor-mismatch.json", blockAnchorMismatch()},
-		{"inconclusive-no-anchor.json", inconclusiveNoAnchor()},
+		// applied-matches-spec (batch 1).
+		{"applied-matches-spec", "pass-controller-drift.json", passCase()},
+		{"applied-matches-spec", "block-manual-edit.json", blockManualEdit()},
+		{"applied-matches-spec", "block-anchor-mismatch.json", blockAnchorMismatch()},
+		{"applied-matches-spec", "inconclusive-no-anchor.json", inconclusiveNoAnchor()},
+		// source-truth-pass (batch 2).
+		{"source-truth-pass", "pass-agreed.json", sourceTruthPassInput()},
+		{"source-truth-pass", "block-mismatch.json", sourceTruthBlockMismatch()},
+		// no-manual-edits-since (batch 2).
+		{"no-manual-edits-since", "pass-controller-only.json", noManualEditsSincePass()},
+		{"no-manual-edits-since", "block-kubectl-edit.json", noManualEditsSinceBlock()},
 	}
 
 	for _, ex := range examples {
 		stmt, err := agent.BuildReceipt(ex.in)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "build %s: %v\n", ex.name, err)
+			fmt.Fprintf(os.Stderr, "build %s/%s: %v\n", ex.predicateDir, ex.name, err)
 			os.Exit(1)
 		}
 		buf, err := json.MarshalIndent(stmt, "", "  ")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "marshal %s: %v\n", ex.name, err)
+			fmt.Fprintf(os.Stderr, "marshal %s/%s: %v\n", ex.predicateDir, ex.name, err)
 			os.Exit(1)
 		}
-		path := filepath.Join(outDir, ex.name)
+		predicateDir := filepath.Join(outDir, ex.predicateDir)
+		if err := os.MkdirAll(predicateDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "mkdir %s: %v\n", predicateDir, err)
+			os.Exit(1)
+		}
+		path := filepath.Join(predicateDir, ex.name)
 		if err := os.WriteFile(path, append(buf, '\n'), 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "write %s: %v\n", path, err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary

Second batch of `#446`. Adds the two remaining v1 predicates planned in the receipt design synthesis. Combined with batch 1 (#454, merged), this completes the **v1 predicate catalog** — three predicates covering:

| Predicate | Required signals | What it claims |
|-----------|------------------|----------------|
| `applied-matches-spec` (batch 1) | Argo/Flux/ConfigHub owner + git anchor | LIVE matches the controller-resolved spec |
| `source-truth-pass` (**this PR**) | `--strategy <name>` + connected mode | `compare source-truth` returned PASS under the declared strategy |
| `no-manual-edits-since` (**this PR**) | `--since <RFC3339 timestamp>` | No `kubectl-*` writer touched `managedFields` after the cutoff |

## What ships

### `source-truth-pass`

- `EvaluateSourceTruthPass` in `pkg/agent/receipt_predicates.go` covers all eight branches (no strategy / no evidence / strategy mismatch / status PASS-WATCH-BLOCK-ASK / proof-gap mirroring)
- `--strategy <name>` CLI flag on `receipt verify`; triggers a connected-mode source-truth derivation via the existing `compare source-truth` helpers and attaches the result to the evidence body
- Strategy mismatch between caller and evidence → **BLOCK** + `OmissionStrategyMismatch`. Never silently honor the caller's strategy over what the evidence claims to be under.
- `proof_gaps[]` from the source-truth derivation are mirrored into receipt `omissions[]` under `OmissionSourceTruthComplete` **regardless of verdict** — converts silent PASS into honest PASS.

### `no-manual-edits-since`

- `EvaluateNoManualEditsSince` walks `live.GetManagedFields()` and classifies each entry by manager:
  - Controller writers → ignored
  - Interactive (`kubectl-*`) writer with `Time > since` → **BLOCK** (next-step names the violating manager + offending timestamp)
  - Interactive writer with nil `Time` → **INCONCLUSIVE** + `OmissionManagedFieldsTime` (cannot place on timeline → refuse to claim)
  - Otherwise → **PASS**
- `--since <RFC3339>` CLI flag; the CLI rejects malformed input upfront
- Honors the field-manager-evidence caveat from `receipts-way-forward.md`: admission-webhook stripping degrades gracefully to INCONCLUSIVE rather than fabricating PASS

### Wiring

- `PredicateInput` extended with `Strategy` / `Since` / `Live` fields
- `BuildReceipt` dispatches to all three evaluators; unknown predicate names now return a helpful error listing `AllPredicates()`
- `AutoDetectPredicate` priority order (locked in the design):
  1. Argo/Flux/ConfigHub owner + resolvable git anchor → `applied-matches-spec`
  2. `--strategy` → `source-truth-pass`
  3. `--since` → `no-manual-edits-since`
  4. Otherwise → `""` + `OmissionAutoDetectedPredicate`
- CLI rejects contradictory pairs (`--predicate source-truth-pass` without `--strategy`, etc.) upfront — silently demoting to INCONCLUSIVE would hide the operator's intent from the receipt

### Tests

- **16** new predicate unit tests in `pkg/agent/receipt_predicates_batch2_test.go`
- **9** new CLI integration tests in `cmd/cub-scout/receipt_batch2_test.go` using a new `collectSourceTruthForReceiptFn` seam (no cluster / no ConfigHub needed)

### Examples + docs

- `tools/gen-receipt-examples` now emits three predicate subdirectories with **8** canonical receipts total. `TestReceiptExamplesAreFresh` walks all subdirs.
- New per-predicate READMEs at `examples/receipts/source-truth-pass/` and `examples/receipts/no-manual-edits-since/`
- `docs/reference/json-contracts.md` § Receipt Contract: full three-row predicate table; expanded omission catalog with 5 new entries
- `docs/reference/commands.md` § receipt verify: new flags, predicate table, auto-detection priority, examples for all three predicates
- ASCII renderer surfaces source-truth evidence (strategy / status / verdict / outlier / proof_gaps) on receipts that carry it

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./pkg/agent/... ./cmd/cub-scout/... ./tools/gen-receipt-examples/...` clean
- [x] `go test ./pkg/agent/... ./cmd/cub-scout/...` all green (16 + 9 new tests pass; all batch 1 tests still pass)
- [x] All three CI parity scripts pass locally (`check-cli-guide-parity.sh`, `check-doc-freshness.sh`, `check-readonly.sh`)
- [x] `TestReceiptExamplesAreFresh` re-runs the generator and confirms byte-identity across all three predicate subdirs

## Read-only triad lock still holds

`TestReceiptPackageReadOnlyClient` continues to pass: no `.Create/.Update/.Patch/.Apply/.Delete` calls in any receipt source file. `FilterNextSteps` still drops the full set of mutating verbs (now 18 with batch 1's Codex round-4 additions).

## What's left in #446

After this PR, only **batch 3** remains: `receipt show / validate / list` management UX with local-directory storage at `\$XDG_DATA_HOME/cub-scout/receipts/`. v2 work (DSSE signing, Sigstore Bundle v0.3, chained receipts via `inputAttestations[]`) is tracked separately (#448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)