### PR TITLE
docs: refresh HANDOVER + AI-README-FIRST + v2.0.0-plan to match v2.2.1 reality

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -23,7 +23,7 @@ Use these for different AI scenarios:
 
 ## Capability Map at a Glance
 
-cub-scout commands fall into seven groups. Each group's **inputs** column tells you whether a command needs only a cluster (standalone), needs a local git checkout, or needs ConfigHub auth (connected). See [README.md § Capability Map](README.md#capability-map) for the full per-command table — this section is the navigation aid.
+cub-scout commands fall into eight groups. Each group's **inputs** column tells you whether a command needs only a cluster (standalone), needs a local git checkout, or needs ConfigHub auth (connected). See [README.md § Capability Map](README.md#capability-map) for the full per-command table — this section is the navigation aid.
 
 | Group | What it answers | Notable commands |
 |---|---|---|
@@ -34,6 +34,7 @@ cub-scout commands fall into seven groups. Each group's **inputs** column tells 
 | **Ingest** | How to bring config into ConfigHub | `import --git-path`, `import parse-repo`, `import argocd`, `import cluster-aggregator`, `import apply`, `app` |
 | **Govern** | Connected history, fleet, views | `history`, `impact`, `fleet outliers`, `summary`, `views`, `audit`, `bundle`, `catalog` |
 | **Integrate** | Setup + AI gateway | `setup`, `quickstart`, `mcp serve`, `context-pack`, `version` |
