### PR TITLE
feat(#446): batch 3 — receipt show / validate / list + local store

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -24,6 +24,8 @@ var (
 	receiptNamespace string
 	receiptPredicate string
 	receiptAtCommit  string
+	receiptStrategy  string
+	receiptSince     string
 	receiptFormat    string
 	receiptOut       string
 )
@@ -31,6 +33,13 @@ var (
 // Function-variable seam for tests. Production reads from the cluster via
 // the dynamic client; tests swap with a fake returning prefab objects.
 var loadReceiptLiveFn = loadReceiptLive
+
+// collectSourceTruthForReceiptFn is the function-variable seam used by the
+// source-truth-pass predicate path. Production wires it to the live
+// source-truth derivation; tests swap with a fake returning prefab
+// evidence so the receipt CLI integration tests do not require a real
+// ConfigHub or cluster.
+var collectSourceTruthForReceiptFn = collectSourceTruthForReceipt
 
 var receiptCmd = &cobra.Command{
 	Use:   "receipt",
@@ -54,18 +63,27 @@ var receiptVerifyCmd = &cobra.Command{
 	Use:   "verify <subject>",
 	Short: "Build a receipt verifying a property of a Kubernetes resource",
 	Long: `verify produces an in-toto Statement v1 receipt asserting a predicate
-about a live Kubernetes resource. v1 batch 1 supports the applied-matches-spec
-predicate (LIVE matches the controller-resolved git anchor).
+about a live Kubernetes resource.
+
+v1 predicates:
+  applied-matches-spec    LIVE matches the controller-resolved git anchor
+  source-truth-pass       compare source-truth returned PASS under --strategy
+  no-manual-edits-since   no kubectl-* writer touched managedFields after --since
 
 Subject is a positional argument in the form <kind>/<name>.
 
 Predicate auto-detection priority (when --predicate is not passed):
-  1. Argo / Flux / ConfigHub-via-GitOps owner → applied-matches-spec
-  2. Otherwise → INCONCLUSIVE + omission (no auto-detected predicate)
+  1. Argo / Flux / ConfigHub-via-GitOps owner WITH a resolvable git anchor
+     → applied-matches-spec
+  2. --strategy provided → source-truth-pass
+  3. --since provided    → no-manual-edits-since
+  4. Otherwise → INCONCLUSIVE + omission (no auto-detected predicate)
 
 Examples:
   cub-scout receipt verify deploy/api -n prod
   cub-scout receipt verify deploy/api -n prod --at-commit abc123
+  cub-scout receipt verify deploy/api -n prod --strategy git-argo
+  cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
   cub-scout receipt verify deploy/api -n prod --predicate applied-matches-spec --format json --out api.receipt.json
 `,
 	Args: cobra.ExactArgs(1),
@@ -77,8 +95,10 @@ func init() {
 	receiptCmd.AddCommand(receiptVerifyCmd)
 
 	receiptVerifyCmd.Flags().StringVarP(&receiptNamespace, "namespace", "n", "", "Namespace of the resource (required for namespaced kinds)")
-	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 batch 1 supports applied-matches-spec only.")
+	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 supports applied-matches-spec, source-truth-pass, no-manual-edits-since.")
 	receiptVerifyCmd.Flags().StringVar(&receiptAtCommit, "at-commit", "", "Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence.")
+	receiptVerifyCmd.Flags().StringVar(&receiptStrategy, "strategy", "", "Source-truth strategy for source-truth-pass (e.g. git-argo). cub-scout does not infer the strategy.")
+	receiptVerifyCmd.Flags().StringVar(&receiptSince, "since", "", "RFC 3339 cutoff for no-manual-edits-since (e.g. 2026-05-22T00:00:00Z).")
 	receiptVerifyCmd.Flags().StringVar(&receiptFormat, "format", "ascii", "Output format: ascii | json")
 	receiptVerifyCmd.Flags().StringVar(&receiptOut, "out", "", "Write the receipt to this file path (also printed to stdout in the chosen format)")
 }
@@ -87,6 +107,28 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 	format := strings.ToLower(strings.TrimSpace(receiptFormat))
 	if format != "ascii" && format != "json" {
 		return fmt.Errorf("invalid --format %q (valid: ascii, json)", receiptFormat)
+	}
+
+	// Parse --since (RFC 3339). Empty means "not provided".
+	var since time.Time
+	if raw := strings.TrimSpace(receiptSince); raw != "" {
+		parsed, perr := time.Parse(time.RFC3339, raw)
+		if perr != nil {
+			return fmt.Errorf("invalid --since %q (expected RFC 3339, e.g. 2026-05-22T00:00:00Z): %w", raw, perr)
+		}
+		since = parsed
+	}
+
+	// Reject contradictory predicate+signal pairs upfront. cub-scout
+	// won't silently demote an explicit --predicate to "INCONCLUSIVE
+	// because you forgot the matching signal" — the CLI tells the user
+	// to fix it.
+	predicateExplicit := agent.PredicateName(strings.TrimSpace(receiptPredicate))
+	if predicateExplicit == agent.PredicateSourceTruthPass && strings.TrimSpace(receiptStrategy) == "" {
+		return fmt.Errorf("--predicate source-truth-pass requires --strategy (cub-scout does not infer the delivery strategy)")
+	}
+	if predicateExplicit == agent.PredicateNoManualEditsSince && since.IsZero() {
+		return fmt.Errorf("--predicate no-manual-edits-since requires --since <RFC3339 timestamp>")
 	}
 
 	kindRaw, name, ok := parseKindName(args[0])
@@ -128,6 +170,20 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 		GitSource:   gitSource,
 	}
 
+	// source-truth evidence is populated only when the caller signaled
+	// the source-truth-pass predicate (explicitly or via --strategy
+	// auto-detect). The runner refuses to silently derive source-truth
+	// for any receipt — that would attach evidence the consumer may not
+	// have asked for. Source-truth requires connected mode, so this
+	// path is connected-only by definition.
+	if strategy := strings.TrimSpace(receiptStrategy); strategy != "" {
+		stEvidence, stErr := collectSourceTruthForReceiptFn(ctx, kind, name, ns, strategy)
+		if stErr != nil {
+			return fmt.Errorf("collect source-truth evidence: %w", stErr)
+		}
+		evidence.SourceTruth = stEvidence
+	}
+
 	// 3. Build the spec anchor. If --at-commit is set, override the
 	// revision; otherwise use the controller-resolved anchor as both
 	// the spec and the evidence (the anchor-match check is then trivially
@@ -159,10 +215,12 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 			Namespace: ns,
 		},
 		Owner:         owner,
-		PredicateName: agent.PredicateName(strings.TrimSpace(receiptPredicate)),
+		PredicateName: predicateExplicit,
 		Spec:          spec,
 		Evidence:      evidence,
 		Connected:     connected,
+		Strategy:      strings.TrimSpace(receiptStrategy),
+		Since:         since,
 		Verifier: agent.Verifier{
 			Tool:    "cub-scout",
 			Version: BuildTag,
@@ -227,3 +285,39 @@ func loadReceiptLive(ctx context.Context, kind, name, namespace string) (*unstru
 
 // parseKindName lives in navigation_hints.go; we reuse its (kind, name, ok)
 // signature here.
+
+// collectSourceTruthForReceipt runs the same three-surface derivation
+// that `cub-scout compare source-truth` runs and returns the structured
+// evidence body. Read-only by construction: every helper here is a Get
+// against the cluster / ConfigHub / controller tracers; nothing writes.
+//
+// Errors are returned only when the caller's input is bad (unknown
+// strategy, runtime fetch failure with no graceful fallback). Soft
+// failures — missing ConfigHub linkage, controller CLI absent — are
+// converted into nil surfaces and surface through Derive as BLOCK /
+// WATCH / proof_gaps. The receipt orchestrator then mirrors those
+// proof_gaps into omissions[].
+func collectSourceTruthForReceipt(ctx context.Context, kind, name, namespace, strategyStr string) (*agent.SourceTruthEvidence, error) {
+	strategy, ok := agent.ParseStrategy(strategyStr)
+	if !ok {
+		return nil, fmt.Errorf("unknown source-truth strategy %q (valid: %v)", strategyStr, agent.AllStrategies())
+	}
+
+	runtime, runtimeObj, runtimeErr := collectRuntimeSurface(ctx, kind, name, namespace)
+	if runtimeErr != nil {
+		// Runtime unfetchable → BLOCKED evidence (the same shape
+		// `compare source-truth` produces in this case).
+		ev := agent.Derive(strategy, agent.SourceTruthSurfaces{})
+		return &ev, nil
+	}
+
+	chSurface, _ := collectConfigHubSurface(ctx, runtimeObj)
+	ctrlSurface := collectControllerSurface(ctx, strategy, kind, name, namespace)
+
+	ev := agent.Derive(strategy, agent.SourceTruthSurfaces{
+		ConfigHub:  chSurface,
+		Controller: ctrlSurface,
+		Runtime:    runtime,
+	})
+	return &ev, nil
+}

--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -28,6 +29,8 @@ var (
 	receiptSince     string
 	receiptFormat    string
 	receiptOut       string
+	receiptSave      bool
+	receiptSaveDir   string
 )
 
 // Function-variable seam for tests. Production reads from the cluster via
@@ -101,6 +104,8 @@ func init() {
 	receiptVerifyCmd.Flags().StringVar(&receiptSince, "since", "", "RFC 3339 cutoff for no-manual-edits-since (e.g. 2026-05-22T00:00:00Z).")
 	receiptVerifyCmd.Flags().StringVar(&receiptFormat, "format", "ascii", "Output format: ascii | json")
 	receiptVerifyCmd.Flags().StringVar(&receiptOut, "out", "", "Write the receipt to this file path (also printed to stdout in the chosen format)")
+	receiptVerifyCmd.Flags().BoolVar(&receiptSave, "save", false, "Save the receipt to the local store ($CUB_SCOUT_RECEIPTS_DIR or $XDG_DATA_HOME/cub-scout/receipts) for later cub-scout receipt list / show / validate")
+	receiptVerifyCmd.Flags().StringVar(&receiptSaveDir, "save-dir", "", "Override the store directory used when --save is set")
 }
 
 func runReceiptVerify(cmd *cobra.Command, args []string) error {
@@ -255,6 +260,33 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 		}
 		if writeErr := os.WriteFile(receiptOut, append(jsonBytes, '\n'), 0o644); writeErr != nil {
 			return fmt.Errorf("write receipt to %s: %w", receiptOut, writeErr)
+		}
+	}
+
+	if receiptSave {
+		// Save into the local store. Resolve dir from --save-dir or the
+		// default (XDG / HOME). agent.SaveStatement is immutable —
+		// duplicate filenames produce ErrExist. We catch that and emit
+		// an informational message so a repeated verify on the same
+		// resource at the same instant doesn't fail the command; the
+		// receipt is already on disk and identical by construction.
+		dir := strings.TrimSpace(receiptSaveDir)
+		if dir == "" {
+			resolved, dErr := agent.DefaultStoreDir()
+			if dErr != nil {
+				return fmt.Errorf("resolve receipt store: %w", dErr)
+			}
+			dir = resolved
+		}
+		savedPath, sErr := agent.SaveStatement(stmt, dir)
+		if sErr != nil {
+			if errors.Is(sErr, os.ErrExist) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "already saved: %s\n", savedPath)
+			} else {
+				return fmt.Errorf("save receipt: %w", sErr)
+			}
+		} else {
+			fmt.Fprintf(cmd.ErrOrStderr(), "saved: %s\n", savedPath)
 		}
 	}
 

--- a/cmd/cub-scout/receipt_batch2_test.go
+++ b/cmd/cub-scout/receipt_batch2_test.go
@@ -1,0 +1,318 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// withFakeSourceTruth installs a fake source-truth collector and restores
+// the production one on cleanup. Lets the source-truth-pass CLI path run
+// without a real ConfigHub or controller CLI.
+func withFakeSourceTruth(t *testing.T, ev *agent.SourceTruthEvidence) {
+	t.Helper()
+	prev := collectSourceTruthForReceiptFn
+	collectSourceTruthForReceiptFn = func(_ context.Context, _, _, _, _ string) (*agent.SourceTruthEvidence, error) {
+		return ev, nil
+	}
+	t.Cleanup(func() { collectSourceTruthForReceiptFn = prev })
+}
+
+// resetReceiptBatch2Flags zeros out the batch-2 receipt flags (strategy,
+// since) so consecutive tests don't bleed state.
+func resetReceiptBatch2Flags(t *testing.T) {
+	t.Helper()
+	resetReceiptFlags(t)
+	prevStrategy, prevSince := receiptStrategy, receiptSince
+	receiptStrategy = ""
+	receiptSince = ""
+	t.Cleanup(func() {
+		receiptStrategy = prevStrategy
+		receiptSince = prevSince
+	})
+}
+
+func makeLiveWithManagedFieldsForCLI(entries []metav1.ManagedFieldsEntry) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "prod",
+			},
+			"spec": map[string]interface{}{"replicas": int64(3)},
+		},
+	}
+	obj.SetManagedFields(entries)
+	return obj
+}
+
+// --- source-truth-pass path ------------------------------------------
+
+func TestReceiptVerify_SourceTruthPass_HappyPath(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyGitArgo.Human(),
+		Status:           agent.StatusPASS,
+		SourceTruth:      agent.VerdictAGREED,
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--strategy", "git-argo",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --strategy returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateSourceTruthPass) {
+		t.Errorf("predicateName: got %q, want source-truth-pass", stmt.Predicate.PredicateName)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictPASS {
+		t.Errorf("verdict: got %q, want PASS", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.SourceTruth == nil {
+		t.Fatal("source-truth-pass receipt must carry SourceTruth evidence")
+	}
+	if stmt.Predicate.Evidence.SourceTruth.Status != agent.StatusPASS {
+		t.Errorf("SourceTruth.Status: got %q, want PASS", stmt.Predicate.Evidence.SourceTruth.Status)
+	}
+	if err := agent.VerifyStatementFingerprint(stmt); err != nil {
+		t.Errorf("fingerprint integrity check failed: %v", err)
+	}
+}
+
+func TestReceiptVerify_SourceTruthPass_ExplicitPredicateNoStrategy_Errors(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--predicate", "source-truth-pass",
+	})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --predicate source-truth-pass without --strategy")
+	}
+	if !strings.Contains(err.Error(), "--strategy") {
+		t.Errorf("error must point at the missing --strategy flag; got %v", err)
+	}
+}
+
+func TestReceiptVerify_SourceTruthPass_StrategyMismatch_BLOCK(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	// Receipt is invoked with --strategy git-argo, but the evidence
+	// derivation came back with confighub-oci-argo. The predicate must
+	// emit BLOCK + OmissionStrategyMismatch.
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyConfigHubOCIArgo.Human(),
+		Status:           agent.StatusPASS,
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--strategy", "git-argo",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Errorf("strategy mismatch must produce BLOCK; got %q", stmt.Predicate.Verdict)
+	}
+	found := false
+	for _, o := range stmt.Predicate.Omissions {
+		if o.Missing == agent.OmissionStrategyMismatch {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected OmissionStrategyMismatch; got %v", stmt.Predicate.Omissions)
+	}
+}
+
+// --- no-manual-edits-since path --------------------------------------
+
+func TestReceiptVerify_NoManualEditsSince_HappyPath_PASS(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	cutoff := "2026-05-22T00:00:00Z"
+	before := metav1.NewTime(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
+	withFakeReceiptLoader(t, makeLiveWithManagedFieldsForCLI([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &before},
+	}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--since", cutoff,
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --since returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateNoManualEditsSince) {
+		t.Errorf("predicateName: got %q, want no-manual-edits-since", stmt.Predicate.PredicateName)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictPASS {
+		t.Errorf("controller-only managedFields must produce PASS; got %q", stmt.Predicate.Verdict)
+	}
+}
+
+func TestReceiptVerify_NoManualEditsSince_KubectlEdit_BLOCK(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+	withFakeReceiptLoader(t, makeLiveWithManagedFieldsForCLI([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+		{Manager: "kubectl-edit", Operation: metav1.ManagedFieldsOperationUpdate, Time: &after},
+	}))
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--since", "2026-05-22T00:00:00Z",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --since returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Errorf("kubectl-edit after cutoff must produce BLOCK; got %q", stmt.Predicate.Verdict)
+	}
+}
+
+func TestReceiptVerify_NoManualEditsSince_BadCutoff_Errors(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--since", "yesterday-ish",
+	})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for malformed --since")
+	}
+	if !strings.Contains(err.Error(), "invalid --since") {
+		t.Errorf("error must explain the parse failure; got %v", err)
+	}
+}
+
+func TestReceiptVerify_NoManualEditsSince_ExplicitPredicateNoSince_Errors(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--predicate", "no-manual-edits-since",
+	})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --predicate no-manual-edits-since without --since")
+	}
+	if !strings.Contains(err.Error(), "--since") {
+		t.Errorf("error must point at the missing --since flag; got %v", err)
+	}
+}
+
+// --- auto-detect (CLI surface) ----------------------------------------
+
+func TestReceiptVerify_AutoDetect_StrategyPicksSourceTruthPass(t *testing.T) {
+	// No --predicate. --strategy alone must auto-detect source-truth-pass.
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyGitArgo.Human(),
+		Status:           agent.StatusPASS,
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--strategy", "git-argo",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateSourceTruthPass) {
+		t.Errorf("predicateName: got %q, want source-truth-pass (auto-detect via --strategy)", stmt.Predicate.PredicateName)
+	}
+}
+
+func TestReceiptVerify_AutoDetect_SincePicksNoManualEditsSince(t *testing.T) {
+	resetReceiptBatch2Flags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--since", "2026-05-22T00:00:00Z",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateNoManualEditsSince) {
+		t.Errorf("predicateName: got %q, want no-manual-edits-since (auto-detect via --since)", stmt.Predicate.PredicateName)
+	}
+}

