### PR TITLE
docs(skills): #442 batch 2 — four verb-group skills (Ingest / Govern / Integrate / Verify)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,11 +79,13 @@ Full design: [`docs/proposals/receipts-way-forward.md`](proposals/receipts-way-f
 
 **v1 scope (post external review): single-resource verify + show + validate only.** Batch / aggregate / chained / watch-driven receipts are explicit v2 work tracked separately.
 
-- [ ] v1 foundation — `pkg/agent/receipt.go` types, **RFC 8785 canonical-JSON**, SHA-256 fingerprint over the **full Statement minus `predicate.fingerprint`**, in-toto Statement v1 envelope with **dual subjects** (`k8s-live://` + `confighub-unit://`), auto-detection priority order, `cub-scout receipt verify` command + ASCII renderer + tests + JSON contract docs — tracked in #446 batch 1
-- [ ] v1 predicates — `applied-matches-spec` (batch 1), `source-truth-pass` (explicit `--strategy` required), `no-manual-edits-since` (batch 2) — tracked in #446 batches 1–2
-- [ ] v1 management UX — `receipt show` / `validate` / `list` subcommands; local-directory storage (`$XDG_DATA_HOME/cub-scout/receipts/`) — tracked in #446 batch 3
-- [ ] `scout-verify` skill added as 8th verb-group skill in #442
-- [ ] v2 deferrals — DSSE signing wrapped in **Sigstore Bundle v0.3** (cosign keyless + ed25519 fallback), OCI 1.1 referrers sink (designed graph-ingestible for GUAC), composition via `inputAttestations[]` digest chains, additional predicates (`no-drift`, `controller-reconciling`, `binding-matches`, `apply-completed`)
+- [x] v1 foundation — `pkg/agent/receipt.go` types, **RFC 8785 canonical-JSON** (via `gowebpki/jcs`, post Codex round-4 review), SHA-256 fingerprint over the **full Statement minus `predicate.fingerprint`** (delete-key, not zero-value), in-toto Statement v1 envelope with **dual subjects** (`k8s-live://` + `confighub-unit://`), auto-detection priority order, `cub-scout receipt verify` command + ASCII renderer + tests + JSON contract docs — shipped in #446 batch 1 (PR #454)
+- [x] v1 predicates — `applied-matches-spec` (batch 1, #454), `source-truth-pass` (explicit `--strategy` required, batch 2 #455), `no-manual-edits-since` (batch 2 #455)
+- [x] v1 management UX — `receipt show` / `validate` / `list` subcommands; local-directory storage (`$XDG_DATA_HOME/cub-scout/receipts/`) with immutable canonical filenames; `--save` flag on `receipt verify` — shipped in #446 batch 3 (PR #456)
+- [x] `scout-verify` skill added as 8th verb-group skill in #442 batch 2
+- [ ] v2 deferrals — DSSE signing wrapped in **Sigstore Bundle v0.3** (cosign keyless + ed25519 fallback), OCI 1.1 referrers sink (designed graph-ingestible for GUAC), composition via `inputAttestations[]` digest chains, additional predicates (`no-drift`, `controller-reconciling`, `binding-matches`, `apply-completed`) — tracked in #448
+
+**`#446` v1 status: complete and merged on `main` (#454 + #455 + #456).** The capability is documented in `docs/reference/json-contracts.md` § Receipt Contract and `docs/reference/commands.md` § receipt, with 8 canonical examples under `examples/receipts/` and a full test suite (17 store + 25 predicate + 26 CLI integration + read-only-triad guards). Parent issue closed.
 
 Read-only-triad invariant: receipts emit artifacts, never mutate. `nextSteps[]` rejects `actionType=mutating` entries at receipt-emit time. The `receipt` package exposes only `Get` / `List` / `Watch` cluster operations — enforced by `TestReceiptPackageReadOnlyClient`. PolicyReport CRD emission is explicitly out of scope (writes cluster state); spin off as a separate external adapter.
 
@@ -99,11 +101,11 @@ Spin-off issues (so v1 stays narrow): #448 aggregate / chained receipts, #449 wa
 
 Coverage gap: cub-scout ships one umbrella `SKILL.md` while `cub` has 23+ scenario-grouped skills in the reference repo. AI agents picking the right cub-scout verb (`doctor` / `map` / `trace` / `compare three-way` / `compare source-truth` / `explain` / `import …` / `views …` / `mcp serve` / …) have to navigate every verb through one router, diluting triggering accuracy. The attribution layer (#435) added a whole evidence surface with no dedicated skill rules.
 
-- [ ] Scaffolding — `SKILL_TEMPLATE.md`, top-level `skills/README.md` router, read-only-triad allowed-tools convention — tracked in #442 batch 1
-- [ ] Verb-grouped scenario skills (7) — `scout-observe` / `scout-diagnose` / `scout-compare` / `scout-attribute` / `scout-ingest` / `scout-govern` / `scout-mcp` — tracked in #442 batches 1–2
+- [x] Scaffolding — `SKILL_TEMPLATE.md`, top-level `skills/README.md` router, read-only-triad allowed-tools convention — shipped in #442 batch 1 (PR #452)
+- [x] Verb-grouped scenario skills (8) — `scout-observe` / `scout-diagnose` / `scout-compare` / `scout-attribute` (batch 1) + `scout-ingest` / `scout-govern` / `scout-mcp` / `scout-verify` (batch 2). All eight verb groups now covered with their own scenario skill.
 - [ ] Controller observer skills (7) — `observe-argocd` / `observe-flux` / `observe-helm` / `observe-crossplane` / `observe-kro` / `observe-confighub-managed` / `observe-native` — tracked in #442 batch 3
 - [ ] Workflow / scenario skills (8) — `triage-unhealthy-workload` / `investigate-drift` / `audit-fleet-conformance` / `prepare-for-confighub` / `migrate-from-kubectl` / `ai-agent-readonly-context` / `operator-incident-evidence` / `confighub-source-truth` — tracked in #442 batch 4
-- [ ] Shared references (9) — `kubernetes-managedfields` / `verified-manager-strings` / `source-truth-strategies` / `standalone-vs-connected` / `read-only-triad` / `plugin-vs-standalone` / `argocd-applicationset` / `flux-source-types` / `mcp-tool-catalog` — tracked in #442 batches 1, 5
+- [x] Shared references (2 of 9) — `kubernetes-managedfields` / `verified-manager-strings` (shipped in batch 1). Remaining 7 (`source-truth-strategies` / `standalone-vs-connected` / `read-only-triad` / `plugin-vs-standalone` / `argocd-applicationset` / `flux-source-types` / `mcp-tool-catalog`) tracked in #442 batch 5
 
 Read-only-triad invariant: every cub-scout skill's `allowed-tools` line stays inside #410/#428. No `apply`/`edit`/`patch`/`delete`/`mutate` patterns anywhere. Skills for `cub` (mutation-capable) belong in [`confighub/confighub-skills`](https://github.com/confighub/confighub-skills), not here.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,10 +20,10 @@ One skill per cub-scout verb group. The skill knows which commands belong to its
 | [`scout-diagnose/`](scout-diagnose/SKILL.md) | Diagnose | `explain` / `debug` / `suggest-remedy` / `patterns` / `gitops status` |
 | [`scout-compare/`](scout-compare/SKILL.md) | Compare | `compare` / `compare drift` / `compare three-way` / `compare source-truth` |
 | [`scout-attribute/`](scout-attribute/SKILL.md) | Attribute | `cause` / `managerHint` / `gitSource` / `bindingSource` on `compare` + `explain` JSON |
-| `scout-ingest/` *(planned, #442 batch 2)* | Ingest | `import --git-path` / `import argocd` / `import cluster-aggregator` / `import apply` / `app` |
-| `scout-govern/` *(planned, #442 batch 2)* | Govern | `history` / `impact` / `fleet` / `summary` / `views` / `audit` / `bundle` / `catalog` |
-| `scout-mcp/` *(planned, #442 batch 2)* | Integrate | `mcp serve` / `context-pack` (AI gateway) |
-| `scout-verify/` *(planned once #446 batch 1 lands)* | Verify | `cub-scout receipt verify / show / validate / list` |
+| [`scout-ingest/`](scout-ingest/SKILL.md) | Ingest | `import --git-path` / `import argocd` / `import cluster-aggregator` / `import parse-repo` / `app` (preview-only — `import apply` is intentionally out of band) |
+| [`scout-govern/`](scout-govern/SKILL.md) | Govern | `history` / `impact` / `fleet` / `summary` / `views` / `audit` / `bundle` / `catalog` |
+| [`scout-mcp/`](scout-mcp/SKILL.md) | Integrate | `mcp serve` / `context-pack` (AI gateway) |
+| [`scout-verify/`](scout-verify/SKILL.md) | Verify | `cub-scout receipt verify / show / validate / list` (typed, fingerprinted evidence — `#446` v1 complete) |
 
 ### Controller observer skills *(planned, #442 batch 3)*
 
@@ -79,4 +79,8 @@ All skills under `skills/` follow the read-only-triad invariant. Concretely:
 
 ## Status
 
-This batch (#442 batch 1) lands the scaffolding plus the first four verb-grouped scenario skills (Observe / Diagnose / Compare / Attribute) and two references (managedFields, verified-manager-strings). Batches 2–5 add the remaining verb groups, controller observer skills, workflow scenarios, and references. See [`docs/roadmap.md`](../docs/roadmap.md) § "AI Agent Skills" for the full plan.
+**Batch 2 shipped (`#442` batch 2)**: the remaining four verb-grouped scenario skills are in — Ingest / Govern / Integrate (`scout-mcp`) / Verify (`scout-verify`, consuming the receipt capability shipped in `#446`). All eight verb-group skills now have full coverage.
+
+**Earlier:** batch 1 landed the scaffolding plus the first four scenario skills (Observe / Diagnose / Compare / Attribute) and two references (managedFields, verified-manager-strings).
+
+**Remaining work:** batch 3 (controller observer skills — argocd / flux / helm / crossplane / kro / confighub-managed / native), batch 4 (workflow scenario skills — triage / investigate-drift / audit-fleet-conformance / etc.), and batch 5 (the remaining shared references). See [`docs/roadmap.md`](../docs/roadmap.md) § "AI Agent Skills" for the full plan.

--- a/skills/cub-scout/SKILL.md
+++ b/skills/cub-scout/SKILL.md
@@ -24,6 +24,10 @@ This skill is the cross-cutting entry point. It picks the right verb-grouped ski
   - [`scout-diagnose`](../scout-diagnose/SKILL.md) — interpret + recommend
   - [`scout-compare`](../scout-compare/SKILL.md) — intended vs actual
   - [`scout-attribute`](../scout-attribute/SKILL.md) — provenance of field values
+  - [`scout-ingest`](../scout-ingest/SKILL.md) — preview import into ConfigHub
+  - [`scout-govern`](../scout-govern/SKILL.md) — connected governance signals
+  - [`scout-mcp`](../scout-mcp/SKILL.md) — MCP gateway + context-pack
+  - [`scout-verify`](../scout-verify/SKILL.md) — typed, fingerprinted evidence receipts
 - ConfigHub authoring or any mutating workflow — load [`confighub/confighub-skills`](https://github.com/confighub/confighub-skills) skills (`cub-mutate`, `cub-apply`, etc.)
 - Live cluster mutation — cub-scout never mutates; route to `kubectl` (user driven) or a `cub` skill
 
@@ -35,10 +39,10 @@ This skill is the cross-cutting entry point. It picks the right verb-grouped ski
 | Diagnose | [`scout-diagnose`](../scout-diagnose/SKILL.md) | shipped (batch 1) |
 | Compare | [`scout-compare`](../scout-compare/SKILL.md) | shipped (batch 1) |
 | Attribute | [`scout-attribute`](../scout-attribute/SKILL.md) | shipped (batch 1) |
-| Ingest | `scout-ingest` | planned (#442 batch 2) |
-| Govern | `scout-govern` | planned (#442 batch 2) |
-| Integrate | `scout-mcp` | planned (#442 batch 2) |
-| Verify | `scout-verify` | planned (after #446 batch 1 ships the receipt foundation) |
+| Ingest | [`scout-ingest`](../scout-ingest/SKILL.md) | shipped (batch 2) |
+| Govern | [`scout-govern`](../scout-govern/SKILL.md) | shipped (batch 2) |
+| Integrate | [`scout-mcp`](../scout-mcp/SKILL.md) | shipped (batch 2) |
+| Verify | [`scout-verify`](../scout-verify/SKILL.md) | shipped (batch 2, consuming the `#446` receipt capability) |
 
 See [`skills/README.md`](../README.md) for the full plan including controller observer skills (`observe-argocd`, `observe-flux`, `observe-helm`, `observe-crossplane`, `observe-kro`), workflow scenario skills (`triage-unhealthy-workload`, `investigate-drift`, `audit-fleet-conformance`, etc.), and shared references.
 
@@ -56,8 +60,10 @@ See [`skills/README.md`](../README.md) for the full plan including controller ob
 - **Diagnose** — `explain`, `debug`, `suggest-remedy`, `patterns`, `gitops status`
 - **Compare** — `compare drift`, `compare three-way`, `compare source-truth`, `compare <kind>/<name>`
 - **Attribute** — read `cause` / `managerHint` / `gitSource` / `bindingSource` on `compare` and `explain` JSON
-- **Ingest** (preview) — `import --git-path`, `import parse-repo`
+- **Ingest** (preview) — `import --git-path`, `import parse-repo`, `import argocd`, `import cluster-aggregator`
+- **Govern** (connected) — `history`, `impact`, `fleet outliers`, `summary`, `views resolve`, `audit list`, `bundle inspect/diff/timeline`, `catalog list`
 - **Integrate** — `mcp serve`, `context-pack`
+- **Verify** — `receipt verify / show / validate / list` (typed, fingerprinted evidence; `#446` v1 complete)
 
 ### Use `cub` for
 
@@ -82,6 +88,7 @@ See [`skills/README.md`](../README.md) for the full plan including controller ob
 - **`doctor` / `explain`** with `--presentation` and `--hint-mode`.
 - **MCP gateway** (`mcp serve`): standalone + connected tool sets.
 - **Stage B back-resolution** (#440): `compare three-way --source-path <local-checkout>` populates `gitSource.file:line` for raw YAML manifests.
+- **Receipt capability** (#446 — v1 complete; #454 + #455 + #456): typed, fingerprinted, immutable evidence artifacts wrapping cub-scout evidence into an in-toto Statement v1 envelope. Three predicates: `applied-matches-spec`, `source-truth-pass`, `no-manual-edits-since`. `verify` / `show` / `validate` / `list` + local store with immutable canonical filenames. See [`scout-verify`](../scout-verify/SKILL.md).
 
 ## Read first (for capability-assistant work)
 

--- a/skills/scout-govern/SKILL.md
+++ b/skills/scout-govern/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: scout-govern
+description: 'Use when the user wants to consume CONNECTED ConfigHub governance signals from cub-scout — the Govern verb group. Natural phrasing: "show me the ChangeSet history for this unit", "what is the blast radius if I change this unit?", "which clusters in my fleet are outliers?", "show me yesterday''s connected summary", "render this view across the fleet", "audit who changed this", "where did the last apply come from?", "list ConfigHub bundles I have", "show me the catalog of past snapshots". Load whenever intent is history / impact / blast-radius / fleet-outliers / summary / view / audit / bundle / catalog / connected-context. Do NOT load for: live cluster comparison (use scout-compare), receipts (use scout-verify), inventory of running pods (use scout-observe), or any mutation via cub. Most of this skill requires `cub auth login` — say so upfront.'
+phase: verify
+allowed-tools: Bash(./cub-scout history *) Bash(cub-scout history *) Bash(cub scout history *) Bash(./cub-scout impact *) Bash(cub-scout impact *) Bash(cub scout impact *) Bash(./cub-scout fleet *) Bash(cub-scout fleet *) Bash(cub scout fleet *) Bash(./cub-scout summary *) Bash(cub-scout summary *) Bash(cub scout summary *) Bash(./cub-scout views *) Bash(cub-scout views *) Bash(cub scout views *) Bash(./cub-scout audit *) Bash(cub-scout audit *) Bash(cub scout audit *) Bash(./cub-scout bundle *) Bash(cub-scout bundle *) Bash(cub scout bundle *) Bash(./cub-scout catalog *) Bash(cub-scout catalog *) Bash(cub scout catalog *) Bash(./cub-scout status) Bash(cub-scout status) Bash(cub scout status) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub unit get *) Bash(cub link list *) Bash(cub history *) Bash(cub auth status)
+---
+
+# scout-govern
+
+The Govern verb group of cub-scout. Read-only consumption of connected ConfigHub governance signals — ChangeSet history, blast-radius impact analysis, fleet conformance, connected summaries, Views, audit trails, and bundle / catalog state.
+
+Most of this skill requires **connected mode** (`cub auth login` or `CONFIGHUB_API_KEY`). Standalone-mode users get `bundle` / `catalog` / `audit` against local artifacts only.
+
+## When to use
+
+Explicit phrasings:
+
+- "Show me the ChangeSet history for unit `payments-api`"
+- "What's the blast radius if I change this unit?" / "what depends on this?"
+- "Which clusters in my fleet are outliers?" / "show fleet conformance"
+- "Show me yesterday's connected summary for cluster X"
+- "Render Hub View `monthly-spend-by-team` across the fleet"
+- "Audit who changed deploy/api recently"
+- "Where did the last apply come from?"
+- "List the ConfigHub bundles I have locally"
+- "Show me the catalog of past snapshots"
+- "What ConfigHub units / spaces does this resource belong to?"
+
+Implicit intents:
+
+- The user is investigating a change *retroactively* (history / audit / postmortem framing)
+- The user is gating a change *prospectively* (impact / blast-radius / promotion-safety framing)
+- The user is reasoning across the fleet (multi-cluster outliers, conformance)
+- The user wants a structured connected-mode snapshot rather than ad-hoc reads
+
+## Do not load for
+
+- Live cluster comparison (DRY/WET/LIVE) — [`scout-compare`](../scout-compare/SKILL.md)
+- Typed, fingerprinted evidence artifacts (receipts) — [`scout-verify`](../scout-verify/SKILL.md)
+- Inventory of running pods / status — [`scout-observe`](../scout-observe/SKILL.md)
+- Interpreting *why* something is broken — [`scout-diagnose`](../scout-diagnose/SKILL.md)
+- ConfigHub mutations (create / update / delete units) — that's `cub`, not cub-scout. Route to [`confighub/confighub-skills`](https://github.com/confighub/confighub-skills).
+
+## Standalone vs connected
+
+- **Connected (cluster + `cub auth login`):** `history`, `impact`, `fleet outliers`, `summary list/slack`, `views resolve`, `audit list` — all require ConfigHub auth.
+- **Standalone (cluster only):** `audit list` against local audit logs; `bundle inspect/replay/diff/summarize/timeline` and `catalog list` against on-disk artifacts. No ConfigHub needed.
+- **Offline (artifact only):** `bundle inspect`, `bundle replay`, `bundle diff`, `bundle timeline`, `catalog list` work against `.bundle.tar` / `.catalog.json` files with no cluster and no ConfigHub.
+
+`cub-scout status` is the entry point that says which mode you're in.
+
+## Tool boundary
+
+- **Allowed (read-only):** all eight Govern verbs; `kubectl get/describe` for cross-reference; `cub * get / list`, `cub unit get`, `cub link list`, `cub history` (connected); `cub auth status` to confirm mode.
+- **Not allowed:** `cub * create/update/delete`, `cub gitops import` (mutating), `kubectl apply/edit/patch/delete`, `argocd app sync`, `flux reconcile --with-source`. Governance verbs *read* the connected surface; they never write to it.
+- **`fleet` and `summary`:** read across multiple clusters via ConfigHub's connected snapshots. They do NOT shell out to each cluster's kubeconfig directly — the connected surface is the source of truth.
+
+## The verb menu
+
+| Question | Verb | Notes |
+|---|---|---|
+| "Who changed this unit, when?" | `cub-scout history <kind>/<name> -n <ns>` | ChangeSet timeline for the unit tied to this resource. Requires connected. |
+| "What depends on this unit?" | `cub-scout impact <unit-slug>` | Blast-radius preview: which downstream units / clusters / Apps would be affected. Requires connected. |
+| "Which clusters are outliers?" | `cub-scout fleet outliers --view <view>` | Fleet-wide conformance against a View. Requires connected. |
+| "Show me the connected summary" | `cub-scout summary list --cluster <name>` | List stored connected summaries. `summary slack` formats for Slack output. |
+| "Render a Hub View" | `cub-scout views resolve <url-or-uuid>` | Resolve a ConfigHub Hub View URL to its structured columns. `--scope cluster` for fleet-wide. |
+| "Audit who changed what" | `cub-scout audit list` | Audit log entries. Read-only access to ConfigHub's audit trail. |
+| "Inspect a debug bundle" | `cub-scout bundle inspect <path>` | `bundle replay / diff / summarize / timeline` for richer per-bundle reads. |
+| "List my bundle catalogs" | `cub-scout catalog list` | Multi-bundle catalog view — useful for time-series / per-environment archives. |
+
+## The loop
+
+1. **Check the mode.** Run `cub-scout status` to confirm whether you're connected. If not and the user needs connected data, say so explicitly — don't half-answer with stale local data.
+2. **Pick the verb.** Most user prompts map cleanly to one of the eight verbs above.
+3. **Invoke.** Use `--format json` for agent / CI consumption; the default ASCII output is human-friendly.
+4. **Read the evidence.** Each verb has a structured shape (ChangeSet timeline, impact graph, fleet outlier list, View column matrix). They feed Pilot's acceptance kernel and similar tooling directly.
+5. **Hand off.** If the user wants to *act* on a governance finding ("revert this change", "promote to staging", "apply the missing unit"), route to a `cub` skill. cub-scout never mutates ConfigHub.
+
+## Worked examples
+
+### A: ChangeSet history (connected)
+
+```bash
+$ cub-scout history deploy/api -n prod
+ChangeSet timeline for unit payments-api:
+  2026-05-22T10:30Z  Apply by ci-bot     rev=42  "promote v2.3.0"
+  2026-05-21T14:00Z  Apply by alice      rev=41  "config tuning"
+  2026-05-20T09:15Z  Create by alice     rev=40  "initial unit"
+
+ConfigHub URL: https://hub.confighub.com/p/payments/u/payments-api
+```
+
+### B: blast-radius impact (connected)
+
+```bash
+$ cub-scout impact payments-api --format json
+{
+  "unit": "payments-api",
+  "downstream": [
+    {"kind": "App", "name": "checkout", "via": "link:env-shared"},
+    {"kind": "Unit", "name": "payments-worker", "via": "link:image-shared"}
+  ],
+  "clusters": ["prod-use2", "prod-euw1", "staging-use2"]
+}
+```
+
+### C: fleet outliers against a View (connected)
+
+```bash
+$ cub-scout fleet outliers --view monthly-spend-by-team
+View: monthly-spend-by-team
+Clusters: 12
+
+  payments  EXPECTED 3 deploys / cluster   prod-euw1: 2 (outlier: missing payments-worker)
+  checkout  EXPECTED 5 deploys / cluster   ALL match
+  search    EXPECTED 4 deploys / cluster   staging-use2: 3 (outlier: missing search-replica)
+```
+
+### D: bundle inspect (offline, no cluster needed)
+
+```bash
+$ cub-scout bundle inspect ./prod-snapshot.bundle.tar
+Bundle: prod-snapshot.bundle.tar
+  capturedAt: 2026-05-22T10:30:00Z
+  cluster: prod-use2
+  resources: 247
+  topNamespaces: payments(48), checkout(32), platform(20)
+```
+
+`bundle diff` / `bundle timeline` work the same way for multi-bundle comparisons.
+
+## Output evidence
+
+| Verb | Returns |
+|---|---|
+| `history` | ChangeSet timeline + ConfigHub deep-link |
+| `impact` | Downstream unit / cluster / App graph |
+| `fleet outliers` | Per-View matrix with outlier rows highlighted |
+| `summary` | Stored connected summaries indexed by cluster / timestamp |
+| `views resolve` | Structured columns from a Hub View URL |
+| `audit` | Audit log entries (read-only ConfigHub audit trail) |
+| `bundle inspect/diff/summarize/timeline` | Per-bundle structured reads |
+| `catalog list` | Multi-bundle catalog metadata |
+
+## Connected-mode trust surface
+
+Where `history` / `impact` / `fleet outliers` return guidance about whether to act, those hints are **trust signals** for Pilot and similar acceptance kernels. They are NEVER action recommendations from cub-scout itself. Per the read-only triad (#410 / #428):
+
+- cub-scout = evidence (this skill)
+- ConfigHub = authority (where the state lives)
+- Pilot = judge (decides accept / wait / block)
+
+If a user is reading impact output and asks "should I promote?", route them to Pilot or to a human acceptance step — never let cub-scout produce an "approved" answer.
+
+## References
+
+- Command reference: [`docs/reference/commands.md`](../../docs/reference/commands.md) § history, § impact, § fleet, § summary, § views, § audit, § bundle, § catalog
+- Bundle format: [`docs/bundle-diff.md`](../../docs/bundle-diff.md), [`docs/bundle-timeline.md`](../../docs/bundle-timeline.md)
+- Catalog format: [`docs/catalog.md`](../../docs/catalog.md)
+- Views: [`docs/reference/json-contracts.md`](../../docs/reference/json-contracts.md), `cub-scout/#391`
+- Read-only triad: `cub-scout/#410`, `cub-scout/#428`
+
+## Constraints
+
+- Connected verbs (history / impact / fleet / summary / views / audit) refuse to run without `cub auth login`. The error message points at auth, not at the verb.
+- `bundle` / `catalog` work in standalone mode but cannot resolve ConfigHub-specific identifiers (unit slugs, space names) without connected context. They surface the unresolved references explicitly.
+- This skill does not generate receipts — receipts are [`scout-verify`](../scout-verify/SKILL.md)'s job. Govern returns *governance evidence*; Verify returns *fingerprinted artifacts*.

--- a/skills/scout-ingest/SKILL.md
+++ b/skills/scout-ingest/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: scout-ingest
+description: 'Use when the user wants to MOVE existing Kubernetes / GitOps workload structure INTO ConfigHub — the Ingest verb group of cub-scout. Natural phrasing: "import this Argo Application set", "bring my Flux Kustomizations into ConfigHub", "discover workloads in this cluster and propose ConfigHub units", "preview what would land in ConfigHub if I imported this repo", "parse my git repo as a ConfigHub import bundle", "import a cluster aggregator", "show me the import proposal before I apply", "what would --git-path produce for this repo?". Load whenever intent is import / ingest / preview / propose / parse-repo / discovery / aggregator / bring-into-confighub / what-would-confighub-see. Do NOT load for: comparing live state to ConfigHub (use scout-compare), inventory of what is currently running (use scout-observe), the actual write to ConfigHub via `cub gitops import` (that is `cub`, not cub-scout — route to cub skills). Important: `cub-scout import apply` IS the mutating write into ConfigHub — this skill teaches the read-only preview path and explicitly refuses to invoke `import apply` itself.'
+phase: verify
+allowed-tools: Bash(./cub-scout import --git-path *) Bash(cub-scout import --git-path *) Bash(cub scout import --git-path *) Bash(./cub-scout import parse-repo *) Bash(cub-scout import parse-repo *) Bash(cub scout import parse-repo *) Bash(./cub-scout import argocd *) Bash(cub-scout import argocd *) Bash(cub scout import argocd *) Bash(./cub-scout import cluster-aggregator *) Bash(cub-scout import cluster-aggregator *) Bash(cub scout import cluster-aggregator *) Bash(./cub-scout app *) Bash(cub-scout app *) Bash(cub scout app *) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub unit list *) Bash(cub gitops discover *) Bash(argocd app get *) Bash(argocd appset get *) Bash(flux get *)
+---
+
+# scout-ingest
+
+The Ingest verb group of cub-scout. Reads cluster + git-repo + controller structure and **proposes** the corresponding ConfigHub unit/space/target tree. Every Ingest verb is **preview-by-default**; the actual write into ConfigHub uses `import apply` and is intentionally NOT in this skill's allowed-tools.
+
+## When to use
+
+Explicit phrasings:
+
+- "Import this Argo Application set into ConfigHub"
+- "Bring my Flux Kustomizations into ConfigHub"
+- "Discover the workloads in this cluster and propose ConfigHub units"
+- "Preview what would land in ConfigHub if I imported this repo"
+- "Parse my git repo as a ConfigHub import bundle"
+- "Import a cluster aggregator" / "aggregator-pattern multi-cluster import"
+- "Show me the import proposal before I apply"
+- "What would `--git-path` produce for this repo layout?"
+- "Generate a proposed unit YAML I can put in a PR"
+
+Implicit intents:
+
+- The user has *existing* GitOps state (cluster, Argo ApplicationSets, Flux Kustomizations, raw git repo) and wants ConfigHub adoption
+- The user is gating on review-before-apply (PR-flow, dry-run mindset)
+- The user is migrating off a different tool and wants ConfigHub to mirror current state
+- The user is exploring "what would ConfigHub see here" without committing
+
+## Do not load for
+
+- Comparing live state to ConfigHub once units exist — [`scout-compare`](../scout-compare/SKILL.md)
+- Inventory of what is currently running (without ConfigHub) — [`scout-observe`](../scout-observe/SKILL.md)
+- The actual cluster-side `cub gitops import` (target + render-target based) — that's `cub`, not cub-scout. Route to [`confighub/confighub-skills`](https://github.com/confighub/confighub-skills).
+- `cub-scout import apply` (mutating; writes to ConfigHub) — this skill refuses to invoke it directly. Recommend the user run it themselves once they've reviewed the preview.
+
+## Standalone vs connected
+
+- **Standalone (cluster only):** `import argocd` and `import cluster-aggregator` read controller state from the cluster + (optionally) the controller CLI; they produce a proposal document. No ConfigHub auth needed for the preview itself.
+- **Standalone (git only):** `import --git-path <repo>` and `import parse-repo <repo>` read a local git checkout and produce a proposal. No cluster, no ConfigHub.
+- **Connected (cluster + `cub auth login`):** the proposal is rendered against the connected ConfigHub instance (existing spaces, naming conflicts, etc. are surfaced) and `import apply` (mutating; not in this skill) becomes available to write the proposal.
+
+## Tool boundary
+
+- **Allowed (read-only preview):** all four import sub-commands in their non-`apply` form; `cub * get/list`, `cub unit list`, `cub gitops discover` for connected-mode context; `argocd app get`, `argocd appset get`, `flux get` for source-side structure reads.
+- **Not allowed (mutating):** `cub-scout import apply` (writes ConfigHub units / spaces / targets), `cub * create/update/delete`, `cub gitops import` (cluster-side; different tool boundary — that's `cub`, not cub-scout), any `kubectl apply/edit/patch/delete`.
+- **`import apply` boundary:** the skill **describes** `import apply`'s shape and what it would do, but explicitly does NOT run it. If the user wants to apply, the skill says "you run `cub-scout import apply --space <s>` yourself after review" — the user is the actor for any mutation.
+
+## The verb menu
+
+| Question | Verb | Notes |
+|---|---|---|
+| "Preview ConfigHub units from a local git repo" | `cub-scout import --git-path <repo>` | Walks the repo, classifies kustomize / helm / raw manifests, emits a proposal. Use `--output-dir <path>` to land proposed unit YAMLs on disk for PR review. |
+| "Parse the repo structure deterministically" | `cub-scout import parse-repo <repo>` | Lower-level parser. Extracts ApplicationSet generator directories, helm chart paths, kustomization roots. Used as a primitive by other verbs. |
+| "Import existing Argo Applications / ApplicationSets" | `cub-scout import argocd --space <s>` | Reads Argo state from the cluster and proposes one ConfigHub unit per Application. ApplicationSet generators (git directories, lists, clusters) preserved as hierarchy. |
+| "Import via a cluster aggregator" | `cub-scout import cluster-aggregator --space <s>` | Multi-cluster bundle-based import. Aggregates per-cluster snapshots into a single ConfigHub proposal. |
+| "Manage ConfigHub Apps (existing units → App)" | `cub-scout app *` | Read-only manipulations of the App/Deployment/Target metadata in ConfigHub. |
+
+## The loop
+
+1. **Identify the source of truth.** Where does the structure come from? A local git checkout? Argo on the cluster? An aggregator snapshot? This determines the verb (see menu above).
+2. **Run the preview verb.** Default to `--format json` if the proposal is going into a script or a PR-bot; ASCII if the user is reading it.
+3. **Read the proposal.** Each proposed unit has a slug, a space, a path (for ApplicationSet generator origin), and a confidence signal. Naming conflicts with existing ConfigHub state are flagged (connected mode).
+4. **Optionally land a disk PR.** `import --git-path --output-dir <path>` writes the proposed unit YAMLs to disk so the user can open a PR for review without ever touching ConfigHub.
+5. **Hand off the mutation.** If the user approves the proposal, they run `cub-scout import apply --space <s>` themselves. The skill **does not** invoke it. The mutation is the user's decision, not the agent's.
+
+## Worked examples
+
+### A: preview a local git repo (standalone, no cluster, no ConfigHub)
+
+```bash
+$ cub-scout import --git-path ./platform-config --format json
+{
+  "units": [
+    {
+      "slug": "apps-prod-api",
+      "path": "apps/prod/api",
+      "kind": "Deployment",
+      "rendererHint": "kustomize",
+      "confidence": "high"
+    },
+    {
+      "slug": "apps-prod-worker",
+      "path": "apps/prod/worker",
+      "kind": "Deployment",
+      "rendererHint": "kustomize",
+      "confidence": "high"
+    }
+  ],
+  "spaces": ["platform-prod"],
+  "targets": ["Kubernetes:prod-use2"]
+}
+```
+
+### B: preview Argo Application import (connected mode)
+
+```bash
+$ cub-scout import argocd --space payments --format json
+$ # proposal has one unit per Argo Application,
+$ # with ApplicationSet origin preserved as hierarchy
+```
+
+### C: write a disk-PR proposal (standalone, no ConfigHub)
+
+```bash
+$ cub-scout import --git-path ./platform-config --output-dir ./proposed-units
+$ git checkout -b adopt-confighub
+$ git add proposed-units/
+$ git commit -m "propose ConfigHub units for platform-config"
+$ # ...PR review happens in git, not in ConfigHub
+```
+
+This is the **safest** workflow: the proposal lives in git, gets reviewed, and only after merge does someone run `cub-scout import apply` to write the units to ConfigHub.
+
+## Output evidence
+
+Every preview returns a structured proposal Pilot or a CI bot can consume:
+
+| Field | Meaning |
+|---|---|
+| `units[]` | Proposed ConfigHub units, one per workload. Each carries slug, path, kind, rendererHint, confidence. |
+| `spaces[]` | Proposed ConfigHub spaces (typically grouped by environment / cluster) |
+| `targets[]` | Proposed ConfigHub targets (the K8s clusters / contexts the units would deploy to) |
+| `conflicts[]` | (Connected mode) existing ConfigHub names that would clash with the proposal |
+| `unsupported[]` | Workloads / resource shapes the parser can't classify — surface as gaps, not silent skips |
+
+## Boundary with `cub gitops import`
+
+cub-scout's `import` verbs are **structure-and-preview** focused:
+
+- `cub-scout import --git-path <repo>` reads a local checkout, classifies it, emits a proposal
+- `cub-scout import argocd` reads Argo Applications, emits a proposal
+- `cub-scout import apply` writes the proposal to ConfigHub (mutation; out of this skill)
+
+`cub gitops import` (in the `cub` CLI) is **cluster discovery + render-target based**:
+
+- Requires a ConfigHub target + render-target already configured
+- Renders the discovered state against the render-target's renderer
+- Writes the rendered output to ConfigHub
+
+The two paths solve different problems. cub-scout's import is for **adoption** (existing state → ConfigHub for the first time); `cub gitops import` is for **on-going ingest** (cluster state → ConfigHub via a configured render pipeline). Don't claim they overlap.
+
+## References
+
+- Command reference: [`docs/reference/commands.md`](../../docs/reference/commands.md) § import, § app
+- Argo import flow: [`examples/argo-import-confighub-demo/`](../../examples/argo-import-confighub-demo/)
+- Flux import flow: [`examples/flux-import-confighub-demo/`](../../examples/flux-import-confighub-demo/)
+- Cluster aggregator pattern: [`examples/fleet-import/`](../../examples/fleet-import/)
+- ApplicationSet generator support: PR #363 (`cub-scout/#363`)
+- `cub` side of the boundary: [`confighub/confighub-skills`](https://github.com/confighub/confighub-skills)
+
+## Constraints
+
+- Receipts are NOT this skill's surface — [`scout-verify`](../scout-verify/SKILL.md) handles typed evidence about a *single resource*. Ingest is about *structural adoption*; the output is a proposal document, not an evidence artifact.
+- `import apply` is intentionally not in the allowed-tools. If a downstream agent is wired to apply automatically, that's an agent-policy decision; this skill says "preview, never apply."
+- For deeply-nested Helm or templated paths, the parser produces lower-confidence proposals — surface those explicitly, never silently drop them.

--- a/skills/scout-mcp/SKILL.md
+++ b/skills/scout-mcp/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: scout-mcp
+description: 'Use when the user wants to expose cub-scout to an AI agent over MCP, or wants a deterministic AI-ready snapshot of cluster context — the Integrate verb group. Natural phrasing: "start the MCP server", "expose cub-scout to Claude / Codex / my agent", "give me an AI-ready context pack of this cluster", "set up the MCP gateway", "what MCP tools does cub-scout expose?", "produce JSON context for an LLM to reason about this cluster". Load whenever intent is mcp / mcp-gateway / mcp-serve / context-pack / agent-context / ai-snapshot / llm-context / model-context-protocol. Do NOT load for: actually running a verb (those are scout-observe / scout-diagnose / scout-compare / scout-attribute / scout-ingest / scout-govern / scout-verify), or `cub` MCP integration (that''s a separate tool surface).'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout mcp *) Bash(cub-scout mcp *) Bash(cub scout mcp *) Bash(./cub-scout context-pack *) Bash(cub-scout context-pack *) Bash(cub scout context-pack *) Bash(./cub-scout version) Bash(cub-scout version) Bash(cub scout version) Bash(./cub-scout status) Bash(cub-scout status) Bash(cub scout status) Bash(kubectl get *) Bash(kubectl describe *) Bash(kubectl config current-context) Bash(cub auth status) Bash(cub * get) Bash(cub * list)
+---
+
+# scout-mcp
+
+The Integrate verb group of cub-scout. Two ways to plug cub-scout into AI workflows:
+
+- **`mcp serve`** — long-running Model Context Protocol gateway exposing cub-scout's verbs as MCP tools for Claude / Codex / any MCP-aware agent
+- **`context-pack`** — one-shot deterministic JSON context bundle an agent can consume directly
+
+Plus the version/status meta-commands the harness uses for cold-start checks.
+
+## When to use
+
+Explicit phrasings:
+
+- "Start the MCP server" / "expose cub-scout to my agent over MCP"
+- "Set up cub-scout as an MCP tool for Claude / Codex"
+- "Give me an AI-ready context pack of this cluster"
+- "What MCP tools does cub-scout expose?"
+- "Produce JSON context an LLM can reason about" / "deterministic context snapshot"
+- "Bootstrap the MCP gateway"
+- "Plug cub-scout into the agent"
+
+Implicit intents:
+
+- The user is integrating cub-scout with an LLM / agent framework
+- The user wants a *deterministic* (no AI, no inference) snapshot for an LLM to reason over
+- The user is debugging MCP tool registration / tool listing / tool calls
+- The user is composing cub-scout with `cub`-side MCP tools
+
+## Do not load for
+
+- Running a single cub-scout verb directly from the CLI — load the verb's own skill (`scout-observe`, etc.)
+- `cub` MCP integration (the ConfigHub-side MCP surface) — that's a separate skill set
+- Generating receipts — [`scout-verify`](../scout-verify/SKILL.md)
+- Comparing live state — [`scout-compare`](../scout-compare/SKILL.md)
+
+## Standalone vs connected
+
+- **Standalone (cluster only):** `mcp serve` exposes the read-only standalone tool set (doctor, explain, map, scan, trace, compare drift, etc.). `context-pack` produces a cluster snapshot with attribution evidence but no ConfigHub linkage.
+- **Connected (cluster + `cub auth login`):** `mcp serve` additionally registers the connected-mode tools (`compare_three_way`, `compare_source_truth`, `history`, `impact`, source-truth, views). Connected `context-pack` includes ConfigHub unit linkage and connected attribution (`bindingSource`).
+- **Offline (no cluster):** `mcp serve` refuses to start without a reachable cluster. `context-pack` works against debug bundles via `--bundle <path>`.
+
+## Tool boundary
+
+- **Allowed (read-only):** `mcp serve` (long-running but no mutation), `context-pack` (deterministic snapshot), `version`, `status`; `kubectl get/describe`, `kubectl config current-context`; `cub * get/list`, `cub auth status`.
+- **Not allowed:** `mcp serve` exposes ONLY the read-only cub-scout verbs as tools. The MCP tool catalog explicitly excludes any mutating verb (`demo`, `import apply`, `compare --suggest --apply`) — see `cmd/cub-scout/mcp.go` `RegisterTools` for the closed list. `context-pack` never writes; it reads + emits.
+- **MCP and the read-only triad:** the MCP gateway is the third party in the architectural triad. cub-scout (evidence) ↔ MCP (transport) ↔ Pilot or agent (judge / actor). The MCP layer NEVER decides; it just streams cub-scout's structured output.
+
+## The verb menu
+
+| Question | Verb | Notes |
+|---|---|---|
+| "Start the MCP gateway" | `cub-scout mcp serve` | Long-running. STDIO transport by default; `--port` for HTTP. |
+| "What MCP tools are registered?" | `cub-scout mcp serve --list-tools` | Dumps the tool catalog as JSON without starting the server. Useful for agent registration debugging. |
+| "Produce deterministic AI context" | `cub-scout context-pack --format json` | One-shot. Cluster snapshot + ownership classifications + attribution evidence in a single JSON. |
+| "Pack a bundle as AI context" | `cub-scout context-pack --bundle <path>` | Same shape, sourced from a debug bundle instead of the live cluster. Offline-friendly. |
+| "Check cub-scout version" | `cub-scout version` | Build tag. Agents that registered cub-scout tools use this to detect breaking-change ranges. |
+| "Confirm mode" | `cub-scout status` | Standalone vs connected. Agents call this first to know which connected tools are available. |
+
+## The loop
+
+1. **Decide MCP vs context-pack.** Long-running agent → `mcp serve`. Single-shot reasoning over a snapshot → `context-pack`.
+2. **Check the mode.** `cub-scout status` confirms standalone vs connected. Tell the agent which tool subset is live.
+3. **Start the surface.** For MCP, `mcp serve` registers tools with the agent. For context-pack, `--format json` and pipe to the agent.
+4. **Compose with sibling skills.** The MCP gateway is plumbing — once it's running, every other verb-group skill (`scout-observe`, `scout-diagnose`, etc.) is reachable via MCP tools and uses the same loops described in those skills.
+5. **Hand off mutations.** No matter what an agent asks the MCP gateway to do, the gateway refuses to call a mutating verb. Mutations route through `cub` skills (in [`confighub/confighub-skills`](https://github.com/confighub/confighub-skills)) or direct `kubectl` with the user driving.
+
+## Worked examples
+
+### A: MCP STDIO for Claude Code
+
+```jsonc
+// .claude/mcp_servers.json (or equivalent for your agent host)
+{
+  "mcpServers": {
+    "cub-scout": {
+      "command": "cub-scout",
+      "args": ["mcp", "serve"],
+      "env": {
+        "KUBECONFIG": "${env:HOME}/.kube/config"
+      }
+    }
+  }
+}
+```
+
+The agent now sees cub-scout's read-only tools (`doctor`, `explain`, `trace`, `compare_drift`, `compare_three_way`, etc.) and can call them like any other MCP tool.
+
+### B: list the tool catalog
+
+```bash
+$ cub-scout mcp serve --list-tools | jq '.tools[] | .name'
+"doctor"
+"explain"
+"map_workloads"
+"map_status"
+"trace"
+"scan"
+"compare_drift"
+"compare_three_way"
+"compare_source_truth"
+"gitops_status"
+"patterns_detect"
+...
+```
+
+Every tool is a thin wrapper over the underlying CLI verb with `--format json` — see `docs/reference/json-contracts.md` for the response shape.
+
+### C: deterministic context pack for an LLM
+
+```bash
+$ cub-scout context-pack --format json > cluster-ctx.json
+$ jq '.ownership | group_by(.type) | map({type: .[0].type, count: length})' cluster-ctx.json
+[
+  {"type": "argo",     "count": 47},
+  {"type": "flux",     "count": 12},
+  {"type": "helm",     "count": 8},
+  {"type": "native",   "count": 23},
+  {"type": "unknown",  "count": 3}
+]
+```
+
+The pack is **deterministic** — same cluster state + same cub-scout version → same JSON bytes. Safe to feed to an LLM with prompt caching, and safe to diff in CI.
+
+### D: connected MCP for promotion workflows
+
+When the agent is connected (`cub auth status` returns OK), `mcp serve` additionally registers:
+
+- `compare_three_way` — DRY/WET/LIVE comparison
+- `compare_source_truth` — strategy-typed verdict
+- `history` — ChangeSet timeline
+- `impact` — blast-radius
+- `views_resolve` — Hub View resolution
+
+These are the typical Pilot acceptance-kernel inputs. The agent composes them; cub-scout produces evidence; Pilot decides.
+
+## Output evidence
+
+### `mcp serve` (the gateway)
+
+- Long-running. STDIO or HTTP transport.
+- Lists tools via the standard MCP `tools/list` request.
+- Each tool call returns `content[0].text` containing the wrapped CLI verb's `--format json` output verbatim.
+- Optional `structuredContent` field on selected connected-mode tools adds parsed evidence + read-only trust guidance for Pilot-shaped consumers.
+
+### `context-pack` (the snapshot)
+
+| Field | Meaning |
+|---|---|
+| `version` | cub-scout build tag + context-pack schema version |
+| `capturedAt` | RFC 3339 timestamp |
+| `cluster` | kubeconfig context + server URL |
+| `mode` | `standalone` or `connected` |
+| `resources[]` | One entry per workload, with kind / name / namespace / ownership classification |
+| `attribution[]` | Per-resource attribution evidence (cause / managerHint / gitSource / bindingSource) |
+| `omissions[]` | What the snapshot deliberately did NOT include (e.g., crashlooping pods skipped, unsupported kinds) |
+
+The snapshot is the *evidence base* a downstream LLM reasons over. It is NOT a recommendation; the LLM forms recommendations.
+
+## MCP tool catalog (current)
+
+The closed list of MCP tools cub-scout registers. The set is verified by `cmd/cub-scout/mcp_test.go` against the connected/standalone modes.
+
+| Tool name | Mode | Verb |
+|---|---|---|
+| `doctor` | standalone | `cub-scout doctor` |
+| `explain` | standalone | `cub-scout explain` |
+| `map_workloads` | standalone | `cub-scout map workloads` |
+| `map_status` | standalone | `cub-scout map status` |
+| `trace` | standalone | `cub-scout trace` |
+| `scan` | standalone | `cub-scout scan` |
+| `compare_drift` | standalone | `cub-scout compare drift` |
+| `gitops_status` | standalone | `cub-scout gitops status` |
+| `patterns_detect` | standalone | `cub-scout patterns detect` |
+| `compare_three_way` | connected | `cub-scout compare three-way` |
+| `compare_source_truth` | connected | `cub-scout compare source-truth` |
+| `history` | connected | `cub-scout history` |
+| `impact` | connected | `cub-scout impact` |
+| `fleet_outliers` | connected | `cub-scout fleet outliers` |
+| `views_resolve` | connected | `cub-scout views resolve` |
+
+The catalog is intentionally narrow: every tool is read-only, every tool has a stable JSON contract, every tool is exercised by an MCP integration test.
+
+## References
+
+- Command reference: [`docs/reference/commands.md`](../../docs/reference/commands.md) § mcp, § context-pack
+- MCP tool descriptions audit: `cub-scout/#377`
+- Connected MCP trust surface: [`docs/reference/json-contracts.md`](../../docs/reference/json-contracts.md) § "MCP connected trust guidance"
+- Context-pack format: [`docs/howto/context-pack-v2.md`](../../docs/howto/context-pack-v2.md)
+- AI integration walkthrough: [`examples/ai-integration/`](../../examples/ai-integration/)
+- MCP gateway example: [`examples/mcp-gateway/`](../../examples/mcp-gateway/)
+
+## Constraints
+
+- The MCP server never starts a mutating tool. The tool catalog is closed and read-only by construction; adding a tool requires a code change + a passing test.
+- `context-pack` is **deterministic** — same input, same bytes. Do not introduce non-determinism (random IDs, timestamps in non-`capturedAt` fields, map iteration order).
+- For long-running agent sessions, prefer MCP STDIO over HTTP unless the agent host requires HTTP — STDIO has lower latency and is sandboxable.
+- `cub-scout mcp serve` is the cub-scout-side MCP. `cub` may also expose an MCP surface; the two are separate, and an agent can register both.

--- a/skills/scout-verify/SKILL.md
+++ b/skills/scout-verify/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: scout-verify
+description: 'Use when the user wants a TYPED, FINGERPRINTED, IMMUTABLE evidence artifact about a Kubernetes resource — the Verify verb group of cub-scout (the receipt capability shipped in #446). Natural phrasing: "produce a receipt that this is in compliance", "give me an attestation that the cluster matches Git", "I need a verifiable record for the audit trail", "build a receipt verifying no manual edits since deploy", "verify deploy/api against source-truth and save the artifact", "validate this receipt is authentic", "show me what receipts we have", "is this receipt tampered with?", "attach evidence to my CI gate". Load whenever intent is receipt / attestation / evidence-artifact / signed-evidence / verified-record / audit-trail / postmortem-evidence / acceptance-judge-input. Do NOT load for: a live comparison without a persisted artifact (use scout-compare), interpreting a single field''s provenance (use scout-attribute), or actually applying a fix (cub-scout never mutates — route to cub / argocd / kubectl with the user driving).'
+phase: verify
+allowed-tools: Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout receipt list) Bash(cub-scout receipt list) Bash(cub scout receipt list) Bash(kubectl get *) Bash(kubectl describe *) Bash(kubectl get --show-managed-fields *) Bash(cub * get) Bash(cub * list) Bash(cub link list *) Bash(cub unit get *) Bash(argocd app get *) Bash(flux get *)
+---
+
+# scout-verify
+
+The Verify verb group of cub-scout. Produces typed, fingerprinted, immutable evidence artifacts — **receipts** — wrapping cub-scout's existing field-level evidence into a verifiable record CI/CD gates, audit trails, postmortems, and acceptance-judge tooling can attach to a decision and later prove the inputs were what they claim to be.
+
+Receipts are HISTORICAL records. Updates produce new receipts; old ones never mutate.
+
+## When to use
+
+Explicit phrasings:
+
+- "Produce a receipt that deploy/api is in compliance"
+- "Give me a verifiable attestation that the cluster matches Git"
+- "I need an evidence artifact for the audit trail"
+- "Build a receipt verifying no manual edits since the freeze started"
+- "Verify deploy/api against source-truth and save the artifact"
+- "Validate this receipt is authentic / hasn't been tampered with"
+- "List the receipts I've generated locally"
+- "Show me yesterday's receipts where the verdict was BLOCK"
+- "Attach typed evidence to my CI gate / promotion gate / release ticket"
+
+Implicit intents:
+
+- The user wants **persistence** of an evidence snapshot, not just an ephemeral comparison
+- The user is gating CI / promotion / acceptance on a verdict
+- The user needs to **prove later** that the inputs were what they claim to be (forensic / audit / postmortem)
+- The user is integrating with Pilot or a similar acceptance kernel that consumes receipt-shaped evidence
+- The user wants a tamper-evident artifact, not a log line
+
+## Do not load for
+
+- Live comparison without a persisted artifact — [`scout-compare`](../scout-compare/SKILL.md) is faster and the right shape
+- Interpreting *why* a single field is wrong (which controller, which file) — [`scout-attribute`](../scout-attribute/SKILL.md)
+- Inventory / status / "what's running" — [`scout-observe`](../scout-observe/SKILL.md)
+- Forcing an apply / sync / patch — cub-scout cannot. Receipts emit; they never act.
+
+## Standalone vs connected
+
+- **Standalone (cluster only):** `receipt verify --predicate applied-matches-spec` and `--predicate no-manual-edits-since` work without ConfigHub. The receipt records `OmissionConfigHubUnitSubject` to flag the missing connected-mode evidence.
+- **Connected (cluster + `cub auth login`):** `--predicate source-truth-pass --strategy <name>` becomes available. Connected mode also adds the `confighub-unit://` subject to every receipt, anchoring it to the unit revision in addition to the live K8s digest.
+- **Offline (file only):** `receipt show` / `receipt validate` / `receipt list` all work on on-disk artifacts with no cluster and no ConfigHub. Useful in CI containers that received the receipt as an artifact from an upstream job.
+
+## Tool boundary
+
+- **Allowed (read-only):** the four receipt verbs (`verify` / `show` / `validate` / `list`); `kubectl get/describe`, `kubectl get --show-managed-fields` (for inspecting what `no-manual-edits-since` saw); `cub * get/list`, `cub unit get`, `cub link list` (connected); `argocd app get`, `flux get` (when building source-truth-pass evidence).
+- **Not allowed:** `kubectl apply/edit/patch/delete`, `argocd app sync` (as mutation), `flux reconcile --with-source`, `cub * create/update/delete`. Receipts are evidence, never recommendations to mutate. `FilterNextSteps` (in `pkg/agent/receipt_predicates.go`) rejects mutating `actionType` / `nextCommand` at receipt-emit time as defense in depth.
+- **`TestReceiptPackageReadOnlyClient`:** the static guard in `cmd/cub-scout/receipt_readonly_test.go` greps every `receipt*.go` source file and fails the build if any mutating K8s client method appears. Receipts are categorically read-only.
+
+## The verb menu
+
+| Question | Verb | Notes |
+|---|---|---|
+| "Produce a receipt about this resource" | `cub-scout receipt verify <kind>/<name> -n <ns>` | Auto-detects the predicate from owner + signals. Defaults to applied-matches-spec for Argo/Flux/ConfigHub-owned resources with a resolved git anchor. |
+| "Render a saved receipt" | `cub-scout receipt show <path>` | ASCII or JSON. Does NOT verify the fingerprint — works on tampered receipts for forensic inspection. |
+| "Is this receipt authentic?" | `cub-scout receipt validate <path>` | Recomputes the fingerprint and compares. Exit 0 OK / 1 mismatch / 2 I/O. JSON output for CI. |
+| "What receipts do I have locally?" | `cub-scout receipt list` | Walks `$CUB_SCOUT_RECEIPTS_DIR → $XDG_DATA_HOME/cub-scout/receipts → $HOME/.local/share/cub-scout/receipts`. Sortable, newest first. |
+
+## The predicates
+
+cub-scout v1 ships three predicates. Each maps a *required input signal* to a *receipt-level verdict*:
+
+| Predicate | Required signal | Verdict logic |
+|---|---|---|
+| `applied-matches-spec` | Argo/Flux/ConfigHub owner + controller-resolved git anchor | PASS on `controller-drift` cause; BLOCK on `manual-edit` cause or anchor mismatch; INCONCLUSIVE on missing anchor or unknown cause. |
+| `source-truth-pass` | `--strategy <name>` (one of 9) + connected-mode ConfigHub auth | Mirrors `compare source-truth` Status → Verdict. Strategy mismatch between caller and evidence → BLOCK. |
+| `no-manual-edits-since` | `--since <RFC3339>` cutoff | PASS when no `kubectl-*` writer touched `managedFields` after the cutoff. BLOCK on any late interactive write. INCONCLUSIVE on missing managedFields or nil-Time entries (parse-don't-guess). |
+
+cub-scout NEVER infers a strategy or a cutoff. `source-truth-pass` requires `--strategy`; `no-manual-edits-since` requires `--since`. Pass them or the CLI errors upfront.
+
+## Verdicts
+
+Every receipt carries one of four:
+
+| Verdict | Meaning |
+|---|---|
+| `PASS` | Evidence supports the claim |
+| `WATCH` | Evidence is ambiguous; situation needs monitoring |
+| `BLOCK` | Evidence contradicts the claim |
+| `INCONCLUSIVE` | Evidence missing or unavailable; always carries one or more `omissions[]` entries |
+
+INCONCLUSIVE is **not** failure — it's an honest "I don't have enough to claim PASS." Pilot and similar acceptance kernels treat it as `ASK` (need human or richer evidence).
+
+## The loop
+
+1. **Pick the predicate.** Most users mean `applied-matches-spec` (default for Argo/Flux/ConfigHub-owned resources with a resolved anchor). If the user mentions a delivery strategy, they want `source-truth-pass`. If they mention a freeze window or cutoff timestamp, they want `no-manual-edits-since`.
+2. **Decide standalone vs connected.** Receipts work in both modes; connected mode adds the `confighub-unit://` subject + ConfigHub-side evidence. Source-truth-pass requires connected mode.
+3. **Invoke verify.** Use `--format json` for CI / agent consumption. Use `--save` to land the artifact in the local store (immutable; refuses overwrite).
+4. **Read the verdict + omissions.** The verdict is the headline; `omissions[]` is the "what I deliberately did not claim" list. Empty omissions = comprehensive coverage. Non-empty = honest gaps.
+5. **Persist or attach.** `--out <path>` writes a specific file; `--save` writes into the store under the canonical name. CI gates that need to attach the artifact to a build record use `--out`.
+6. **Hand off.** If the verdict is BLOCK and the user wants to *act*, refuse to mutate. Point them at the appropriate `cub` skill (for ConfigHub state changes), at `kubectl get --show-managed-fields` (to investigate a manual-edit BLOCK), or at the original-author path (commit the change back to git).
+
+## Worked examples
+
+### A: applied-matches-spec, standalone
+
+The default path for an Argo-owned Deployment. Works without ConfigHub auth.
+
+```bash
+$ cub-scout receipt verify deploy/api -n prod
+Receipt: applied-matches-spec
+  Verdict: PASS
+  Claim:   applied matches spec at apps/prod/api
+  Scope:   Deployment/api in prod
+  By:      cub-scout v2.3.0 at 2026-05-22T10:30:00Z
+  Spec:    https://github.com/org/platform-config @abc123def456 path=apps/prod/api
+
+Subjects
+  - k8s-live://apps/v1/Deployment/prod/api  sha256:595f08ae073d…
+
+Evidence (attribution)
+  cause:       controller-drift
+  managerHint: argocd-controller
+  gitSource:   https://github.com/org/platform-config @abc123def456 path=apps/prod/api
+
+Omissions (deliberate non-claims)
+  - confighub-unit-subject  — standalone-mode build; no ConfigHub auth available to fetch unit subject  [info]
+
+Next steps (read-only)
+  - [read-only] controller is reconciling; spec anchor matches the resolved git source
+      → cub-scout explain
+
+Fingerprint: sha256:252ef3104d0a3cc8ac62e7bde40cf6174b6f045d8ed2b97c6512781d8cb690f4
+```
+
+Save it to disk for a build record:
+
+```bash
+$ cub-scout receipt verify deploy/api -n prod --format json --out api-prod.receipt.json
+```
+
+Or land it in the local store for casual accumulation:
+
+```bash
+$ cub-scout receipt verify deploy/api -n prod --save
+saved: /home/user/.local/share/cub-scout/receipts/2026-05-22T10-30-00Z__applied-matches-spec__Deployment-api__252ef3104d0a.receipt.json
+```
+
+### B: source-truth-pass, declared strategy (connected mode)
+
+```bash
+$ cub-scout receipt verify deploy/api -n prod --strategy git-argo --format json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {"name": "k8s-live://apps/v1/Deployment/prod/api", "digest": {"sha256": "..."}},
+    {"name": "confighub-unit://payments-api@rev=42", "digest": {"sha256": "..."}}
+  ],
+  "predicateType": "https://cub-scout.dev/receipt/v1",
+  "predicate": {
+    "predicateName": "source-truth-pass",
+    "verdict": "PASS",
+    "evidence": {
+      "sourceTruth": {
+        "declared_strategy": "Git -> Argo -> Kubernetes",
+        "status": "PASS",
+        "source_truth": "AGREED",
+        "surfaces": { ... }
+      }
+    },
+    "omissions": [],
+    "fingerprint": "sha256:..."
+  }
+}
+```
+
+Strategy mismatch is BLOCK — never silently honor the caller's strategy over what the evidence records:
+
+```bash
+$ cub-scout receipt verify deploy/api -n prod --strategy git-argo
+# ... evidence carries confighub-oci-argo, not git-argo ...
+Verdict: BLOCK
+Omissions
+  - strategy-mismatch  — receipt was asked to verify under strategy "git-argo" but source-truth evidence carries "ConfigHub -> OCI -> Argo -> Kubernetes"
+```
+
+### C: no-manual-edits-since freeze gate (standalone)
+
+```bash
+$ cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z --save
+saved: /home/user/.local/share/cub-scout/receipts/2026-05-22T10-30-00Z__no-manual-edits-since__Deployment-api__abc123.receipt.json
+
+$ cub-scout receipt show ~/.local/share/cub-scout/receipts/2026-05-22T10-30-00Z__no-manual-edits-since__Deployment-api__abc123.receipt.json
+Receipt: no-manual-edits-since
+  Verdict: PASS
+  Claim:   no manual edits to Deployment/api in prod since 2026-05-22T00:00:00Z
+```
+
+A late `kubectl edit` produces BLOCK and names the offending writer:
+
+```
+Verdict: BLOCK
+Next steps (read-only)
+  - [read-only] interactive writer wrote managedFields after the cutoff (2026-05-22T00:00:00Z): kubectl-edit@2026-05-22T12:00:00Z — investigate the unplanned edit before any apply
+      → kubectl get --show-managed-fields
+```
+
+### D: validate + list
+
+```bash
+$ cub-scout receipt validate ./api-prod.receipt.json
+Fingerprint OK: ./api-prod.receipt.json
+  sha256:252ef3104d0a3cc8ac62e7bde40cf6174b6f045d8ed2b97c6512781d8cb690f4
+
+$ cub-scout receipt list
+Store: /home/user/.local/share/cub-scout/receipts
+
+VERDICT        PREDICATE               SCOPE                                     VERIFIED-AT             PATH
+PASS           applied-matches-spec    Deployment/api in prod                    2026-05-22T10:30:00Z    2026-05-22T10-30-00Z__applied-matches-spec__Deployment-api__252ef3104d0a.receipt.json
+BLOCK          no-manual-edits-since   Deployment/api in prod                    2026-05-22T08:00:00Z    2026-05-22T08-00-00Z__no-manual-edits-since__Deployment-api__abc123.receipt.json
+```
+
+JSON list output for CI consumption (filter by verdict):
+
+```bash
+$ cub-scout receipt list --format json | jq '.[] | select(.verdict == "BLOCK")'
+```
+
+## Output evidence
+
+What every receipt carries (the structured surface a downstream consumer pattern-matches on):
+
+| Field | Meaning |
+|---|---|
+| `predicate.predicateName` | One of `applied-matches-spec` / `source-truth-pass` / `no-manual-edits-since` |
+| `predicate.verdict` | One of `PASS` / `WATCH` / `BLOCK` / `INCONCLUSIVE` |
+| `predicate.scope` | `kind / name / namespace / cluster` |
+| `predicate.verifier` | `{tool, version}` — always `cub-scout` plus the build tag |
+| `predicate.verifiedAt` | RFC 3339 timestamp |
+| `predicate.spec.anchor` | Git repo + revision + path (applied-matches-spec only) |
+| `predicate.evidence.attribution` | `cause` / `managerHint` / `gitSource` — cub-scout's existing attribution layer |
+| `predicate.evidence.sourceTruth` | Source-truth derivation surfaces (source-truth-pass only) |
+| `predicate.omissions[]` | Structured list of what the receipt deliberately does NOT claim — empty array means comprehensive coverage |
+| `predicate.nextSteps[]` | Read-only follow-up hints (mutating verbs filtered at emit time) |
+| `predicate.fingerprint` | `sha256:` SHA-256 over RFC 8785 canonical JSON of the full Statement minus only this field |
+
+## Storage convention
+
+The local receipt store is a flat directory of `*.receipt.json` files keyed by a deterministic sortable name:
+
+```
+<verifiedAt-rfc3339-safe>__<predicate>__<kind>-<name>__<short-fingerprint>.receipt.json
+```
+
+Resolved in priority order:
+
+1. `--save-dir <path>` on verify, `--dir <path>` on list (explicit override)
+2. `$CUB_SCOUT_RECEIPTS_DIR` env var
+3. `$XDG_DATA_HOME/cub-scout/receipts`
+4. `$HOME/.local/share/cub-scout/receipts`
+
+The store is **immutable**: re-running verify on the same resource at the same instant with the same fingerprint produces the same canonical filename → "already saved" warning and exit 0. The on-disk artifact never changes.
+
+## v2 (deferred)
+
+Currently NOT in cub-scout, tracked in #448 / #449:
+
+- DSSE signing wrapped in **Sigstore Bundle v0.3** (cosign keyless + ed25519 fallback) — purely additive on the existing envelope
+- Aggregate / chained receipts via `inputAttestations[]` digest references
+- `cub-scout watch --emit-receipt-on <event>` for event-driven receipt generation
+- `--fail-on RECEIPT_VERDICT` exit code for CI gates that gate on verdict
+
+v1 ships fingerprint-only and is honest about it — the contract is in `docs/reference/json-contracts.md` § Receipt Contract.
+
+## References
+
+- Contract: [`docs/reference/json-contracts.md`](../../docs/reference/json-contracts.md) § Receipt Contract
+- Locked design: [`docs/proposals/receipts-way-forward.md`](../../docs/proposals/receipts-way-forward.md)
+- Examples: [`examples/receipts/`](../../examples/receipts/) — 8 canonical receipts across the three predicates, generated deterministically by `tools/gen-receipt-examples`
+- Implementation: `pkg/agent/receipt*.go`, `cmd/cub-scout/receipt*.go`
+- Read-only triad: [`scout-attribute`](../scout-attribute/SKILL.md) (companion evidence surface), [`scout-compare`](../scout-compare/SKILL.md) (live comparison sibling)


### PR DESCRIPTION
## Summary

Closes the verb-grouped scenario-skill coverage. All eight cub-scout verb groups now have a dedicated scenario skill that names exact CLI verbs, locks the read-only allowed-tools surface, and routes the mutating-side handoff to \`cub\` skills upstream.

Builds on **batch 1** (#452, merged) which shipped the scaffolding plus four verb-group skills (Observe / Diagnose / Compare / Attribute) and two references (managedFields, verified-manager-strings).

## Four new skills

| Skill | Verb group | Covers |
|-------|-----------|--------|
| [\`scout-ingest/\`](./skills/scout-ingest/SKILL.md) | Ingest | \`import --git-path\` / \`import argocd\` / \`import cluster-aggregator\` / \`import parse-repo\` / \`app\`. Carves OUT \`import apply\` (mutating; user-driven) and the cluster-side \`cub gitops import\` (different boundary). |
| [\`scout-govern/\`](./skills/scout-govern/SKILL.md) | Govern | \`history\` / \`impact\` / \`fleet outliers\` / \`summary\` / \`views resolve\` / \`audit\` / \`bundle\` / \`catalog\`. Most verbs require \`cub auth login\`; \`bundle\` + \`catalog\` work offline. |
| [\`scout-mcp/\`](./skills/scout-mcp/SKILL.md) | Integrate | \`mcp serve\` (STDIO/HTTP MCP gateway) + \`context-pack\` (deterministic AI-ready snapshot). Documents the closed 15-tool catalog and the no-mutating-tool invariant. Includes a Claude Code MCP server config snippet. |
| [\`scout-verify/\`](./skills/scout-verify/SKILL.md) | Verify | \`receipt verify / show / validate / list\` — consumes the receipt capability shipped in \`#446\`. Worked examples for all three predicates (\`applied-matches-spec\`, \`source-truth-pass\`, \`no-manual-edits-since\`). Documents verdicts, omissions, local store priority chain, immutability guarantee. |

## Router updates

- **\`skills/README.md\`**: all four planned-batch-2 rows flip to shipped in the verb-group table; Status section updated
- **\`skills/cub-scout/SKILL.md\`** (umbrella): all eight scenario skills now listed with shipped status; "Use cub scout for" list expanded; "High-signal shipped capabilities" gets a Receipt-capability entry
- **\`docs/roadmap.md\`**:
  - Receipt-capability section's three checkboxes flip to shipped with PR cites #454/#455/#456 (since #446 v1 is now complete on main)
  - AI Agent Skills section advances batches 1 + 2 to shipped, leaving batches 3 (controller observers) + 4 (workflow scenarios) + 5 (remaining references) open

## Authoring rules (preserved)

Each new skill follows the \`SKILL_TEMPLATE.md\` scaffold and the read-only-triad invariant:

- YAML frontmatter with explicit "do NOT load for" cases (Codex round-2 feedback from batch 1)
- Enumerated \`allowed-tools\` — **no broad \`Bash(cub-scout *)\` wildcards** that would silently grant \`demo\` / \`import apply\` / \`compare --suggest --apply\`. Every verb is named.
- "Do not load for" cross-links to sibling skills
- Standalone-mode first in worked examples; connected is the enrichment
- Tool boundary with explicit "not allowed" list naming mutating patterns
- The loop pattern matching the read-only triad: identify → pick verb → invoke → interpret → hand off

Zero mutating patterns (\`apply\`/\`edit\`/\`patch\`/\`delete\`/\`sync\`/\`create\`/\`update\`/\`replace\`/\`scale\`/\`rollout\`/\`reconcile\`/\`annotate\`/\`label\`/\`set\`/\`exec\`/\`debug\`/\`helm install\`/\`helm upgrade\`) appear anywhere across the four new files.

## What's left in #442

- **Batch 3** — 7 controller observer skills (observe-argocd / -flux / -helm / -crossplane / -kro / -confighub-managed / -native)
- **Batch 4** — 8 workflow scenario skills (triage-unhealthy-workload / investigate-drift / audit-fleet-conformance / prepare-for-confighub / migrate-from-kubectl / ai-agent-readonly-context / operator-incident-evidence / confighub-source-truth)
- **Batch 5** — 7 remaining shared references (source-truth-strategies / standalone-vs-connected / read-only-triad / plugin-vs-standalone / argocd-applicationset / flux-source-types / mcp-tool-catalog)

## Test plan

- [x] All three CI parity scripts pass locally (\`check-cli-guide-parity.sh\`, \`check-doc-freshness.sh\`, \`check-readonly.sh\`)
- [x] Docs-only change; no Go code touched. \`go test ./pkg/agent/... ./cmd/cub-scout/...\` passes (the only failure on full \`go test ./...\` is the pre-existing \`TestDemoWorkerLifecycleScript_*\` local-environment flake that bit the receipt PRs too, unrelated to skills)
- [x] No mutating patterns in any new skill's \`allowed-tools\` line — grepped manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)