+| **Verify** | Typed, fingerprinted evidence artifacts | `receipt verify`, `receipt show`, `receipt validate`, `receipt list` |
 
 When a user asks "can cub scout do X?", first locate X in this map, then verify the exact flag surface with local `--help` (see [Quick Reality Checks](#quick-reality-checks)).
 
@@ -51,6 +52,8 @@ Use it for:
 - Compare: `compare three-way`, `compare source-truth`, `compare drift`, `compare` (resource mode)
 - Attribute (read-only enrichment surfacing on `compare` + `explain` JSON)
 - Local Git structure discovery with `import --git-path` and `import parse-repo`
+- Govern (connected): `history`, `impact`, `fleet outliers`, `summary`, `views resolve`, `audit list`, `bundle inspect/diff/timeline`, `catalog list`
+- Verify: `receipt verify / show / validate / list` (typed, fingerprinted evidence — v1 complete)
 - Model Context Protocol (MCP) serving via `mcp serve`
 
 Important:
@@ -85,9 +88,25 @@ Do not claim that `cub scout` can do SDK/renderer work locally unless the curren
 
 ## Current High-Signal Shipped Capabilities
 
-As of 2026-05-21, these areas are fully or materially shipped:
+Current release: **v2.2.1**. As of 2026-05-22, these areas are fully or materially shipped:
 
-- **Attribution layer** (`#435` — A1, A1.5, A2, B, C1, C2)
+- **Receipts v1** (`#446` — closed; PRs `#454` + `#455` + `#456` + Codex round-5 `#461`)
+  - Typed, fingerprinted, immutable evidence artifacts wrapping the existing attribution + source-truth + gitSource evidence
+  - In-toto Statement v1 envelope wrapping `https://cub-scout.dev/receipt/v1`; SHA-256 over RFC 8785 canonical JSON via `gowebpki/jcs`; dual subjects (`k8s-live://` + `confighub-unit://` when connected)
+  - Three v1 predicates: `applied-matches-spec` (Argo/Flux/ConfigHub anchor matches LIVE), `source-truth-pass` (with explicit `--strategy`), `no-manual-edits-since` (with explicit `--since` RFC 3339 cutoff)
+  - Four verdicts: PASS / WATCH / BLOCK / INCONCLUSIVE
+  - CLI: `receipt verify / show / validate / list`; `--save` writes to immutable local store at `$CUB_SCOUT_RECEIPTS_DIR → $XDG_DATA_HOME/cub-scout/receipts → $HOME/.local/share/cub-scout/receipts`
+  - Store immutability: `O_EXCL` atomic create; `--out` rejects paths under the store; receipt validate exit codes 0/1/2 via `errors.As` dispatch
+  - Read-only-triad guards: `TestReceiptPackageReadOnlyClient` static-greps for mutating K8s client methods; `FilterNextSteps` drops mutating actionType / nextCommand at emit
+  - Documented in `docs/reference/json-contracts.md` § Receipt Contract; examples at `examples/receipts/`
+- **AI-agent skill catalog** (`#442` — closed; 5 PRs `#452` + `#457` + `#458` + `#459` + `#460`)
+  - ~35 skill files + 9 references modeled on `confighub/confighub-skills` for `cub`
+  - 8 verb-group skills (`scout-observe`, `scout-diagnose`, `scout-compare`, `scout-attribute`, `scout-ingest`, `scout-govern`, `scout-mcp`, `scout-verify`)
+  - 7 controller-observer skills (`observe-argocd`, `observe-flux`, `observe-helm`, `observe-crossplane`, `observe-kro`, `observe-confighub-managed`, `observe-native`) — each verified against `pkg/agent/ownership.go` + `pkg/agent/manager_strings.go`
+  - 8 workflow scenario skills (`triage-unhealthy-workload`, `investigate-drift`, `audit-fleet-conformance`, `prepare-for-confighub`, `migrate-from-kubectl`, `ai-agent-readonly-context`, `operator-incident-evidence`, `confighub-source-truth`)
+  - 9 shared references (`kubernetes-managedfields`, `verified-manager-strings`, `source-truth-strategies`, `standalone-vs-connected`, `read-only-triad`, `plugin-vs-standalone`, `argocd-applicationset`, `flux-source-types`, `mcp-tool-catalog`)
+  - Every skill's `allowed-tools` enumerates read-only verbs only — no broad wildcards
+- **Attribution layer** (`#435` — A1, A1.5, A2, B, C1, C2; all stages shipped)
   - `cause` + `managerHint` on every field mismatch — classifies controller-drift vs manual-edit via K8s `managedFields` co-signaled with detected owner
   - Verified manager-string enumeration (`pkg/agent/manager_strings.go`) covers Argo CD, Flux (kustomize/helm/source), Helm direct, Crossplane (composite/composed/claim/MRD/refs), kro (applyset/parent/labeller), `kubectl-*` — strings not in the enumeration return `unknown`
   - Per-field-path resolution via `FieldsV1` decoding (`pkg/agent/field_ownership_paths.go`)
@@ -95,19 +114,20 @@ As of 2026-05-21, these areas are fully or materially shipped:
   - `gitSource{file, line}` raw-YAML back-resolution via `--source-path <local-checkout>` flag (`pkg/agent/source_back_resolution.go`)
   - Connected `incomingBindings[]` from `cub link list` — surfaces upstream units feeding this unit
   - Connected per-field `bindingSource` — answers "this field's value came from upstream unit X at path Y via link Z"
-  - Documented in `docs/reference/json-contracts.md` § Field Mutation Attribution Contract
-  - Example: `examples/drift/mutation-cause-attribution/`
-- **Source-truth contract** (`#393`)
+  - Documented in `docs/reference/json-contracts.md` § Field Mutation Attribution Contract; example at `examples/drift/mutation-cause-attribution/`
+- **Source-truth contract** (`#393` Phase 1 + `#418` Phase 2)
   - `compare source-truth <kind>/<name> -n <ns> --strategy <s>` emits the structured JSON Pilot's acceptance kernel consumes
-  - 4 strategies today: `confighub-oci-argo`, `confighub-oci-flux`, `git-argo`, `git-flux`
+  - **9 strategies**: `confighub-oci-argo`, `confighub-oci-flux`, `git-argo`, `git-flux`, `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`
   - Strategy-relative correctness + missing-proof rule enforced in tests
+  - 4-status (PASS/WATCH/BLOCK/ASK) × 5-verdict (AGREED/MISMATCH/INCOMPLETE/BLOCKED/UNKNOWN) enum split — these are SEPARATE axes
   - 6-fixture producer suite with byte-equal goldens at `test/fixtures/source-truth/`
-- **Architectural triad locked**
+- **Architectural triad locked** (`#410` / `#428`)
   - cub-scout = read-only evidence provider
   - Pilot = acceptance judge
   - ConfigHub = authority and workflow engine
   - cub-scout never mutates, repairs, approves, or infers authority
   - `suggest-remedy` (was `remedy`) is categorically read-only — describes but never applies; the executor was removed in `#428`
+  - Three layers of enforcement: `scripts/check-readonly.sh` CI gate + `TestReceiptPackageReadOnlyClient` static grep + `FilterNextSteps` runtime filter
 - **kstatus migration complete** (`#394`)
   - All readiness derivation flows through `sigs.k8s.io/cli-utils/pkg/kstatus`
   - Same library Argo CD and Flux use upstream
@@ -115,29 +135,57 @@ As of 2026-05-21, these areas are fully or materially shipped:
   - `views resolve` accepts UUIDs or View Explorer URLs (`#403`)
   - `compare three-way --view <uuid-or-url>` scopes to a ConfigHub View (`#414`)
   - `views project --with-reality` composes View columns with source-truth verdicts (`#420`)
+- **MCP gateway** — `mcp serve` exposes a closed, read-only-by-construction tool catalog:
+  - 5 standalone tools: `doctor`, `map`, `scan`, `trace`, `explain`
+  - 5 connected tools: `compare_three_way`, `compare_source_truth`, `confighub_changesets`, `confighub_units`, `confighub_unit_get`
+  - Verified by `cmd/cub-scout/mcp_test.go`; full per-tool reference at `skills/references/mcp-tool-catalog.md`
 - `doctor` / `explain` with `--presentation human|ai|paired` and `--hint-mode default|beginner|operator`
 - Argo truth-and-guidance track — truthful `explain` ownership for ApplicationSet-managed resources, connected three-way disagreement surfacing, phase-aware next-step hints
 - `compare three-way` — connected DRY/WET/LIVE comparison, `--fail-on` conformance exit codes, agreement/convergence summary in CLI + JSON, `--source-path` raw-YAML back-resolution (`#440`)
-- MCP gateway — `mcp serve` exposes `doctor` / `explain` / `map` / `scan` / `trace` standalone; connected mode adds read-only ConfigHub query tools
 - Secrets track — trace secret evidence, Crossplane `ProviderConfig` secrets, `map issues` findings, TUI secret panel
 - Git import track — `import --git-path` local preview, ApplicationSet git-generator support, path-centric duplicate-safe proposal identifiers
+- `cub scout` is the preferred invocation form (v2.0.0 plugin switchover shipped); `cub-scout` standalone binary still works identically
 
 ## Current Open Queue
 
-Verify live state before acting. As of 2026-05-21 the open follow-ons are:
+Verify live state before acting. As of 2026-05-22 the open follow-ons are:
 
-- **`#409`** — source-truth v0.2 cross-surface revision equality. Phase 1 (existing four strategies) shipped; Phase 2 (enum expansion to `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`) shipped in `#418`. Phase 3 (multi-source Argo) remains. Verify ConfigHub-side rendered-digest exposure before extending further.
-- **`#391`** — Views integration tail. Scope #1 (`--view` on `compare three-way`) shipped in `#414`. Scope #2 (TUI Hub View column projection) shipped in `#419`/`#420`. Scope #3 (reality overlay) is the active follow-on.
+### Receipts v2 + small follow-ons
+
+- **`#448`** — Aggregate / chained receipts via `inputAttestations[]` composition. v1 envelope already emits `inputAttestations: []`; v2 wires the cross-receipt digest semantics.
+- **`#449`** — `cub-scout watch --emit-receipt-on <event-type>`: event-driven receipt emission so receipts can land in real time. Becomes the real-time channel into Pilot.
+- **`#451`** — `--fail-on RECEIPT_VERDICT` exit semantics extension for CI gating.
+- **MCP `compare_source_truth` strategy-enum drift** — schema enum lists 4 strategies (Phase 1); CLI supports 9 (Phase 2). One-file fix in `cmd/cub-scout/mcp.go`.
+- **Codex round-5 P3** — source-truth receipt precedence tests (`StatusBLOCK + VerdictBLOCKED`, `StatusWATCH + VerdictINCOMPLETE`). Not blocking; nice-to-have.
+
+### Pilot integration
+
+- **`#444`** — Pilot–cub-scout integration skills: 9 consumer-side scenarios (CD gate / fleet conformance / patch+drift / rollback / promotion / incident evidence / compliance / release verification / watch alert). Closes the trust-triad loop on the consumer side.
+
+### Adjacent open issues
+
+- **`#432`** — Grafana collector / data-source path using existing cub-scout outputs.
+- **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design).
+- **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up).
+- **`#421`** — Views project: CEL + JSONPath column evaluators.
+- **`#391` scope #3** — reality overlay composing View columns with source-truth verdicts.
+- **`#409` Phase 3** — source-truth multi-source Argo (`spec.sources[]` len > 1). Phases 1 + 2 shipped (9 strategies).
 - **`#392`** — Initiatives compliance overlay; **deferred** until ConfigHub exposes Initiative as a backend primitive. Design doc at `docs/howto/initiatives-integration-when-ready.md`.