--- a/cmd/cub-scout/receipt_batch3_test.go
+++ b/cmd/cub-scout/receipt_batch3_test.go
@@ -1,0 +1,356 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+// resetReceiptBatch3Flags zeros the show/validate/list flags so
+// consecutive tests don't bleed state.
+func resetReceiptBatch3Flags(t *testing.T) {
+	t.Helper()
+	prev := struct {
+		showFmt, valFmt, listDir, listFmt string
+		save                              bool
+		saveDir                           string
+	}{
+		showFmt: receiptShowFormat,
+		valFmt:  receiptValidateFormat,
+		listDir: receiptListDir,
+		listFmt: receiptListFormat,
+		save:    receiptSave,
+		saveDir: receiptSaveDir,
+	}
+	receiptShowFormat = "ascii"
+	receiptValidateFormat = "ascii"
+	receiptListDir = ""
+	receiptListFormat = "ascii"
+	receiptSave = false
+	receiptSaveDir = ""
+	t.Cleanup(func() {
+		receiptShowFormat = prev.showFmt
+		receiptValidateFormat = prev.valFmt
+		receiptListDir = prev.listDir
+		receiptListFormat = prev.listFmt
+		receiptSave = prev.save
+		receiptSaveDir = prev.saveDir
+	})
+}
+
+// seedReceiptOnDisk runs `receipt verify --out` against a fake live
+// object and returns the path of the receipt on disk.
+func seedReceiptOnDisk(t *testing.T) string {
+	t.Helper()
+	resetReceiptFlags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	tmp := t.TempDir()
+	outPath := filepath.Join(tmp, "seed.receipt.json")
+	captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--format", "json",
+			"--out", outPath,
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("seed verify: %v", err)
+		}
+	})
+	return outPath
+}
+
+// --- receipt show -----------------------------------------------------
+
+func TestReceiptShow_ASCII_RendersFromDisk(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	path := seedReceiptOnDisk(t)
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "show", path})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt show: %v", err)
+		}
+	})
+	for _, want := range []string{
+		"Receipt: ",
+		"Verdict: ",
+		"Scope:   Deployment/api in prod",
+		"Fingerprint: ",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in show ASCII; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestReceiptShow_JSON_RendersFromDisk(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	path := seedReceiptOnDisk(t)
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "show", path, "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt show --format json: %v", err)
+		}
+	})
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("show json output is not a valid Statement: %v\nraw:\n%s", err, out)
+	}
+	if stmt.Type != agent.StatementType {
+		t.Errorf("Statement type: got %q, want %q", stmt.Type, agent.StatementType)
+	}
+}
+
+func TestReceiptShow_MissingFile_Errors(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	rootCmd.SetArgs([]string{"receipt", "show", "/tmp/does-not-exist-receipt.json"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// --- receipt validate -------------------------------------------------
+
+func TestReceiptValidate_HappyPath_OK(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	path := seedReceiptOnDisk(t)
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "validate", path})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt validate: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Fingerprint OK") {
+		t.Errorf("expected 'Fingerprint OK' in validate output; got:\n%s", out)
+	}
+}
+
+func TestReceiptValidate_TamperedReceipt_Errors(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	path := seedReceiptOnDisk(t)
+
+	// Read, mutate the verdict, write back. Fingerprint must mismatch.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read seed: %v", err)
+	}
+	tampered := strings.ReplaceAll(string(data), `"verdict": "PASS"`, `"verdict": "BLOCK"`)
+	if tampered == string(data) {
+		// The seed receipt might be INCONCLUSIVE; tamper that instead.
+		tampered = strings.ReplaceAll(string(data), `"verdict": "INCONCLUSIVE"`, `"verdict": "PASS"`)
+	}
+	if tampered == string(data) {
+		t.Fatalf("seed receipt verdict not mutateable; raw:\n%s", string(data))
+	}
+	if err := os.WriteFile(path, []byte(tampered), 0o644); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"receipt", "validate", path})
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected fingerprint mismatch error on tampered receipt")
+	}
+	if !strings.Contains(err.Error(), "fingerprint mismatch") {
+		t.Errorf("error must mention fingerprint mismatch; got %v", err)
+	}
+}
+
+func TestReceiptValidate_JSON_StructuredOutput(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	path := seedReceiptOnDisk(t)
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "validate", path, "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("validate --format json: %v", err)
+		}
+	})
+	var result receiptValidateResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("validate json is not valid receiptValidateResult: %v\nraw:\n%s", err, out)
+	}
+	if !result.Valid {
+		t.Errorf("expected Valid=true; got %+v", result)
+	}
+	if result.Fingerprint == "" {
+		t.Error("expected fingerprint in JSON output")
+	}
+}
+
+// --- receipt list -----------------------------------------------------
+
+func TestReceiptList_EmptyStore_PrintsZeroState(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	tmp := t.TempDir()
+	receiptListDir = tmp
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "list", "--dir", tmp})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt list: %v", err)
+		}
+	})
+	if !strings.Contains(out, "(no receipts found)") {
+		t.Errorf("empty store must print zero-state message; got:\n%s", out)
+	}
+}
+
+func TestReceiptList_PopulatedStore_PrintsRows(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	storeDir := t.TempDir()
+
+	// Save two receipts via --save into the store.
+	for i := 0; i < 2; i++ {
+		resetReceiptFlags(t)
+		withFakeReceiptLoader(t, makeReceiptArgoLive())
+		receiptSave = true
+		receiptSaveDir = storeDir
+		// Different namespaces so the second save doesn't dedupe.
+		ns := "prod"
+		if i == 1 {
+			ns = "staging"
+		}
+		captureStdout(t, func() {
+			rootCmd.SetArgs([]string{
+				"receipt", "verify", "deploy/api",
+				"-n", ns,
+				"--format", "json",
+			})
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("seed verify %d: %v", i, err)
+			}
+		})
+	}
+	// receiptSave / receiptSaveDir are cleared by the inner reset
+	// each iteration; reset them here for the list call.
+	resetReceiptBatch3Flags(t)
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "list", "--dir", storeDir})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt list: %v", err)
+		}
+	})
+	if !strings.Contains(out, "VERDICT") || !strings.Contains(out, "PREDICATE") {
+		t.Errorf("list ASCII must include header; got:\n%s", out)
+	}
+	// Two entries → both namespaces present.
+	if !strings.Contains(out, "Deployment/api in prod") || !strings.Contains(out, "Deployment/api in staging") {
+		t.Errorf("expected both scopes in list output; got:\n%s", out)
+	}
+}
+
+func TestReceiptList_JSON_RoundTrips(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	storeDir := t.TempDir()
+
+	resetReceiptFlags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	receiptSave = true
+	receiptSaveDir = storeDir
+	captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "deploy/api", "-n", "prod", "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	})
+	resetReceiptBatch3Flags(t)
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "list", "--dir", storeDir, "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("list --format json: %v", err)
+		}
+	})
+	var entries []agent.ReceiptListEntry
+	if err := json.Unmarshal([]byte(out), &entries); err != nil {
+		t.Fatalf("list JSON output is not []ReceiptListEntry: %v\nraw:\n%s", err, out)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry; got %d", len(entries))
+	}
+}
+
+// --- receipt verify --save --------------------------------------------
+
+func TestReceiptVerify_Save_WritesToStore(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	resetReceiptFlags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	storeDir := t.TempDir()
+	receiptSave = true
+	receiptSaveDir = storeDir
+
+	captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --save: %v", err)
+		}
+	})
+
+	entries, err := os.ReadDir(storeDir)
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".receipt.json") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a .receipt.json under %s; got entries: %v", storeDir, entries)
+	}
+}
+
+func TestReceiptVerify_Save_DefaultStoreHonorsEnv(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	resetReceiptFlags(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	// Point the default store env var at a tempdir; --save (no --save-dir)
+	// must land there.
+	tmp := t.TempDir()
+	t.Setenv("CUB_SCOUT_RECEIPTS_DIR", tmp)
+	receiptSave = true
+
+	captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--format", "json",
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify --save: %v", err)
+		}
+	})
+
+	entries, _ := os.ReadDir(tmp)
+	found := false
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".receipt.json") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("CUB_SCOUT_RECEIPTS_DIR must be honored by --save; got entries: %v", entries)
+	}
+}

--- a/cmd/cub-scout/receipt_examples_test.go
+++ b/cmd/cub-scout/receipt_examples_test.go
@@ -14,14 +14,15 @@ import (
 )
 
 // TestReceiptExamplesAreFresh re-runs the gen-receipt-examples tool and
-// compares its output to the committed files under
-// examples/receipts/applied-matches-spec. Drift fails the build — the
-// example receipts are a contract surface, not loose docs.
+// compares its output to the committed files under examples/receipts/.
+// Drift fails the build — the example receipts are a contract surface,
+// not loose docs. Both batch 1 (applied-matches-spec) and batch 2
+// (source-truth-pass, no-manual-edits-since) subdirectories are covered.
 //
 // To regenerate after an intentional change to the generator or to a
 // pkg/agent type that changes the wire format:
 //
-//	go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec
+//	go run ./tools/gen-receipt-examples examples/receipts
 func TestReceiptExamplesAreFresh(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("go run via exec is awkward on Windows; the linux/macos CI matrix catches drift")
@@ -37,65 +38,78 @@ func TestReceiptExamplesAreFresh(t *testing.T) {
 		t.Fatalf("regenerate examples: %v\noutput:\n%s", err, out)
 	}
 
-	committedDir := filepath.Join(repoRoot, "examples", "receipts", "applied-matches-spec")
-	committedEntries, err := os.ReadDir(committedDir)
-	if err != nil {
-		t.Fatalf("read committed dir %s: %v", committedDir, err)
+	// Each receipt-predicate subdirectory under examples/receipts/ is a
+	// contract surface. The generator writes the same layout into the
+	// tmp dir; walk both and diff.
+	predicateDirs := []string{
+		"applied-matches-spec",
+		"source-truth-pass",
+		"no-manual-edits-since",
 	}
 
-	var committedJSON []string
-	for _, e := range committedEntries {
-		if strings.HasSuffix(e.Name(), ".json") {
-			committedJSON = append(committedJSON, e.Name())
-		}
-	}
-	if len(committedJSON) == 0 {
-		t.Fatalf("no .json files in %s; the example directory must contain receipts", committedDir)
-	}
+	for _, predicateDir := range predicateDirs {
+		committedDir := filepath.Join(repoRoot, "examples", "receipts", predicateDir)
+		regenDir := filepath.Join(tmp, predicateDir)
 
-	regenEntries, err := os.ReadDir(tmp)
-	if err != nil {
-		t.Fatalf("read tmp output dir: %v", err)
-	}
-	regenSet := map[string]bool{}
-	for _, e := range regenEntries {
-		if strings.HasSuffix(e.Name(), ".json") {
-			regenSet[e.Name()] = true
-		}
-	}
-
-	// Same set of files (no rename / addition / deletion drift).
-	for _, name := range committedJSON {
-		if !regenSet[name] {
-			t.Errorf("committed file %q is no longer produced by the generator; regenerate or update the generator", name)
-		}
-	}
-	for name := range regenSet {
-		found := false
-		for _, c := range committedJSON {
-			if c == name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("generator produces %q but it is not committed; run `go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec`", name)
-		}
-	}
-
-	// Byte-for-byte content match.
-	for _, name := range committedJSON {
-		got, err := os.ReadFile(filepath.Join(tmp, name))
+		committedEntries, err := os.ReadDir(committedDir)
 		if err != nil {
-			continue // file-set mismatch already reported above
-		}
-		want, err := os.ReadFile(filepath.Join(committedDir, name))
-		if err != nil {
-			t.Errorf("read committed %s: %v", name, err)
+			t.Errorf("read committed dir %s: %v", committedDir, err)
 			continue
 		}
-		if !bytes.Equal(got, want) {
-			t.Errorf("committed %s differs from generator output; run `go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec`", name)
+		var committedJSON []string
+		for _, e := range committedEntries {
+			if strings.HasSuffix(e.Name(), ".json") {
+				committedJSON = append(committedJSON, e.Name())
+			}
+		}
+		if len(committedJSON) == 0 {
+			t.Errorf("no .json files in %s; the example directory must contain receipts", committedDir)
+			continue
+		}
+
+		regenEntries, err := os.ReadDir(regenDir)
+		if err != nil {
+			t.Errorf("read regen dir %s: %v", regenDir, err)
+			continue
+		}
+		regenSet := map[string]bool{}
+		for _, e := range regenEntries {
+			if strings.HasSuffix(e.Name(), ".json") {
+				regenSet[e.Name()] = true
+			}
+		}
+
+		for _, name := range committedJSON {
+			if !regenSet[name] {
+				t.Errorf("[%s] committed file %q is no longer produced by the generator; regenerate or update the generator", predicateDir, name)
+			}
+		}
+		for name := range regenSet {
+			found := false
+			for _, c := range committedJSON {
+				if c == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("[%s] generator produces %q but it is not committed; run `go run ./tools/gen-receipt-examples examples/receipts`", predicateDir, name)
+			}
+		}
+
+		for _, name := range committedJSON {
+			got, err := os.ReadFile(filepath.Join(regenDir, name))
+			if err != nil {
+				continue
+			}
+			want, err := os.ReadFile(filepath.Join(committedDir, name))
+			if err != nil {
+				t.Errorf("read committed %s/%s: %v", predicateDir, name, err)
+				continue
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("committed %s/%s differs from generator output; run `go run ./tools/gen-receipt-examples examples/receipts`", predicateDir, name)
+			}
 		}
 	}
 }

--- a/cmd/cub-scout/receipt_list.go
+++ b/cmd/cub-scout/receipt_list.go
@@ -1,0 +1,133 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+)
+
+var (
+	receiptListDir    string
+	receiptListFormat string
+)
+
+var receiptListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List receipts stored locally",
+	Long: `list walks the local receipt store and prints one line per
+receipt sorted by VerifiedAt descending (newest first). The store is
+resolved in this priority order:
+
+  1. --dir <path> (explicit override)
+  2. $CUB_SCOUT_RECEIPTS_DIR
+  3. $XDG_DATA_HOME/cub-scout/receipts
+  4. $HOME/.local/share/cub-scout/receipts
+
+Receipts are written to the store when you pass --save to receipt
+verify, when --out points inside the store directory, or by any other
+process that drops *.receipt.json files there.
+
+ASCII output (default):
+  VERDICT  PREDICATE              SCOPE                          VERIFIED-AT          PATH
+  PASS     applied-matches-spec   Deployment/api in prod         2026-05-22T10:30:00Z .../...
+  BLOCK    no-manual-edits-since  Deployment/api in prod         2026-05-22T08:00:00Z .../...
+
+JSON output is the structured ReceiptListEntry array — same content,
+machine-readable.
+
+Examples:
+  cub-scout receipt list
+  cub-scout receipt list --dir ./ci-receipts/
+  cub-scout receipt list --format json | jq '.[] | select(.verdict == "BLOCK")'
+`,
+	Args: cobra.NoArgs,
+	RunE: runReceiptList,
+}
+
+func init() {
+	receiptCmd.AddCommand(receiptListCmd)
+	receiptListCmd.Flags().StringVar(&receiptListDir, "dir", "", "Receipt store directory (default: $CUB_SCOUT_RECEIPTS_DIR or $XDG_DATA_HOME/cub-scout/receipts)")
+	receiptListCmd.Flags().StringVar(&receiptListFormat, "format", "ascii", "Output format: ascii | json")
+}
+
+func runReceiptList(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(receiptListFormat))
+	if format != "ascii" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json)", receiptListFormat)
+	}
+
+	dir := strings.TrimSpace(receiptListDir)
+	if dir == "" {
+		resolved, err := agent.DefaultStoreDir()
+		if err != nil {
+			return fmt.Errorf("resolve receipt store: %w", err)
+		}
+		dir = resolved
+	}
+
+	entries, listErr := agent.ListStatements(dir)
+	// listErr may be non-nil with a partial result (one or more files
+	// failed to parse). Surface as a warning rather than fatal.
+
+	switch format {
+	case "json":
+		buf, mErr := json.MarshalIndent(entries, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal list: %w", mErr)
+		}
+		fmt.Println(string(buf))
+	case "ascii":
+		renderReceiptListASCII(entries, dir)
+	}
+
+	if listErr != nil {
+		// Print a warning to stderr but exit 0 — partial list is the
+		// designed semantics.
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: %v\n", listErr)
+	}
+	return nil
+}
+
+// renderReceiptListASCII prints a fixed-width table of receipts. Style
+// matches the existing cub-scout map/explain output (no color, simple
+// header underline, columns padded for readability).
+func renderReceiptListASCII(entries []agent.ReceiptListEntry, dir string) {
+	fmt.Printf("Store: %s\n\n", dir)
+	if len(entries) == 0 {
+		fmt.Println("(no receipts found)")
+		return
+	}
+
+	fmt.Printf("%-13s  %-22s  %-40s  %-22s  %s\n",
+		"VERDICT", "PREDICATE", "SCOPE", "VERIFIED-AT", "PATH")
+	fmt.Println(strings.Repeat("-", 120))
+	for _, e := range entries {
+		scope := fmt.Sprintf("%s/%s in %s", e.Scope.Kind, e.Scope.Name, e.Scope.Namespace)
+		fmt.Printf("%-13s  %-22s  %-40s  %-22s  %s\n",
+			e.Verdict,
+			e.PredicateName,
+			truncateReceiptScope(scope, 40),
+			e.VerifiedAt,
+			filepath.Base(e.Path))
+	}
+}
+
+// truncateReceiptScope shortens s to at most n runes, appending an ellipsis byte
+// when truncateReceiptScoped. Cheap; non-ASCII-safe but adequate for K8s identifiers
+// (which are ASCII per RFC 1123).
+func truncateReceiptScope(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n < 1 {
+		return ""
+	}
+	return s[:n-1] + "…"
+}

--- a/cmd/cub-scout/receipt_render.go
+++ b/cmd/cub-scout/receipt_render.go
@@ -87,6 +87,22 @@ func renderReceiptASCII(stmt agent.Statement) string {
 		}
 	}
 
+	// Source-truth evidence (when present — only the source-truth-pass
+	// path attaches this surface).
+	if pred.Evidence.SourceTruth != nil {
+		st := pred.Evidence.SourceTruth
+		b.WriteString("\nEvidence (source-truth)\n")
+		fmt.Fprintf(&b, "  strategy:    %s\n", st.DeclaredStrategy)
+		fmt.Fprintf(&b, "  status:      %s\n", st.Status)
+		fmt.Fprintf(&b, "  verdict:     %s\n", st.SourceTruth)
+		if st.Outlier != "" {
+			fmt.Fprintf(&b, "  outlier:     %s\n", st.Outlier)
+		}
+		if len(st.ProofGaps) > 0 {
+			fmt.Fprintf(&b, "  proof_gaps:  %s\n", strings.Join(st.ProofGaps, ", "))
+		}
+	}
+
 	// Omissions are critical — they convert silent PASS into honest PASS.
 	if len(pred.Omissions) > 0 {
 		b.WriteString("\nOmissions (deliberate non-claims)\n")

--- a/cmd/cub-scout/receipt_show.go
+++ b/cmd/cub-scout/receipt_show.go
@@ -1,0 +1,63 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+)
+
+var receiptShowFormat string
+
+var receiptShowCmd = &cobra.Command{
+	Use:   "show <receipt-path>",
+	Short: "Render an on-disk receipt artifact",
+	Long: `show reads a receipt artifact from disk and renders it as ASCII
+(default) or JSON. This is the read-side complement to receipt verify,
+useful for inspecting receipts produced earlier in the pipeline, in CI
+output, or attached to an audit trail.
+
+show does NOT verify the fingerprint — that's receipt validate's job.
+It's read-only by construction.
+
+Examples:
+  cub-scout receipt show ./api.receipt.json
+  cub-scout receipt show ~/.local/share/cub-scout/receipts/2026-05-22T10-30-00Z__applied-matches-spec__Deployment-api__abc123def456.receipt.json --format json
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: runReceiptShow,
+}
+
+func init() {
+	receiptCmd.AddCommand(receiptShowCmd)
+	receiptShowCmd.Flags().StringVar(&receiptShowFormat, "format", "ascii", "Output format: ascii | json")
+}
+
+func runReceiptShow(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(receiptShowFormat))
+	if format != "ascii" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json)", receiptShowFormat)
+	}
+
+	stmt, err := agent.LoadStatement(args[0])
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "json":
+		buf, mErr := json.MarshalIndent(stmt, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal receipt: %w", mErr)
+		}
+		fmt.Println(string(buf))
+	case "ascii":
+		fmt.Print(renderReceiptASCII(stmt))
+	}
+	return nil
+}

--- a/cmd/cub-scout/receipt_validate.go
+++ b/cmd/cub-scout/receipt_validate.go
@@ -1,0 +1,103 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+)
+
+var receiptValidateFormat string
+
+var receiptValidateCmd = &cobra.Command{
+	Use:   "validate <receipt-path>",
+	Short: "Verify the fingerprint integrity of an on-disk receipt artifact",
+	Long: `validate reads a receipt artifact from disk and recomputes its
+fingerprint, comparing against the stamped value. Any tampering with
+_type, subject, predicateType, or any predicate field other than
+fingerprint produces a non-zero exit and an explanatory message.
+
+validate is read-only and never touches the cluster. It catches:
+  - receipt body modification (e.g., verdict flip, scope rename, subject digest swap)
+  - envelope tampering (e.g., predicateType change)
+  - corrupted on-disk JSON
+
+Exit code:
+  0   fingerprint matches
+  1   fingerprint mismatch (tampering or corruption)
+  2   I/O or parse error
+
+Examples:
+  cub-scout receipt validate ./api.receipt.json
+  cub-scout receipt validate ~/.local/share/cub-scout/receipts/2026-05-22T10-30-00Z__applied-matches-spec__Deployment-api__abc123def456.receipt.json
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: runReceiptValidate,
+}
+
+func init() {
+	receiptCmd.AddCommand(receiptValidateCmd)
+	receiptValidateCmd.Flags().StringVar(&receiptValidateFormat, "format", "ascii", "Output format: ascii | json (json emits a structured validation result)")
+}
+
+// receiptValidateResult is the JSON shape emitted by --format json. The
+// schema is intentionally tiny because consumers should drive CI pass/
+// fail on the exit code, not the JSON.
+type receiptValidateResult struct {
+	Path        string `json:"path"`
+	Fingerprint string `json:"fingerprint"`
+	Valid       bool   `json:"valid"`
+	Error       string `json:"error,omitempty"`
+}
+
+func runReceiptValidate(cmd *cobra.Command, args []string) error {
+	format := strings.ToLower(strings.TrimSpace(receiptValidateFormat))
+	if format != "ascii" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json)", receiptValidateFormat)
+	}
+
+	path := args[0]
+	stmt, err := agent.LoadStatement(path)
+	if err != nil {
+		// I/O or parse error: exit code 2 path.
+		return fmt.Errorf("load receipt %s: %w", path, err)
+	}
+
+	vErr := agent.VerifyStatementFingerprint(stmt)
+	result := receiptValidateResult{
+		Path:        path,
+		Fingerprint: stmt.Predicate.Fingerprint,
+		Valid:       vErr == nil,
+	}
+	if vErr != nil {
+		result.Error = vErr.Error()
+	}
+
+	switch format {
+	case "json":
+		buf, mErr := json.MarshalIndent(result, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal validate result: %w", mErr)
+		}
+		fmt.Println(string(buf))
+	case "ascii":
+		if result.Valid {
+			fmt.Printf("Fingerprint OK: %s\n  %s\n", path, result.Fingerprint)
+		} else {
+			fmt.Printf("Fingerprint MISMATCH: %s\n  recorded:  %s\n  error:     %s\n", path, result.Fingerprint, result.Error)
+		}
+	}
+
+	if vErr != nil {
+		// Exit code 1 path. RunE returning non-nil makes cobra exit
+		// non-zero; we wrap a stable sentinel-like error so future
+		// tests can match on it.
+		return fmt.Errorf("receipt fingerprint mismatch")
+	}
+	return nil
+}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2460,19 +2460,47 @@ cub-scout receipt verify <kind>/<name> -n <namespace> [flags]
 | Flag | Description |
 |------|-------------|
 | `-n, --namespace` | Namespace of the resource (required for namespaced kinds) |
-| `--predicate` | Predicate to evaluate. v1 batch 1 supports `applied-matches-spec`. Empty triggers auto-detect from owner. |
-| `--at-commit` | Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence. |
+| `--predicate` | Predicate to evaluate. v1 supports `applied-matches-spec`, `source-truth-pass`, `no-manual-edits-since`. Empty triggers auto-detect from owner + signals. |
+| `--at-commit` | Override the spec anchor revision (Git SHA) for `applied-matches-spec`. When empty, the controller-resolved anchor is used as both the spec and the evidence. |
+| `--strategy` | Source-truth strategy for `source-truth-pass` (e.g. `git-argo`, `confighub-oci-flux`, `helm-argo`). cub-scout does not infer the strategy. |
+| `--since` | RFC 3339 cutoff timestamp for `no-manual-edits-since` (e.g. `2026-05-22T00:00:00Z`). |
 | `--format` | Output format: `ascii` (default, one-screen human summary) or `json` (canonical in-toto Statement v1 envelope) |
 | `--out` | Write the receipt to this file path. Always JSON regardless of `--format` — disk is the long-lived artifact. |
+
+v1 predicates:
+
+| Predicate | Required | What it claims |
+|-----------|----------|----------------|
+| `applied-matches-spec` | Argo / Flux / ConfigHub owner + controller-resolved git anchor | LIVE matches the controller-resolved git anchor |
+| `source-truth-pass` | `--strategy <name>` + connected-mode ConfigHub auth | `compare source-truth` under the declared strategy returns PASS (mirrors Status into receipt Verdict) |
+| `no-manual-edits-since` | `--since <RFC3339 timestamp>` | No interactive (`kubectl-*`) writer touched `managedFields` after the cutoff |
+
+Auto-detection priority (when `--predicate` is not passed):
+
+1. Argo / Flux / ConfigHub owner WITH a resolvable git anchor → `applied-matches-spec`
+2. `--strategy` provided → `source-truth-pass`
+3. `--since` provided → `no-manual-edits-since`
+4. Otherwise → INCONCLUSIVE + `auto-detected-predicate` omission
+
+The CLI also rejects contradictory pairs upfront: `--predicate
+source-truth-pass` without `--strategy`, or `--predicate
+no-manual-edits-since` without `--since`, return an error rather than
+silently demoting to INCONCLUSIVE.
 
 Examples:
 
 ```bash
-# Standalone-mode verification — works without ConfigHub auth.
+# applied-matches-spec — standalone-mode verification (no ConfigHub auth required).
 cub-scout receipt verify deploy/api -n prod
 
-# Pin to an explicit revision (e.g., the SHA in a release ticket).
+# applied-matches-spec — pin to an explicit revision (e.g., the SHA in a release ticket).
 cub-scout receipt verify deploy/api -n prod --at-commit abc123def456
+
+# source-truth-pass — declared strategy, connected mode.
+cub-scout receipt verify deploy/api -n prod --strategy git-argo
+
+# no-manual-edits-since — cutoff at midnight UTC today.
+cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
 
 # Write the canonical JSON form to disk for audit attachment.
 cub-scout receipt verify deploy/api -n prod --format json --out api.receipt.json

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2515,6 +2515,86 @@ cub-scout receipt verify deploy/api -n prod --format json --out api.receipt.json
 | `BLOCK` | Evidence contradicts the claim |
 | `INCONCLUSIVE` | Evidence is missing or unavailable; always carries one or more `omissions[]` entries |
 
+### receipt show
+
+```bash
+cub-scout receipt show <path> [--format ascii|json]
+```
+
+Render an on-disk receipt artifact. ASCII (default) renders the
+one-screen human summary; JSON re-emits the canonical in-toto Statement
+v1 envelope verbatim. `show` does NOT verify the fingerprint — that's
+`receipt validate`'s job — so it works on tampered receipts for
+forensic inspection.
+
+### receipt validate
+
+```bash
+cub-scout receipt validate <path> [--format ascii|json]
+```
+
+Recompute the fingerprint of an on-disk receipt and compare against
+the stamped value. Catches any tampering with `_type`, `subject`,
+`predicateType`, or any predicate field other than `fingerprint`.
+
+Exit codes:
+
+- `0` — fingerprint matches
+- `1` — fingerprint mismatch (tampering or corruption)
+- `2` — I/O or parse error
+
+JSON output emits `{ "path": "…", "fingerprint": "…", "valid": true|false, "error": "…" }`
+for CI consumption.
+
+### receipt list
+
+```bash
+cub-scout receipt list [--dir <path>] [--format ascii|json]
+```
+
+List receipts stored locally. The store is resolved in priority order:
+
+1. `--dir <path>` (explicit override)
+2. `$CUB_SCOUT_RECEIPTS_DIR`
+3. `$XDG_DATA_HOME/cub-scout/receipts`
+4. `$HOME/.local/share/cub-scout/receipts`
+
+Receipts are written to the store when you pass `--save` to `receipt
+verify`. Files are flat JSON, named
+`<verifiedAt>__<predicate>__<kind>-<name>__<short-fingerprint>.receipt.json`
+so a normal `ls` yields chronological order.
+
+ASCII output is a five-column fixed-width table (verdict / predicate /
+scope / verifiedAt / filename). JSON emits the `ReceiptListEntry[]`
+shape — same content, machine-readable — sorted by `verifiedAt`
+descending.
+
+### Saving receipts to the local store
+
+`receipt verify --save` writes the receipt to the resolved store
+directory under its canonical filename. Useful for casual local
+accumulation; CI/scripts that need a specific path should keep using
+`--out <path>` instead.
+
+```bash
+# Save into the default store.
+cub-scout receipt verify deploy/api -n prod --save
+
+# Save into an explicit directory.
+cub-scout receipt verify deploy/api -n prod --save --save-dir ./ci-receipts/
+
+# Use the env var to set the default for a whole session.
+export CUB_SCOUT_RECEIPTS_DIR=./ci-receipts/
+cub-scout receipt verify deploy/api -n prod --save
+cub-scout receipt list
+```
+
+The store is immutable: `SaveStatement` refuses to overwrite an
+existing file. A repeated verify on the same resource at the same
+instant produces the same canonical filename → `--save` emits "already
+saved" to stderr and exits 0; the receipt on disk is identical by
+construction.
+
 ### Read-Only Triad Lock
 
 Receipts emit artifacts; they never mutate. Static guards

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -678,30 +678,38 @@ reason string.
 | `BLOCK` | Evidence contradicts the claim |
 | `INCONCLUSIVE` | Evidence is missing or unavailable; always carries one or more `omissions[]` entries explaining what's missing |
 
-### v1 Batch 1 Predicates
+### v1 Predicates
 
-| Predicate | Verdict Logic |
-|-----------|---------------|
-| `applied-matches-spec` | `Spec missing` or `GitSource missing` → INCONCLUSIVE + `OmissionGitSourceAnchor`. `Anchor mismatch (repoUrl/revision/path)` → BLOCK. `Cause = manual-edit` → BLOCK. `Cause = controller-drift` → PASS. `Cause = unknown` or unrecognized → INCONCLUSIVE + `OmissionManagedFields`. |
-
-`source-truth-pass` and `no-manual-edits-since` land in batch 2.
+| Predicate | Required signals | Verdict Logic |
+|-----------|------------------|---------------|
+| `applied-matches-spec` | Controller-resolved `gitSource` on the resource | `Spec missing` or `GitSource missing` → INCONCLUSIVE + `OmissionGitSourceAnchor`. `Anchor mismatch (repoUrl/revision/path)` → BLOCK. `Cause = manual-edit` → BLOCK. `Cause = controller-drift` → PASS. `Cause = unknown` or unrecognized → INCONCLUSIVE + `OmissionManagedFields`. |
+| `source-truth-pass` | `--strategy` (one of nine) + connected-mode ConfigHub auth | `--strategy` empty → INCONCLUSIVE + `OmissionStrategyMissing`. No source-truth evidence body → INCONCLUSIVE + `OmissionSourceTruthEvidence`. Strategy mismatch between caller and evidence → BLOCK + `OmissionStrategyMismatch`. Otherwise: Status PASS → PASS, WATCH → WATCH, BLOCK → BLOCK, ASK → INCONCLUSIVE. Source-truth `proof_gaps[]` are mirrored into `omissions[]` under `source-truth-complete` regardless of verdict. |
+| `no-manual-edits-since` | `--since <RFC3339>` cutoff | `--since` zero → INCONCLUSIVE + `OmissionSinceMissing`. Live nil or no managedFields → INCONCLUSIVE + `OmissionManagedFields`. Any interactive (`kubectl-*`) manager with `Time > since` → BLOCK. Any interactive manager with nil `Time` → INCONCLUSIVE + `OmissionManagedFieldsTime`. Otherwise → PASS. |
 
 ### Auto-Detection Priority
 
-When `--predicate` is not passed, cub-scout picks one based on detected
-ownership AND the resolvability of the git anchor:
+When `--predicate` is not passed, cub-scout picks one from these signals
+in priority order:
 
 1. `OwnerArgo` / `OwnerFlux` / `OwnerConfigHub` **with** a resolved git
    anchor (`evidence.gitSource` non-nil) → `applied-matches-spec`
-2. Same owners **without** a resolved git anchor → `""` (no predicate) +
-   `OmissionAutoDetectedPredicate` — the predicate evaluator could only
-   emit INCONCLUSIVE anyway, so we record the *missing default* rather
-   than masking the auto-detect-declined-here case as a different
-   omission.
-3. Other owners → `""` + `OmissionAutoDetectedPredicate`.
+2. `--strategy` provided → `source-truth-pass`
+3. `--since` provided → `no-manual-edits-since`
+4. Same owners **without** a resolved git anchor, no other signals → `""`
+   (no predicate) + `OmissionAutoDetectedPredicate` — the predicate
+   evaluator could only emit INCONCLUSIVE anyway, so we record the
+   *missing default* rather than masking the auto-detect-declined-here
+   case as a different omission.
+5. Other owners with no signals → `""` + `OmissionAutoDetectedPredicate`.
 
 The result is always an INCONCLUSIVE receipt when auto-detect declines;
 the omission entry names exactly which signal was missing.
+
+Explicit `--predicate` always wins over auto-detect. The CLI also
+rejects contradictory pairs upfront: `--predicate source-truth-pass`
+without `--strategy` errors, and `--predicate no-manual-edits-since`
+without `--since` errors — silently demoting either to INCONCLUSIVE
+would hide the operator's intent from the receipt.
 
 ### Omissions
 
@@ -711,11 +719,17 @@ Each entry explicitly converts a silent PASS into an honest PASS:
 | Omission `missing` | Meaning |
 |--------------------|---------|
 | `confighub-unit-subject` | No ConfigHub unit subject available (standalone mode, or connected mode but no linkage) |
-| `managedFields` | Attribution layer returned `cause:unknown` or an unrecognized cause |
+| `managedFields` | Attribution layer returned `cause:unknown`, or no-manual-edits-since saw no entries on the live object |
+| `managedFields-time` | An interactive `managedFields` entry has nil `Time`; no-manual-edits-since cannot place it on the timeline |
 | `git-source-anchor` | No spec anchor or no controller-resolved git anchor |
-| `auto-detected-predicate` | Owner has no v1 default predicate; `--predicate` must be passed |
+| `auto-detected-predicate` | No signal supported a default predicate; pass `--predicate`, `--strategy`, or `--since` |
+| `strategy` | source-truth-pass invoked without `--strategy`; cub-scout does not infer delivery strategy |
+| `strategy-mismatch` | The receipt's declared strategy disagrees with the strategy recorded in the source-truth evidence body |
+| `source-truth-evidence` | source-truth-pass invoked but no source-truth evidence body was attached |
+| `source-truth-complete` | A proof gap from `compare source-truth` (e.g. `runtime.helm_chart_anchor`); mirrored into `omissions[]` regardless of receipt verdict |
+| `since` | no-manual-edits-since invoked without `--since`; cub-scout does not invent a cutoff |
 | `next-step-allowed-action` | A nextStep with mutating `actionType` was dropped at receipt-emit time |
-| `next-step-allowed-command` | A nextStep with mutating `nextCommand` (apply/edit/patch/delete/sync/create/update/replace/scale/rollout/reconcile) was dropped |
+| `next-step-allowed-command` | A nextStep with mutating `nextCommand` (apply/edit/patch/delete/sync/create/update/replace/scale/rollout/reconcile/annotate/label/set/exec/debug/`helm install`/`helm upgrade`) was dropped |
 
 ### Read-Only Triad Lock
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -781,6 +781,63 @@ verification.
 `--format`. The on-disk artifact is the long-lived evidence; ASCII is for
 human review.
 
+### Receipt Management Surface (`show` / `validate` / `list`)
+
+cub-scout ships three read-side subcommands that operate on receipt
+artifacts produced earlier:
+
+| Subcommand | Purpose | Exit code |
+|------------|---------|-----------|
+| `receipt show <path>` | Render an on-disk receipt as ASCII or JSON. Does NOT verify fingerprint. | 0 on success |
+| `receipt validate <path>` | Recompute fingerprint and compare against stamped value. | 0 OK, 1 mismatch, 2 I/O |
+| `receipt list [--dir <path>]` | Walk the store directory; one row per receipt. | 0 (partial list on parse failure with warning) |
+
+#### Storage Convention
+
+The receipt store is a flat directory of `*.receipt.json` files keyed
+by a deterministic sortable name:
+
+```
+<verifiedAt-rfc3339-safe>__<predicateName>__<kind>-<name>__<short-fingerprint>.receipt.json
+```
+
+`verifiedAt-rfc3339-safe` replaces `:` with `-` (POSIX-portable);
+`short-fingerprint` is the first 12 hex chars after the `sha256:`
+prefix. The shape makes `ls` chronological and `ls | grep <predicate>`
+useful.
+
+Default store directory, resolved in priority order:
+
+1. `--save-dir <path>` (on `receipt verify`) or `--dir <path>` (on `receipt list`)
+2. `$CUB_SCOUT_RECEIPTS_DIR` env var
+3. `$XDG_DATA_HOME/cub-scout/receipts`
+4. `$HOME/.local/share/cub-scout/receipts`
+
+`receipt verify --save` writes into the store. The store is
+**immutable**: `SaveStatement` refuses to overwrite an existing
+filename. A re-verify at the same instant on the same scope with the
+same fingerprint produces the same name → "already saved" warning on
+stderr, exit 0, the on-disk artifact unchanged.
+
+#### `ReceiptListEntry` JSON Shape
+
+`receipt list --format json` emits a sorted `ReceiptListEntry[]`:
+
+```json
+[
+  {
+    "path": "/home/user/.local/share/cub-scout/receipts/2026-05-22T10-30-00Z__applied-matches-spec__Deployment-api__a1b2c3d4e5f6.receipt.json",
+    "verifiedAt": "2026-05-22T10:30:00Z",
+    "predicateName": "applied-matches-spec",
+    "scope": { "kind": "Deployment", "name": "api", "namespace": "prod" },
+    "verdict": "PASS",
+    "fingerprint": "sha256:a1b2c3d4e5f6..."
+  }
+]
+```
+
+Sort order: `verifiedAt` descending (newest first).
+
 Source: `pkg/agent/receipt*.go`, `cmd/cub-scout/receipt*.go`. See
 `docs/proposals/receipts-way-forward.md` for the full design synthesis and
 the Codex review rounds that locked the wire format.

--- a/examples/receipts/README.md
+++ b/examples/receipts/README.md
@@ -12,20 +12,42 @@ Wire format: **in-toto Statement v1** envelope (`_type =
 DSSE signing wrapped in Sigstore Bundle v0.3 (purely additive — no
 envelope change).
 