-- **Attribution layer next-up** (no separate issues yet; tracked in [README § What's coming next](README.md#whats-coming-next)):
-  - Helm / Kustomize back-resolution to populate `gitSource.file:line` for templated sources
-  - List-key selectors (e.g., `[name="api"]` for container images) in `compareFieldToPath`
-  - Standalone `--source-path` as DRY source for `compare three-way`
-  - `import --git-path --output-dir` to emit proposals to disk
-  - Hierarchy-aware ingest (preserve ApplicationSet / app-of-apps / Flux composition)
-  - Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)
-- `confighubai/confighub#4356` — cross-repo dependency for ArgoCDOCI Helm-source shape symptom classifier.
-- `confighub-ai-demo#264` — Pilot consumer-side fixtures (paired with cub-scout `#395` + future `#409` fixtures).
+- **`#386`** — `preferInvocationForm` lint extension to non-hint legacy string leaks.
+
+### Attribution-layer next-up (no separate issues yet; tracked in README § What's coming next)
+
+- Helm / Kustomize back-resolution to populate `gitSource.file:line` for templated sources
+- List-key selectors (e.g., `[name="api"]` for container images) in `compareFieldToPath`
+- Standalone `--source-path` as DRY source for `compare three-way`
+- `import --git-path --output-dir` polish (disk-PR proposal flow)
+- Hierarchy-aware ingest (preserve ApplicationSet / app-of-apps / Flux composition)
+- Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)
+
+### Cross-repo dependencies
+
+- `confighub/confighub#4356` — ArgoCDOCI Helm-source shape symptom classifier.
+- `confighubai/confighub-ai-demo#264` — Pilot consumer-side fixtures.
 
 ## Non-Negotiables
 

--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -166,9 +166,8 @@ Verify live state before acting. As of 2026-05-22 the open follow-ons are:
 
 - **`#432`** — Grafana collector / data-source path using existing cub-scout outputs.
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design).
-- **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up).
+- **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up). Scopes #1 (`#414`) and #3 (`#420`) already shipped.
 - **`#421`** — Views project: CEL + JSONPath column evaluators.
-- **`#391` scope #3** — reality overlay composing View columns with source-truth verdicts.
 - **`#409` Phase 3** — source-truth multi-source Argo (`spec.sources[]` len > 1). Phases 1 + 2 shipped (9 strategies).
 - **`#392`** — Initiatives compliance overlay; **deferred** until ConfigHub exposes Initiative as a backend primitive. Design doc at `docs/howto/initiatives-integration-when-ready.md`.
 - **`#386`** — `preferInvocationForm` lint extension to non-hint legacy string leaks.