-## v1 Batch 1: `applied-matches-spec`
+## v1 Predicates
 
-See [`applied-matches-spec/`](./applied-matches-spec/) for the four
-canonical example receipts (PASS, BLOCK on manual-edit, BLOCK on anchor
-mismatch, INCONCLUSIVE) and the contract reference.
+| Predicate | Inputs | Verdict semantics |
+|-----------|--------|-------------------|
+| [`applied-matches-spec`](./applied-matches-spec/) | Argo / Flux / ConfigHub owner + controller-resolved git anchor, optional `--at-commit` | LIVE matches the controller-resolved git anchor (PASS on controller-drift cause, BLOCK on manual-edit / anchor mismatch, INCONCLUSIVE on missing anchor) |
+| [`source-truth-pass`](./source-truth-pass/) | Explicit `--strategy <name>` (one of 9 strategies), connected-mode ConfigHub auth | Mirrors `compare source-truth` Status → Verdict (PASS / WATCH / BLOCK / INCONCLUSIVE). Strategy mismatch between caller and evidence → BLOCK + `OmissionStrategyMismatch`. |
+| [`no-manual-edits-since`](./no-manual-edits-since/) | `--since <RFC3339 timestamp>` cutoff | PASS when no interactive (`kubectl-*`) writer touched `metadata.managedFields` after the cutoff; BLOCK on any late interactive write; INCONCLUSIVE on missing managedFields or nil-Time entries. |
+
+Each subdirectory ships canonical example receipts produced
+deterministically by [`tools/gen-receipt-examples`](../../tools/gen-receipt-examples/)
+and validated by `TestReceiptExamplesAreFresh`.
+
+## Auto-Detection Priority
+
+When `--predicate` is not passed, cub-scout picks one from these signals:
+
+1. Argo / Flux / ConfigHub owner WITH a resolvable git anchor →
+   `applied-matches-spec`
+2. `--strategy` provided → `source-truth-pass`
+3. `--since` provided → `no-manual-edits-since`
+4. Otherwise → INCONCLUSIVE + `OmissionAutoDetectedPredicate`
 
 ## Generating Your Own
 
 ```bash
-# Standalone-mode receipt — works without ConfigHub auth.
+# applied-matches-spec — standalone-mode receipt (works without ConfigHub auth).
 ./cub-scout receipt verify deploy/api -n prod
 
-# Pin to an explicit revision (e.g., the SHA in a release ticket).
+# applied-matches-spec — pin to an explicit revision (e.g., the SHA in a release ticket).
 ./cub-scout receipt verify deploy/api -n prod --at-commit abc123def456
+
+# source-truth-pass — connected mode, declared strategy.
+./cub-scout receipt verify deploy/api -n prod --strategy git-argo
+
+# no-manual-edits-since — cutoff before today.
+./cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
 
 # Write the canonical JSON form to disk for audit attachment.
 ./cub-scout receipt verify deploy/api -n prod --format json --out api.receipt.json

--- a/examples/receipts/README.md
+++ b/examples/receipts/README.md
@@ -53,6 +53,48 @@ When `--predicate` is not passed, cub-scout picks one from these signals:
 ./cub-scout receipt verify deploy/api -n prod --format json --out api.receipt.json
 ```
 
+## Reading Receipts Back
+
+Once a receipt is on disk, three subcommands let you work with it
+without re-running the verification:
+
+```bash
+# Render a receipt (no fingerprint check).
+./cub-scout receipt show ./api.receipt.json
+
+# Verify fingerprint integrity. Exit 0 = OK, 1 = mismatch, 2 = I/O error.
+./cub-scout receipt validate ./api.receipt.json
+
+# List receipts in the local store.
+./cub-scout receipt list
+./cub-scout receipt list --format json | jq '.[] | select(.verdict == "BLOCK")'
+```
+
+## Local Receipt Store
+
+`receipt verify --save` writes the receipt to a flat directory:
+
+| Override | Default |
+|----------|---------|
+| `--save-dir <path>` on the verify command | (priority chain below) |
+| `--dir <path>` on `receipt list` | (priority chain below) |
+| `$CUB_SCOUT_RECEIPTS_DIR` env var | (priority chain below) |
+| `$XDG_DATA_HOME/cub-scout/receipts` | (priority chain below) |
+| `$HOME/.local/share/cub-scout/receipts` | (default) |
+
+Filenames are canonical and sortable:
+
+```
+<verifiedAt>__<predicate>__<kind>-<name>__<short-fingerprint>.receipt.json
+
+2026-05-22T10-30-00Z__applied-matches-spec__Deployment-api__a1b2c3d4e5f6.receipt.json
+```
+
+Files are immutable — `SaveStatement` refuses to overwrite an existing
+filename. A re-verify at the same instant produces the same canonical
+name → the on-disk artifact is unchanged and `--save` reports "already
+saved" to stderr.
+
 ## Read-Only Triad Lock
 
 Receipts emit artifacts; they never mutate. Static guards in

--- a/examples/receipts/no-manual-edits-since/README.md
+++ b/examples/receipts/no-manual-edits-since/README.md
@@ -1,0 +1,81 @@
+# Receipt Example: `no-manual-edits-since`
+
+`no-manual-edits-since` verifies that no interactive (`kubectl-*`)
+writer touched `metadata.managedFields` after a given cutoff
+timestamp. It's the receipt-shaped complement to the attribution
+layer's `manual-edit` cause classification — useful for release-gate
+checks like "no operator emergency-edited this Deployment after the
+freeze started."
+
+cub-scout **never invents a cutoff** — you must pass `--since` in
+RFC 3339 form.
+
+## Quick Start
+
+```bash
+# "No manual edits after midnight UTC today."
+./cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
+
+# Write the canonical JSON form to disk for audit attachment.
+./cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z --format json --out api.no-edits.receipt.json
+```
+
+## Verdict Logic
+
+The predicate walks `live.metadata.managedFields` and classifies each
+entry by manager:
+
+- **Controller writer** (e.g. `argocd-controller`, `kustomize-controller`,
+  `helm-controller`) → ignored. We don't claim anything about
+  controller writes; only about interactive ones.
+- **Interactive writer** (any `kubectl-*` manager, plus the verified
+  enumeration in `pkg/agent/manager_strings.go`) → checked against
+  the cutoff:
+  - `e.Time > since` → **BLOCK**. A human bypassed the GitOps loop
+    after the freeze.
+  - `e.Time <= since` → ignored. Old edit, already accounted for.
+  - `e.Time == nil` → **INCONCLUSIVE** + `OmissionManagedFieldsTime`.
+    We cannot place the entry on the timeline and refuse to claim
+    "no manual edits since T" without proof.
+- **Unknown writer** (not in the verified manager-string enumeration)
+  → ignored. Conservative — same `parse, don't guess` rule the
+  attribution layer uses.
+
+If no managedFields exist at all → **INCONCLUSIVE** +
+`OmissionManagedFields`. Old K8s versions, admission-webhook-stripped
+resources, or replayed objects all degrade gracefully rather than
+producing false PASS.
+
+## Caveat: managedFields Is Best-Effort
+
+K8s `managedFields` is the only field-level evidence cub-scout has in
+standalone mode. The predicate inherits its limitations:
+
+- An admission webhook can strip the entries.
+- A `kubectl apply --server-side` with a custom field manager can mask
+  the writer identity.
+- A namespace migration can rewrite the entries with a fresh Time.
+
+In all these cases the predicate emits INCONCLUSIVE rather than
+fabricating a PASS. See `docs/proposals/receipts-way-forward.md` § "field-manager evidence caveat" for the full discussion.
+
+## Example Files
+
+### `pass-controller-only.json` — PASS
+
+`argocd-controller` is the only writer; its Time predates the cutoff.
+No interactive writer present, so verdict: PASS.
+
+### `block-kubectl-edit.json` — BLOCK
+
+Same Deployment, but a `kubectl-edit` entry now appears with Time
+after the cutoff. Verdict: BLOCK. The `nextStep` reason names the
+violating manager and the offending timestamp so the operator can
+investigate in `kubectl get --show-managed-fields`.
+
+## References
+
+- Parent issue: [`confighub/cub-scout#446`](https://github.com/confighub/cub-scout/issues/446) — Receipt capability
+- Manager-string enumeration: `pkg/agent/manager_strings.go`
+- Attribution layer (companion evidence): [`examples/drift/mutation-cause-attribution/`](../../drift/mutation-cause-attribution/)
+- Implementation: `pkg/agent/receipt_predicates.go` `EvaluateNoManualEditsSince`

--- a/examples/receipts/no-manual-edits-since/block-kubectl-edit.json
+++ b/examples/receipts/no-manual-edits-since/block-kubectl-edit.json
@@ -1,0 +1,47 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "no manual edits to Deployment/api in prod since 2026-05-22T00:00:00Z",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "no-manual-edits-since",
+    "verdict": "BLOCK",
+    "evidence": {},
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "interactive writer wrote managedFields after the cutoff (2026-05-22T00:00:00Z): kubectl-edit@2026-05-22T12:00:00Z — investigate the unplanned edit before any apply",
+        "nextCommand": "kubectl get --show-managed-fields",
+        "nextSurface": "kubectl"
+      }
+    ],
+    "fingerprint": "sha256:af4c1c1384823207457e9892ae28d548c924a595e8dcccce51d58b2c1c6c3fc0"
+  }
+}

--- a/examples/receipts/no-manual-edits-since/pass-controller-only.json
+++ b/examples/receipts/no-manual-edits-since/pass-controller-only.json
@@ -1,0 +1,47 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "no manual edits to Deployment/api in prod since 2026-05-22T00:00:00Z",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "no-manual-edits-since",
+    "verdict": "PASS",
+    "evidence": {},
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "no interactive writer touched managedFields after 2026-05-22T00:00:00Z",
+        "nextCommand": "cub-scout explain Deployment/api -n prod",
+        "nextSurface": "cub-scout"
+      }
+    ],
+    "fingerprint": "sha256:07ff1d0c34d17c4ac4140ce913cab45140e4f694535a743bc193da9add589eeb"
+  }
+}

--- a/examples/receipts/source-truth-pass/README.md
+++ b/examples/receipts/source-truth-pass/README.md
@@ -1,0 +1,77 @@
+# Receipt Example: `source-truth-pass`
+
+`source-truth-pass` wraps cub-scout's existing `compare source-truth`
+derivation into a typed, fingerprinted receipt. The predicate verifies
+that the three observed surfaces (ConfigHub / controller / runtime) agree
+under an explicitly-declared delivery strategy.
+
+cub-scout **never infers a strategy** — you must pass `--strategy`. The
+nine v1 strategies (see [source-truth strategies reference](../../../docs/reference/json-contracts.md))
+cover the common Argo / Flux / Helm / OCI / Kustomize combinations.
+
+## Quick Start
+
+```bash
+# Vanilla Git -> Argo -> Kubernetes.
+./cub-scout receipt verify deploy/api -n prod --strategy git-argo
+
+# ConfigHub -> OCI -> Argo -> Kubernetes.
+./cub-scout receipt verify deploy/api -n prod --strategy confighub-oci-argo
+
+# Write the canonical JSON form to disk for audit attachment.
+./cub-scout receipt verify deploy/api -n prod --strategy git-argo --format json --out api.source-truth.receipt.json
+```
+
+## Connected-Mode Required
+
+`source-truth-pass` reads the ConfigHub surface via the `cub` CLI. The
+predicate requires connected mode (`cub auth login` or
+`CONFIGHUB_API_KEY`). Standalone-mode runs decline with an INCONCLUSIVE
+verdict + the source-truth proof gaps mirrored into `omissions[]`.
+
+## Verdict Mapping
+
+The source-truth derivation produces a four-valued **Status** (PASS /
+WATCH / BLOCK / ASK). The receipt maps these directly to receipt-level
+verdicts:
+
+| `compare source-truth` Status | Receipt Verdict |
+|-------------------------------|-----------------|
+| `PASS`  | `PASS` |
+| `WATCH` | `WATCH` |
+| `BLOCK` | `BLOCK` |
+| `ASK`   | `INCONCLUSIVE` (with the evidence's `proof_gaps` mirrored into `omissions[]`) |
+
+The receipt always carries the full `SourceTruthEvidence` body
+(surfaces, proof gaps, outlier, native verdict) in
+`predicate.evidence.sourceTruth` so consumers needing the unflattened
+detail can read it directly.
+
+## Strategy Mismatch Is BLOCK
+
+If the receipt is asked to verify under one strategy but the underlying
+source-truth derivation runs under a different one, the predicate emits
+**BLOCK** with an `OmissionStrategyMismatch` entry. We never silently
+honor the caller's strategy over what the evidence claims to be under
+— that would let a CI gate paper over a real strategy disagreement.
+
+## Example Files
+
+### `pass-agreed.json` — PASS
+
+Vanilla `git-argo` strategy. All three surfaces agree, `Status: PASS`,
+`SourceTruth: AGREED`, no proof gaps. Receipt verdict: PASS.
+
+### `block-mismatch.json` — BLOCK
+
+Same `git-argo` strategy, but the controller's observed revision
+(`feedface...`) doesn't match the runtime's expectations. The
+source-truth derivation emits `Status: BLOCK` with controller as the
+outlier. Receipt verdict: BLOCK.
+
+## References
+
+- Parent issue: [`confighub/cub-scout#446`](https://github.com/confighub/cub-scout/issues/446) — Receipt capability
+- Source-truth contract: [`docs/reference/json-contracts.md`](../../../docs/reference/json-contracts.md) § Source-Truth Evidence Contract
+- Strategy enumeration: `pkg/agent/source_truth.go` `AllStrategies()`
+- Implementation: `pkg/agent/receipt_predicates.go` `EvaluateSourceTruthPass`

--- a/examples/receipts/source-truth-pass/block-mismatch.json
+++ b/examples/receipts/source-truth-pass/block-mismatch.json
@@ -1,0 +1,72 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "source-truth PASS under strategy \"git-argo\" for Deployment/api in prod",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "source-truth-pass",
+    "verdict": "BLOCK",
+    "evidence": {
+      "sourceTruth": {
+        "declared_strategy": "Git -\u003e Argo -\u003e Kubernetes",
+        "status": "BLOCK",
+        "source_truth": "MISMATCH",
+        "outlier": "controller",
+        "surfaces": {
+          "confighub": {
+            "space": "payments",
+            "unit": "api",
+            "revision": "42"
+          },
+          "controller": {
+            "kind": "Argo",
+            "source": "https://github.com/org/platform-config",
+            "revision_or_digest": "feedfacefeedfacefeedfacefeedfacefeedface"
+          },
+          "runtime": {
+            "resource": "Deployment/api in prod",
+            "field": "spec.template.spec.containers[0].image",
+            "value": "ghcr.io/org/api:v2.3.0",
+            "health": "Ready"
+          }
+        }
+      }
+    },
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "source-truth BLOCK; a hard rule failed (strategy mismatch, controller-source resolution failure, etc.) — investigate before acceptance",
+        "nextCommand": "cub-scout compare source-truth --strategy git-argo",
+        "nextSurface": "cub-scout"
+      }
+    ],
+    "fingerprint": "sha256:cf0e510a4e50b08e57431cd5e107f7ca5f184f66d4dd9e8dd582fa848d3ec859"
+  }
+}

--- a/examples/receipts/source-truth-pass/pass-agreed.json
+++ b/examples/receipts/source-truth-pass/pass-agreed.json
@@ -1,0 +1,72 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "k8s-live://apps/v1/Deployment/prod/api",
+      "digest": {
+        "sha256": "595f08ae073d5a9df5fab2deb16e1c151c4d0a20484c3f91891cd657e2a63dda"
+      }
+    }
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "version": "v1",
+    "claim": "source-truth PASS under strategy \"git-argo\" for Deployment/api in prod",
+    "scope": {
+      "kind": "Deployment",
+      "name": "api",
+      "namespace": "prod",
+      "cluster": "prod-use2"
+    },
+    "verifier": {
+      "tool": "cub-scout",
+      "version": "v0.99.0-receipt-batch-1"
+    },
+    "verifiedAt": "2026-05-21T10:30:00Z",
+    "predicateName": "source-truth-pass",
+    "verdict": "PASS",
+    "evidence": {
+      "sourceTruth": {
+        "declared_strategy": "Git -\u003e Argo -\u003e Kubernetes",
+        "status": "PASS",
+        "source_truth": "AGREED",
+        "outlier": "unknown",
+        "surfaces": {
+          "confighub": {
+            "space": "payments",
+            "unit": "api",
+            "revision": "42"
+          },
+          "controller": {
+            "kind": "Argo",
+            "source": "https://github.com/org/platform-config",
+            "revision_or_digest": "abc123def456abc123def456abc123def456abcd"
+          },
+          "runtime": {
+            "resource": "Deployment/api in prod",
+            "field": "spec.template.spec.containers[0].image",
+            "value": "ghcr.io/org/api:v2.3.0",
+            "health": "Ready"
+          }
+        }
+      }
+    },
+    "omissions": [
+      {
+        "missing": "confighub-unit-subject",
+        "reason": "standalone-mode build; no ConfigHub auth available to fetch unit subject",
+        "severity": "info"
+      }
+    ],
+    "inputAttestations": [],
+    "nextSteps": [
+      {
+        "actionType": "read-only",
+        "reason": "source-truth PASS under the declared strategy; all three surfaces agree under the strategy-implied authority",
+        "nextCommand": "cub-scout explain Deployment/api -n prod",
+        "nextSurface": "cub-scout"
+      }
+    ],
+    "fingerprint": "sha256:2363cd2b192c8926595d55b7e37330a6343ba375ad9aae0247be86fabdb7cd11"
+  }
+}

--- a/pkg/agent/receipt.go
+++ b/pkg/agent/receipt.go
@@ -243,10 +243,38 @@ type ReceiptNextStep struct {
 // Common omission Missing values, exposed as constants so callers and
 // tests can reference them by name rather than free string.
 const (
-	OmissionConfigHubUnitSubject = "confighub-unit-subject"
-	OmissionManagedFields        = "managedFields"
-	OmissionGitSourceAnchor      = "git-source-anchor"
-	OmissionSourceTruthComplete  = "source-truth-complete"
+	OmissionConfigHubUnitSubject  = "confighub-unit-subject"
+	OmissionManagedFields         = "managedFields"
+	OmissionGitSourceAnchor       = "git-source-anchor"
+	OmissionSourceTruthComplete   = "source-truth-complete"
 	OmissionAutoDetectedPredicate = "auto-detected-predicate"
-	OmissionFieldCoverage        = "field-coverage"
+	OmissionFieldCoverage         = "field-coverage"
+
+	// OmissionStrategyMissing is recorded by the source-truth-pass
+	// predicate when no --strategy was passed. cub-scout never infers a
+	// strategy — the receipt either records the declared strategy or
+	// declines to claim.
+	OmissionStrategyMissing = "strategy"
+
+	// OmissionStrategyMismatch is recorded when the receipt was asked to
+	// verify under a strategy that disagrees with what the source-truth
+	// evidence in the live cluster actually carries.
+	OmissionStrategyMismatch = "strategy-mismatch"
+
+	// OmissionSourceTruthEvidence is recorded by the source-truth-pass
+	// predicate when the evidence body has no source-truth surface to
+	// evaluate.
+	OmissionSourceTruthEvidence = "source-truth-evidence"
+
+	// OmissionSinceMissing is recorded by the no-manual-edits-since
+	// predicate when no --since cutoff was passed. cub-scout will not
+	// invent a cutoff.
+	OmissionSinceMissing = "since"
+
+	// OmissionManagedFieldsTime is recorded by the no-manual-edits-since
+	// predicate when a managedFields entry has no Time stamp. Old K8s
+	// versions or replayed objects can have entries with nil Time;
+	// cub-scout cannot claim "no manual edits since T" if it cannot place
+	// each entry on the timeline.
+	OmissionManagedFieldsTime = "managedFields-time"
 )

--- a/pkg/agent/receipt_build.go
+++ b/pkg/agent/receipt_build.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -66,6 +67,17 @@ type BuildReceiptInput struct {
 	// VerifiedAt is the timestamp. If zero, BuildReceipt uses
 	// time.Now().UTC().
 	VerifiedAt time.Time
+
+	// Strategy is the source-truth strategy the caller declared (via
+	// --strategy). Required for source-truth-pass; signals auto-detect
+	// to pick source-truth-pass when no Argo/Flux/ConfigHub anchor
+	// resolved. cub-scout never infers a strategy.
+	Strategy string
+
+	// Since is the cutoff timestamp for no-manual-edits-since (via
+	// --since). Zero means "not provided"; the predicate then declines
+	// with OmissionSinceMissing.
+	Since time.Time
 }
 
 // BuildReceipt orchestrates: build subjects → resolve predicate →
@@ -117,13 +129,20 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 	}
 
 	// 2. Resolve the predicate. Caller-provided wins; otherwise auto-