@@ -185,7 +184,7 @@ Verify live state before acting. As of 2026-05-22 the open follow-ons are:
 ### Cross-repo dependencies
 
 - `confighub/confighub#4356` — ArgoCDOCI Helm-source shape symptom classifier.
-- `confighubai/confighub-ai-demo#264` — Pilot consumer-side fixtures.
+- Pilot consumer-side fixtures (tracked in a separate non-public repo).
 
 ## Non-Negotiables
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,6 +1,6 @@
 # cub-scout Handover for the Next AI Coder
 
-Last updated: 2026-05-21
+Last updated: 2026-05-22 — refreshed to drop stale v2.0.0-plugin-switchover framing (v2.0.0 shipped long ago — current release is v2.2.1), and to record the receipts (`#446`) and skills (`#442`) work merged this session.
 
 ## Current repo state
 
@@ -14,6 +14,50 @@ Last updated: 2026-05-21
   - `docs/reference/cli-reference.md` = A-Z command catalog
   - `docs/reference/commands.md` = detailed usage and examples
   - `docs/reference/cli-contract.md` = stable flags, exit codes, and schemas
+
+## May 2026 completions — session 2026-05-22 (receipts v1 + AI-agent skills)
+
+Two major issue trees closed this session: `#446` (Verify / Receipt capability) v1 and `#442` (Comprehensive skills coverage). Both arrived in their full scope plus a Codex round-5 review fix-up.
+
+### `#446` Receipts v1 — complete
+
+Typed, fingerprinted, immutable evidence artifacts wrapping cub-scout's existing field-level evidence into a verifiable record. Wire format is the in-toto Statement v1 envelope wrapping `https://cub-scout.dev/receipt/v1`. Fingerprint is SHA-256 over RFC 8785 canonical JSON of the full Statement minus only `predicate.fingerprint` (delete-the-key, not zero-it; per Codex round-4 + round-5).
+
+| PR | Subject |
+|----|---------|
+| [#454](https://github.com/confighub/cub-scout/pull/454) | Foundation — types, canonical JSON via `gowebpki/jcs`, fingerprint, dual subjects (`k8s-live://` + `confighub-unit://`), `applied-matches-spec` predicate, ASCII renderer, `verify` subcommand, 4 example receipts |
+| [#455](https://github.com/confighub/cub-scout/pull/455) | Predicates batch 2 — `source-truth-pass` + `no-manual-edits-since`; `--strategy` / `--since` flags; `collectSourceTruthForReceiptFn` seam; 4 more example receipts |
+| [#456](https://github.com/confighub/cub-scout/pull/456) | Management UX — `receipt show / validate / list`; local store at `$CUB_SCOUT_RECEIPTS_DIR → $XDG_DATA_HOME/cub-scout/receipts → $HOME/.local/share/cub-scout/receipts`; `--save` flag |
+| [#461](https://github.com/confighub/cub-scout/pull/461) | Codex round-5 fix-up — ASK → WATCH (locked design); `O_EXCL` atomic save + `--out` rejects store paths; exit codes 0/1/2 via `errors.As`; mutating-wildcard scrub in 4 skills; public repo-path leak scrub |
+
+Read-only-triad guards: `TestReceiptPackageReadOnlyClient` static-greps receipt source files for any mutating K8s client method; `FilterNextSteps` drops 18 mutating-verb fragments at emit time. `#446` parent issue closed.
+
+### `#442` AI-agent skill catalog — complete
+
+Modeled on [`confighub/confighub-skills`](https://github.com/confighub/confighub-skills) for `cub`. Five PRs total; ~35 skill files plus 9 references:
+
+| PR | Subject |
+|----|---------|
+| [#452](https://github.com/confighub/cub-scout/pull/452) | Batch 1 — scaffolding (`SKILL_TEMPLATE.md`, router, umbrella) + 4 verb-group skills (Observe/Diagnose/Compare/Attribute) + 2 references |
+| [#457](https://github.com/confighub/cub-scout/pull/457) | Batch 2 — 4 more verb-group skills (Ingest/Govern/Integrate/Verify) |
+| [#458](https://github.com/confighub/cub-scout/pull/458) | Batch 3 — 7 controller-observer skills (argocd/flux/helm/crossplane/kro/confighub-managed/native), each verified against `pkg/agent/ownership.go` + `pkg/agent/manager_strings.go` |
+| [#459](https://github.com/confighub/cub-scout/pull/459) | Batch 4 — 8 workflow scenario skills (triage / drift / fleet / adopt / migrate / agent-context / incident / source-truth) |
+| [#460](https://github.com/confighub/cub-scout/pull/460) | Batch 5 — 7 remaining shared references; closes `#442` |
+
+### Key design decisions locked this session
+
+- **Receipts are evidence, never recommendations to mutate.** `FilterNextSteps` rejects `actionType=mutating` + a long list of mutating-command fragments at emit time. Documented in `references/read-only-triad.md`.
+- **Receipt store is immutable by construction.** `SaveStatement` uses `O_EXCL` atomic create; the on-disk filename is canonical (`<verifiedAt>__<predicate>__<kind>-<name>__<short-fingerprint>.receipt.json`); duplicate saves return `os.ErrExist` and never overwrite. `--out` refuses to write under the resolved store path.
+- **Fingerprint covers the full Statement.** Not just the predicate body — `_type`, `subject`, `predicateType`, and every predicate field other than `fingerprint` itself are in scope. Hashing predicate-only would leave the envelope unprotected.
+- **ASK → WATCH (not INCONCLUSIVE).** Per the locked synthesis in `docs/proposals/receipts-way-forward.md`; INCONCLUSIVE is reserved for receipts that themselves can't be built (missing strategy, missing evidence body), not for cases where the source-truth surface couldn't classify.
+- **Skill `allowed-tools` enumerate read-only verbs only.** No broad `Bash(cub-scout *)` / `Bash(./cub-scout *)` wildcards anywhere — those would silently grant `demo`, `import apply`, `compare --suggest --apply`, all mutating. Verified clean across all ~35 skill files (Codex round-5 caught 4 leaks, all fixed).
+
+### Open follow-ons from this session
+
+- **`#446` v2** (no separate issues for the umbrella; tracked by 3 spin-offs): `#448` chained / aggregate receipts via `inputAttestations[]`; `#449` `cub-scout watch --emit-receipt-on`; `#451` `--fail-on RECEIPT_VERDICT` exit semantics
+- **MCP enum drift** — `compare_source_truth` MCP schema lists 4 strategies; CLI supports 9 (Phase 2 from `#418`). One-file fix in `cmd/cub-scout/mcp.go`.
+- **Codex P3** — source-truth receipt precedence tests (`StatusBLOCK + VerdictBLOCKED`, `StatusWATCH + VerdictINCOMPLETE`). Not blocking; nice-to-have.
+- **`#444` Pilot–cub-scout integration skills** — 9 scenarios across batch A (5) + batch B (4). Consumes the receipts + source-truth surface from the Pilot side.
 
 ## May 2026 completions — session 2026-05-21 (attribution layer)
 
@@ -130,53 +174,61 @@ Key deliverables now in place:
 
 ## Open issues
 
-Current tracked follow-ons (verified 2026-05-21):
+Current tracked follow-ons (verified 2026-05-22):
 
-- **`#435` attribution-layer next-up (no separate issues yet, tracked in `README.md` § What's coming next):**
-  - Helm / Kustomize back-resolution to extend stage B's `gitSource.file:line` from raw YAML to templated sources
-  - List-key selectors in `compareFieldToPath` (e.g., `.spec.template.spec.containers[name="api"].image`) so per-field classification covers container images and other list-keyed fields
-  - Standalone `--source-path` as a DRY source for `compare three-way` — would let raw-YAML repos run the same three-way view without ConfigHub
-  - `import --git-path --output-dir` to emit proposed unit YAMLs to disk for PR review (one bundle, two workflows — disk PR + Installer `--merge-external-source`)
-  - Hierarchy-aware ingest preserving ApplicationSet / app-of-apps / Flux Kustomization composition in import proposals
-  - Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)
-- **#391** — Views integration. Scopes #1 (`--view` on `compare three-way`, `#414`) and #2 (TUI Hub View column projection, `#419`/`#420`) shipped. Scope #3 (reality overlay composing View columns with `#393` source-truth verdicts) is the active follow-on.
-- **#409** — source-truth v0.2 cross-surface revision equality. Phase 1 (existing four strategies) shipped; Phase 2 (enum expansion to `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`) shipped in `#418`. Phase 3 (multi-source Argo) remains.
-- **#410 / #428** — Triad-compliance audit. Major item resolved: cub-scout is categorically read-only (`suggest-remedy` describes but never applies). Lower-severity findings on `import apply` wording and a hint-command lint rule remain open in #410.
-- **#392** — Initiatives compliance overlay. **Still deferred.** ConfigHub side has no backend primitive yet. Design doc at [`docs/howto/initiatives-integration-when-ready.md`](docs/howto/initiatives-integration-when-ready.md) holds the integration spec.
-- **confighubai/confighub#4356** — cross-repo dependency for ArgoCDOCI Helm-source shape. Blocks accurate `confighub-oci-argo` symptom classification in `compare source-truth`.
-- **confighub-ai-demo#264** — Pilot consumer-side fixtures pairing with cub-scout #395 + future #409 fixtures.
+- **`#448`** — Receipts v2: aggregate / chained receipts via `inputAttestations[]` composition. v1 envelope already emits `inputAttestations: []`; v2 wires the cross-receipt digest semantics.
+- **`#449`** — `cub-scout watch --emit-receipt-on <event-type>`: event-driven receipt emission so receipts can land in real time. Becomes the real-time channel into Pilot.
+- **`#451`** — `--fail-on RECEIPT_VERDICT` exit semantics extension for CI gates (read a verdict, exit accordingly).
+- **`#444`** — Pilot–cub-scout integration skills: 9 scenarios (CD gate / fleet conformance / patch+drift / rollback / promotion / incident evidence / compliance / release verification / watch alert). Consumes the receipts + source-truth surface from the Pilot side.
+- **`#432`** — Grafana collector / data-source path using existing cub-scout outputs.
+- **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design needed).
+- **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up).
+- **`#421`** — Views project: CEL + JSONPath column evaluators.
+- **`#391`** — Views integration. Scopes #1 (`--view` on `compare three-way`, `#414`) and #2 (TUI Hub View column projection, `#419`/`#420`) shipped. Scope #3 (reality overlay composing View columns with `#393` source-truth verdicts) is the active follow-on.
+- **`#409`** Phase 3 — source-truth multi-source Argo (`spec.sources[]` len > 1). Phases 1 + 2 shipped (9 strategies total via `#393` + `#418`).
+- **`#410 / #428`** — Triad-compliance audit. Major item resolved: cub-scout is categorically read-only. Lower-severity follow-ons on `import apply` wording remain; the hint-command lint rule continues in `#386`.
+- **`#392`** — Initiatives compliance overlay. **Still deferred.** ConfigHub side has no backend primitive yet. Design doc at [`docs/howto/initiatives-integration-when-ready.md`](docs/howto/initiatives-integration-when-ready.md) holds the integration spec.
+- **`#386`** — `preferInvocationForm` lint extension to catch non-hint legacy invocation-form leaks in strings.
+
+### Attribution-layer next-up (tracked in `README.md` § What's coming next, no separate issues yet)
+
+- Helm / Kustomize back-resolution to extend stage B's `gitSource.file:line` from raw YAML to templated sources
+- List-key selectors in `compareFieldToPath` (e.g., `.spec.template.spec.containers[name="api"].image`)
+- Standalone `--source-path` as a DRY source for `compare three-way`
+- `import --git-path --output-dir` polish (disk-PR proposal flow)
+- Hierarchy-aware ingest (ApplicationSet / app-of-apps / Flux Kustomization composition)
+- Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)
+
+### Cross-repo dependencies
+
+- **`confighub/confighub#4356`** — ArgoCDOCI Helm-source shape symptom classifier. Blocks accurate `confighub-oci-argo` classification in `compare source-truth`.
+- **`confighubai/confighub-ai-demo#264`** — Pilot consumer-side fixtures pairing with cub-scout's source-truth + receipts surfaces.
 
 ## Current checkpoint
 
-`go test ./...` is green as of 2026-05-21 across every package touched by the attribution-layer work. The only failure on a clean main checkout is the pre-existing `test/unit/demo_worker_lifecycle_script_test.go` — unrelated to attribution work, fails on a `git stash`-clean tree too. Main CI is green. GitHub Actions workflows now run on Node 24 (PRs #412, #413).
+Current release tag: **`v2.2.1`**. The v2.0.0 plugin switchover (`cub scout` as the preferred invocation, MCP gateway as the AI front door) shipped in `v2.0.0` and is now historical — `docs/releases/v2.0.0-plugin-plan.md` is preserved as a historical artifact, not an active milestone.
 
-The practical state heading into the `cub scout` plugin switchover is:
+`go test ./...` is green as of 2026-05-22 across every package touched by the receipts + skills work. The only failure on a clean local checkout is the pre-existing `test/unit/demo_worker_lifecycle_script_test.go` — environmental flake; main CI is green for it.
 
-- M0 decision lock: done
-- M2 trust/proof polish: materially advanced
-- M3 AI/MCP gateway readiness: materially advanced
-- M1 plugin packaging: still not started, and still the real `v2.0.0` blocker
-- M4 migration/install docs: still partial
+Recent shipped capability surface (sessions 2026-05-21 and 2026-05-22):
 
-Recent connected trust-surface work now covers:
-- canonical ConfigHub unit/revisions URLs in compare/trace/explain/history/MCP
-- revision-aware hints that tell AI/operators when to review revision history before sign-off
-- connected `history` JSON trust guidance
-- release-gate cleanup that brought the full test suite back to green
+- Attribution layer end-to-end (`cause` / `managerHint` / `gitSource` / `bindingSource` per field; stage B file:line back-resolution)
+- Source-truth contract Phase 1 + 2 (9 strategies)
+- Architectural triad locked in code (read-only-triad invariant)
+- Receipts v1 — typed, fingerprinted, immutable evidence artifacts (3 predicates: `applied-matches-spec`, `source-truth-pass`, `no-manual-edits-since`)
+- AI-agent skill catalog (~35 skill files + 9 references) modeled on `confighub/confighub-skills`
+- MCP gateway with closed read-only tool catalog (5 standalone + 5 connected tools)
+- `--presentation human|ai|paired` on `doctor` / `explain` / `trace`
 
 ## Next milestone
 
-The next major milestone is now the `cub scout` plugin switchover for `v2.0.0`.
+There is **no single "next milestone"** the way v2.0.0 was. The codebase is in steady-state with three credible directions, in roughly descending leverage:
 
-Canonical planning doc:
+1. **Receipts v2 + small follow-ons** — `#448` chained receipts via `inputAttestations[]`, `#449` `watch --emit-receipt-on` for real-time emission, `#451` `--fail-on RECEIPT_VERDICT` for CI gating. Plus the small Codex round-5 follow-ups: MCP `compare_source_truth` strategy-enum drift (4 vs 9), source-truth receipt precedence tests.
+2. **Pilot–cub-scout integration skills** (`#444`) — 9 consumer-side skill scenarios (CD gate / fleet conformance / patch+drift / rollback / promotion / incident evidence / compliance / release verification / watch alert). Closes the trust-triad loop on the consumer side.
+3. **Views project tail** — `#391` scope #3 reality overlay; `#421` CEL+JSONPath column evaluators; `#422` TUI Hub View integration. Smaller surface than receipts/skills but a real follow-on for the Views work.
 
-- `docs/releases/v2.0.0-plugin-plan.md`
-
-Core direction:
-
-- `cub scout` becomes the preferred invocation
-- `cub scout mcp serve` becomes the preferred explorer/investigation gateway
-- `cub` remains the authority and governed-execution host
+Other open issues with lower urgency: `#432` Grafana collector, `#427` watch kstatus migration, `#392` ConfigHub Initiatives (deferred until backend primitive), `#386` `preferInvocationForm` lint extension.
 
 ### CLI migration table (`#375`)
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -114,7 +114,7 @@ The council (April 2026) prescribed the **truth-floor → source-truth contract 
 ### Architectural triad locked in code (not just intent)
 
 - **cub-scout** = read-only evidence provider for source truth
-- **Pilot** = acceptance judge (lives in `confighubai/confighub-ai-demo`)
+- **Pilot** = acceptance judge (separate consumer of cub-scout's surfaces)
 - **ConfigHub** = authority and workflow engine
 
 cub-scout never mutates, repairs, approves, or infers authority. The source-truth contract enforces this surface in code.
@@ -184,7 +184,7 @@ Current tracked follow-ons (verified 2026-05-22):
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design needed).
 - **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up).
 - **`#421`** — Views project: CEL + JSONPath column evaluators.
-- **`#391`** — Views integration. Scopes #1 (`--view` on `compare three-way`, `#414`) and #2 (TUI Hub View column projection, `#419`/`#420`) shipped. Scope #3 (reality overlay composing View columns with `#393` source-truth verdicts) is the active follow-on.
+- **`#391`** — Views integration. Scope #1 (`--view` on `compare three-way`, `#414`) and scope #3 (reality overlay composing View columns with `#393` source-truth verdicts, `#420`) shipped. Scope #2 (TUI Hub View column projection) is the open follow-on (tracked under `#422`).
 - **`#409`** Phase 3 — source-truth multi-source Argo (`spec.sources[]` len > 1). Phases 1 + 2 shipped (9 strategies total via `#393` + `#418`).
 - **`#410 / #428`** — Triad-compliance audit. Major item resolved: cub-scout is categorically read-only. Lower-severity follow-ons on `import apply` wording remain; the hint-command lint rule continues in `#386`.
 - **`#392`** — Initiatives compliance overlay. **Still deferred.** ConfigHub side has no backend primitive yet. Design doc at [`docs/howto/initiatives-integration-when-ready.md`](docs/howto/initiatives-integration-when-ready.md) holds the integration spec.
@@ -202,7 +202,7 @@ Current tracked follow-ons (verified 2026-05-22):
 ### Cross-repo dependencies
 
 - **`confighub/confighub#4356`** — ArgoCDOCI Helm-source shape symptom classifier. Blocks accurate `confighub-oci-argo` classification in `compare source-truth`.
-- **`confighubai/confighub-ai-demo#264`** — Pilot consumer-side fixtures pairing with cub-scout's source-truth + receipts surfaces.
+- Pilot consumer-side fixtures pairing with cub-scout's source-truth + receipts surfaces (tracked in a separate non-public repo; cub-scout's surface contract is the canonical reference for downstream consumers).
 
 ## Current checkpoint
 
@@ -226,7 +226,7 @@ There is **no single "next milestone"** the way v2.0.0 was. The codebase is in s
 
 1. **Receipts v2 + small follow-ons** — `#448` chained receipts via `inputAttestations[]`, `#449` `watch --emit-receipt-on` for real-time emission, `#451` `--fail-on RECEIPT_VERDICT` for CI gating. Plus the small Codex round-5 follow-ups: MCP `compare_source_truth` strategy-enum drift (4 vs 9), source-truth receipt precedence tests.
 2. **Pilot–cub-scout integration skills** (`#444`) — 9 consumer-side skill scenarios (CD gate / fleet conformance / patch+drift / rollback / promotion / incident evidence / compliance / release verification / watch alert). Closes the trust-triad loop on the consumer side.
-3. **Views project tail** — `#391` scope #3 reality overlay; `#421` CEL+JSONPath column evaluators; `#422` TUI Hub View integration. Smaller surface than receipts/skills but a real follow-on for the Views work.
+3. **Views project tail** — `#391` scope #2 TUI Hub View column projection (`#422`); `#421` CEL+JSONPath column evaluators. Scopes #1 and #3 already shipped (`#414` and `#420` respectively). Smaller surface than receipts/skills but a real follow-on for the Views work.
 
 Other open issues with lower urgency: `#432` Grafana collector, `#427` watch kstatus migration, `#392` ConfigHub Initiatives (deferred until backend primitive), `#386` `preferInvocationForm` lint extension.
 
@@ -374,7 +374,7 @@ CLI import/rendering path is essential for continuing the Git import track.
    - Enables Git↔cluster comparison for verification
    - Initial implementation: uses `gitops.ParseRepo()` for Flux-style patterns
 
-### The Full ConfigHub Loop (from Slack discussion)
+### The Full ConfigHub Loop
 
 ```
 Git repo → ArgoCD syncs to cluster
@@ -467,8 +467,8 @@ No separate `--compare` flag needed.
 Do not publish work externally without explicit user approval.
 
 That includes:
-- pushing to `confighubai/confighub`
-- opening PRs or issue comments there
+- pushing to any non-public ConfigHub repository
+- opening PRs or issue comments in non-public repositories
 - creating public or secret gists for the work
 - posting branch status externally
 

--- a/docs/releases/v2.0.0-plugin-plan.md
+++ b/docs/releases/v2.0.0-plugin-plan.md
@@ -1,7 +1,10 @@
 # v2.0.0 Plugin Plan — `cub scout` as the Explorer Plugin
 
-**Status:** In execution — M0, M2, M3 fully landed; M1 in-binary foundations + M4 docs + M5 parity test landed in `main`. Gating artifact is the v2.0.0 release tag that publishes the plugin-compatible archive.
-**Date:** 2026-04-11 (plan) • 2026-04-15 (status refresh)
+**Status: HISTORICAL.** The v2.0.0 release shipped (along with v2.1.0, v2.2.0, v2.2.1 follow-ups). All milestones described below are complete. This file is preserved as the planning artifact that drove the switchover; do not treat it as an active roadmap. Current release notes live at `docs/releases/v2.0.0.md` (the actual release), and the canonical roadmap is `docs/roadmap.md`.
+
+**Original status (at time of writing, 2026-04-15):** In execution — M0, M2, M3 fully landed; M1 in-binary foundations + M4 docs + M5 parity test landed in `main`. Gating artifact was the v2.0.0 release tag that publishes the plugin-compatible archive (subsequently cut and published).
+
+**Date:** 2026-04-11 (plan) • 2026-04-15 (status refresh) • marked historical 2026-05-22 (after v2.2.1)
 **Audience:** Product, platform, docs, AI/MCP, and CLI maintainers shaping the `cub` + `cub-scout` family boundary
 
 > Canonical roadmap: `docs/roadmap.md`


### PR DESCRIPTION
## Summary

The two top-of-funnel "what's the state of cub-scout?" docs (\`HANDOVER.md\`, \`AI-README-FIRST.md\`) had drifted significantly behind reality. Both were last refreshed 2026-05-21, anchored at the attribution-layer milestone, and described the v2.0.0 plugin switchover as "the next major milestone" with M1 plugin packaging "still not started, the real v2.0.0 blocker."

**Reality check:** v2.0.0 shipped, followed by v2.1.0, v2.2.0, and v2.2.1. The plugin switchover is history. The receipts capability (\`#446\`) and the AI-agent skill catalog (\`#442\`) both shipped in their full scope plus a Codex round-5 fix-up, and neither is mentioned in either doc.

This PR is a docs-only refresh covering three files:

## Changes

### \`HANDOVER.md\`
- Header note flagging the refresh + the v2.0.0 framing fix
- New "May 2026 completions — session 2026-05-22 (receipts v1 + AI-agent skills)" section near the top with PR tables (#454/#455/#456/#461 for receipts; #452/#457/#458/#459/#460 for skills), key design decisions, and open follow-ons
- Replaced stale "Current checkpoint" v2.0.0 M0/M1/M2/M3/M4 block with current-state summary (release tag v2.2.1)
- Replaced stale "Next milestone" v2.0.0 framing with three credible next-direction options (receipts v2; #444 Pilot skills; Views project tail)
- Refreshed "Open issues" list to current state — removed stale items, added #448/#449/#451, #444, #432, #427, #422, #421, #386

### \`AI-README-FIRST.md\`
- "Capability Map" verb-group table extended from 7 to **8** groups (added Verify)
- "Use cub scout for" list expanded with Govern + Verify bullets
- "Current High-Signal Shipped Capabilities" gains Receipts v1 and the AI-agent skill catalog as top entries with full PR provenance
- Corrected "4 strategies today" → "9 strategies" (Phase 2 from #418 shipped before this session)
- MCP gateway bullet updated to name the actual 5+5 tool catalog (cross-linked to \`skills/references/mcp-tool-catalog.md\`)
- Triad-locked bullet gains the three enforcement layers (\`check-readonly.sh\` + \`TestReceiptPackageReadOnlyClient\` + \`FilterNextSteps\`)
- Added "cub scout is the preferred invocation form (v2.0.0 plugin switchover shipped)" — closes the framing question
- "Current Open Queue" restructured into Receipts v2 + Pilot integration + Adjacent + Attribution-next-up + Cross-repo

### \`docs/releases/v2.0.0-plugin-plan.md\`
- Header status updated to **\"Status: HISTORICAL\"** with a note that v2.0.0/v2.1.0/v2.2.0/v2.2.1 have all shipped. Original in-execution status preserved below as historical record so the planning narrative isn't lost.

## How this was caught

This drift surfaced while answering "what is the 'blocker' exactly?" — the answer turned out to be "there isn't one; v2.0.0 shipped five releases ago, the docs just hadn't caught up." The first time a reader looks at \`HANDOVER.md\` after this PR, they'll see the current state, not a 4-week-old snapshot.

## Test plan

- [x] No code touched. \`go test\` and \`golangci-lint\` not relevant.
- [x] All three CI parity scripts pass locally (\`check-cli-guide-parity.sh\`, \`check-doc-freshness.sh\`, \`check-readonly.sh\`)
- [x] No new internal-repo paths introduced. The earlier scrub of \`confighubai/confighub-ai-demo\` (Codex round-5 #461) holds.
- [x] All PR cite numbers verified against \`git log\` and \`gh issue\` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)