-	// detect from owner. Empty after auto-detect → INCONCLUSIVE.
+	// detect from owner + signals (--strategy, --since). Empty after
+	// auto-detect → INCONCLUSIVE.
+	predicateInput := PredicateInput{
+		Scope:     in.Scope,
+		Evidence:  in.Evidence,
+		Spec:      in.Spec,
+		Connected: in.Connected,
+		Strategy:  in.Strategy,
+		Since:     in.Since,
+		Live:      in.Live,
+	}
 	predName := in.PredicateName
 	if predName == "" {
-		detected, detectedOmission := AutoDetectPredicate(
-			PredicateInput{Scope: in.Scope, Evidence: in.Evidence, Spec: in.Spec, Connected: in.Connected},
-			in.Owner,
-		)
+		detected, detectedOmission := AutoDetectPredicate(predicateInput, in.Owner)
 		predName = detected
 		if detectedOmission != nil {
 			omissions = append(omissions, *detectedOmission)
@@ -134,12 +153,11 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 	var result PredicateResult
 	switch predName {
 	case PredicateAppliedMatchesSpec:
-		result = EvaluateAppliedMatchesSpec(PredicateInput{
-			Scope:     in.Scope,
-			Evidence:  in.Evidence,
-			Spec:      in.Spec,
-			Connected: in.Connected,
-		})
+		result = EvaluateAppliedMatchesSpec(predicateInput)
+	case PredicateSourceTruthPass:
+		result = EvaluateSourceTruthPass(predicateInput)
+	case PredicateNoManualEditsSince:
+		result = EvaluateNoManualEditsSince(predicateInput)
 	case "":
 		// Auto-detect failed. The omission entry was already appended
 		// above; the predicate evaluation produces INCONCLUSIVE.
@@ -149,7 +167,7 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 			NextSteps: []ReceiptNextStep{},
 		}
 	default:
-		return Statement{}, fmt.Errorf("build-receipt: predicate %q not implemented in v1 batch 1 (planned in batch 2)", predName)
+		return Statement{}, fmt.Errorf("build-receipt: unknown predicate %q (cub-scout v1 implements %v)", predName, AllPredicates())
 	}
 
 	// 4. Filter nextSteps (defense in depth — predicate evaluators must
@@ -161,7 +179,7 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 	// 5. Derive a default claim if the caller didn't provide one.
 	claim := in.Claim
 	if claim == "" {
-		claim = deriveDefaultClaim(predName, in.Scope, in.Spec)
+		claim = deriveDefaultClaim(predName, in.Scope, in.Spec, in.Strategy, in.Since)
 	}
 
 	// 6. Set timestamp.
@@ -204,13 +222,23 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 
 // deriveDefaultClaim builds a human-readable claim from the predicate
 // and scope when the caller doesn't provide one.
-func deriveDefaultClaim(name PredicateName, scope Scope, spec *SpecAnchor) string {
+func deriveDefaultClaim(name PredicateName, scope Scope, spec *SpecAnchor, strategy string, since time.Time) string {
 	switch name {
 	case PredicateAppliedMatchesSpec:
 		if spec != nil && spec.Anchor.Path != "" {
 			return fmt.Sprintf("applied matches spec at %s", spec.Anchor.Path)
 		}
 		return fmt.Sprintf("applied matches spec for %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
+	case PredicateSourceTruthPass:
+		if strings.TrimSpace(strategy) != "" {
+			return fmt.Sprintf("source-truth PASS under strategy %q for %s/%s in %s", strategy, scope.Kind, scope.Name, scope.Namespace)
+		}
+		return fmt.Sprintf("source-truth PASS for %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
+	case PredicateNoManualEditsSince:
+		if !since.IsZero() {
+			return fmt.Sprintf("no manual edits to %s/%s in %s since %s", scope.Kind, scope.Name, scope.Namespace, since.UTC().Format(time.RFC3339))
+		}
+		return fmt.Sprintf("no manual edits to %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
 	case "":
 		return fmt.Sprintf("no predicate could be auto-detected for %s/%s in %s", scope.Kind, scope.Name, scope.Namespace)
 	default:

--- a/pkg/agent/receipt_build_test.go
+++ b/pkg/agent/receipt_build_test.go
@@ -303,16 +303,20 @@ func TestBuildReceipt_NilLive_Errors(t *testing.T) {
 	}
 }
 
-func TestBuildReceipt_UnimplementedPredicate_Errors(t *testing.T) {
+func TestBuildReceipt_UnknownPredicate_Errors(t *testing.T) {
+	// After #446 batch 2 implemented source-truth-pass and
+	// no-manual-edits-since, the unknown-predicate path is reached only
+	// for genuinely-unrecognized names. The error message must enumerate
+	// the implemented predicates so the operator knows what's valid.
 	in := makeReceiptInput(func(in *BuildReceiptInput) {
-		in.PredicateName = PredicateSourceTruthPass // batch 2 work, not implemented
+		in.PredicateName = PredicateName("not-a-real-predicate")
 	})
 	_, err := BuildReceipt(in)
 	if err == nil {
-		t.Error("BuildReceipt with unimplemented predicate must error")
+		t.Fatal("BuildReceipt with unknown predicate must error")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("error must explain unimplementation; got %v", err)
+	if !strings.Contains(err.Error(), "unknown predicate") {
+		t.Errorf("error must explain unknown-predicate; got %v", err)
 	}
 }
 

--- a/pkg/agent/receipt_predicates.go
+++ b/pkg/agent/receipt_predicates.go
@@ -6,6 +6,9 @@ package agent
 import (
 	"fmt"
 	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // PredicateName is the canonical name of a receipt predicate.
@@ -61,6 +64,22 @@ type PredicateInput struct {
 	// evidence is genuinely missing" from "we never had it because
 	// standalone mode".
 	Connected bool
+
+	// Strategy is the explicit source-truth strategy the caller passed
+	// (via --strategy). Required for source-truth-pass; cub-scout never
+	// infers a strategy. Empty means "not provided".
+	Strategy string
+
+	// Since is the cutoff timestamp for the no-manual-edits-since
+	// predicate. A zero value means "not provided" — the predicate then
+	// emits INCONCLUSIVE + OmissionSinceMissing.
+	Since time.Time
+
+	// Live carries the resource the no-manual-edits-since predicate
+	// walks for managedFields entries. Other predicates ignore this
+	// field. Receipts are built from the same Live the orchestrator
+	// already fetched; passing it down avoids a re-read.
+	Live *unstructured.Unstructured
 }
 
 // EvaluateAppliedMatchesSpec runs the `applied-matches-spec` predicate.
@@ -220,14 +239,31 @@ func pathsEquivalent(a, b string) bool {
 // Returns the chosen predicate name (or "" for no auto-detect) plus an
 // omission entry to record when the auto-detect failed.
 func AutoDetectPredicate(in PredicateInput, owner Ownership) (PredicateName, *Omission) {
+	// Priority 1: Argo/Flux/ConfigHub + resolvable anchor → applied-matches-spec.
 	switch owner.Type {
 	case OwnerArgo, OwnerFlux, OwnerConfigHub:
-		// Controller-owned resources can run applied-matches-spec WHEN
-		// a git anchor was resolved. Otherwise the predicate cannot
-		// evaluate honestly and auto-detect must decline.
 		if in.Evidence.GitSource != nil {
 			return PredicateAppliedMatchesSpec, nil
 		}
+	}
+
+	// Priority 2: --strategy provided → source-truth-pass. The predicate
+	// itself enforces the connected-mode gate; auto-detect only needs to
+	// see the strategy signal.
+	if strings.TrimSpace(in.Strategy) != "" {
+		return PredicateSourceTruthPass, nil
+	}
+
+	// Priority 3: --since provided → no-manual-edits-since.
+	if !in.Since.IsZero() {
+		return PredicateNoManualEditsSince, nil
+	}
+
+	// Owner-specific decline reason takes precedence when the owner is one
+	// of the controller types but no anchor resolved — that's a more
+	// actionable hint than the generic "no signal" message.
+	switch owner.Type {
+	case OwnerArgo, OwnerFlux, OwnerConfigHub:
 		return "", &Omission{
 			Missing: OmissionAutoDetectedPredicate,
 			Reason: fmt.Sprintf(
@@ -238,10 +274,266 @@ func AutoDetectPredicate(in PredicateInput, owner Ownership) (PredicateName, *Om
 	default:
 		return "", &Omission{
 			Missing:  OmissionAutoDetectedPredicate,
-			Reason:   fmt.Sprintf("no signal for default predicate (detected owner %q has no v1 default predicate); pass --predicate", owner.Type),
+			Reason:   fmt.Sprintf("no signal for default predicate (detected owner %q has no v1 default predicate); pass --predicate, --strategy, or --since", owner.Type),
 			Severity: "info",
 		}
 	}
+}
+
+// EvaluateSourceTruthPass runs the `source-truth-pass` predicate.
+//
+// Semantics:
+//   - No --strategy passed → INCONCLUSIVE + OmissionStrategyMissing.
+//     cub-scout never infers a delivery strategy; that's the operator's
+//     declared input (`compare source-truth` enforces the same rule).
+//   - No source-truth evidence in the body → INCONCLUSIVE +
+//     OmissionSourceTruthEvidence. The orchestrator should have run
+//     `Derive` and attached the SourceTruthEvidence; if it didn't, the
+//     receipt cannot claim anything about source truth.
+//   - Strategy mismatch between caller and evidence → BLOCK +
+//     OmissionStrategyMismatch. Don't silently honor the caller's strategy
+//     over what the evidence claims to be under.
+//   - Map Status to ReceiptVerdict:
+//     PASS  → VerdictPASS
+//     WATCH → VerdictWATCH
+//     BLOCK → VerdictBLOCK
+//     ASK   → VerdictINCONCLUSIVE (with the evidence's proof_gaps mirrored
+//             into omissions[])
+//
+// Proof gaps in the source-truth evidence are mirrored into the receipt's
+// omissions[] under OmissionSourceTruthComplete so a consumer reading
+// only the receipt knows what the underlying source-truth derivation
+// flagged.
+func EvaluateSourceTruthPass(in PredicateInput) PredicateResult {
+	res := PredicateResult{
+		Omissions: []Omission{},
+		NextSteps: []ReceiptNextStep{},
+	}
+
+	declared := strings.TrimSpace(in.Strategy)
+	if declared == "" {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionStrategyMissing,
+			Reason:   "source-truth-pass requires --strategy; cub-scout does not infer the delivery strategy",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	if in.Evidence.SourceTruth == nil {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthEvidence,
+			Reason:   fmt.Sprintf("no source-truth evidence body attached; run `cub-scout compare source-truth --strategy %s` and feed the result back into the receipt orchestrator", declared),
+			Severity: "warning",
+		})
+		return res
+	}
+
+	// Compare declared strategy with the strategy already captured in the
+	// evidence body. The evidence stores the Human-rendered form
+	// ("Git -> Argo -> Kubernetes"), so we normalize through ParseStrategy
+	// when comparing — accept either the machine name ("git-argo") or the
+	// Human form.
+	evStrategy := in.Evidence.SourceTruth.DeclaredStrategy
+	if !strategyAgrees(declared, evStrategy) {
+		res.Verdict = VerdictBLOCK
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionStrategyMismatch,
+			Reason:   fmt.Sprintf("receipt was asked to verify under strategy %q but source-truth evidence carries %q", declared, evStrategy),
+			Severity: "warning",
+		})
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "rerun the source-truth derivation with the same strategy you want the receipt to claim; do not paper over the disagreement",
+			NextCommand: "cub-scout compare source-truth --strategy " + declared,
+			NextSurface: "cub-scout",
+		})
+		return res
+	}
+
+	// Mirror proof gaps into omissions[] regardless of status.
+	for _, gap := range in.Evidence.SourceTruth.ProofGaps {
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthComplete,
+			Reason:   "source-truth proof gap: " + gap,
+			Severity: "info",
+		})
+	}
+
+	switch in.Evidence.SourceTruth.Status {
+	case StatusPASS:
+		res.Verdict = VerdictPASS
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "source-truth PASS under the declared strategy; all three surfaces agree under the strategy-implied authority",
+			NextCommand: "cub-scout explain " + in.Scope.Kind + "/" + in.Scope.Name + " -n " + in.Scope.Namespace,
+			NextSurface: "cub-scout",
+		})
+	case StatusWATCH:
+		res.Verdict = VerdictWATCH
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "source-truth WATCH; soft proof gap or signal warrants confirmation before acceptance",
+			NextCommand: "cub-scout compare source-truth --strategy " + declared,
+			NextSurface: "cub-scout",
+		})
+	case StatusBLOCK:
+		res.Verdict = VerdictBLOCK
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "source-truth BLOCK; a hard rule failed (strategy mismatch, controller-source resolution failure, etc.) — investigate before acceptance",
+			NextCommand: "cub-scout compare source-truth --strategy " + declared,
+			NextSurface: "cub-scout",
+		})
+	case StatusASK:
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthComplete,
+			Reason:   "source-truth ASK; cub-scout cannot classify deterministically — the evidence's proof_gaps explain what's missing",
+			Severity: "warning",
+		})
+	default:
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSourceTruthComplete,
+			Reason:   fmt.Sprintf("unrecognized source-truth status %q; cub-scout enumerates PASS / WATCH / BLOCK / ASK", string(in.Evidence.SourceTruth.Status)),
+			Severity: "warning",
+		})
+	}
+	return res
+}
+
+// strategyAgrees returns true if declared (caller's CLI form like
+// "git-argo") names the same strategy as evidence (the Human form like
+// "Git -> Argo -> Kubernetes" recorded by Derive). Either side may be
+// empty after trim.
+func strategyAgrees(declared, evStrategy string) bool {
+	declared = strings.TrimSpace(declared)
+	evStrategy = strings.TrimSpace(evStrategy)
+	if declared == "" || evStrategy == "" {
+		return false
+	}
+	// Same machine form.
+	if declared == evStrategy {
+		return true
+	}
+	// Caller passed the machine form; evidence has the Human form.
+	if parsed, ok := ParseStrategy(declared); ok {
+		if parsed.Human() == evStrategy {
+			return true
+		}
+	}
+	return false
+}
+
+// EvaluateNoManualEditsSince runs the `no-manual-edits-since` predicate.
+//
+// Semantics:
+//   - No --since cutoff → INCONCLUSIVE + OmissionSinceMissing.
+//   - No live object on the input → INCONCLUSIVE + OmissionManagedFields
+//     (defensive — orchestrator should always pass Live).
+//   - No managedFields entries on the object → INCONCLUSIVE +
+//     OmissionManagedFields. Old K8s, stripped admission webhook, etc.
+//   - Any managedFields entry from an interactive manager (kubectl-*)
+//     with Time > since → BLOCK.
+//   - Any managedFields entry from an interactive manager with no Time
+//     → INCONCLUSIVE + OmissionManagedFieldsTime. We cannot place it on
+//     the timeline so we cannot honestly claim "no manual edits since T".
+//   - Otherwise → PASS.
+//
+// Important caveat (from the receipts-way-forward.md design): K8s
+// managedFields evidence is best-effort. If an admission webhook strips
+// the entries, or the resource is migrated across K8s versions, the
+// predicate degrades to INCONCLUSIVE rather than producing false PASS.
+// `parse, don't guess`.
+func EvaluateNoManualEditsSince(in PredicateInput) PredicateResult {
+	res := PredicateResult{
+		Omissions: []Omission{},
+		NextSteps: []ReceiptNextStep{},
+	}
+
+	if in.Since.IsZero() {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionSinceMissing,
+			Reason:   "no-manual-edits-since requires --since <RFC3339 timestamp>; cub-scout does not invent a cutoff",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	if in.Live == nil {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionManagedFields,
+			Reason:   "no live object passed to no-manual-edits-since; cub-scout cannot read managedFields without the resource",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	entries := in.Live.GetManagedFields()
+	if len(entries) == 0 {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionManagedFields,
+			Reason:   "live resource has no managedFields entries; no-manual-edits-since cannot establish a baseline without them",
+			Severity: "warning",
+		})
+		return res
+	}
+
+	// Walk entries. Treat any interactive manager with Time > since as a
+	// late manual edit (BLOCK). Treat any interactive manager with nil
+	// Time as a timestamp gap (INCONCLUSIVE).
+	var (
+		violatingManagers []string
+		nilTimeManagers   []string
+	)
+	for _, e := range entries {
+		if !IsInteractiveManager(e.Manager) {
+			continue
+		}
+		if e.Time == nil {
+			nilTimeManagers = append(nilTimeManagers, e.Manager)
+			continue
+		}
+		if e.Time.Time.After(in.Since) {
+			violatingManagers = append(violatingManagers, fmt.Sprintf("%s@%s", e.Manager, e.Time.Time.UTC().Format(time.RFC3339)))
+		}
+	}
+
+	if len(violatingManagers) > 0 {
+		res.Verdict = VerdictBLOCK
+		res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      fmt.Sprintf("interactive writer wrote managedFields after the cutoff (%s): %s — investigate the unplanned edit before any apply", in.Since.UTC().Format(time.RFC3339), strings.Join(violatingManagers, ", ")),
+			NextCommand: "kubectl get --show-managed-fields",
+			NextSurface: "kubectl",
+		})
+		return res
+	}
+
+	if len(nilTimeManagers) > 0 {
+		res.Verdict = VerdictINCONCLUSIVE
+		res.Omissions = append(res.Omissions, Omission{
+			Missing:  OmissionManagedFieldsTime,
+			Reason:   fmt.Sprintf("interactive managedFields entries have nil Time; cannot place them on the timeline: %s", strings.Join(nilTimeManagers, ", ")),
+			Severity: "warning",
+		})
+		return res
+	}
+
+	res.Verdict = VerdictPASS
+	res.NextSteps = append(res.NextSteps, ReceiptNextStep{
+		ActionType:  "read-only",
+		Reason:      fmt.Sprintf("no interactive writer touched managedFields after %s", in.Since.UTC().Format(time.RFC3339)),
+		NextCommand: "cub-scout explain " + in.Scope.Kind + "/" + in.Scope.Name + " -n " + in.Scope.Namespace,
+		NextSurface: "cub-scout",
+	})
+	return res
 }
 
 // FilterNextSteps drops any nextSteps with mutating actionType or

--- a/pkg/agent/receipt_predicates_batch2_test.go
+++ b/pkg/agent/receipt_predicates_batch2_test.go
@@ -1,0 +1,364 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// --- EvaluateSourceTruthPass -----------------------------------------
+
+func TestEvaluateSourceTruthPass_NoStrategy_INCONCLUSIVE(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionStrategyMissing) {
+		t.Errorf("missing-strategy must produce OmissionStrategyMissing; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateSourceTruthPass_NoEvidence_INCONCLUSIVE(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionSourceTruthEvidence) {
+		t.Errorf("missing-evidence must produce OmissionSourceTruthEvidence; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StrategyMismatch_BLOCK(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyConfigHubOCIArgo.Human(),
+				Status:           StatusPASS,
+			},
+		},
+	})
+	if res.Verdict != VerdictBLOCK {
+		t.Fatalf("strategy mismatch must produce BLOCK; got %q", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionStrategyMismatch) {
+		t.Errorf("strategy mismatch must produce OmissionStrategyMismatch; got %v", res.Omissions)
+	}
+	if len(res.NextSteps) == 0 || res.NextSteps[0].ActionType != "read-only" {
+		t.Errorf("strategy mismatch next step must be read-only; got %+v", res.NextSteps)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StrategyAgreesHumanForm_PASS(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				// Evidence stores the Human form; declared can be machine form.
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusPASS,
+				SourceTruth:      VerdictAGREED,
+			},
+		},
+	})
+	if res.Verdict != VerdictPASS {
+		t.Fatalf("PASS status must map to VerdictPASS; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StatusWATCH_VerdictWATCH(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusWATCH,
+				ProofGaps:        []string{"controller.revision_or_digest"},
+			},
+		},
+	})
+	if res.Verdict != VerdictWATCH {
+		t.Errorf("WATCH status must map to VerdictWATCH; got %q", res.Verdict)
+	}
+	// Proof gap should be mirrored as an omission.
+	if !hasOmission(res.Omissions, OmissionSourceTruthComplete) {
+		t.Errorf("WATCH must mirror proof_gaps into OmissionSourceTruthComplete; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StatusBLOCK_VerdictBLOCK(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusBLOCK,
+				SourceTruth:      VerdictMISMATCH,
+			},
+		},
+	})
+	if res.Verdict != VerdictBLOCK {
+		t.Errorf("BLOCK status must map to VerdictBLOCK; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateSourceTruthPass_StatusASK_VerdictINCONCLUSIVE(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusASK,
+				SourceTruth:      VerdictUNKNOWN,
+			},
+		},
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Errorf("ASK status must map to VerdictINCONCLUSIVE; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateSourceTruthPass_ProofGapsMirroredOnPASS(t *testing.T) {
+	res := EvaluateSourceTruthPass(PredicateInput{
+		Scope:    Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			SourceTruth: &SourceTruthEvidence{
+				DeclaredStrategy: StrategyGitArgo.Human(),
+				Status:           StatusPASS,
+				ProofGaps:        []string{"runtime.helm_chart_anchor"},
+			},
+		},
+	})
+	if res.Verdict != VerdictPASS {
+		t.Fatalf("PASS status must map to VerdictPASS; got %q", res.Verdict)
+	}
+	// Even on PASS, proof_gaps must be visible — that's the omissions[]
+	// contract.
+	found := false
+	for _, o := range res.Omissions {
+		if o.Missing == OmissionSourceTruthComplete && strings.Contains(o.Reason, "runtime.helm_chart_anchor") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("PASS with proof_gaps must mirror them into omissions; got %v", res.Omissions)
+	}
+}
+
+// --- EvaluateNoManualEditsSince --------------------------------------
+
+func makeLiveWithManagedFields(entries []metav1.ManagedFieldsEntry) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "prod",
+			},
+		},
+	}
+	obj.SetManagedFields(entries)
+	return obj
+}
+
+func TestEvaluateNoManualEditsSince_NoSince_INCONCLUSIVE(t *testing.T) {
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionSinceMissing) {
+		t.Errorf("missing-since must produce OmissionSinceMissing; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_NoLive_INCONCLUSIVE(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live:  nil,
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionManagedFields) {
+		t.Errorf("nil-live must produce OmissionManagedFields; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_NoManagedFields_INCONCLUSIVE(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live:  makeLiveWithManagedFields(nil),
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict: got %q, want INCONCLUSIVE", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionManagedFields) {
+		t.Errorf("empty-managedFields must produce OmissionManagedFields; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_OnlyController_PASS(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerArgoCD, Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+		}),
+	})
+	if res.Verdict != VerdictPASS {
+		t.Errorf("only-controller writers after cutoff must produce PASS; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_KubectlEditAfterCutoff_BLOCK(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerArgoCD, Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+			{Manager: ManagerKubectlEdit, Operation: metav1.ManagedFieldsOperationUpdate, Time: &after},
+		}),
+	})
+	if res.Verdict != VerdictBLOCK {
+		t.Errorf("kubectl-edit after cutoff must produce BLOCK; got %q", res.Verdict)
+	}
+	// The BLOCK message must include the violating manager name on the
+	// nextStep reason so an operator can pinpoint the writer.
+	if len(res.NextSteps) == 0 || !strings.Contains(res.NextSteps[0].Reason, ManagerKubectlEdit) {
+		t.Errorf("BLOCK next step must name the violating manager; got %+v", res.NextSteps)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_KubectlEditBeforeCutoff_PASS(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	before := metav1.NewTime(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerKubectlEdit, Operation: metav1.ManagedFieldsOperationUpdate, Time: &before},
+		}),
+	})
+	if res.Verdict != VerdictPASS {
+		t.Errorf("kubectl-edit before cutoff must produce PASS; got %q", res.Verdict)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_KubectlNilTime_INCONCLUSIVE(t *testing.T) {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerKubectlEdit, Operation: metav1.ManagedFieldsOperationUpdate, Time: nil},
+		}),
+	})
+	if res.Verdict != VerdictINCONCLUSIVE {
+		t.Errorf("nil Time on interactive writer must produce INCONCLUSIVE; got %q", res.Verdict)
+	}
+	if !hasOmission(res.Omissions, OmissionManagedFieldsTime) {
+		t.Errorf("nil Time must produce OmissionManagedFieldsTime; got %v", res.Omissions)
+	}
+}
+
+func TestEvaluateNoManualEditsSince_ControllerNilTime_StillPASS(t *testing.T) {
+	// A nil-Time controller entry is fine — we don't claim anything about
+	// controller writers, only about interactive ones. PASS as long as
+	// no interactive writer is present.
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	res := EvaluateNoManualEditsSince(PredicateInput{
+		Scope: Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Since: cutoff,
+		Live: makeLiveWithManagedFields([]metav1.ManagedFieldsEntry{
+			{Manager: ManagerArgoCD, Operation: metav1.ManagedFieldsOperationApply, Time: nil},
+		}),
+	})
+	if res.Verdict != VerdictPASS {
+		t.Errorf("controller-only with nil Time must still PASS; got %q", res.Verdict)
+	}
+}
+
+// --- AutoDetectPredicate (extended for batch 2 signals) --------------
+
+func TestAutoDetectPredicate_StrategyOnly_PicksSourceTruthPass(t *testing.T) {
+	name, om := AutoDetectPredicate(PredicateInput{
+		Strategy: "git-argo",
+	}, Ownership{Type: OwnerUnknown})
+	if name != PredicateSourceTruthPass {
+		t.Errorf("--strategy must auto-detect source-truth-pass; got %q", name)
+	}
+	if om != nil {
+		t.Errorf("--strategy must not produce an omission; got %+v", om)
+	}
+}
+
+func TestAutoDetectPredicate_SinceOnly_PicksNoManualEditsSince(t *testing.T) {
+	name, om := AutoDetectPredicate(PredicateInput{
+		Since: time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC),
+	}, Ownership{Type: OwnerUnknown})
+	if name != PredicateNoManualEditsSince {
+		t.Errorf("--since must auto-detect no-manual-edits-since; got %q", name)
+	}
+	if om != nil {
+		t.Errorf("--since must not produce an omission; got %+v", om)
+	}
+}
+
+func TestAutoDetectPredicate_ArgoAnchorBeatsStrategy(t *testing.T) {
+	// Priority order is locked: Argo + resolvable anchor wins over
+	// --strategy because applied-matches-spec is the more specific claim.
+	name, _ := AutoDetectPredicate(PredicateInput{
+		Strategy: "git-argo",
+		Evidence: Evidence{
+			GitSource: &GitSourceAnchor{
+				RepoURL:  "https://github.com/org/repo",
+				Revision: "abc",
+				Path:     "apps/api",
+			},
+		},
+	}, Ownership{Type: OwnerArgo})
+	if name != PredicateAppliedMatchesSpec {
+		t.Errorf("Argo + anchor must beat --strategy in auto-detect; got %q", name)
+	}
+}
+
+func TestAutoDetectPredicate_StrategyBeatsSince(t *testing.T) {
+	// When both signals are present, --strategy takes precedence per the
+	// locked priority order.
+	name, _ := AutoDetectPredicate(PredicateInput{
+		Strategy: "git-argo",
+		Since:    time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC),
+	}, Ownership{Type: OwnerUnknown})
+	if name != PredicateSourceTruthPass {
+		t.Errorf("--strategy must beat --since in auto-detect; got %q", name)
+	}
+}

--- a/pkg/agent/receipt_store.go
+++ b/pkg/agent/receipt_store.go
@@ -1,0 +1,242 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// receipt_store.go — local file-system store for receipt artifacts.
+//
+// Receipts are HISTORICAL, IMMUTABLE records (per the #446 design).
+// The store enforces that: once a receipt is saved, the file content
+// (including fingerprint) is the artifact. The store never modifies an
+// existing file — Save() refuses to overwrite, returning the existing
+// path. Tests assert this invariant.
+//
+// Layout: one JSON file per receipt at `<dir>/<filename>` where dir is
+// resolved from $CUB_SCOUT_RECEIPTS_DIR (override), then
+// $XDG_DATA_HOME/cub-scout/receipts (XDG basedir convention), then
+// $HOME/.local/share/cub-scout/receipts (XDG default). No subdirectories,
+// no DB, no index — flat files keyed by a sortable filename.
+
+const (
+	// StoreSubdir is the path under XDG_DATA_HOME (or HOME) where
+	// receipts live.
+	StoreSubdir = "cub-scout/receipts"
+
+	// ReceiptFileExt is the conventional extension. Used by List() to
+	// filter the directory.
+	ReceiptFileExt = ".receipt.json"
+)
+
+// DefaultStoreDir returns the canonical receipt store directory,
+// resolved in priority order:
+//
+//  1. $CUB_SCOUT_RECEIPTS_DIR (explicit override; useful for tests
+//     and CI sandboxes)
+//  2. $XDG_DATA_HOME/cub-scout/receipts
+//  3. $HOME/.local/share/cub-scout/receipts (XDG default)
+//
+// Returns an empty string and an error if HOME cannot be resolved. The
+// directory may not exist on disk — callers create on demand. Pure
+// (no filesystem reads); test-friendly.
+func DefaultStoreDir() (string, error) {
+	if explicit := strings.TrimSpace(os.Getenv("CUB_SCOUT_RECEIPTS_DIR")); explicit != "" {
+		return explicit, nil
+	}
+	if xdg := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); xdg != "" {
+		return filepath.Join(xdg, StoreSubdir), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", fmt.Errorf("cannot resolve home directory for receipt store; set $CUB_SCOUT_RECEIPTS_DIR or $XDG_DATA_HOME")
+	}
+	return filepath.Join(home, ".local", "share", StoreSubdir), nil
+}
+
+// DeriveFilename builds the canonical filename for a receipt. The shape
+// is deterministic and sortable:
+//
+//	<verifiedAt-rfc3339-safe>__<predicate>__<kind>-<name>__<short-fingerprint>.receipt.json
+//
+// "rfc3339-safe" replaces ":" with "-" because POSIX-portable filenames
+// cannot contain colons. The short fingerprint is the first 12 hex
+// chars after the "sha256:" prefix and makes co-existing receipts for
+// the same scope distinguishable in `ls`.
+//
+// Empty fingerprint produces a filename ending in "__unstamped".
+func DeriveFilename(stmt Statement) string {
+	predicate := stmt.Predicate.PredicateName
+	if predicate == "" {
+		predicate = "noop"
+	}
+	kind := stmt.Predicate.Scope.Kind
+	if kind == "" {
+		kind = "unknown"
+	}
+	name := stmt.Predicate.Scope.Name
+	if name == "" {
+		name = "unknown"
+	}
+
+	verifiedAt := stmt.Predicate.VerifiedAt
+	if verifiedAt == "" {
+		verifiedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	// Filename-safe: replace ":" with "-".
+	verifiedAt = strings.ReplaceAll(verifiedAt, ":", "-")
+
+	short := "unstamped"
+	if fp := stmt.Predicate.Fingerprint; strings.HasPrefix(fp, "sha256:") {
+		hex := strings.TrimPrefix(fp, "sha256:")
+		if len(hex) >= 12 {
+			short = hex[:12]
+		} else {
+			short = hex
+		}
+	}
+
+	// Sanitize any path separator from the parts. Receipt scopes shouldn't
+	// contain "/" in kind or name, but be defensive.
+	safe := func(s string) string {
+		s = strings.ReplaceAll(s, "/", "_")
+		s = strings.ReplaceAll(s, string(os.PathSeparator), "_")
+		return s
+	}
+
+	return fmt.Sprintf("%s__%s__%s-%s__%s%s",
+		verifiedAt,
+		safe(string(predicate)),
+		safe(kind),
+		safe(name),
+		short,
+		ReceiptFileExt,
+	)
+}
+
+// SaveStatement writes stmt to the store directory under its canonical
+// filename. Creates the directory if missing.
+//
+// Receipts are immutable: SaveStatement REFUSES to overwrite an existing
+// file and returns the existing path with a wrapped os.ErrExist. The
+// rationale: a duplicate filename means the same VerifiedAt + same
+// predicate + same scope + same fingerprint already exists on disk;
+// re-writing serves no purpose and a different fingerprint at the same
+// filename is impossible (the fingerprint is part of the filename).
+//
+// Returns the absolute path written.
+func SaveStatement(stmt Statement, dir string) (string, error) {
+	if dir == "" {
+		return "", fmt.Errorf("save-receipt: empty store directory")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("save-receipt: mkdir %s: %w", dir, err)
+	}
+	filename := DeriveFilename(stmt)
+	path := filepath.Join(dir, filename)
+
+	if _, err := os.Stat(path); err == nil {
+		return path, fmt.Errorf("save-receipt: %s: %w", path, os.ErrExist)
+	}
+
+	buf, err := json.MarshalIndent(stmt, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("save-receipt: marshal: %w", err)
+	}
+	if err := os.WriteFile(path, append(buf, '\n'), 0o644); err != nil {
+		return "", fmt.Errorf("save-receipt: write %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// LoadStatement reads a receipt from path and parses it. The fingerprint
+// is NOT verified here — that's `cub-scout receipt validate`'s job —
+// because a tampered receipt may still need to be loaded for forensic
+// inspection. Callers that need verification call
+// VerifyStatementFingerprint after Load.
+func LoadStatement(path string) (Statement, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Statement{}, fmt.Errorf("load-receipt: read %s: %w", path, err)
+	}
+	var stmt Statement
+	if err := json.Unmarshal(data, &stmt); err != nil {
+		return Statement{}, fmt.Errorf("load-receipt: parse %s: %w", path, err)
+	}
+	return stmt, nil
+}
+
+// ReceiptListEntry summarizes a receipt for `cub-scout receipt list`
+// output. The full Statement is left on disk; this is enough to render
+// a one-line-per-receipt table.
+type ReceiptListEntry struct {
+	Path          string         `json:"path"`
+	VerifiedAt    string         `json:"verifiedAt"`
+	PredicateName string         `json:"predicateName"`
+	Scope         Scope          `json:"scope"`
+	Verdict       ReceiptVerdict `json:"verdict"`
+	Fingerprint   string         `json:"fingerprint"`
+}
+
+// ListStatements walks dir, parses every *.receipt.json file, and
+// returns one ReceiptListEntry per receipt sorted by VerifiedAt
+// descending (most recent first — matches how operators scan logs).
+//
+// Files that fail to parse are skipped silently and a non-nil
+// error is returned alongside the partial list. The store is meant
+// to tolerate stray files (a partial write, an unrelated JSON) without
+// failing the whole list. Callers that need strict semantics check
+// the error.
+func ListStatements(dir string) ([]ReceiptListEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list-receipts: read dir %s: %w", dir, err)
+	}
+
+	out := make([]ReceiptListEntry, 0, len(entries))
+	var skipErrors []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(e.Name(), ReceiptFileExt) {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		stmt, err := LoadStatement(path)
+		if err != nil {
+			skipErrors = append(skipErrors, fmt.Sprintf("%s: %v", e.Name(), err))
+			continue
+		}
+		out = append(out, ReceiptListEntry{
+			Path:          path,
+			VerifiedAt:    stmt.Predicate.VerifiedAt,
+			PredicateName: stmt.Predicate.PredicateName,
+			Scope:         stmt.Predicate.Scope,
+			Verdict:       stmt.Predicate.Verdict,
+			Fingerprint:   stmt.Predicate.Fingerprint,
+		})
+	}
+
+	// Sort by VerifiedAt descending. RFC 3339 strings sort
+	// lexicographically in chronological order.
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].VerifiedAt > out[j].VerifiedAt
+	})
+
+	if len(skipErrors) > 0 {
+		return out, fmt.Errorf("list-receipts: skipped %d unparseable file(s): %s", len(skipErrors), strings.Join(skipErrors, "; "))
+	}
+	return out, nil
+}

--- a/pkg/agent/receipt_store_test.go
+++ b/pkg/agent/receipt_store_test.go
@@ -1,0 +1,321 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeStubStatement(verifiedAt, predicate, kind, name, fingerprint string) Statement {
+	return Statement{
+		Type:          StatementType,
+		Subject:       []Subject{{Name: "k8s-live://apps/v1/Deployment/prod/api", Digest: map[string]string{"sha256": "deadbeef"}}},
+		PredicateType: PredicateTypeReceiptV1,
+		Predicate: Predicate{
+			Version:           PredicateVersion,
+			Claim:             "test",
+			Scope:             Scope{Kind: kind, Name: name, Namespace: "prod"},
+			Verifier:          Verifier{Tool: "cub-scout", Version: "v0.0.0-test"},
+			VerifiedAt:        verifiedAt,
+			PredicateName:     predicate,
+			Verdict:           VerdictPASS,
+			Omissions:         []Omission{},
+			InputAttestations: []AttestationRef{},
+			Fingerprint:       fingerprint,
+		},
+	}
+}
+
+// --- DefaultStoreDir ---------------------------------------------------
+
+func TestDefaultStoreDir_HonorsExplicitOverride(t *testing.T) {
+	t.Setenv("CUB_SCOUT_RECEIPTS_DIR", "/tmp/cub-scout-override")
+	t.Setenv("XDG_DATA_HOME", "/tmp/xdg")
+	dir, err := DefaultStoreDir()
+	if err != nil {
+		t.Fatalf("DefaultStoreDir: %v", err)
+	}
+	if dir != "/tmp/cub-scout-override" {
+		t.Errorf("CUB_SCOUT_RECEIPTS_DIR must win; got %q", dir)
+	}
+}
+
+func TestDefaultStoreDir_FallsBackToXDG(t *testing.T) {
+	t.Setenv("CUB_SCOUT_RECEIPTS_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "/tmp/xdg-data")
+	dir, err := DefaultStoreDir()
+	if err != nil {
+		t.Fatalf("DefaultStoreDir: %v", err)
+	}
+	if dir != filepath.Join("/tmp/xdg-data", StoreSubdir) {
+		t.Errorf("XDG path mismatch; got %q", dir)
+	}
+}
+
+func TestDefaultStoreDir_FallsBackToHomeShare(t *testing.T) {
+	t.Setenv("CUB_SCOUT_RECEIPTS_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	dir, err := DefaultStoreDir()
+	if err != nil {
+		t.Skipf("home dir unresolvable in this environment: %v", err)
+	}
+	if !strings.HasSuffix(dir, filepath.Join(".local", "share", StoreSubdir)) {
+		t.Errorf("home default mismatch; got %q", dir)
+	}
+}
+
+// --- DeriveFilename ---------------------------------------------------
+
+func TestDeriveFilename_Shape(t *testing.T) {
+	stmt := makeStubStatement(
+		"2026-05-22T10:30:00Z",
+		"applied-matches-spec",
+		"Deployment",
+		"api",
+		"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	)
+	name := DeriveFilename(stmt)
+
+	// Sortable timestamp prefix (colons replaced by hyphens).
+	if !strings.HasPrefix(name, "2026-05-22T10-30-00Z__") {
+		t.Errorf("filename must start with filename-safe RFC3339; got %q", name)
+	}
+	if !strings.Contains(name, "applied-matches-spec") {
+		t.Errorf("filename must contain predicate; got %q", name)
+	}
+	if !strings.Contains(name, "Deployment-api") {
+		t.Errorf("filename must contain kind-name; got %q", name)
+	}
+	if !strings.Contains(name, "0123456789ab") {
+		t.Errorf("filename must contain 12-char fingerprint prefix; got %q", name)
+	}
+	if !strings.HasSuffix(name, ReceiptFileExt) {
+		t.Errorf("filename must end with %s; got %q", ReceiptFileExt, name)
+	}
+}
+
+func TestDeriveFilename_SortsChronologically(t *testing.T) {
+	older := DeriveFilename(makeStubStatement("2026-05-22T08:00:00Z", "applied-matches-spec", "Deployment", "api", "sha256:aaaaaaaaaaaa"))
+	newer := DeriveFilename(makeStubStatement("2026-05-22T10:00:00Z", "applied-matches-spec", "Deployment", "api", "sha256:bbbbbbbbbbbb"))
+	if !(older < newer) {
+		t.Errorf("filename lex order must match chronological: older=%q newer=%q", older, newer)
+	}
+}
+
+func TestDeriveFilename_UnstampedReceipt(t *testing.T) {
+	stmt := makeStubStatement("2026-05-22T10:30:00Z", "applied-matches-spec", "Deployment", "api", "")
+	name := DeriveFilename(stmt)
+	if !strings.Contains(name, "unstamped") {
+		t.Errorf("unstamped receipt filename must signal that; got %q", name)
+	}
+}
+
+func TestDeriveFilename_SanitizesPathSeparators(t *testing.T) {
+	stmt := makeStubStatement("2026-05-22T10:30:00Z", "applied-matches-spec", "weird/Kind", "weird/name", "sha256:cccccccccccc")
+	name := DeriveFilename(stmt)
+	if strings.Contains(name, "weird/Kind") || strings.Contains(name, "weird/name") {
+		t.Errorf("path separators must be sanitized; got %q", name)
+	}
+}
+
+// --- SaveStatement / LoadStatement ------------------------------------
+
+func TestSaveStatement_WritesAndCanLoad(t *testing.T) {
+	dir := t.TempDir()
+	stmt := makeStubStatement("2026-05-22T10:30:00Z", "applied-matches-spec", "Deployment", "api", "sha256:0123456789ab0123")
+
+	path, err := SaveStatement(stmt, dir)
+	if err != nil {
+		t.Fatalf("SaveStatement: %v", err)
+	}
+	if !strings.HasPrefix(path, dir) {
+		t.Errorf("path must live under store dir; got %q", path)
+	}
+
+	loaded, err := LoadStatement(path)
+	if err != nil {
+		t.Fatalf("LoadStatement: %v", err)
+	}
+	if loaded.Predicate.Fingerprint != stmt.Predicate.Fingerprint {
+		t.Errorf("round-trip fingerprint mismatch: %q vs %q", loaded.Predicate.Fingerprint, stmt.Predicate.Fingerprint)
+	}
+}
+
+func TestSaveStatement_RefusesToOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	stmt := makeStubStatement("2026-05-22T10:30:00Z", "applied-matches-spec", "Deployment", "api", "sha256:0123456789ab0123")
+	if _, err := SaveStatement(stmt, dir); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	// Same VerifiedAt + predicate + scope + fingerprint → same filename
+	// → SaveStatement must refuse.
+	_, err := SaveStatement(stmt, dir)
+	if err == nil {
+		t.Fatal("expected ErrExist on duplicate save; got nil")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Errorf("expected os.ErrExist sentinel; got %v", err)
+	}
+}
+
+func TestSaveStatement_CreatesMissingDir(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "nested", "store")
+	stmt := makeStubStatement("2026-05-22T10:30:00Z", "applied-matches-spec", "Deployment", "api", "sha256:0123456789ab0123")
+	if _, err := SaveStatement(stmt, dir); err != nil {
+		t.Fatalf("SaveStatement must mkdir; %v", err)
+	}
+}
+
+func TestSaveStatement_RejectsEmptyDir(t *testing.T) {
+	stmt := makeStubStatement("2026-05-22T10:30:00Z", "applied-matches-spec", "Deployment", "api", "sha256:0123456789ab0123")
+	_, err := SaveStatement(stmt, "")
+	if err == nil {
+		t.Error("SaveStatement with empty dir must error")
+	}
+}
+
+func TestLoadStatement_RejectsInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad"+ReceiptFileExt)
+	if err := os.WriteFile(path, []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("seed bad file: %v", err)
+	}
+	_, err := LoadStatement(path)
+	if err == nil {
+		t.Error("LoadStatement on malformed JSON must error")
+	}
+}
+
+// --- ListStatements --------------------------------------------------
+
+func TestListStatements_ReturnsSortedDescending(t *testing.T) {
+	dir := t.TempDir()
+	stmts := []Statement{
+		makeStubStatement("2026-05-22T08:00:00Z", "applied-matches-spec", "Deployment", "api", "sha256:aaaa000000000000aaaa"),
+		makeStubStatement("2026-05-22T12:00:00Z", "no-manual-edits-since", "Deployment", "api", "sha256:bbbb000000000000bbbb"),
+		makeStubStatement("2026-05-22T10:00:00Z", "source-truth-pass", "Deployment", "api", "sha256:cccc000000000000cccc"),
+	}
+	for _, s := range stmts {
+		if _, err := SaveStatement(s, dir); err != nil {
+			t.Fatalf("seed save: %v", err)
+		}
+	}
+
+	entries, err := ListStatements(dir)
+	if err != nil {
+		t.Fatalf("ListStatements: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries; got %d", len(entries))
+	}
+	// Sorted by VerifiedAt descending.
+	if entries[0].VerifiedAt != "2026-05-22T12:00:00Z" {
+		t.Errorf("first entry must be newest; got VerifiedAt=%q", entries[0].VerifiedAt)
+	}
+	if entries[2].VerifiedAt != "2026-05-22T08:00:00Z" {
+		t.Errorf("last entry must be oldest; got VerifiedAt=%q", entries[2].VerifiedAt)
+	}
+}
+
+func TestListStatements_TolerataesNonReceiptFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Drop a non-receipt file in the dir. List should skip it.
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("seed text file: %v", err)
+	}
+	stmt := makeStubStatement("2026-05-22T10:00:00Z", "applied-matches-spec", "Deployment", "api", "sha256:aaaa000000000000aaaa")
+	if _, err := SaveStatement(stmt, dir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	entries, err := ListStatements(dir)
+	if err != nil {
+		t.Fatalf("ListStatements: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("non-receipt files must be skipped; got %d entries", len(entries))
+	}
+}
+
+func TestListStatements_PartialOnParseFailure(t *testing.T) {
+	dir := t.TempDir()
+	stmt := makeStubStatement("2026-05-22T10:00:00Z", "applied-matches-spec", "Deployment", "api", "sha256:aaaa000000000000aaaa")
+	if _, err := SaveStatement(stmt, dir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Drop a malformed receipt file alongside the good one.
+	if err := os.WriteFile(filepath.Join(dir, "malformed"+ReceiptFileExt), []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("seed malformed: %v", err)
+	}
+	entries, err := ListStatements(dir)
+	if err == nil {
+		t.Error("List must return non-nil error when a file failed to parse")
+	}
+	// Partial list: the good entry is still there.
+	if len(entries) != 1 {
+		t.Errorf("partial list must include parseable entry; got %d", len(entries))
+	}
+}
+
+func TestListStatements_MissingDirReturnsEmpty(t *testing.T) {
+	entries, err := ListStatements("/tmp/this/does/not/exist/cub-scout-test")
+	if err != nil {
+		t.Errorf("missing dir must be a non-error empty list; got %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty list; got %d entries", len(entries))
+	}
+}
+
+func TestListStatements_VerifyFingerprintRoundTrip(t *testing.T) {
+	// Save a *real* receipt (built via BuildReceipt) and verify the
+	// loaded copy still passes the fingerprint integrity check. Catches
+	// any subtle JSON serialization drift in Save/Load.
+	dir := t.TempDir()
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "prod",
+			},
+			"spec": map[string]interface{}{"replicas": int64(1)},
+		},
+	}
+	stmt, err := BuildReceipt(BuildReceiptInput{
+		Live: live,
+		Scope: Scope{
+			Kind:      "Deployment",
+			Name:      "api",
+			Namespace: "prod",
+		},
+		Owner:         Ownership{Type: OwnerUnknown},
+		PredicateName: "",
+		Verifier:      Verifier{Tool: "cub-scout", Version: "v0.0.0-test"},
+		VerifiedAt:    time.Date(2026, 5, 22, 10, 30, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("BuildReceipt: %v", err)
+	}
+
+	path, err := SaveStatement(stmt, dir)
+	if err != nil {
+		t.Fatalf("SaveStatement: %v", err)
+	}
+	loaded, err := LoadStatement(path)
+	if err != nil {
+		t.Fatalf("LoadStatement: %v", err)
+	}
+	if err := VerifyStatementFingerprint(loaded); err != nil {
+		t.Errorf("round-tripped receipt fails fingerprint check: %v", err)
+	}
+}

--- a/tools/gen-receipt-examples/main.go
+++ b/tools/gen-receipt-examples/main.go
@@ -1,10 +1,11 @@
 // Copyright (C) ConfigHub, Inc.
 // SPDX-License-Identifier: MIT
 
-// gen-receipt-examples emits the four canonical example receipts under
-// examples/receipts/applied-matches-spec/. Run from the repo root:
+// gen-receipt-examples emits the canonical example receipts under
+// examples/receipts/. Run from the repo root pointing at the receipts
+// root (the generator writes one subdirectory per predicate):
 //
-//	go run ./tools/gen-receipt-examples examples/receipts/applied-matches-spec
+//	go run ./tools/gen-receipt-examples examples/receipts
 //
 // The generator is deterministic: same input data + same VerifiedAt → same
 // fingerprint. CI re-runs it and diffs against the committed files (see
@@ -19,6 +20,7 @@ import (
 	"time"
 
 	"github.com/confighub/cub-scout/pkg/agent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -135,9 +137,79 @@ func inconclusiveNoAnchor() agent.BuildReceiptInput {
 	return in
 }
 
+// --- batch 2: source-truth-pass examples ----------------------------
+
+func sourceTruthPassInput() agent.BuildReceiptInput {
+	in := baseInput()
+	in.PredicateName = agent.PredicateSourceTruthPass
+	in.Spec = nil // source-truth-pass doesn't use a spec anchor
+	in.Strategy = string(agent.StrategyGitArgo)
+	in.Evidence = agent.Evidence{
+		SourceTruth: &agent.SourceTruthEvidence{
+			DeclaredStrategy: agent.StrategyGitArgo.Human(),
+			Status:           agent.StatusPASS,
+			SourceTruth:      agent.VerdictAGREED,
+			Outlier:          agent.OutlierUnknown,
+			Surfaces: agent.SourceTruthSurfaces{
+				ConfigHub:  &agent.ConfigHubSurface{Space: "payments", Unit: "api", Revision: "42"},
+				Controller: &agent.ControllerSurface{Kind: "Argo", Source: "https://github.com/org/platform-config", RevisionOrDigest: "abc123def456abc123def456abc123def456abcd"},
+				Runtime:    &agent.RuntimeSurface{Resource: "Deployment/api in prod", Field: "spec.template.spec.containers[0].image", Value: "ghcr.io/org/api:v2.3.0", Health: "Ready"},
+			},
+		},
+	}
+	return in
+}
+
+func sourceTruthBlockMismatch() agent.BuildReceiptInput {
+	in := sourceTruthPassInput()
+	in.Evidence.SourceTruth.Status = agent.StatusBLOCK
+	in.Evidence.SourceTruth.SourceTruth = agent.VerdictMISMATCH
+	in.Evidence.SourceTruth.Outlier = agent.OutlierController
+	in.Evidence.SourceTruth.Surfaces.Controller.RevisionOrDigest = "feedfacefeedfacefeedfacefeedfacefeedface"
+	return in
+}
+
+// --- batch 2: no-manual-edits-since examples ------------------------
+
+func noManualEditsSincePass() agent.BuildReceiptInput {
+	cutoff := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	before := metav1.NewTime(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
+
+	in := baseInput()
+	in.PredicateName = agent.PredicateNoManualEditsSince
+	in.Spec = nil
+	in.Strategy = ""
+	in.Since = cutoff
+	in.Evidence = agent.Evidence{}
+
+	// Live carries the managedFields the predicate walks. The base Live
+	// is a bare Deployment; rebuild with a single Argo controller entry
+	// dated before the cutoff so the predicate emits PASS.
+	live := makeArgoLive()
+	live.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &before},
+	})
+	in.Live = live
+	return in
+}
+
+func noManualEditsSinceBlock() agent.BuildReceiptInput {
+	after := metav1.NewTime(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+
+	in := noManualEditsSincePass()
+	live := makeArgoLive()
+	live.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{Manager: "argocd-controller", Operation: metav1.ManagedFieldsOperationApply, Time: &after},
+		{Manager: "kubectl-edit", Operation: metav1.ManagedFieldsOperationUpdate, Time: &after},
+	})
+	in.Live = live
+	return in
+}
+
 type example struct {
-	name string
-	in   agent.BuildReceiptInput
+	predicateDir string // subdirectory under outDir, e.g. "applied-matches-spec"
+	name         string // filename within that subdirectory
+	in           agent.BuildReceiptInput
 }
 
 func main() {
@@ -152,24 +224,36 @@ func main() {
 	}
 
 	examples := []example{
-		{"pass-controller-drift.json", passCase()},
-		{"block-manual-edit.json", blockManualEdit()},
-		{"block-anchor-mismatch.json", blockAnchorMismatch()},
-		{"inconclusive-no-anchor.json", inconclusiveNoAnchor()},
+		// applied-matches-spec (batch 1).
+		{"applied-matches-spec", "pass-controller-drift.json", passCase()},
+		{"applied-matches-spec", "block-manual-edit.json", blockManualEdit()},
+		{"applied-matches-spec", "block-anchor-mismatch.json", blockAnchorMismatch()},
+		{"applied-matches-spec", "inconclusive-no-anchor.json", inconclusiveNoAnchor()},
+		// source-truth-pass (batch 2).
+		{"source-truth-pass", "pass-agreed.json", sourceTruthPassInput()},
+		{"source-truth-pass", "block-mismatch.json", sourceTruthBlockMismatch()},
+		// no-manual-edits-since (batch 2).
+		{"no-manual-edits-since", "pass-controller-only.json", noManualEditsSincePass()},
+		{"no-manual-edits-since", "block-kubectl-edit.json", noManualEditsSinceBlock()},
 	}
 
 	for _, ex := range examples {
 		stmt, err := agent.BuildReceipt(ex.in)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "build %s: %v\n", ex.name, err)
+			fmt.Fprintf(os.Stderr, "build %s/%s: %v\n", ex.predicateDir, ex.name, err)
 			os.Exit(1)
 		}
 		buf, err := json.MarshalIndent(stmt, "", "  ")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "marshal %s: %v\n", ex.name, err)
+			fmt.Fprintf(os.Stderr, "marshal %s/%s: %v\n", ex.predicateDir, ex.name, err)
 			os.Exit(1)
 		}
-		path := filepath.Join(outDir, ex.name)
+		predicateDir := filepath.Join(outDir, ex.predicateDir)
+		if err := os.MkdirAll(predicateDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "mkdir %s: %v\n", predicateDir, err)
+			os.Exit(1)
+		}
+		path := filepath.Join(predicateDir, ex.name)
 		if err := os.WriteFile(path, append(buf, '\n'), 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "write %s: %v\n", path, err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary

Third and final batch of `#446`. Adds the read-side management UX locked in the design synthesis: three subcommands that work on receipts produced earlier, plus a `--save` flag on `receipt verify` that drops the artifact into a canonical local store.

Together with **batch 1** (#454, merged) and **batch 2** (#455), this **closes v1 of the receipt capability** — predicates, fingerprint, examples, contract docs, and management UX are all in main.

**Built on top of batch 2** (`claude/receipt-batch-2`) — merge #455 first; this PR's diff is self-contained but the base contains the batch 2 commit.

## What ships

### Store package (`pkg/agent/receipt_store.go`)

Pure filesystem IO. No DB, no index, no subdirectories — flat files keyed by a sortable canonical name:

```
<verifiedAt-rfc3339-safe>__<predicate>__<kind>-<name>__<short-fingerprint>.receipt.json
```

Public API:
- `DefaultStoreDir()` resolves `$CUB_SCOUT_RECEIPTS_DIR → $XDG_DATA_HOME/cub-scout/receipts → $HOME/.local/share/cub-scout/receipts`
- `DeriveFilename(stmt)` is deterministic and chronologically sortable
- `SaveStatement(stmt, dir)` is **immutable** — refuses to overwrite (wraps `os.ErrExist`)
- `LoadStatement(path)` parses without verifying fingerprint (forensic inspection of tampered receipts must still be possible)
- `ListStatements(dir)` walks the dir, returns `[]ReceiptListEntry` sorted by VerifiedAt descending, tolerates non-receipt files and partial parse failures

### Three subcommands

| Subcommand | Purpose | Exit code |
|------------|---------|-----------|
| `receipt show <path>` | Render ASCII or JSON. No fingerprint check. | 0 |
| `receipt validate <path>` | Recompute and compare fingerprint. | 0 OK, 1 mismatch, 2 I/O |
| `receipt list [--dir]` | Walk the store, one row per receipt, newest first. | 0 (partial on parse failure) |

### `--save` on `receipt verify`

```bash
# Save into the default store.
cub-scout receipt verify deploy/api -n prod --save

# Save into an explicit directory.
cub-scout receipt verify deploy/api -n prod --save --save-dir ./ci-receipts/

# Env var sets the default for the session.
export CUB_SCOUT_RECEIPTS_DIR=./ci-receipts/
cub-scout receipt verify deploy/api -n prod --save
cub-scout receipt list
```

Duplicate saves emit "already saved: <path>" on stderr and exit 0; the on-disk artifact is unchanged.

## Tests

- **17** new store unit tests (`pkg/agent/receipt_store_test.go`) covering env-var resolution, XDG/HOME fallback, filename shape + chronological sort, save round-trip, overwrite refusal, mkdir-on-save, malformed JSON load, partial-list semantics, fingerprint round-trip after Save/Load
- **11** new CLI integration tests (`cmd/cub-scout/receipt_batch3_test.go`) covering all three subcommands + the new `--save` flag. Uses the existing `loadReceiptLiveFn` seam — no cluster needed.

## Docs

- `docs/reference/commands.md` § receipt: four new sub-sections (show, validate, list, save) with examples
- `docs/reference/json-contracts.md` § Receipt Contract: full Receipt Management Surface section with the filename convention, store priority chain, immutability guarantee, and `ReceiptListEntry` JSON shape
- `examples/receipts/README.md`: "Reading Receipts Back" and "Local Receipt Store" sections

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./pkg/agent/... ./cmd/cub-scout/...` clean
- [x] `go test ./pkg/agent/... ./cmd/cub-scout/...` all green (17 + 11 new tests pass; all batch 1 + batch 2 tests still pass)
- [x] All three CI parity scripts pass locally
- [x] `TestReceiptPackageReadOnlyClient` still passes — no mutating K8s client calls in any receipt source file
- [x] `TestReceiptExamplesAreFresh` still passes — the example generator output is byte-identical

## Read-only triad lock holds

- `receipt show`, `receipt validate`, `receipt list` never touch the cluster
- `receipt_store.go` does pure filesystem IO — no Get/List/Watch on K8s, no ConfigHub reads
- `--save` writes are flat-file appends to an immutable artifact dir
- All previous mutating-verb guards (`FilterNextSteps`, source-file grep) still enforced

## What closes with this PR

After this merges, **#446 v1 is complete**. The roadmap entry's three checkboxes (foundation, predicates, management UX) all flip. v2 work (DSSE signing, Sigstore Bundle v0.3, chained receipts via `inputAttestations[]`) is tracked separately (#448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)