### PR TITLE
feat(#446 v2): receipts v2 — #451 fail-on + #448 chained half + #449 watch emit

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -60,9 +60,11 @@ Receipts are HISTORICAL, IMMUTABLE records of past events. Updates produce
 new receipts, never mutate old ones. cub-scout never mutates the cluster
 or ConfigHub.
 
-v1 ships fingerprint-only (SHA-256 over RFC 8785 canonical JSON of the full
-in-toto Statement v1 envelope minus only predicate.fingerprint). v2 will
-add DSSE signing wrapped in Sigstore Bundle v0.3.`,
+Current shipping releases use fingerprint-only integrity (SHA-256 over RFC 8785
+canonical JSON of the full in-toto Statement v1 envelope minus only
+predicate.fingerprint). Cryptographic signing (e.g., DSSE wrapped in a Sigstore
+Bundle, or a comparable scheme) is a future hardening direction — purely
+additive to the wire format, no envelope change required.`,
 }
 
 var receiptVerifyCmd = &cobra.Command{
@@ -139,6 +141,27 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 	}
 	if predicateExplicit == agent.PredicateNoManualEditsSince && since.IsZero() {
 		return fmt.Errorf("--predicate no-manual-edits-since requires --since <RFC3339 timestamp>")
+	}
+
+	// Parse --fail-on UPFRONT so a typo or invalid value rejects the
+	// command before any side effect (stdout print, --out write, --save
+	// to store). The fail-on check itself fires later (after the
+	// receipt is built and the artifact is persisted), but the parse
+	// must not let the artifact escape on a misconfigured gate.
+	//
+	// Codex round-6 P2 fix (#463): the prior order let an invalid
+	// --fail-on value print the receipt, write --out, and save before
+	// returning the parse error — which is a CI footgun (the gate
+	// "fires" with the wrong exit code because the typo error wraps to
+	// 1, not 2, and the artifact is already on disk).
+	var failOnSet map[agent.ReceiptVerdict]bool
+	failOnRaw := strings.TrimSpace(receiptFailOn)
+	if failOnRaw != "" {
+		parsed, parseErr := parseReceiptFailOn(failOnRaw)
+		if parseErr != nil {
+			return parseErr
+		}
+		failOnSet = parsed
 	}
 
 	kindRaw, name, ok := parseKindName(args[0])
@@ -220,8 +243,10 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 	// (repeatable). Each path is loaded + fingerprint-verified before
 	// being chained — a tampered referenced receipt fails the chain
 	// construction upfront rather than silently propagating bad
-	// evidence. See pkg/agent/receipt_inputattestations.go.
-	var inputAttestations []agent.AttestationRef
+	// evidence. The returned wrappers are the API-boundary-checked type
+	// (`VerifiedAttestationRef`); BuildReceipt unwraps them when it
+	// populates the wire shape. See pkg/agent/receipt_inputattestations.go.
+	var inputAttestations []agent.VerifiedAttestationRef
 	if len(receiptInputAttestations) > 0 {
 		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
 		if refErr != nil {
@@ -344,20 +369,18 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 	// audit artifact in place. The exitCodeError wrapping (per
 	// cmd/cub-scout/exit_code.go + main.go's errors.As dispatcher)
 	// drives the actual os.Exit(2).
-	if failOn := strings.TrimSpace(receiptFailOn); failOn != "" {
-		failSet, parseErr := parseReceiptFailOn(failOn)
-		if parseErr != nil {
-			return parseErr
-		}
-		if failSet[stmt.Predicate.Verdict] {
-			return newExitCodeError(
-				fmt.Errorf(
-					"receipt verdict %q matches --fail-on %q",
-					stmt.Predicate.Verdict, failOn,
-				),
-				2,
-			)
-		}
+	//
+	// The fail-on set was parsed upfront (above) so an invalid value
+	// could never produce side effects. This block only consults the
+	// already-validated set.
+	if failOnSet != nil && failOnSet[stmt.Predicate.Verdict] {
+		return newExitCodeError(
+			fmt.Errorf(
+				"receipt verdict %q matches --fail-on %q",
+				stmt.Predicate.Verdict, failOnRaw,
+			),
+			2,
+		)
 	}
 
 	return nil

--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -23,15 +23,17 @@ import (
 
 // receipt flags
 var (
-	receiptNamespace string
-	receiptPredicate string
-	receiptAtCommit  string
-	receiptStrategy  string
-	receiptSince     string
-	receiptFormat    string
-	receiptOut       string
-	receiptSave      bool
-	receiptSaveDir   string
+	receiptNamespace         string
+	receiptPredicate         string
+	receiptAtCommit          string
+	receiptStrategy          string
+	receiptSince             string
+	receiptFormat            string
+	receiptOut               string
+	receiptSave              bool
+	receiptSaveDir           string
+	receiptFailOn            string
+	receiptInputAttestations []string
 )
 
 // Function-variable seam for tests. Production reads from the cluster via
@@ -107,6 +109,8 @@ func init() {
 	receiptVerifyCmd.Flags().StringVar(&receiptOut, "out", "", "Write the receipt to this file path (also printed to stdout in the chosen format)")
 	receiptVerifyCmd.Flags().BoolVar(&receiptSave, "save", false, "Save the receipt to the local store ($CUB_SCOUT_RECEIPTS_DIR or $XDG_DATA_HOME/cub-scout/receipts) for later cub-scout receipt list / show / validate")
 	receiptVerifyCmd.Flags().StringVar(&receiptSaveDir, "save-dir", "", "Override the store directory used when --save is set")
+	receiptVerifyCmd.Flags().StringVar(&receiptFailOn, "fail-on", "", "Exit non-zero (code 2) when the receipt verdict matches. Accepts a comma-separated list of verdicts (WATCH, BLOCK, INCONCLUSIVE) or the sugar 'any-non-pass' (= WATCH,BLOCK,INCONCLUSIVE). The receipt is still printed / saved / written to --out regardless of exit code.")
+	receiptVerifyCmd.Flags().StringArrayVar(&receiptInputAttestations, "input-attestation", nil, "Path to a prior receipt to reference via inputAttestations[] (repeatable). Each referenced receipt's fingerprint is verified at chain-construction time; tampered receipts are refused. The new receipt's fingerprint covers the inputAttestations[] field by construction.")
 }
 
 func runReceiptVerify(cmd *cobra.Command, args []string) error {
@@ -212,6 +216,20 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 	// 4. Detect connected mode (for the second subject + omission logic).
 	connected := hub.NewClient().RequireConnected() == nil
 
+	// 4b. Build the inputAttestations[] from --input-attestation
+	// (repeatable). Each path is loaded + fingerprint-verified before
+	// being chained — a tampered referenced receipt fails the chain
+	// construction upfront rather than silently propagating bad
+	// evidence. See pkg/agent/receipt_inputattestations.go.
+	var inputAttestations []agent.AttestationRef
+	if len(receiptInputAttestations) > 0 {
+		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
+		if refErr != nil {
+			return fmt.Errorf("build input-attestations: %w", refErr)
+		}
+		inputAttestations = refs
+	}
+
 	// 5. Build the receipt.
 	stmt, err := agent.BuildReceipt(agent.BuildReceiptInput{
 		Live: live,
@@ -220,13 +238,14 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 			Name:      name,
 			Namespace: ns,
 		},
-		Owner:         owner,
-		PredicateName: predicateExplicit,
-		Spec:          spec,
-		Evidence:      evidence,
-		Connected:     connected,
-		Strategy:      strings.TrimSpace(receiptStrategy),
-		Since:         since,
+		Owner:             owner,
+		PredicateName:     predicateExplicit,
+		Spec:              spec,
+		Evidence:          evidence,
+		Connected:         connected,
+		Strategy:          strings.TrimSpace(receiptStrategy),
+		Since:             since,
+		InputAttestations: inputAttestations,
 		Verifier: agent.Verifier{
 			Tool:    "cub-scout",
 			Version: BuildTag,
@@ -318,7 +337,76 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// --fail-on: exit code 2 if the receipt verdict matches one of the
+	// listed verdicts (or the 'any-non-pass' sugar). This is the
+	// CI-gate hook; the receipt has ALREADY been printed / saved /
+	// written to --out above, so a failing gate still leaves the
+	// audit artifact in place. The exitCodeError wrapping (per
+	// cmd/cub-scout/exit_code.go + main.go's errors.As dispatcher)
+	// drives the actual os.Exit(2).
+	if failOn := strings.TrimSpace(receiptFailOn); failOn != "" {
+		failSet, parseErr := parseReceiptFailOn(failOn)
+		if parseErr != nil {
+			return parseErr
+		}
+		if failSet[stmt.Predicate.Verdict] {
+			return newExitCodeError(
+				fmt.Errorf(
+					"receipt verdict %q matches --fail-on %q",
+					stmt.Predicate.Verdict, failOn,
+				),
+				2,
+			)
+		}
+	}
+
 	return nil
+}
+
+// parseReceiptFailOn parses the --fail-on flag value into the set of
+// verdicts that should trigger exit code 2. Accepts:
+//
+//   - "any-non-pass" — sugar for WATCH,BLOCK,INCONCLUSIVE
+//   - comma-separated list of WATCH / BLOCK / INCONCLUSIVE (case-insensitive)
+//
+// PASS is not a valid --fail-on value (gating on success doesn't make
+// sense). The function rejects unknown verdicts upfront with a clear
+// error rather than silently accepting them — this is a CI gate, the
+// CI shouldn't see a typo become a "never fires" gate.
+func parseReceiptFailOn(raw string) (map[agent.ReceiptVerdict]bool, error) {
+	out := map[agent.ReceiptVerdict]bool{}
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	if lower == "any-non-pass" {
+		out[agent.VerdictWATCH] = true
+		out[agent.VerdictBLOCK] = true
+		out[agent.VerdictINCONCLUSIVE] = true
+		return out, nil
+	}
+
+	for _, part := range strings.Split(raw, ",") {
+		v := strings.ToUpper(strings.TrimSpace(part))
+		if v == "" {
+			continue
+		}
+		switch agent.ReceiptVerdict(v) {
+		case agent.VerdictWATCH, agent.VerdictBLOCK, agent.VerdictINCONCLUSIVE:
+			out[agent.ReceiptVerdict(v)] = true
+		case agent.VerdictPASS:
+			return nil, fmt.Errorf(
+				"--fail-on PASS is not allowed (gating on a passing receipt is a no-op; if you want every receipt to fail, that's a workflow bug)",
+			)
+		default:
+			return nil, fmt.Errorf(
+				"--fail-on %q: unknown verdict %q (valid: WATCH, BLOCK, INCONCLUSIVE, or the sugar 'any-non-pass')",
+				raw, v,
+			)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--fail-on %q resolved to empty verdict set", raw)
+	}
+	return out, nil
 }
 
 // loadReceiptLive fetches the live K8s object via the dynamic client. The

--- a/cmd/cub-scout/receipt_fail_on_test.go
+++ b/cmd/cub-scout/receipt_fail_on_test.go
@@ -1,0 +1,298 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+// resetReceiptFailOnFlag clears the --fail-on flag between tests.
+func resetReceiptFailOnFlag(t *testing.T) {
+	t.Helper()
+	prev := receiptFailOn
+	receiptFailOn = ""
+	t.Cleanup(func() { receiptFailOn = prev })
+}
+
+// --- parseReceiptFailOn unit tests ---
+
+func TestParseReceiptFailOn_AnyNonPass(t *testing.T) {
+	set, err := parseReceiptFailOn("any-non-pass")
+	if err != nil {
+		t.Fatalf("any-non-pass should parse: %v", err)
+	}
+	for _, v := range []agent.ReceiptVerdict{agent.VerdictWATCH, agent.VerdictBLOCK, agent.VerdictINCONCLUSIVE} {
+		if !set[v] {
+			t.Errorf("any-non-pass must include %q in fail set", v)
+		}
+	}
+	if set[agent.VerdictPASS] {
+		t.Error("any-non-pass must NOT include PASS")
+	}
+}
+
+func TestParseReceiptFailOn_SingleVerdict(t *testing.T) {
+	cases := []struct {
+		in      string
+		matches agent.ReceiptVerdict
+		others  []agent.ReceiptVerdict
+	}{
+		{"WATCH", agent.VerdictWATCH, []agent.ReceiptVerdict{agent.VerdictBLOCK, agent.VerdictINCONCLUSIVE}},
+		{"BLOCK", agent.VerdictBLOCK, []agent.ReceiptVerdict{agent.VerdictWATCH, agent.VerdictINCONCLUSIVE}},
+		{"INCONCLUSIVE", agent.VerdictINCONCLUSIVE, []agent.ReceiptVerdict{agent.VerdictWATCH, agent.VerdictBLOCK}},
+	}
+	for _, tc := range cases {
+		set, err := parseReceiptFailOn(tc.in)
+		if err != nil {
+			t.Errorf("%s: parse failed: %v", tc.in, err)
+			continue
+		}
+		if !set[tc.matches] {
+			t.Errorf("%s: must include %q", tc.in, tc.matches)
+		}
+		for _, other := range tc.others {
+			if set[other] {
+				t.Errorf("%s: must NOT include %q", tc.in, other)
+			}
+		}
+	}
+}
+
+func TestParseReceiptFailOn_CommaList(t *testing.T) {
+	set, err := parseReceiptFailOn("WATCH,BLOCK")
+	if err != nil {
+		t.Fatalf("WATCH,BLOCK should parse: %v", err)
+	}
+	if !set[agent.VerdictWATCH] {
+		t.Error("WATCH,BLOCK must include WATCH")
+	}
+	if !set[agent.VerdictBLOCK] {
+		t.Error("WATCH,BLOCK must include BLOCK")
+	}
+	if set[agent.VerdictINCONCLUSIVE] {
+		t.Error("WATCH,BLOCK must NOT include INCONCLUSIVE")
+	}
+}
+
+func TestParseReceiptFailOn_CaseInsensitive(t *testing.T) {
+	for _, in := range []string{"watch", "Watch", "WATCH", " watch "} {
+		set, err := parseReceiptFailOn(in)
+		if err != nil {
+			t.Errorf("%q must parse case-insensitively: %v", in, err)
+			continue
+		}
+		if !set[agent.VerdictWATCH] {
+			t.Errorf("%q must resolve to WATCH", in)
+		}
+	}
+}
+
+func TestParseReceiptFailOn_RejectsPASS(t *testing.T) {
+	_, err := parseReceiptFailOn("PASS")
+	if err == nil {
+		t.Fatal("--fail-on PASS must be rejected")
+	}
+	if !strings.Contains(err.Error(), "PASS") {
+		t.Errorf("error must name the problem; got %v", err)
+	}
+}
+
+func TestParseReceiptFailOn_RejectsUnknownVerdict(t *testing.T) {
+	_, err := parseReceiptFailOn("MAYBE")
+	if err == nil {
+		t.Fatal("unknown verdict must be rejected")
+	}
+	if !strings.Contains(err.Error(), "MAYBE") {
+		t.Errorf("error must echo the bad input; got %v", err)
+	}
+}
+
+func TestParseReceiptFailOn_EmptyAfterParse_Errors(t *testing.T) {
+	// "," alone resolves to empty after trim; not a valid gate spec.
+	_, err := parseReceiptFailOn(",")
+	if err == nil {
+		t.Fatal(",-only input must be rejected")
+	}
+}
+
+// --- end-to-end CLI integration tests ---
+
+func TestReceiptVerify_FailOn_BlockTriggersExit2(t *testing.T) {
+	// Force a BLOCK verdict by injecting a strategy-mismatched
+	// source-truth evidence. The receipt builds successfully; --fail-on
+	// then turns the verdict into an exit-code-2 error wrap.
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptFailOnFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	// Evidence says git-argo; caller says confighub-oci-argo →
+	// strategy mismatch → BLOCK.
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyGitArgo.Human(),
+		Status:           agent.StatusPASS,
+	})
+	receiptFailOn = "BLOCK"
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--strategy", "confighub-oci-argo",
+		"--format", "json",
+	})
+
+	captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("BLOCK verdict + --fail-on BLOCK must error")
+		}
+		if !strings.Contains(err.Error(), "fail-on") {
+			t.Errorf("error must mention --fail-on; got %v", err)
+		}
+		var ec interface{ ExitCode() int }
+		if !errors.As(err, &ec) {
+			t.Fatal("error must wrap exitCodeError so main.go exits 2")
+		}
+		if got := ec.ExitCode(); got != 2 {
+			t.Errorf("--fail-on BLOCK on BLOCK verdict must signal exit 2; got %d", got)
+		}
+	})
+}
+
+func TestReceiptVerify_FailOn_PassDoesNotTrigger(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptFailOnFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	withFakeSourceTruth(t, &agent.SourceTruthEvidence{
+		DeclaredStrategy: agent.StrategyGitArgo.Human(),
+		Status:           agent.StatusPASS,
+		SourceTruth:      agent.VerdictAGREED,
+	})
+	receiptFailOn = "any-non-pass"
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--strategy", "git-argo",
+		"--format", "json",
+	})
+
+	captureStdout(t, func() {
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("PASS verdict + --fail-on any-non-pass must succeed (exit 0); got %v", err)
+		}
+	})
+}
+
+func TestReceiptVerify_FailOn_InconclusiveOnly(t *testing.T) {
+	// Default applied-matches-spec with no Argo tracer wired = INCONCLUSIVE.
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptFailOnFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	receiptFailOn = "INCONCLUSIVE"
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--format", "json",
+	})
+
+	captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("INCONCLUSIVE verdict + --fail-on INCONCLUSIVE must error")
+		}
+		var ec interface{ ExitCode() int }
+		if !errors.As(err, &ec) || ec.ExitCode() != 2 {
+			t.Errorf("INCONCLUSIVE + --fail-on INCONCLUSIVE must signal exit 2; got %v", err)
+		}
+	})
+}
+
+func TestReceiptVerify_FailOn_BadValue_NoExit2(t *testing.T) {
+	// Bad --fail-on value is a usage error (operational), not a verdict
+	// gate. Falls through to exit 1, not exit 2.
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptFailOnFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	receiptFailOn = "MAYBE"
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--format", "json",
+	})
+
+	captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("bad --fail-on value must error")
+		}
+		var ec interface{ ExitCode() int }
+		if errors.As(err, &ec) {
+			t.Errorf("bad --fail-on must NOT wrap exitCodeError (it's a usage error → default exit 1); got ExitCode=%d", ec.ExitCode())
+		}
+	})
+}
+
+// TestReceiptVerify_FailOn_PreservesArtifact verifies that --fail-on
+// triggering exit 2 still produces the receipt as stdout + --save +
+// --out output. The artifact is a postmortem requirement; the gate
+// triggers AFTER the artifact is durable.
+func TestReceiptVerify_FailOn_PreservesArtifact(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptFailOnFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	storeDir := t.TempDir()
+	receiptSave = true
+	receiptSaveDir = storeDir
+	receiptFailOn = "any-non-pass"
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--format", "json",
+	})
+
+	out := captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("INCONCLUSIVE verdict + --fail-on any-non-pass must error")
+		}
+		// We want the failure exit code, but ALSO the artifact.
+	})
+
+	// stdout should still contain the JSON receipt.
+	if !strings.Contains(out, "\"_type\": \"https://in-toto.io/Statement/v1\"") {
+		t.Errorf("expected JSON receipt on stdout despite --fail-on; got:\n%s", out)
+	}
+
+	// --save should still have written the artifact to the store.
+	entries, err := os.ReadDir(storeDir)
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".receipt.json") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		names := []string{}
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected receipt saved to store despite --fail-on; store entries: %v", names)
+	}
+}

--- a/cmd/cub-scout/receipt_fail_on_test.go
+++ b/cmd/cub-scout/receipt_fail_on_test.go
@@ -243,6 +243,66 @@ func TestReceiptVerify_FailOn_BadValue_NoExit2(t *testing.T) {
 	})
 }
 
+// TestReceiptVerify_FailOn_BadValue_NoSideEffects verifies the Codex
+// round-6 P2 fix: an invalid --fail-on value rejects the command
+// BEFORE any side effect (stdout print, --out write, --save to store).
+// The prior order parsed --fail-on after artifact emission, which left
+// a footgun in CI: a typo would error out (correctly with exit 1) but
+// the artifact had already been printed and persisted with the wrong
+// gate semantics.
+func TestReceiptVerify_FailOn_BadValue_NoSideEffects(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptFailOnFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	saveDir := t.TempDir()
+	outDir := t.TempDir() // separate from saveDir so neither read pollutes the other
+	outPath := outDir + "/should-not-be-written.receipt.json"
+	receiptSave = true
+	receiptSaveDir = saveDir
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--format", "json",
+		"--out", outPath,
+		"--fail-on", "GARBAGE-VALUE",
+	})
+
+	out := captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("bad --fail-on must reject upfront")
+		}
+		var ec interface{ ExitCode() int }
+		if errors.As(err, &ec) {
+			t.Errorf("bad --fail-on must NOT wrap exitCodeError; got ExitCode=%d", ec.ExitCode())
+		}
+	})
+
+	// stdout must be empty — the receipt was never printed.
+	if strings.Contains(out, "\"_type\":") {
+		t.Errorf("expected NO receipt on stdout when --fail-on is invalid; got:\n%s", out)
+	}
+
+	// --out file must not exist — the receipt was never written.
+	if _, err := os.Stat(outPath); err == nil {
+		t.Errorf("--out file %q must NOT be written when --fail-on is invalid", outPath)
+	}
+
+	// --save store must be empty — the receipt was never persisted.
+	entries, err := os.ReadDir(saveDir)
+	if err == nil {
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".receipt.json") {
+				t.Errorf("save store must be empty when --fail-on is invalid; found %s", e.Name())
+			}
+		}
+	}
+}
+
 // TestReceiptVerify_FailOn_PreservesArtifact verifies that --fail-on
 // triggering exit 2 still produces the receipt as stdout + --save +
 // --out output. The artifact is a postmortem requirement; the gate

--- a/cmd/cub-scout/receipt_input_attestation_test.go
+++ b/cmd/cub-scout/receipt_input_attestation_test.go
@@ -1,0 +1,168 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+// resetReceiptInputAttestationFlag clears --input-attestation between tests.
+func resetReceiptInputAttestationFlag(t *testing.T) {
+	t.Helper()
+	prev := receiptInputAttestations
+	receiptInputAttestations = nil
+	t.Cleanup(func() { receiptInputAttestations = prev })
+}
+
+// seedTwoReceipts produces two distinct receipts on disk (different
+// scopes → different fingerprints) and returns their paths. Used by
+// the multi-input-attestation chain test.
+func seedTwoReceipts(t *testing.T) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "a.receipt.json")
+	b := filepath.Join(tmp, "b.receipt.json")
+
+	for _, spec := range []struct {
+		path, ns string
+	}{
+		{a, "prod-a"}, {b, "prod-b"},
+	} {
+		resetReceiptFlags(t)
+		withFakeReceiptLoader(t, makeReceiptArgoLive())
+		captureStdout(t, func() {
+			rootCmd.SetArgs([]string{
+				"receipt", "verify", "deploy/api",
+				"-n", spec.ns,
+				"--format", "json",
+				"--out", spec.path,
+			})
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("seed %s: %v", spec.path, err)
+			}
+		})
+	}
+	return a, b
+}
+
+func TestReceiptVerify_InputAttestation_AttachesRefs(t *testing.T) {
+	pathA, pathB := seedTwoReceipts(t)
+
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptInputAttestationFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+	receiptInputAttestations = []string{pathA, pathB}
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{
+			"receipt", "verify", "deploy/api",
+			"-n", "prod",
+			"--format", "json",
+			"--input-attestation", pathA,
+			"--input-attestation", pathB,
+		})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("verify with --input-attestation: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(stmt.Predicate.InputAttestations) != 2 {
+		t.Fatalf("expected 2 inputAttestations; got %d", len(stmt.Predicate.InputAttestations))
+	}
+	// Verify each ref points at one of the seeded receipts (fingerprint
+	// equality, not URI equality — URI is just the readable label).
+	a, err := agent.LoadStatement(pathA)
+	if err != nil {
+		t.Fatalf("load A: %v", err)
+	}
+	b, err := agent.LoadStatement(pathB)
+	if err != nil {
+		t.Fatalf("load B: %v", err)
+	}
+	expected := map[string]bool{
+		strings.TrimPrefix(a.Predicate.Fingerprint, "sha256:"): true,
+		strings.TrimPrefix(b.Predicate.Fingerprint, "sha256:"): true,
+	}
+	for _, ref := range stmt.Predicate.InputAttestations {
+		if !expected[ref.Digest["sha256"]] {
+			t.Errorf("inputAttestation digest %q not among seeded receipts %v", ref.Digest["sha256"], expected)
+		}
+		if !strings.HasPrefix(ref.URI, agent.AttestationURIScheme) {
+			t.Errorf("URI must use the cub-scout-receipt scheme; got %q", ref.URI)
+		}
+	}
+	// The new receipt's own fingerprint integrity holds with the
+	// inputAttestations[] populated.
+	if err := agent.VerifyStatementFingerprint(stmt); err != nil {
+		t.Errorf("downstream fingerprint must verify: %v", err)
+	}
+}
+
+func TestReceiptVerify_InputAttestation_TamperedRefuses(t *testing.T) {
+	pathA, _ := seedTwoReceipts(t)
+
+	// Tamper with the upstream receipt: change its verdict, write back.
+	raw, err := os.ReadFile(pathA)
+	if err != nil {
+		t.Fatalf("read A: %v", err)
+	}
+	tampered := strings.ReplaceAll(string(raw), `"verdict": "PASS"`, `"verdict": "BLOCK"`)
+	if tampered == string(raw) {
+		tampered = strings.ReplaceAll(string(raw), `"verdict": "INCONCLUSIVE"`, `"verdict": "PASS"`)
+	}
+	if tampered == string(raw) {
+		t.Fatalf("seed receipt has no PASS or INCONCLUSIVE to mutate; raw:\n%s", string(raw))
+	}
+	if err := os.WriteFile(pathA, []byte(tampered), 0o644); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptInputAttestationFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--format", "json",
+		"--input-attestation", pathA,
+	})
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatal("tampered input-attestation must be rejected at chain construction")
+	}
+	if !strings.Contains(err.Error(), "input-attestation") && !strings.Contains(err.Error(), "fingerprint") {
+		t.Errorf("error must name the chain-construction failure; got %v", err)
+	}
+}
+
+func TestReceiptVerify_InputAttestation_MissingFile_Errors(t *testing.T) {
+	resetReceiptBatch3Flags(t)
+	resetReceiptBatch2Flags(t)
+	resetReceiptInputAttestationFlag(t)
+	withFakeReceiptLoader(t, makeReceiptArgoLive())
+
+	rootCmd.SetArgs([]string{
+		"receipt", "verify", "deploy/api",
+		"-n", "prod",
+		"--format", "json",
+		"--input-attestation", "/tmp/does-not-exist.receipt.json",
+	})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("missing input-attestation file must error")
+	}
+}

--- a/cmd/cub-scout/receipt_readonly_test.go
+++ b/cmd/cub-scout/receipt_readonly_test.go
@@ -21,9 +21,19 @@ import (
 // 3, source-truth-pass / no-manual-edits-since predicates) inherits this
 // guard automatically.
 //
-// Scope:
-//   - cmd/cub-scout/receipt*.go and cmd/cub-scout/receipt_render*.go
+// Scope (any source file whose basename CONTAINS "receipt", in either
+// the cmd/cub-scout or pkg/agent tree):
+//   - cmd/cub-scout/receipt*.go
+//   - cmd/cub-scout/receipt_render*.go
+//   - cmd/cub-scout/watch_receipt*.go (#449 v2: the watch-emit path
+//     builds receipts in-process; same trust invariant applies)
 //   - pkg/agent/receipt*.go
+//
+// The glob is `*receipt*` (substring), not `receipt*` (prefix). Earlier
+// versions of this test used a prefix and silently missed
+// `watch_receipt.go` — Codex round-6 catch (PR #463). Future files
+// whose names embed "receipt" anywhere (e.g., `aggregate_receipt.go`,
+// `receipt_chain.go`) are covered automatically.
 //
 // Forbidden tokens (each is a substring check; word-boundary not needed
 // because the goal is "no mutating verb appears anywhere in this code"):
@@ -39,6 +49,12 @@ import (
 //
 // .Watch( is NOT forbidden — Watch is a read-only API on K8s.
 // .Get( and .List( are allowed.
+//
+// expectedFiles is a small allow-set the test asserts on at the end:
+// if any listed file is NOT scanned, the test fails loudly rather than
+// silently passing. This guards against future renames or basename
+// changes that would silently drop a file from the guard. Adding a new
+// receipt-shaped file means adding its basename here.
 func TestReceiptPackageReadOnlyClient(t *testing.T) {
 	forbidden := []string{
 		".Create(",
@@ -59,6 +75,34 @@ func TestReceiptPackageReadOnlyClient(t *testing.T) {
 		"../../pkg/agent",
 	}
 
+	// expectedPaths names the receipt-shaped files this guard MUST scan,
+	// keyed by `<root>/<basename>` so basename collisions across roots
+	// (e.g. cmd/cub-scout/receipt.go and pkg/agent/receipt.go are
+	// different files) are tracked independently. Mismatch (path
+	// present in tree but skipped, or listed here but missing from
+	// tree) fails the test. Keeps the glob honest as new files land.
+	expectedPaths := map[string]bool{
+		"cmd/cub-scout/receipt.go":           false,
+		"cmd/cub-scout/receipt_render.go":    false,
+		"cmd/cub-scout/receipt_show.go":      false,
+		"cmd/cub-scout/receipt_validate.go":  false,
+		"cmd/cub-scout/receipt_list.go":      false,
+		"cmd/cub-scout/watch_receipt.go":     false,
+		"pkg/agent/receipt.go":                       false,
+		"pkg/agent/receipt_build.go":                 false,
+		"pkg/agent/receipt_canonicaljson.go":         false,
+		"pkg/agent/receipt_fingerprint.go":           false,
+		"pkg/agent/receipt_inputattestations.go":     false,
+		"pkg/agent/receipt_predicates.go":            false,
+		"pkg/agent/receipt_store.go":                 false,
+		"pkg/agent/receipt_subject.go":               false,
+	}
+	rootDisplay := map[string]string{
+		".":               "cmd/cub-scout",
+		"../../pkg/agent": "pkg/agent",
+	}
+
+	scannedPaths := map[string]bool{}
 	var scanned int
 	for _, root := range roots {
 		entries, err := os.ReadDir(root)
@@ -67,7 +111,10 @@ func TestReceiptPackageReadOnlyClient(t *testing.T) {
 		}
 		for _, e := range entries {
 			name := e.Name()
-			if !strings.HasPrefix(name, "receipt") {
+			// Substring-match (not prefix). Catches `watch_receipt.go`,
+			// `aggregate_receipt.go`, etc. — anything with "receipt" in
+			// the basename.
+			if !strings.Contains(name, "receipt") {
 				continue
 			}
 			if !strings.HasSuffix(name, ".go") {
@@ -89,6 +136,7 @@ func TestReceiptPackageReadOnlyClient(t *testing.T) {
 					t.Errorf("%s contains forbidden mutating call fragment %q; receipt code is read-only by design (#410/#428/#446)", path, frag)
 				}
 			}
+			scannedPaths[rootDisplay[root]+"/"+name] = true
 			scanned++
 		}
 	}
@@ -97,5 +145,16 @@ func TestReceiptPackageReadOnlyClient(t *testing.T) {
 	// is silently useless. Catch that.
 	if scanned == 0 {
 		t.Fatal("no receipt*.go source files scanned; test would silently pass — check roots")
+	}
+
+	// Stronger guard: every file in the expected allow-set must have
+	// been scanned. A skipped file means the glob silently dropped it.
+	// Codex round-6 caught the prior glob (`strings.HasPrefix(name,
+	// "receipt")`) silently missing watch_receipt.go; this assertion
+	// makes that class of bug loud rather than silent.
+	for path := range expectedPaths {
+		if !scannedPaths[path] {
+			t.Errorf("expected to scan %q under the read-only guard but it was not visited; either the file was renamed or the glob is broken", path)
+		}
 	}
 }

--- a/cmd/cub-scout/watch.go
+++ b/cmd/cub-scout/watch.go
@@ -51,10 +51,18 @@ type watchEvent struct {
 	// sinks emit one line per event regardless of whether the event
 	// carries a receipt; webhook sinks see the same structured shape.
 	//
+	// Wire shape: `omitempty`. When Receipt is nil, the JSON `receipt`
+	// key is OMITTED entirely (not emitted as `"receipt": null`).
+	// Consumers should check key presence rather than null-ness:
+	//
+	//	if "receipt" in event:           # idiomatic
+	//	    process(event["receipt"])
+	//	# NOT: if event["receipt"] is not None
+	//
 	// Receipt-build failures are NOT fatal to event emission — the
-	// underlying watch event is still emitted with Receipt=nil and a
-	// warning is written to stderr. This keeps the watch loop robust
-	// against transient cluster-read hiccups.
+	// underlying watch event is still emitted (with the receipt key
+	// absent) and a warning is written to stderr. This keeps the watch
+	// loop robust against transient cluster-read hiccups.
 	//
 	// #449 v1: only `drift.detected` and `ownership.changed` event
 	// types are supported in the predicate-mapping; other event types
@@ -183,6 +191,28 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Codex round-6 P2 fix (#463): emit a one-time startup warning when
+	// --emit-receipt-on includes event types that the v1 mapping does
+	// NOT actually build receipts for. The flag is "lenient on type,
+	// strict on receipt-build" (so `all` is forward-compatible), but a
+	// user who asks for `scan.finding` thinking they'll get receipts
+	// gets silent skipping. The warning makes that expectation gap
+	// visible up front rather than as a "why aren't my receipts firing"
+	// debug session later.
+	if len(emitReceiptOn) > 0 {
+		unsupported := unsupportedEmitReceiptTypes(emitReceiptOn)
+		if len(unsupported) > 0 {
+			fmt.Fprintf(os.Stderr,
+				"Warning: --emit-receipt-on includes event types that don't yet build a receipt (#449 v1): %s. "+
+					"The flag accepts these for forward-compat (so `--emit-receipt-on all` keeps working as new types land), "+
+					"but receipt-build is skipped for them. Supported in v1: %s.\n",
+				strings.Join(unsupported, ", "),
+				strings.Join(supportedEmitReceiptTypesSorted(), ", "),
+			)
+		}
+	}
+
 	sinks, cleanup, err := buildWatchSinks(webhookURL, outputFile)
 	if err != nil {
 		return err
@@ -213,9 +243,15 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	// duration of the watch loop. Used by the receipt-emission path to
 	// decide whether to include a confighub-unit:// subject.
 	connected := hub.NewClient().RequireConnected() == nil
-	warnFn := func(format string, args ...interface{}) {
+	baseWarnFn := func(format string, args ...interface{}) {
 		fmt.Fprintf(os.Stderr, "Warning: "+format+"\n", args...)
 	}
+	// Codex round-6 P2 (#463): rate-limit receipt-build warnings. A
+	// long-running watch with transient cluster-read failures (e.g.,
+	// an API-server hiccup hitting every poll) would otherwise spam
+	// stderr indefinitely. First N pass through; after that, periodic
+	// summary.
+	warnFn := makeReceiptWarnFn(baseWarnFn, watchReceiptWarnFirstN, watchReceiptWarnSummaryEvery)
 
 	if watchOnce {
 		curr, err := watchCollectState(ctx, dynClient, watchNamespace)

--- a/cmd/cub-scout/watch.go
+++ b/cmd/cub-scout/watch.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/confighub/cub-scout/pkg/hub"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -33,6 +34,7 @@ var (
 	watchSeverity        string
 	watchOnce            bool
 	watchMaxQueuedEvents int
+	watchEmitReceiptOn   string
 )
 
 type watchEvent struct {
@@ -42,6 +44,24 @@ type watchEvent struct {
 	Owner     *watchEventOwner       `json:"owner,omitempty"`
 	Severity  string                 `json:"severity,omitempty"`
 	Details   map[string]interface{} `json:"details,omitempty"`
+
+	// Receipt is the in-toto Statement v1 envelope (a cub-scout receipt)
+	// built when `--emit-receipt-on` is enabled and this event's type
+	// matches. Nil otherwise. Inlined into the event payload so JSONL
+	// sinks emit one line per event regardless of whether the event
+	// carries a receipt; webhook sinks see the same structured shape.
+	//
+	// Receipt-build failures are NOT fatal to event emission — the
+	// underlying watch event is still emitted with Receipt=nil and a
+	// warning is written to stderr. This keeps the watch loop robust
+	// against transient cluster-read hiccups.
+	//
+	// #449 v1: only `drift.detected` and `ownership.changed` event
+	// types are supported in the predicate-mapping; other event types
+	// (`resource.discovered`, `scan.finding`) accept the flag but
+	// receipt-build is skipped to avoid flooding on first-poll
+	// discovery. Future iterations can broaden the mapping.
+	Receipt *agent.Statement `json:"receipt,omitempty"`
 }
 
 type watchEventResource struct {
@@ -141,6 +161,7 @@ func init() {
 	watchCmd.Flags().StringVar(&watchSeverity, "severity", "", "Filter finding/drift events by severity (comma-separated: critical,warning,info)")
 	watchCmd.Flags().BoolVar(&watchOnce, "once", false, "Run one collection cycle and exit")
 	watchCmd.Flags().IntVar(&watchMaxQueuedEvents, "max-queued-events", 1000, "Maximum buffered events when webhook is unavailable")
+	watchCmd.Flags().StringVar(&watchEmitReceiptOn, "emit-receipt-on", "", "Comma-separated watch event types to attach a cub-scout receipt to (e.g. 'drift.detected,ownership.changed' or 'all' for all four). Receipt-build failures are non-fatal — the underlying event still emits with receipt=null and a stderr warning. #449 v1 builds receipts only for 'drift.detected' and 'ownership.changed' to avoid flooding on first-poll discovery; other event types pass through silently.")
 }
 
 func runWatch(cmd *cobra.Command, args []string) error {
@@ -154,6 +175,13 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	}
 	if watchMaxQueuedEvents <= 0 {
 		return fmt.Errorf("--max-queued-events must be > 0")
+	}
+
+	// Parse --emit-receipt-on upfront so a bad value fails before the
+	// long-running watch loop starts. Empty input disables the feature.
+	emitReceiptOn, err := parseWatchEmitReceiptOn(watchEmitReceiptOn)
+	if err != nil {
+		return err
 	}
 	sinks, cleanup, err := buildWatchSinks(webhookURL, outputFile)
 	if err != nil {
@@ -181,12 +209,21 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		queue     []watchEvent
 	)
 
+	// connected mode is read once at watch start; it's stable for the
+	// duration of the watch loop. Used by the receipt-emission path to
+	// decide whether to include a confighub-unit:// subject.
+	connected := hub.NewClient().RequireConnected() == nil
+	warnFn := func(format string, args ...interface{}) {
+		fmt.Fprintf(os.Stderr, "Warning: "+format+"\n", args...)
+	}
+
 	if watchOnce {
 		curr, err := watchCollectState(ctx, dynClient, watchNamespace)
 		if err != nil {
 			return err
 		}
 		events := buildWatchEvents(prevState, curr, severityFilter, ownerFilter, watchEventNow)
+		events = attachReceiptsIfRequested(ctx, events, emitReceiptOn, dynClient, connected, warnFn)
 		queue = appendWatchQueue(queue, events, watchMaxQueuedEvents)
 		_, err = flushWatchQueue(ctx, sinks, queue)
 		return err
@@ -213,6 +250,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 				continue
 			}
 			events := buildWatchEvents(prevState, curr, severityFilter, ownerFilter, watchEventNow)
+			events = attachReceiptsIfRequested(ctx, events, emitReceiptOn, dynClient, connected, warnFn)
 			queue = appendWatchQueue(queue, events, watchMaxQueuedEvents)
 			remaining, err := flushWatchQueue(ctx, sinks, queue)
 			queue = remaining

--- a/cmd/cub-scout/watch_receipt.go
+++ b/cmd/cub-scout/watch_receipt.go
@@ -1,0 +1,247 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// watch_receipt.go — receipt emission on watch events (#449).
+//
+// `--emit-receipt-on <event-types>` accepts a comma-separated list of
+// watch event type names. When buildWatchEvents produces an event of a
+// matching type, attachReceiptsIfRequested loads the live resource and
+// runs an in-process BuildReceipt to attach the in-toto Statement to
+// the event payload. Failures are logged and non-fatal: the underlying
+// watch event still emits with receipt=null.
+//
+// Predicate mapping (#449 v1, locked):
+//
+//	drift.detected     → applied-matches-spec
+//	ownership.changed  → applied-matches-spec
+//	scan.finding       → skipped (would flood on initial finding burst)
+//	resource.discovered → skipped (every first-poll discovery would emit)
+//
+// The skipped event types still accept the flag (so `--emit-receipt-on all`
+// is a valid sugar) but produce nil receipts with no error — the watch
+// stream is unchanged.
+
+// watchEventTypeAll is the sugar value for `--emit-receipt-on` that
+// covers every known watch event type. New event types added to
+// buildWatchEvents automatically participate.
+const watchEventTypeAll = "all"
+
+// watchKnownEventTypes is the closed list of event types
+// buildWatchEvents emits. Used to validate the --emit-receipt-on flag
+// upfront so CI gates don't silently accept typos.
+var watchKnownEventTypes = []string{
+	"resource.discovered",
+	"ownership.changed",
+	"drift.detected",
+	"scan.finding",
+}
+
+// watchEventTypesWithReceiptSupport names the subset of event types for
+// which #449 v1 actually builds a receipt. The flag accepts other
+// types for forward-compat, but receipt-build is a no-op for them in
+// v1 — the rationale lives in watch_receipt.go's package doc.
+var watchEventTypesWithReceiptSupport = map[string]bool{
+	"drift.detected":    true,
+	"ownership.changed": true,
+}
+
+// parseWatchEmitReceiptOn parses the --emit-receipt-on flag value into
+// the set of event types that should trigger receipt emission. Empty
+// input returns nil (feature disabled).
+//
+// Accepts:
+//   - "" — feature disabled, returns nil set
+//   - "all" — every entry in watchKnownEventTypes
+//   - comma-separated subset of watchKnownEventTypes
+//
+// Unknown event types are rejected upfront. Same rationale as
+// parseReceiptFailOn: CI gates shouldn't silently accept typos.
+func parseWatchEmitReceiptOn(raw string) (map[string]bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	if strings.EqualFold(trimmed, watchEventTypeAll) {
+		out := make(map[string]bool, len(watchKnownEventTypes))
+		for _, t := range watchKnownEventTypes {
+			out[t] = true
+		}
+		return out, nil
+	}
+
+	known := map[string]bool{}
+	for _, t := range watchKnownEventTypes {
+		known[t] = true
+	}
+
+	out := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		t := strings.TrimSpace(part)
+		if t == "" {
+			continue
+		}
+		if !known[t] {
+			return nil, fmt.Errorf(
+				"--emit-receipt-on %q: unknown event type %q (valid: %s, or the sugar 'all')",
+				raw, t, strings.Join(watchKnownEventTypes, ", "),
+			)
+		}
+		out[t] = true
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--emit-receipt-on %q resolved to empty event-type set", raw)
+	}
+	return out, nil
+}
+
+// attachReceiptsIfRequested walks events and, for each one whose type
+// is in `emitOn` AND whose type has receipt-build support
+// (watchEventTypesWithReceiptSupport), builds a receipt and attaches
+// it to event.Receipt. The receipt-build call goes through the same
+// loadReceiptLiveFn seam tests already swap; production hits the
+// dynamic client.
+//
+// Failures are logged to stderr (`warnFn`) and non-fatal — the
+// underlying event still emits with Receipt=nil.
+func attachReceiptsIfRequested(
+	ctx context.Context,
+	events []watchEvent,
+	emitOn map[string]bool,
+	dynClient dynamic.Interface,
+	connected bool,
+	warnFn func(format string, args ...interface{}),
+) []watchEvent {
+	if len(emitOn) == 0 || len(events) == 0 {
+		return events
+	}
+	for i := range events {
+		if !emitOn[events[i].Type] {
+			continue
+		}
+		if !watchEventTypesWithReceiptSupport[events[i].Type] {
+			// Caller asked us to consider this event type, but v1
+			// support is narrow; skip with no warning (the doc on
+			// --emit-receipt-on tells the user this is expected).
+			continue
+		}
+		stmt, err := watchBuildReceiptForEventFn(ctx, events[i], dynClient, connected)
+		if err != nil {
+			if warnFn != nil {
+				warnFn("receipt build for %s/%s in %s (%s) failed: %v",
+					events[i].Resource.Kind, events[i].Resource.Name, events[i].Resource.Namespace,
+					events[i].Type, err)
+			}
+			continue
+		}
+		events[i].Receipt = stmt
+	}
+	return events
+}
+
+// watchBuildReceiptForEventFn is the function-variable seam tests swap
+// to inject prefab receipts. Production wires it to
+// watchBuildReceiptForEvent below.
+var watchBuildReceiptForEventFn = watchBuildReceiptForEvent
+
+// watchBuildReceiptForEvent loads the live resource named by the event
+// and runs an in-process BuildReceipt with the applied-matches-spec
+// predicate auto-detected from owner. Reuses the same evidence-
+// collection helpers `cub-scout receipt verify` uses
+// (DetectOwnership, AttributeFieldMutation, CollectGitSourceAnchorForOwner).
+//
+// Returns a Statement pointer (so the JSON shape is `receipt: { ... }`
+// or `receipt: null`, never an empty object).
+func watchBuildReceiptForEvent(
+	ctx context.Context,
+	event watchEvent,
+	dynClient dynamic.Interface,
+	connected bool,
+) (*agent.Statement, error) {
+	kind := strings.TrimSpace(event.Resource.Kind)
+	name := strings.TrimSpace(event.Resource.Name)
+	namespace := strings.TrimSpace(event.Resource.Namespace)
+	if kind == "" || name == "" {
+		return nil, fmt.Errorf("event missing kind/name: %+v", event.Resource)
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	live, err := loadLiveForWatchReceiptFn(ctx, dynClient, kind, name, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("load live %s/%s in %s: %w", kind, name, namespace, err)
+	}
+
+	owner := agent.DetectOwnership(live)
+	attribution := agent.AttributeFieldMutation(live, owner)
+	gitSource := agent.CollectGitSourceAnchorForOwner(ctx, live, owner)
+
+	evidence := agent.Evidence{
+		Attribution: &attribution,
+		GitSource:   gitSource,
+	}
+
+	var spec *agent.SpecAnchor
+	if gitSource != nil {
+		spec = &agent.SpecAnchor{
+			Anchor: agent.SpecAnchorBody{
+				Type:     "git",
+				RepoURL:  gitSource.RepoURL,
+				Revision: gitSource.Revision,
+				Path:     gitSource.Path,
+			},
+		}
+	}
+
+	stmt, err := agent.BuildReceipt(agent.BuildReceiptInput{
+		Live: live,
+		Scope: agent.Scope{
+			Kind:      kind,
+			Name:      name,
+			Namespace: namespace,
+		},
+		Owner:     owner,
+		Spec:      spec,
+		Evidence:  evidence,
+		Connected: connected,
+		Verifier: agent.Verifier{
+			Tool:    "cub-scout",
+			Version: BuildTag,
+		},
+		VerifiedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build receipt: %w", err)
+	}
+	return &stmt, nil
+}
+
+// loadLiveForWatchReceipt fetches the live K8s object via the dynamic
+// client. Tests can override via the loadLiveForWatchReceiptFn seam.
+var loadLiveForWatchReceiptFn = loadLiveForWatchReceipt
+
+func loadLiveForWatchReceipt(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	kind, name, namespace string,
+) (*unstructured.Unstructured, error) {
+	gvr := kindToGVR(kind)
+	if gvr.Resource == "" {
+		return nil, fmt.Errorf("unsupported kind %q", kind)
+	}
+	return dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
+}

--- a/cmd/cub-scout/watch_receipt.go
+++ b/cmd/cub-scout/watch_receipt.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -22,7 +23,9 @@ import (
 // matching type, attachReceiptsIfRequested loads the live resource and
 // runs an in-process BuildReceipt to attach the in-toto Statement to
 // the event payload. Failures are logged and non-fatal: the underlying
-// watch event still emits with receipt=null.
+// watch event still emits, with the `receipt` key omitted from the
+// JSON (omitempty; see watchEvent.Receipt in watch.go for the wire
+// shape rationale).
 //
 // Predicate mapping (#449 v1, locked):
 //
@@ -108,6 +111,86 @@ func parseWatchEmitReceiptOn(raw string) (map[string]bool, error) {
 	return out, nil
 }
 
+// Rate-limit knobs for makeReceiptWarnFn. Exported as package-level
+// vars so tests can shrink them; production keeps the defaults.
+//
+// Defaults (Codex round-6 P2, #463):
+//   - first 10 warnings emit verbatim — operator sees the failure mode
+//   - after that, suppress; every 100 suppressed warnings emit a
+//     single summary line ("suppressed N since last summary")
+//
+// The intent is: the operator sees enough of the first burst to debug,
+// but a long-running watch hitting a transient cluster-read issue on
+// every poll doesn't fill stderr indefinitely.
+var (
+	watchReceiptWarnFirstN       = 10
+	watchReceiptWarnSummaryEvery = 100
+)
+
+// makeReceiptWarnFn wraps `base` with rate-limit behavior for
+// receipt-build failures. The first `firstN` warnings pass through
+// verbatim; after that the wrapper counts suppressed warnings and
+// emits a single summary line every `summaryEvery` calls.
+//
+// The counters live on the closure, so the wrapper is stateful and
+// persists across poll cycles. The watch loop constructs ONE wrapper
+// at startup and reuses it for the duration.
+//
+// A `firstN` or `summaryEvery` of <= 0 disables the rate limit
+// entirely (every call passes through).
+func makeReceiptWarnFn(base func(format string, args ...interface{}), firstN, summaryEvery int) func(format string, args ...interface{}) {
+	if base == nil {
+		return func(string, ...interface{}) {}
+	}
+	if firstN <= 0 || summaryEvery <= 0 {
+		return base
+	}
+	var count, sinceLastSummary int
+	return func(format string, args ...interface{}) {
+		count++
+		if count <= firstN {
+			base(format, args...)
+			return
+		}
+		sinceLastSummary++
+		if sinceLastSummary >= summaryEvery {
+			base(
+				"receipt-build warnings: suppressed %d additional warnings since the last summary (rate-limited to first %d + summary every %d; raise --emit-receipt-on supported set or check cluster connectivity if this is unexpected)",
+				sinceLastSummary, firstN, summaryEvery,
+			)
+			sinceLastSummary = 0
+		}
+	}
+}
+
+// unsupportedEmitReceiptTypes returns the (sorted) subset of `emitOn`
+// event types that are NOT in watchEventTypesWithReceiptSupport. The
+// watch loop calls this once at startup to emit a one-time warning so
+// users who ask for, say, `scan.finding` don't silently get no
+// receipts. Empty result = every requested type is supported.
+func unsupportedEmitReceiptTypes(emitOn map[string]bool) []string {
+	var out []string
+	for t := range emitOn {
+		if !watchEventTypesWithReceiptSupport[t] {
+			out = append(out, t)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// supportedEmitReceiptTypesSorted returns the supported event types in
+// stable alphabetical order. Used by the startup-warning message so
+// the listed set is deterministic across runs.
+func supportedEmitReceiptTypesSorted() []string {
+	out := make([]string, 0, len(watchEventTypesWithReceiptSupport))
+	for t := range watchEventTypesWithReceiptSupport {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // attachReceiptsIfRequested walks events and, for each one whose type
 // is in `emitOn` AND whose type has receipt-build support
 // (watchEventTypesWithReceiptSupport), builds a receipt and attaches
@@ -163,8 +246,10 @@ var watchBuildReceiptForEventFn = watchBuildReceiptForEvent
 // collection helpers `cub-scout receipt verify` uses
 // (DetectOwnership, AttributeFieldMutation, CollectGitSourceAnchorForOwner).
 //
-// Returns a Statement pointer (so the JSON shape is `receipt: { ... }`
-// or `receipt: null`, never an empty object).
+// Returns a Statement pointer; combined with `omitempty` on
+// watchEvent.Receipt, the wire shape is either `receipt: { ... }` (key
+// present, full Statement) or the receipt key omitted entirely (never
+// `receipt: null` and never an empty object).
 func watchBuildReceiptForEvent(
 	ctx context.Context,
 	event watchEvent,

--- a/cmd/cub-scout/watch_receipt_test.go
+++ b/cmd/cub-scout/watch_receipt_test.go
@@ -1,0 +1,234 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// --- parseWatchEmitReceiptOn ----------------------------------------
+
+func TestParseWatchEmitReceiptOn_Empty(t *testing.T) {
+	set, err := parseWatchEmitReceiptOn("")
+	if err != nil {
+		t.Fatalf("empty input should not error: %v", err)
+	}
+	if set != nil {
+		t.Errorf("empty input should disable feature (nil set); got %v", set)
+	}
+}
+
+func TestParseWatchEmitReceiptOn_All(t *testing.T) {
+	set, err := parseWatchEmitReceiptOn("all")
+	if err != nil {
+		t.Fatalf("'all' should parse: %v", err)
+	}
+	for _, want := range watchKnownEventTypes {
+		if !set[want] {
+			t.Errorf("'all' should include %q", want)
+		}
+	}
+}
+
+func TestParseWatchEmitReceiptOn_CommaList(t *testing.T) {
+	set, err := parseWatchEmitReceiptOn("drift.detected,ownership.changed")
+	if err != nil {
+		t.Fatalf("comma list should parse: %v", err)
+	}
+	if !set["drift.detected"] || !set["ownership.changed"] {
+		t.Error("expected both event types in set")
+	}
+	if set["resource.discovered"] {
+		t.Error("resource.discovered must NOT be in set")
+	}
+}
+
+func TestParseWatchEmitReceiptOn_RejectsUnknown(t *testing.T) {
+	_, err := parseWatchEmitReceiptOn("drift.detected,not-a-real-type")
+	if err == nil {
+		t.Fatal("unknown event type must be rejected")
+	}
+	if !strings.Contains(err.Error(), "not-a-real-type") {
+		t.Errorf("error must echo the bad value; got %v", err)
+	}
+}
+
+// --- attachReceiptsIfRequested --------------------------------------
+
+func TestAttachReceiptsIfRequested_DisabledNoChange(t *testing.T) {
+	events := []watchEvent{
+		{Type: "drift.detected", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+	}
+	out := attachReceiptsIfRequested(context.Background(), events, nil, nil, false, nil)
+	if len(out) != 1 || out[0].Receipt != nil {
+		t.Errorf("disabled feature should leave events untouched; got %+v", out)
+	}
+}
+
+func TestAttachReceiptsIfRequested_DriftDetectedGetsReceipt(t *testing.T) {
+	// Use the seam to inject a prefab Statement; no real BuildReceipt
+	// call needed.
+	stmt := &agent.Statement{
+		Type:          agent.StatementType,
+		PredicateType: agent.PredicateTypeReceiptV1,
+		Predicate: agent.Predicate{
+			Version: agent.PredicateVersion,
+			Verdict: agent.VerdictPASS,
+		},
+	}
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		return stmt, nil
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+
+	events := []watchEvent{
+		{Type: "drift.detected", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+	}
+	emitOn := map[string]bool{"drift.detected": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, nil)
+	if len(out) != 1 || out[0].Receipt == nil {
+		t.Fatalf("drift.detected event should get a receipt attached; got %+v", out)
+	}
+	if out[0].Receipt.Predicate.Verdict != agent.VerdictPASS {
+		t.Errorf("attached receipt verdict mismatch")
+	}
+}
+
+func TestAttachReceiptsIfRequested_UnsupportedEventTypeSkipsSilently(t *testing.T) {
+	// scan.finding is in the emitOn set but NOT in
+	// watchEventTypesWithReceiptSupport — should pass through silently
+	// (no warning, no receipt).
+	var warnings []string
+	warnFn := func(format string, args ...interface{}) {
+		warnings = append(warnings, format)
+	}
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		t.Fatal("watchBuildReceiptForEventFn must NOT be called for unsupported event types")
+		return nil, nil
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+
+	events := []watchEvent{
+		{Type: "scan.finding", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+	}
+	emitOn := map[string]bool{"scan.finding": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, warnFn)
+	if out[0].Receipt != nil {
+		t.Error("scan.finding should not get a receipt in #449 v1")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unsupported event type should pass through silently; got warnings: %v", warnings)
+	}
+}
+
+func TestAttachReceiptsIfRequested_BuildFailureNonFatal(t *testing.T) {
+	// Receipt-build returns an error; the watch event must still emit
+	// with Receipt=nil and a warning must fire.
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		return nil, &simulatedErr{msg: "transient cluster read failure"}
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+
+	var warnings []string
+	warnFn := func(format string, args ...interface{}) {
+		warnings = append(warnings, format)
+	}
+
+	events := []watchEvent{
+		{Type: "drift.detected", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+	}
+	emitOn := map[string]bool{"drift.detected": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, warnFn)
+	if len(out) != 1 {
+		t.Fatalf("event count must be preserved on build failure; got %d", len(out))
+	}
+	if out[0].Receipt != nil {
+		t.Errorf("build failure must leave Receipt=nil; got %+v", out[0].Receipt)
+	}
+	if len(warnings) != 1 {
+		t.Errorf("build failure must emit exactly one warning; got %d", len(warnings))
+	}
+}
+
+type simulatedErr struct{ msg string }
+
+func (e *simulatedErr) Error() string { return e.msg }
+
+// --- watchBuildReceiptForEvent end-to-end ----------------------------
+
+func TestWatchBuildReceiptForEvent_HappyPath(t *testing.T) {
+	// Use the loadLiveForWatchReceiptFn seam to inject a fake live
+	// resource (an Argo-owned Deployment). BuildReceipt then auto-
+	// detects applied-matches-spec; without a real Argo tracer, the
+	// receipt verdict is INCONCLUSIVE (no git anchor) — that's
+	// fine; we're testing the build path, not the verdict.
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "prod",
+				"labels": map[string]interface{}{
+					"argocd.argoproj.io/instance": "payments-api",
+				},
+			},
+		},
+	}
+	prev := loadLiveForWatchReceiptFn
+	loadLiveForWatchReceiptFn = func(_ context.Context, _ dynamic.Interface, kind, name, namespace string) (*unstructured.Unstructured, error) {
+		if kind != "Deployment" || name != "api" || namespace != "prod" {
+			t.Fatalf("unexpected lookup: %s/%s in %s", kind, name, namespace)
+		}
+		return live, nil
+	}
+	defer func() { loadLiveForWatchReceiptFn = prev }()
+
+	// Patch the *production* function (not the seam) so the test
+	// exercises the real watchBuildReceiptForEvent path. We do this by
+	// resetting watchBuildReceiptForEventFn to the production value if
+	// a prior test swapped it.
+	watchBuildReceiptForEventFn = watchBuildReceiptForEvent
+
+	event := watchEvent{
+		Type:      "drift.detected",
+		Timestamp: time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC),
+		Resource:  watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"},
+	}
+	stmt, err := watchBuildReceiptForEvent(context.Background(), event, nil, false)
+	if err != nil {
+		t.Fatalf("watchBuildReceiptForEvent: %v", err)
+	}
+	if stmt == nil {
+		t.Fatal("expected non-nil receipt")
+	}
+	if stmt.Type != agent.StatementType {
+		t.Errorf("wrong statement type: %q", stmt.Type)
+	}
+	if stmt.Predicate.Scope.Kind != "Deployment" {
+		t.Errorf("scope kind: %q", stmt.Predicate.Scope.Kind)
+	}
+	// Fingerprint must be stamped and verify.
+	if err := agent.VerifyStatementFingerprint(*stmt); err != nil {
+		t.Errorf("emitted receipt fingerprint must verify: %v", err)
+	}
+}
+
+func TestWatchBuildReceiptForEvent_MissingKindOrName_Errors(t *testing.T) {
+	event := watchEvent{Type: "drift.detected", Resource: watchEventResource{Kind: "", Name: "", Namespace: "prod"}}
+	_, err := watchBuildReceiptForEvent(context.Background(), event, nil, false)
+	if err == nil {
+		t.Fatal("missing kind/name must error")
+	}
+}

--- a/cmd/cub-scout/watch_receipt_test.go
+++ b/cmd/cub-scout/watch_receipt_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -58,6 +59,150 @@ func TestParseWatchEmitReceiptOn_RejectsUnknown(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not-a-real-type") {
 		t.Errorf("error must echo the bad value; got %v", err)
+	}
+}
+
+// --- unsupportedEmitReceiptTypes startup-warning helper -------------
+
+func TestUnsupportedEmitReceiptTypes_AllSupported(t *testing.T) {
+	emitOn := map[string]bool{
+		"drift.detected":    true,
+		"ownership.changed": true,
+	}
+	got := unsupportedEmitReceiptTypes(emitOn)
+	if len(got) != 0 {
+		t.Errorf("all-supported emit set must return empty unsupported list; got %v", got)
+	}
+}
+
+func TestUnsupportedEmitReceiptTypes_SomeUnsupported(t *testing.T) {
+	// `all` includes resource.discovered + scan.finding which v1 does
+	// not build receipts for. Codex round-6 P2: surface this gap up
+	// front so the user isn't surprised later.
+	emitOn := map[string]bool{
+		"drift.detected":      true,
+		"ownership.changed":   true,
+		"resource.discovered": true,
+		"scan.finding":        true,
+	}
+	got := unsupportedEmitReceiptTypes(emitOn)
+	wantSet := map[string]bool{
+		"resource.discovered": true,
+		"scan.finding":        true,
+	}
+	if len(got) != len(wantSet) {
+		t.Fatalf("expected %d unsupported types; got %d (%v)", len(wantSet), len(got), got)
+	}
+	for _, t2 := range got {
+		if !wantSet[t2] {
+			t.Errorf("unexpected unsupported type %q", t2)
+		}
+	}
+	// Output must be sorted for stable warning text across runs.
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Errorf("unsupportedEmitReceiptTypes must return sorted output; got %v", got)
+		}
+	}
+}
+
+func TestSupportedEmitReceiptTypesSorted_StableOrder(t *testing.T) {
+	got := supportedEmitReceiptTypesSorted()
+	if len(got) != len(watchEventTypesWithReceiptSupport) {
+		t.Errorf("must return all supported types; got %d want %d", len(got), len(watchEventTypesWithReceiptSupport))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Errorf("output must be sorted; got %v", got)
+		}
+	}
+}
+
+// --- makeReceiptWarnFn rate-limit -----------------------------------
+
+// TestMakeReceiptWarnFn_FirstNPassThrough is the Codex round-6 P2
+// (#463) regression: the first `firstN` warnings emit verbatim, after
+// which the wrapper rate-limits with periodic summaries. Verifies the
+// counts at each boundary.
+func TestMakeReceiptWarnFn_FirstNPassThrough(t *testing.T) {
+	var captured []string
+	base := func(format string, args ...interface{}) {
+		captured = append(captured, fmt.Sprintf(format, args...))
+	}
+	// firstN=3, summaryEvery=5 → first 3 pass; then suppressed until
+	// the 5th post-burst call emits a summary.
+	warn := makeReceiptWarnFn(base, 3, 5)
+
+	// First 3 — pass through.
+	for i := 0; i < 3; i++ {
+		warn("burst warn %d", i)
+	}
+	if len(captured) != 3 {
+		t.Fatalf("first 3 calls must pass through; got %d captured (%v)", len(captured), captured)
+	}
+	for i, msg := range captured {
+		want := fmt.Sprintf("burst warn %d", i)
+		if msg != want {
+			t.Errorf("captured[%d] = %q; want %q", i, msg, want)
+		}
+	}
+
+	// Next 4 — suppressed, no new output.
+	for i := 0; i < 4; i++ {
+		warn("suppressed warn %d", i)
+	}
+	if len(captured) != 3 {
+		t.Errorf("4 suppressed warnings must not add output; got %d (%v)", len(captured), captured)
+	}
+
+	// 5th suppressed warn triggers the summary (sinceLastSummary
+	// hits 5).
+	warn("summary trigger")
+	if len(captured) != 4 {
+		t.Fatalf("5th suppressed warn must emit a summary; got %d captured (%v)", len(captured), captured)
+	}
+	summary := captured[3]
+	if !strings.Contains(summary, "suppressed 5") {
+		t.Errorf("summary must report 5 suppressed; got %q", summary)
+	}
+
+	// Another 4 suppressed — no new output.
+	for i := 0; i < 4; i++ {
+		warn("post-summary suppressed %d", i)
+	}
+	if len(captured) != 4 {
+		t.Errorf("post-summary suppressed warnings must not add output; got %d", len(captured))
+	}
+
+	// 5th after summary triggers the next summary.
+	warn("next summary trigger")
+	if len(captured) != 5 {
+		t.Fatalf("next summary must fire after another `summaryEvery` suppressions; got %d", len(captured))
+	}
+	if !strings.Contains(captured[4], "suppressed 5") {
+		t.Errorf("second summary must also report 5 suppressed since last; got %q", captured[4])
+	}
+}
+
+// TestMakeReceiptWarnFn_NilBase guards against a programmer-error nil
+// base. The wrapper must no-op rather than panic.
+func TestMakeReceiptWarnFn_NilBase(t *testing.T) {
+	warn := makeReceiptWarnFn(nil, 10, 100)
+	// Should be a no-op, not a panic.
+	warn("anything")
+}
+
+// TestMakeReceiptWarnFn_DisabledRateLimit verifies that <=0 knobs
+// disable the rate limit (every call passes through).
+func TestMakeReceiptWarnFn_DisabledRateLimit(t *testing.T) {
+	var captured int
+	base := func(string, ...interface{}) { captured++ }
+	warn := makeReceiptWarnFn(base, 0, 100)
+	for i := 0; i < 50; i++ {
+		warn("warn %d", i)
+	}
+	if captured != 50 {
+		t.Errorf("firstN<=0 must disable rate limit; got %d, want 50", captured)
 	}
 }
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -836,7 +836,7 @@ At least one destination is required: `--webhook` and/or `--output-file`.
 | `--severity` | Finding severity filter (`critical,warning,info`) |
 | `--once` | Run one collection cycle and exit |
 | `--max-queued-events` | Max buffered events while webhook is unreachable |
-| `--emit-receipt-on` | Comma-separated watch event types to attach a `cub-scout receipt` to (`drift.detected`, `ownership.changed`, or sugar `all`). Receipt-build failures are non-fatal: the watch event still emits with `receipt: null` and a stderr warning. (#449 v1: only `drift.detected` and `ownership.changed` actually build a receipt; other types pass through silently.) |
+| `--emit-receipt-on` | Comma-separated watch event types to attach a `cub-scout receipt` to (`drift.detected`, `ownership.changed`, or sugar `all`). Receipt-build failures are non-fatal: the watch event still emits but the JSON `receipt` key is **omitted** (the field uses `omitempty`; consumers should check key presence, not null-ness), with a stderr warning. (#449 v1: only `drift.detected` and `ownership.changed` actually build a receipt; other types pass through silently.) |
 
 ### Event Types
 
@@ -2448,9 +2448,11 @@ envelope. CI/CD gates, audit trails, postmortems, and acceptance-judge
 tooling can attach a receipt to a decision and later prove the inputs
 were what they claim to be.
 
-v1 ships fingerprint-only (SHA-256 over RFC 8785 canonical JSON of the
-full Statement minus only `predicate.fingerprint`). v2 adds DSSE signing
-wrapped in Sigstore Bundle v0.3 — purely additive, no envelope change.
+Current shipping releases use fingerprint-only integrity (SHA-256 over
+RFC 8785 canonical JSON of the full Statement minus only
+`predicate.fingerprint`). Cryptographic signing (e.g., DSSE wrapped in a
+Sigstore Bundle, or a comparable scheme) is a future hardening direction —
+purely additive to the wire format, no envelope change required.
 
 ### receipt verify
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -836,6 +836,7 @@ At least one destination is required: `--webhook` and/or `--output-file`.
 | `--severity` | Finding severity filter (`critical,warning,info`) |
 | `--once` | Run one collection cycle and exit |
 | `--max-queued-events` | Max buffered events while webhook is unreachable |
+| `--emit-receipt-on` | Comma-separated watch event types to attach a `cub-scout receipt` to (`drift.detected`, `ownership.changed`, or sugar `all`). Receipt-build failures are non-fatal: the watch event still emits with `receipt: null` and a stderr warning. (#449 v1: only `drift.detected` and `ownership.changed` actually build a receipt; other types pass through silently.) |
 
 ### Event Types
 
@@ -2466,6 +2467,8 @@ cub-scout receipt verify <kind>/<name> -n <namespace> [flags]
 | `--since` | RFC 3339 cutoff timestamp for `no-manual-edits-since` (e.g. `2026-05-22T00:00:00Z`). |
 | `--format` | Output format: `ascii` (default, one-screen human summary) or `json` (canonical in-toto Statement v1 envelope) |
 | `--out` | Write the receipt to this file path. Always JSON regardless of `--format` — disk is the long-lived artifact. **Overwrites existing files** (this is the non-immutable, ad-hoc-path contract). Paths under the resolved receipt store are **rejected** — use `--save` for store writes (which are immutable; see below). |
+| `--fail-on` | (v2 `#451`) Exit non-zero (code 2) when the receipt verdict matches. Accepts a comma-separated list of verdicts (`WATCH`, `BLOCK`, `INCONCLUSIVE`) or the sugar `any-non-pass` (= `WATCH,BLOCK,INCONCLUSIVE`). The receipt is still printed / saved / written to `--out` regardless of exit code. `--fail-on PASS` is rejected upfront. |
+| `--input-attestation` | (v2 `#448`) Path to a prior receipt to reference via `predicate.inputAttestations[]` (repeatable for chains). Each referenced receipt's fingerprint is verified at chain-construction time; tampered receipts are refused. The new receipt's fingerprint covers the `inputAttestations[]` field by construction. |
 
 v1 predicates:
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -600,10 +600,12 @@ Source: `pkg/agent/event_timeline.go`, `internal/mapsvc/jsonout.go`
 
 The receipt surface emits typed, fingerprinted, immutable evidence artifacts
 wrapping cub-scout's existing field-level evidence (compareThreeWay,
-attribution, sourceTruth, gitSource) into a verifiable record. v1 ships
-fingerprint-only (SHA-256 over RFC 8785 canonical JSON of the full in-toto
-Statement v1 envelope minus only `predicate.fingerprint`). v2 will add DSSE
-signing wrapped in Sigstore Bundle v0.3 — purely additive, no envelope change.
+attribution, sourceTruth, gitSource) into a verifiable record. Current
+shipping releases use fingerprint-only integrity (SHA-256 over RFC 8785
+canonical JSON of the full in-toto Statement v1 envelope minus only
+`predicate.fingerprint`). Cryptographic signing (e.g., DSSE wrapped in a
+Sigstore Bundle, or a comparable scheme) is a future hardening direction —
+purely additive to the wire format, no envelope change required.
 
 Receipts are **historical, immutable records** of past events. Updates produce
 new receipts, never mutate old ones. cub-scout never mutates the cluster or
@@ -925,7 +927,18 @@ The flag is **lenient on type, strict on receipt-build**: unsupported event
 types pass through without a warning (so `--emit-receipt-on all` is
 forward-compatible as new event types land). Build failures on
 supported types emit a stderr warning and continue — the underlying
-watch event still emits with `receipt: null`.
+watch event still emits, but with the `receipt` key **omitted** from
+the JSON (the field uses `omitempty`; consumers should check for key
+presence rather than null-ness):
+
+```python
+# correct
+if "receipt" in event:
+    process(event["receipt"])
+
+# incorrect — `event["receipt"]` raises KeyError when receipt-build
+# was skipped or failed
+```
 
 Sample JSONL line with a receipt:
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -838,7 +838,112 @@ stderr, exit 0, the on-disk artifact unchanged.
 
 Sort order: `verifiedAt` descending (newest first).
 
-Source: `pkg/agent/receipt*.go`, `cmd/cub-scout/receipt*.go`. See
+### v2 Extensions
+
+The v1 envelope locks `inputAttestations[]`, the verdict enum, and the
+receipt store. v2 layers three CI/agent-shaped extensions on top
+without changing the wire format.
+
+#### `--fail-on <verdict-list>` on `cub-scout receipt verify` (`#451`)
+
+Exit non-zero (code 2) when the receipt's verdict matches one of the
+listed values. The receipt is still printed / saved / written to
+`--out` — the gate fires AFTER the artifact is durable.
+
+Accepted values:
+
+- `WATCH`, `BLOCK`, `INCONCLUSIVE` — exact match (comma-separated for multiple)
+- `any-non-pass` — sugar for `WATCH,BLOCK,INCONCLUSIVE`
+- `PASS` — rejected upfront (gating on a passing receipt is a no-op; treated as a workflow bug)
+
+Exit codes:
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Verdict is PASS, or verdict not in the fail-on set |
+| `2` | Verdict matches the fail-on set (CI gate fired) |
+| `1` | Operational error (bad flag value, cluster unreachable, etc.) — same as everything else |
+
+Implementation: `cmd/cub-scout/receipt.go` `parseReceiptFailOn` +
+`exitCodeError` from `cmd/cub-scout/exit_code.go`.
+
+#### `--input-attestation <path>` chained receipts (`#448` chained half)
+
+A new receipt can reference prior receipts via `predicate.inputAttestations[]`
+for chain / DAG semantics. Each `--input-attestation <path>` flag
+(repeatable) loads a prior receipt, recomputes its fingerprint, and
+attaches an `AttestationRef` to the new receipt's `inputAttestations[]`.
+
+```json
+"inputAttestations": [
+  {
+    "uri": "cub-scout-receipt://abc123def456",
+    "digest": {
+      "sha256": "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+    }
+  }
+]
+```
+
+URI scheme: `cub-scout-receipt://<short-fingerprint>` where the short
+form is the first 12 hex chars after the `sha256:` prefix. The full
+SHA-256 is in the `digest.sha256` field — that's what's cryptographically
+meaningful; the URI is a readable label.
+
+**Integrity check at chain-construction time:** `BuildAttestationRef`
+calls `VerifyStatementFingerprint` on the referenced receipt and
+**refuses** to chain a tampered receipt. The downstream receipt's
+fingerprint covers the `inputAttestations[]` field by construction, so
+tampering an upstream digest invalidates the downstream fingerprint too.
+
+The aggregate-with-discovery half of `#448` (`--scope namespace/<ns>`
+emits N per-resource receipts + 1 aggregate via
+`synthetic-aggregate://` subject) is a separate follow-up PR; this v2
+ships only the explicit-construction half (`--input-attestation`).
+
+Implementation: `pkg/agent/receipt_inputattestations.go`
+(`BuildAttestationRef`, `BuildAttestationRefsFromPaths`,
+`AttestationURIScheme`); `cmd/cub-scout/receipt.go` flag plumbing.
+
+#### `watch --emit-receipt-on <event-types>` (`#449`)
+
+`cub-scout watch` accepts a new flag that attaches a receipt to each
+matching event payload inline. The watch event shape gains an optional
+`receipt` field carrying the full in-toto Statement.
+
+Event-type set (v1 of this flag):
+
+| Event type | Receipt-build? | Notes |
+|------------|---------------|-------|
+| `drift.detected` | Yes — `applied-matches-spec` auto-detected | Highest signal: drift event already implies a verdict question |
+| `ownership.changed` | Yes — `applied-matches-spec` auto-detected | Owner shifts often indicate a delivery-chain change worth attesting |
+| `resource.discovered` | No (passes through silently) | Would flood on first poll; deferred to future iterations |
+| `scan.finding` | No (passes through silently) | Would flood on initial scan burst; deferred |
+| `all` | Sugar — accepts every known event type, but the build set is the supported subset above |
+
+The flag is **lenient on type, strict on receipt-build**: unsupported event
+types pass through without a warning (so `--emit-receipt-on all` is
+forward-compatible as new event types land). Build failures on
+supported types emit a stderr warning and continue — the underlying
+watch event still emits with `receipt: null`.
+
+Sample JSONL line with a receipt:
+
+```json
+{"type":"drift.detected","timestamp":"2026-05-22T10:30:00Z","resource":{"kind":"Deployment","name":"api","namespace":"prod"},"owner":{"type":"argo","name":"payments-api"},"severity":"warning","details":{"category":"DRIFT"},"receipt":{"_type":"https://in-toto.io/Statement/v1","subject":[...],"predicateType":"https://cub-scout.dev/receipt/v1","predicate":{...}}}
+```
+
+Implementation: `cmd/cub-scout/watch.go` (flag init + per-event
+attachment loop) + `cmd/cub-scout/watch_receipt.go` (the
+`parseWatchEmitReceiptOn` / `attachReceiptsIfRequested` /
+`watchBuildReceiptForEvent` helpers).
+
+Backpressure / batching for high-frequency events is deferred — the
+issue's open question 3 is a v2-of-this-feature concern, not a v1
+gate.
+
+Source: `pkg/agent/receipt*.go`, `cmd/cub-scout/receipt*.go`,
+`cmd/cub-scout/watch*.go`. See
 `docs/proposals/receipts-way-forward.md` for the full design synthesis and
 the Codex review rounds that locked the wire format.
 

--- a/pkg/agent/receipt_build.go
+++ b/pkg/agent/receipt_build.go
@@ -84,17 +84,25 @@ type BuildReceiptInput struct {
 	// v2 lets callers attach explicit references via --input-attestation
 	// (the CLI path) or programmatically (the agent-API path).
 	//
+	// The field type is `[]VerifiedAttestationRef` rather than the raw
+	// `[]AttestationRef` wire shape: external callers cannot construct a
+	// VerifiedAttestationRef directly (the type's only field is
+	// unexported), so they MUST go through BuildAttestationRef or
+	// BuildAttestationRefsFromPaths — both of which verify the source
+	// Statement's fingerprint before returning. This enforces the
+	// chained-receipt trust property at the API boundary, not just on
+	// the CLI path (#463 / Codex round-6 P1 #463-B).
+	//
 	// Construction primitives live in receipt_inputattestations.go:
-	// BuildAttestationRef (single Statement → AttestationRef) and
+	// BuildAttestationRef (single Statement → VerifiedAttestationRef) and
 	// BuildAttestationRefsFromPaths (file paths → loaded statements →
-	// refs). The construction step verifies each referenced receipt's
-	// fingerprint before chaining.
+	// verified refs).
 	//
 	// BuildReceipt always emits an explicit JSON array — empty when no
 	// refs are attached, non-empty when they are. The full Statement's
 	// canonical JSON (and therefore its fingerprint) covers this field
 	// by construction.
-	InputAttestations []AttestationRef
+	InputAttestations []VerifiedAttestationRef
 }
 
 // BuildReceipt orchestrates: build subjects → resolve predicate →
@@ -207,14 +215,23 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 
 	// 7. Build the predicate body.
 	//
-	// InputAttestations: forwarded from BuildReceiptInput verbatim
-	// (defaults to an empty slice when the caller didn't attach any).
+	// InputAttestations: unwrap each VerifiedAttestationRef into its
+	// underlying AttestationRef for the wire shape. Reject zero-valued
+	// wrappers at the API boundary — the only way to obtain a non-zero
+	// VerifiedAttestationRef is via BuildAttestationRef (which verifies
+	// the source Statement's fingerprint), so a zero value is a forgery
+	// attempt and must not enter the chain. See #463 / Codex round-6
+	// P1 #463-B.
+	//
 	// Always serialize as a JSON array, never null — the receipt
 	// contract guarantees consumers can iterate the field without a
 	// nil-check. v2 #448 wires non-empty values through this path.
-	inputAttestations := in.InputAttestations
-	if inputAttestations == nil {
-		inputAttestations = []AttestationRef{}
+	inputAttestations := make([]AttestationRef, 0, len(in.InputAttestations))
+	for i, v := range in.InputAttestations {
+		if v.IsZero() {
+			return Statement{}, fmt.Errorf("build-receipt: inputAttestations[%d] is a zero-value VerifiedAttestationRef; construct via BuildAttestationRef or BuildAttestationRefsFromPaths so the source receipt's fingerprint is verified before chaining", i)
+		}
+		inputAttestations = append(inputAttestations, v.Ref())
 	}
 	pred := Predicate{
 		Version:           PredicateVersion,

--- a/pkg/agent/receipt_build.go
+++ b/pkg/agent/receipt_build.go
@@ -78,6 +78,23 @@ type BuildReceiptInput struct {
 	// --since). Zero means "not provided"; the predicate then declines
 	// with OmissionSinceMissing.
 	Since time.Time
+
+	// InputAttestations references prior receipts by digest, forming a
+	// chain or DAG of evidence artifacts (#448). v1 always emitted [];
+	// v2 lets callers attach explicit references via --input-attestation
+	// (the CLI path) or programmatically (the agent-API path).
+	//
+	// Construction primitives live in receipt_inputattestations.go:
+	// BuildAttestationRef (single Statement → AttestationRef) and
+	// BuildAttestationRefsFromPaths (file paths → loaded statements →
+	// refs). The construction step verifies each referenced receipt's
+	// fingerprint before chaining.
+	//
+	// BuildReceipt always emits an explicit JSON array — empty when no
+	// refs are attached, non-empty when they are. The full Statement's
+	// canonical JSON (and therefore its fingerprint) covers this field
+	// by construction.
+	InputAttestations []AttestationRef
 }
 
 // BuildReceipt orchestrates: build subjects → resolve predicate →
@@ -189,6 +206,16 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 	}
 
 	// 7. Build the predicate body.
+	//
+	// InputAttestations: forwarded from BuildReceiptInput verbatim
+	// (defaults to an empty slice when the caller didn't attach any).
+	// Always serialize as a JSON array, never null — the receipt
+	// contract guarantees consumers can iterate the field without a
+	// nil-check. v2 #448 wires non-empty values through this path.
+	inputAttestations := in.InputAttestations
+	if inputAttestations == nil {
+		inputAttestations = []AttestationRef{}
+	}
 	pred := Predicate{
 		Version:           PredicateVersion,
 		Claim:             claim,
@@ -200,7 +227,7 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 		Verdict:           result.Verdict,
 		Evidence:          in.Evidence,
 		Omissions:         omissions,
-		InputAttestations: []AttestationRef{}, // v1 emits []
+		InputAttestations: inputAttestations,
 		NextSteps:         filteredSteps,
 	}
 

--- a/pkg/agent/receipt_inputattestations.go
+++ b/pkg/agent/receipt_inputattestations.go
@@ -1,0 +1,131 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// receipt_inputattestations.go — helpers for the chained-receipts half
+// of #446 v2 (#448). A receipt can reference earlier receipts by digest
+// via the `predicate.inputAttestations[]` field, forming a chain or DAG
+// of evidence artifacts.
+//
+// This file implements the CONSTRUCTION primitives — turning a loaded
+// receipt into an AttestationRef the caller can attach to a new
+// BuildReceiptInput. The full aggregate flow (auto-discovery across
+// namespace / cluster + verdict synthesis + synthetic-aggregate://
+// subject construction) is the second half of #448 and will land in a
+// follow-up PR.
+//
+// URI scheme
+// ----------
+//
+// The `AttestationRef.URI` for a receipt-to-receipt reference uses the
+// scheme `cub-scout-receipt://<short-fingerprint>` where short-fingerprint
+// is the first 12 hex chars after the `sha256:` prefix of the
+// referenced receipt's fingerprint. The short form keeps the URI
+// readable in JSON output; the full integrity check lives in the
+// `digest` field on AttestationRef itself (which carries the complete
+// SHA-256). This is symmetric with how the local store's canonical
+// filename works (see `pkg/agent/receipt_store.go` DeriveFilename).
+//
+// Verification semantics
+// ----------------------
+//
+// `BuildAttestationRef` always verifies the referenced receipt's
+// fingerprint by recomputing it from the in-memory Statement. This
+// catches corruption and tampering at chain-construction time —
+// downstream consumers can re-verify each `inputAttestations[]` entry
+// by loading the referenced receipt (the URI is just a label; the
+// digest is what's actually cryptographically meaningful).
+//
+// A future Codex review may want to also verify the chain at *load*
+// time (i.e., when reading an aggregate receipt, walk every input
+// attestation and confirm the digests match). That's a separate
+// helper; this file is only about construction.
+
+// AttestationURIScheme is the URI prefix this package uses for
+// receipt-to-receipt references. Format:
+//
+//	cub-scout-receipt://<short-fingerprint>
+//
+// The short fingerprint is the first 12 hex chars after the `sha256:`
+// prefix. Symmetric with `DeriveFilename`.
+const AttestationURIScheme = "cub-scout-receipt://"
+
+// BuildAttestationRef turns a loaded Statement into an AttestationRef
+// suitable for the `inputAttestations[]` field of another receipt.
+//
+// The returned AttestationRef carries:
+//   - URI: cub-scout-receipt://<short-fingerprint>
+//   - Digest: { "sha256": "<full hex without sha256: prefix>" }
+//
+// The function verifies the referenced statement's fingerprint
+// (recomputes via VerifyStatementFingerprint) before returning. If the
+// recomputed digest doesn't match the stamped one, the function
+// returns an error — the caller should NOT silently chain a tampered
+// receipt.
+//
+// Errors:
+//   - stmt has empty Predicate.Fingerprint
+//   - stmt.Predicate.Fingerprint is malformed (no sha256: prefix)
+//   - VerifyStatementFingerprint fails (the in-memory Statement does
+//     not match its stamped fingerprint)
+func BuildAttestationRef(stmt Statement) (AttestationRef, error) {
+	fp := strings.TrimSpace(stmt.Predicate.Fingerprint)
+	if fp == "" {
+		return AttestationRef{}, fmt.Errorf("build-attestation-ref: statement has empty fingerprint; cannot chain an unstamped receipt")
+	}
+	if !strings.HasPrefix(fp, "sha256:") {
+		return AttestationRef{}, fmt.Errorf("build-attestation-ref: malformed fingerprint %q (expected sha256:<hex>)", fp)
+	}
+	hex := strings.TrimPrefix(fp, "sha256:")
+	if len(hex) < 12 {
+		return AttestationRef{}, fmt.Errorf("build-attestation-ref: fingerprint hex %q is shorter than 12 chars", hex)
+	}
+
+	// Verify the referenced receipt's integrity before chaining it.
+	// Silently chaining a tampered receipt would break the chain's
+	// trust property — the consumer of an aggregate / chained receipt
+	// expects every reference to be a real attestation, not a forgery.
+	if err := VerifyStatementFingerprint(stmt); err != nil {
+		return AttestationRef{}, fmt.Errorf("build-attestation-ref: refusing to chain a receipt whose fingerprint doesn't verify: %w", err)
+	}
+
+	return AttestationRef{
+		URI: AttestationURIScheme + hex[:12],
+		Digest: map[string]string{
+			"sha256": hex,
+		},
+	}, nil
+}
+
+// BuildAttestationRefsFromPaths is a convenience helper for the CLI
+// path: take a list of receipt file paths, load each, build the
+// AttestationRef, and return the slice. Errors at any step short-
+// circuit — there is no "partial chain" semantics (chaining is an
+// integrity claim; partial is not the right shape).
+//
+// The loader is injected as `loadFn` so tests can swap in a fake
+// without touching the filesystem.
+func BuildAttestationRefsFromPaths(paths []string, loadFn func(path string) (Statement, error)) ([]AttestationRef, error) {
+	if loadFn == nil {
+		loadFn = LoadStatement
+	}
+	out := make([]AttestationRef, 0, len(paths))
+	for _, p := range paths {
+		stmt, err := loadFn(p)
+		if err != nil {
+			return nil, fmt.Errorf("load input-attestation %s: %w", p, err)
+		}
+		ref, err := BuildAttestationRef(stmt)
+		if err != nil {
+			return nil, fmt.Errorf("build input-attestation from %s: %w", p, err)
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}

--- a/pkg/agent/receipt_inputattestations.go
+++ b/pkg/agent/receipt_inputattestations.go
@@ -46,6 +46,19 @@ import (
 // time (i.e., when reading an aggregate receipt, walk every input
 // attestation and confirm the digests match). That's a separate
 // helper; this file is only about construction.
+//
+// API-boundary enforcement (#463 / Codex round-6 P1 #463-B)
+// ---------------------------------------------------------
+//
+// `VerifiedAttestationRef` is a typed wrapper around `AttestationRef`
+// with only unexported fields. External callers cannot construct one
+// directly — they MUST go through `BuildAttestationRef` or
+// `BuildAttestationRefsFromPaths`, both of which verify the source
+// Statement's fingerprint before producing a wrapper. BuildReceipt
+// accepts `[]VerifiedAttestationRef` and rejects zero-valued wrappers
+// at the boundary, so a programmatic caller cannot forge a raw ref and
+// bypass the verify step. The wire shape (Predicate.InputAttestations
+// is still []AttestationRef) is unchanged.
 
 // AttestationURIScheme is the URI prefix this package uses for
 // receipt-to-receipt references. Format:
@@ -56,10 +69,50 @@ import (
 // prefix. Symmetric with `DeriveFilename`.
 const AttestationURIScheme = "cub-scout-receipt://"
 
-// BuildAttestationRef turns a loaded Statement into an AttestationRef
-// suitable for the `inputAttestations[]` field of another receipt.
+// VerifiedAttestationRef wraps an AttestationRef whose source Statement
+// was verified at construction time. Only `BuildAttestationRef` and
+// `BuildAttestationRefsFromPaths` produce values of this type; both
+// recompute and verify the source Statement's fingerprint before
+// returning. The zero value is invalid and `BuildReceipt` rejects it.
 //
-// The returned AttestationRef carries:
+// This type enforces the chained-receipt trust property at the API
+// boundary: a programmatic caller of `BuildReceipt` CANNOT construct a
+// raw `AttestationRef`, hand-pick a digest, and have BuildReceipt
+// accept it. The only path into the chain is through the verify-and-
+// wrap helpers below. See #463 / Codex round-6 P1 #463-B for the
+// rationale.
+//
+// The wire shape is unchanged: BuildReceipt unwraps each
+// VerifiedAttestationRef back to a plain AttestationRef when it
+// populates Predicate.InputAttestations, so the serialized receipt
+// looks exactly the same as the v1 spec.
+type VerifiedAttestationRef struct {
+	// ref is the plain AttestationRef that will be serialized. It is
+	// unexported so external packages cannot populate it — they must
+	// call BuildAttestationRef (which sets it after a verify step).
+	ref AttestationRef
+}
+
+// Ref returns the underlying AttestationRef. Provided for inspection
+// and debugging; the typical caller passes the wrapper directly to
+// BuildReceipt and never needs this.
+func (v VerifiedAttestationRef) Ref() AttestationRef {
+	return v.ref
+}
+
+// IsZero reports whether the wrapper is the zero value (the only way
+// external code could obtain a VerifiedAttestationRef without going
+// through BuildAttestationRef). BuildReceipt calls this to reject
+// forged wrappers at the API boundary.
+func (v VerifiedAttestationRef) IsZero() bool {
+	return v.ref.URI == "" || v.ref.Digest["sha256"] == ""
+}
+
+// BuildAttestationRef turns a loaded Statement into a
+// VerifiedAttestationRef suitable for the `InputAttestations` field of
+// BuildReceiptInput.
+//
+// The wrapped AttestationRef carries:
 //   - URI: cub-scout-receipt://<short-fingerprint>
 //   - Digest: { "sha256": "<full hex without sha256: prefix>" }
 //
@@ -74,17 +127,17 @@ const AttestationURIScheme = "cub-scout-receipt://"
 //   - stmt.Predicate.Fingerprint is malformed (no sha256: prefix)
 //   - VerifyStatementFingerprint fails (the in-memory Statement does
 //     not match its stamped fingerprint)
-func BuildAttestationRef(stmt Statement) (AttestationRef, error) {
+func BuildAttestationRef(stmt Statement) (VerifiedAttestationRef, error) {
 	fp := strings.TrimSpace(stmt.Predicate.Fingerprint)
 	if fp == "" {
-		return AttestationRef{}, fmt.Errorf("build-attestation-ref: statement has empty fingerprint; cannot chain an unstamped receipt")
+		return VerifiedAttestationRef{}, fmt.Errorf("build-attestation-ref: statement has empty fingerprint; cannot chain an unstamped receipt")
 	}
 	if !strings.HasPrefix(fp, "sha256:") {
-		return AttestationRef{}, fmt.Errorf("build-attestation-ref: malformed fingerprint %q (expected sha256:<hex>)", fp)
+		return VerifiedAttestationRef{}, fmt.Errorf("build-attestation-ref: malformed fingerprint %q (expected sha256:<hex>)", fp)
 	}
 	hex := strings.TrimPrefix(fp, "sha256:")
 	if len(hex) < 12 {
-		return AttestationRef{}, fmt.Errorf("build-attestation-ref: fingerprint hex %q is shorter than 12 chars", hex)
+		return VerifiedAttestationRef{}, fmt.Errorf("build-attestation-ref: fingerprint hex %q is shorter than 12 chars", hex)
 	}
 
 	// Verify the referenced receipt's integrity before chaining it.
@@ -92,30 +145,32 @@ func BuildAttestationRef(stmt Statement) (AttestationRef, error) {
 	// trust property — the consumer of an aggregate / chained receipt
 	// expects every reference to be a real attestation, not a forgery.
 	if err := VerifyStatementFingerprint(stmt); err != nil {
-		return AttestationRef{}, fmt.Errorf("build-attestation-ref: refusing to chain a receipt whose fingerprint doesn't verify: %w", err)
+		return VerifiedAttestationRef{}, fmt.Errorf("build-attestation-ref: refusing to chain a receipt whose fingerprint doesn't verify: %w", err)
 	}
 
-	return AttestationRef{
-		URI: AttestationURIScheme + hex[:12],
-		Digest: map[string]string{
-			"sha256": hex,
+	return VerifiedAttestationRef{
+		ref: AttestationRef{
+			URI: AttestationURIScheme + hex[:12],
+			Digest: map[string]string{
+				"sha256": hex,
+			},
 		},
 	}, nil
 }
 
 // BuildAttestationRefsFromPaths is a convenience helper for the CLI
 // path: take a list of receipt file paths, load each, build the
-// AttestationRef, and return the slice. Errors at any step short-
-// circuit — there is no "partial chain" semantics (chaining is an
-// integrity claim; partial is not the right shape).
+// VerifiedAttestationRef, and return the slice. Errors at any step
+// short-circuit — there is no "partial chain" semantics (chaining is
+// an integrity claim; partial is not the right shape).
 //
 // The loader is injected as `loadFn` so tests can swap in a fake
 // without touching the filesystem.
-func BuildAttestationRefsFromPaths(paths []string, loadFn func(path string) (Statement, error)) ([]AttestationRef, error) {
+func BuildAttestationRefsFromPaths(paths []string, loadFn func(path string) (Statement, error)) ([]VerifiedAttestationRef, error) {
 	if loadFn == nil {
 		loadFn = LoadStatement
 	}
-	out := make([]AttestationRef, 0, len(paths))
+	out := make([]VerifiedAttestationRef, 0, len(paths))
 	for _, p := range paths {
 		stmt, err := loadFn(p)
 		if err != nil {

--- a/pkg/agent/receipt_inputattestations_test.go
+++ b/pkg/agent/receipt_inputattestations_test.go
@@ -74,15 +74,16 @@ func TestBuildAttestationRef_HappyPath(t *testing.T) {
 		t.Fatalf("BuildAttestationRef: %v", err)
 	}
 
-	if !strings.HasPrefix(ref.URI, AttestationURIScheme) {
-		t.Errorf("URI must start with %q; got %q", AttestationURIScheme, ref.URI)
+	raw := ref.Ref()
+	if !strings.HasPrefix(raw.URI, AttestationURIScheme) {
+		t.Errorf("URI must start with %q; got %q", AttestationURIScheme, raw.URI)
 	}
 	hex := strings.TrimPrefix(stmt.Predicate.Fingerprint, "sha256:")
-	if !strings.HasSuffix(ref.URI, hex[:12]) {
-		t.Errorf("URI must end with the 12-char short fingerprint %q; got %q", hex[:12], ref.URI)
+	if !strings.HasSuffix(raw.URI, hex[:12]) {
+		t.Errorf("URI must end with the 12-char short fingerprint %q; got %q", hex[:12], raw.URI)
 	}
-	if ref.Digest["sha256"] != hex {
-		t.Errorf("Digest sha256 must equal full hex %q; got %q", hex, ref.Digest["sha256"])
+	if raw.Digest["sha256"] != hex {
+		t.Errorf("Digest sha256 must equal full hex %q; got %q", hex, raw.Digest["sha256"])
 	}
 }
 
@@ -158,8 +159,8 @@ func TestBuildAttestationRefsFromPaths_HappyPath(t *testing.T) {
 	if len(refs) != 2 {
 		t.Fatalf("expected 2 refs; got %d", len(refs))
 	}
-	if refs[0].Digest["sha256"] == refs[1].Digest["sha256"] {
-		t.Errorf("two different statements must produce different digests; both = %q", refs[0].Digest["sha256"])
+	if refs[0].Ref().Digest["sha256"] == refs[1].Ref().Digest["sha256"] {
+		t.Errorf("two different statements must produce different digests; both = %q", refs[0].Ref().Digest["sha256"])
 	}
 }
 
@@ -218,7 +219,7 @@ func TestBuildReceipt_InputAttestationsAttached(t *testing.T) {
 		Scope:             Scope{Kind: "Deployment", Name: "worker", Namespace: "prod"},
 		Owner:             Ownership{Type: OwnerUnknown},
 		PredicateName:     "",
-		InputAttestations: []AttestationRef{upstreamRef},
+		InputAttestations: []VerifiedAttestationRef{upstreamRef},
 		Verifier:          Verifier{Tool: "cub-scout", Version: "v0.0.0-test"},
 		VerifiedAt:        time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC),
 	})
@@ -228,9 +229,9 @@ func TestBuildReceipt_InputAttestationsAttached(t *testing.T) {
 	if len(downstream.Predicate.InputAttestations) != 1 {
 		t.Fatalf("downstream should reference 1 attestation; got %d", len(downstream.Predicate.InputAttestations))
 	}
-	if downstream.Predicate.InputAttestations[0].Digest["sha256"] != upstreamRef.Digest["sha256"] {
+	if downstream.Predicate.InputAttestations[0].Digest["sha256"] != upstreamRef.Ref().Digest["sha256"] {
 		t.Errorf("downstream attestation digest must match upstream; got %q vs %q",
-			downstream.Predicate.InputAttestations[0].Digest["sha256"], upstreamRef.Digest["sha256"])
+			downstream.Predicate.InputAttestations[0].Digest["sha256"], upstreamRef.Ref().Digest["sha256"])
 	}
 
 	// The downstream's fingerprint MUST cover the inputAttestations[]
@@ -244,6 +245,42 @@ func TestBuildReceipt_InputAttestationsAttached(t *testing.T) {
 	}
 	if recomputed == downstream.Predicate.Fingerprint {
 		t.Error("stripping inputAttestations[] must change the recomputed fingerprint; the field is supposed to be covered")
+	}
+}
+
+// TestBuildReceipt_RejectsZeroValueVerifiedAttestationRef is the
+// regression for the #463 / Codex round-6 P1 #463-B fix: programmatic
+// callers who skip BuildAttestationRef and construct a zero-value
+// VerifiedAttestationRef (the only thing they CAN do from outside the
+// package, since the inner field is unexported) must be rejected at
+// the BuildReceipt boundary. A silent acceptance would let a hostile
+// caller forge an empty input-attestation entry into the chain.
+//
+// The zero value is the entire forgeable surface: external packages
+// cannot mint a non-zero VerifiedAttestationRef without going through
+// BuildAttestationRef (the inner `ref` field is unexported, so even
+// reflection-via-package-export can't reach it without unsafe).
+func TestBuildReceipt_RejectsZeroValueVerifiedAttestationRef(t *testing.T) {
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "api", "namespace": "prod"},
+		},
+	}
+	_, err := BuildReceipt(BuildReceiptInput{
+		Live:              live,
+		Scope:             Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Owner:             Ownership{Type: OwnerUnknown},
+		InputAttestations: []VerifiedAttestationRef{{}}, // forged zero value
+		Verifier:          Verifier{Tool: "cub-scout", Version: "v0.0.0-test"},
+		VerifiedAt:        time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("zero-value VerifiedAttestationRef must be rejected; the only way to obtain a non-zero one is via BuildAttestationRef (which verifies fingerprint)")
+	}
+	if !strings.Contains(err.Error(), "zero-value VerifiedAttestationRef") {
+		t.Errorf("error must name the API-boundary check; got %v", err)
 	}
 }
 

--- a/pkg/agent/receipt_inputattestations_test.go
+++ b/pkg/agent/receipt_inputattestations_test.go
@@ -1,0 +1,278 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// buildSampleReceipt produces a real, fingerprint-stamped Statement for
+// the input-attestation tests. The Statement is what would come out of
+// `cub-scout receipt verify` for an Argo-owned Deployment with a
+// resolved git anchor.
+func buildSampleReceipt(t *testing.T) Statement {
+	t.Helper()
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "api",
+				"namespace": "prod",
+			},
+			"spec": map[string]interface{}{"replicas": int64(3)},
+		},
+	}
+	stmt, err := BuildReceipt(BuildReceiptInput{
+		Live: live,
+		Scope: Scope{
+			Kind:      "Deployment",
+			Name:      "api",
+			Namespace: "prod",
+		},
+		Owner:         Ownership{Type: OwnerArgo, SubType: "application"},
+		PredicateName: PredicateAppliedMatchesSpec,
+		Spec: &SpecAnchor{
+			Anchor: SpecAnchorBody{
+				Type:     "git",
+				RepoURL:  "https://github.com/org/repo",
+				Revision: "abc123def456",
+				Path:     "apps/prod/api",
+			},
+		},
+		Evidence: Evidence{
+			Attribution: &FieldMutationAttribution{
+				Cause:       CauseControllerDrift,
+				ManagerHint: "argocd-controller",
+			},
+			GitSource: &GitSourceAnchor{
+				RepoURL:  "https://github.com/org/repo",
+				Revision: "abc123def456",
+				Path:     "apps/prod/api",
+			},
+		},
+		Verifier:   Verifier{Tool: "cub-scout", Version: "v0.0.0-test"},
+		VerifiedAt: time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("buildSampleReceipt: %v", err)
+	}
+	return stmt
+}
+
+// --- BuildAttestationRef --------------------------------------------
+
+func TestBuildAttestationRef_HappyPath(t *testing.T) {
+	stmt := buildSampleReceipt(t)
+	ref, err := BuildAttestationRef(stmt)
+	if err != nil {
+		t.Fatalf("BuildAttestationRef: %v", err)
+	}
+
+	if !strings.HasPrefix(ref.URI, AttestationURIScheme) {
+		t.Errorf("URI must start with %q; got %q", AttestationURIScheme, ref.URI)
+	}
+	hex := strings.TrimPrefix(stmt.Predicate.Fingerprint, "sha256:")
+	if !strings.HasSuffix(ref.URI, hex[:12]) {
+		t.Errorf("URI must end with the 12-char short fingerprint %q; got %q", hex[:12], ref.URI)
+	}
+	if ref.Digest["sha256"] != hex {
+		t.Errorf("Digest sha256 must equal full hex %q; got %q", hex, ref.Digest["sha256"])
+	}
+}
+
+func TestBuildAttestationRef_RejectsEmptyFingerprint(t *testing.T) {
+	stmt := buildSampleReceipt(t)
+	stmt.Predicate.Fingerprint = ""
+	_, err := BuildAttestationRef(stmt)
+	if err == nil {
+		t.Fatal("empty fingerprint must be rejected")
+	}
+	if !strings.Contains(err.Error(), "empty fingerprint") {
+		t.Errorf("error must name the problem; got %v", err)
+	}
+}
+
+func TestBuildAttestationRef_RejectsMalformedFingerprint(t *testing.T) {
+	stmt := buildSampleReceipt(t)
+	stmt.Predicate.Fingerprint = "md5:abc123" // wrong algorithm prefix
+	_, err := BuildAttestationRef(stmt)
+	if err == nil {
+		t.Fatal("malformed fingerprint must be rejected")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("error must explain malformed; got %v", err)
+	}
+}
+
+func TestBuildAttestationRef_RejectsTamperedStatement(t *testing.T) {
+	// Build a valid receipt, then tamper with the verdict. The
+	// fingerprint no longer matches the body. BuildAttestationRef
+	// MUST refuse to chain — silently chaining a tampered receipt
+	// would break the trust property of inputAttestations[].
+	stmt := buildSampleReceipt(t)
+	stmt.Predicate.Verdict = VerdictBLOCK // was PASS
+
+	_, err := BuildAttestationRef(stmt)
+	if err == nil {
+		t.Fatal("tampered statement must be rejected")
+	}
+	if !strings.Contains(err.Error(), "fingerprint") {
+		t.Errorf("error must name the fingerprint mismatch; got %v", err)
+	}
+}
+
+// --- BuildAttestationRefsFromPaths ----------------------------------
+
+func TestBuildAttestationRefsFromPaths_HappyPath(t *testing.T) {
+	stmt1 := buildSampleReceipt(t)
+	stmt2 := buildSampleReceipt(t)
+	stmt2.Predicate.Scope.Name = "worker" // different fingerprint
+	if err := StampFingerprint(&stmt2); err != nil {
+		t.Fatalf("StampFingerprint: %v", err)
+	}
+
+	fakeLoad := func(path string) (Statement, error) {
+		switch path {
+		case "/fake/api.receipt.json":
+			return stmt1, nil
+		case "/fake/worker.receipt.json":
+			return stmt2, nil
+		}
+		t.Fatalf("unexpected path %q", path)
+		return Statement{}, nil
+	}
+
+	refs, err := BuildAttestationRefsFromPaths(
+		[]string{"/fake/api.receipt.json", "/fake/worker.receipt.json"},
+		fakeLoad,
+	)
+	if err != nil {
+		t.Fatalf("BuildAttestationRefsFromPaths: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs; got %d", len(refs))
+	}
+	if refs[0].Digest["sha256"] == refs[1].Digest["sha256"] {
+		t.Errorf("two different statements must produce different digests; both = %q", refs[0].Digest["sha256"])
+	}
+}
+
+func TestBuildAttestationRefsFromPaths_LoaderErrorShortCircuits(t *testing.T) {
+	stmt := buildSampleReceipt(t)
+	loaded := false
+	fakeLoad := func(path string) (Statement, error) {
+		if path == "/fake/api.receipt.json" {
+			loaded = true
+			return stmt, nil
+		}
+		// Second call returns an I/O error
+		return Statement{}, &testIOErr{path: path}
+	}
+
+	_, err := BuildAttestationRefsFromPaths(
+		[]string{"/fake/api.receipt.json", "/fake/missing.receipt.json"},
+		fakeLoad,
+	)
+	if err == nil {
+		t.Fatal("loader error on second path must short-circuit")
+	}
+	if !loaded {
+		t.Error("first path should have been loaded before the second's error")
+	}
+}
+
+type testIOErr struct{ path string }
+
+func (e *testIOErr) Error() string { return "i/o error on " + e.path }
+
+// --- BuildReceipt with InputAttestations -----------------------------
+
+func TestBuildReceipt_InputAttestationsAttached(t *testing.T) {
+	// The chain target: build a downstream receipt that references the
+	// upstream one. Verify the downstream's predicate.inputAttestations[]
+	// contains the right ref AND the downstream fingerprint covers
+	// that field (changing the upstream changes the downstream
+	// fingerprint).
+	upstream := buildSampleReceipt(t)
+	upstreamRef, err := BuildAttestationRef(upstream)
+	if err != nil {
+		t.Fatalf("BuildAttestationRef upstream: %v", err)
+	}
+
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "worker", "namespace": "prod"},
+			"spec":       map[string]interface{}{"replicas": int64(1)},
+		},
+	}
+	downstream, err := BuildReceipt(BuildReceiptInput{
+		Live:              live,
+		Scope:             Scope{Kind: "Deployment", Name: "worker", Namespace: "prod"},
+		Owner:             Ownership{Type: OwnerUnknown},
+		PredicateName:     "",
+		InputAttestations: []AttestationRef{upstreamRef},
+		Verifier:          Verifier{Tool: "cub-scout", Version: "v0.0.0-test"},
+		VerifiedAt:        time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("BuildReceipt downstream: %v", err)
+	}
+	if len(downstream.Predicate.InputAttestations) != 1 {
+		t.Fatalf("downstream should reference 1 attestation; got %d", len(downstream.Predicate.InputAttestations))
+	}
+	if downstream.Predicate.InputAttestations[0].Digest["sha256"] != upstreamRef.Digest["sha256"] {
+		t.Errorf("downstream attestation digest must match upstream; got %q vs %q",
+			downstream.Predicate.InputAttestations[0].Digest["sha256"], upstreamRef.Digest["sha256"])
+	}
+
+	// The downstream's fingerprint MUST cover the inputAttestations[]
+	// field. Tampering the field on the loaded copy and recomputing
+	// should produce a different digest.
+	tampered := downstream
+	tampered.Predicate.InputAttestations = []AttestationRef{} // strip
+	recomputed, err := ComputeStatementFingerprint(tampered)
+	if err != nil {
+		t.Fatalf("ComputeStatementFingerprint: %v", err)
+	}
+	if recomputed == downstream.Predicate.Fingerprint {
+		t.Error("stripping inputAttestations[] must change the recomputed fingerprint; the field is supposed to be covered")
+	}
+}
+
+func TestBuildReceipt_NilInputAttestations_EmptyArray(t *testing.T) {
+	// When the caller passes nil, the receipt must still serialize as
+	// an empty JSON array — never null. Consumers iterate the field
+	// unconditionally; null would break them.
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "api", "namespace": "prod"},
+		},
+	}
+	stmt, err := BuildReceipt(BuildReceiptInput{
+		Live:              live,
+		Scope:             Scope{Kind: "Deployment", Name: "api", Namespace: "prod"},
+		Owner:             Ownership{Type: OwnerUnknown},
+		InputAttestations: nil,
+		Verifier:          Verifier{Tool: "cub-scout", Version: "v0.0.0-test"},
+		VerifiedAt:        time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("BuildReceipt: %v", err)
+	}
+	if stmt.Predicate.InputAttestations == nil {
+		t.Fatal("nil input must serialize as empty array, not nil")
+	}
+	if len(stmt.Predicate.InputAttestations) != 0 {
+		t.Errorf("nil input must produce empty inputAttestations[]; got %d entries", len(stmt.Predicate.InputAttestations))
+	}
+}

--- a/skills/scout-verify/SKILL.md
+++ b/skills/scout-verify/SKILL.md
@@ -279,16 +279,16 @@ Three v2 extensions layer on top of the v1 envelope without changing the wire fo
   --emit-receipt-on drift.detected,ownership.changed
 ```
 
-## v2 still deferred
+## Not yet in cub-scout
 
-Not yet in cub-scout:
+Future directions worth flagging — none of these are implemented today:
 
-- DSSE signing wrapped in **Sigstore Bundle v0.3** (cosign keyless + ed25519 fallback) — purely additive on the existing envelope
+- Cryptographic signing as a hardening layer on top of fingerprint-only — DSSE wrapped in a Sigstore Bundle (cosign keyless + ed25519 fallback) is one candidate design; the wire format is intentionally additive-friendly so signatures can land without an envelope change
 - Aggregate-with-discovery half of `#448` — `cub-scout receipt verify --scope namespace/<ns>` that emits N per-resource receipts + 1 aggregate via `synthetic-aggregate://` subject + max-severity verdict synthesis
 - Backpressure / batching for high-frequency `--emit-receipt-on` events (Codex round-1 open question on `#449`)
 - `resource.discovered` / `scan.finding` event-type support for `--emit-receipt-on` (would flood on first poll; deferred pending the backpressure design)
 
-v1 ships fingerprint-only and v2 is honest about what's not yet there — the contract is in `docs/reference/json-contracts.md` § Receipt Contract.
+Shipping releases use fingerprint-only integrity; future hardening is honest about what's not yet there — the contract is in `docs/reference/json-contracts.md` § Receipt Contract.
 
 ## References
 

--- a/skills/scout-verify/SKILL.md
+++ b/skills/scout-verify/SKILL.md
@@ -256,16 +256,39 @@ Resolved in priority order:
 
 The store is **immutable**: re-running verify on the same resource at the same instant with the same fingerprint produces the same canonical filename → "already saved" warning and exit 0. The on-disk artifact never changes.
 
-## v2 (deferred)
+## v2 surface (CI / agent shaped)
 
-Currently NOT in cub-scout, tracked in #448 / #449:
+Three v2 extensions layer on top of the v1 envelope without changing the wire format:
+
+- **`--fail-on <verdict-list>` on `receipt verify`** (`#451`) — exit non-zero (code 2) when the verdict matches. Accepts `WATCH`, `BLOCK`, `INCONCLUSIVE` (comma-separated) or the sugar `any-non-pass`. The receipt is still printed / saved / written to `--out` — the gate fires AFTER the artifact is durable.
+- **`--input-attestation <path>` chained receipts** (`#448` chained half) — repeatable; each referenced receipt is loaded + fingerprint-verified + attached to the new receipt's `inputAttestations[]`. Tampered references refused at chain-construction time. The downstream fingerprint covers the field by construction.
+- **`cub-scout watch --emit-receipt-on <event-types>`** (`#449`) — attaches a receipt to each matching event payload inline (JSONL or webhook). v1 of the flag builds receipts for `drift.detected` and `ownership.changed` (highest signal); other event types pass through silently. Failures are non-fatal.
+
+```bash
+# CI gate
+./cub-scout receipt verify deploy/api -n prod --fail-on any-non-pass
+
+# Chain a per-resource receipt with an upstream "release gate passed" one
+./cub-scout receipt verify deploy/api -n prod \
+  --input-attestation ./release-gate.receipt.json \
+  --save
+
+# Streaming acceptance: each drift event becomes a fingerprinted receipt
+./cub-scout watch -n prod \
+  --output-file ./acceptance.jsonl \
+  --emit-receipt-on drift.detected,ownership.changed
+```
+
+## v2 still deferred
+
+Not yet in cub-scout:
 
 - DSSE signing wrapped in **Sigstore Bundle v0.3** (cosign keyless + ed25519 fallback) — purely additive on the existing envelope
-- Aggregate / chained receipts via `inputAttestations[]` digest references
-- `cub-scout watch --emit-receipt-on <event>` for event-driven receipt generation
-- `--fail-on RECEIPT_VERDICT` exit code for CI gates that gate on verdict
+- Aggregate-with-discovery half of `#448` — `cub-scout receipt verify --scope namespace/<ns>` that emits N per-resource receipts + 1 aggregate via `synthetic-aggregate://` subject + max-severity verdict synthesis
+- Backpressure / batching for high-frequency `--emit-receipt-on` events (Codex round-1 open question on `#449`)
+- `resource.discovered` / `scan.finding` event-type support for `--emit-receipt-on` (would flood on first poll; deferred pending the backpressure design)
 
-v1 ships fingerprint-only and is honest about it — the contract is in `docs/reference/json-contracts.md` § Receipt Contract.
+v1 ships fingerprint-only and v2 is honest about what's not yet there — the contract is in `docs/reference/json-contracts.md` § Receipt Contract.
 
 ## References
 


### PR DESCRIPTION
## Summary

Three v2 extensions on top of the v1 \`#446\` receipt envelope. Wire format unchanged (in-toto Statement v1 wrapping \`https://cub-scout.dev/receipt/v1\`); all three are purely additive. This PR ships as much of the open v2 issue queue as can be reviewed cleanly in one batch; intentionally honest about what's deferred.

## Three issues addressed

### `#451` — `receipt verify --fail-on RECEIPT_VERDICT`

CI-gate exit semantics extension. cub-scout's receipt is already a typed evidence artifact; `--fail-on` makes it gate-able without per-pipeline glue.

- Accepts: \`WATCH\` / \`BLOCK\` / \`INCONCLUSIVE\` (comma-separated) or \`any-non-pass\` sugar
- \`PASS\` rejected upfront (workflow-bug surface)
- Exit codes: \`0\` OK / \`2\` gate fired / \`1\` operational (matches \`compare three-way --fail-on\` convention)
- **Artifact preserved on fail**: the receipt is printed / saved / written to \`--out\` BEFORE the gate evaluates. CI gets both the failure code and the durable evidence.

### `#448` — chained receipts (chained half)

The explicit-construction half of \`#448\`. A receipt can reference prior receipts via \`predicate.inputAttestations[]\` for chain / DAG semantics.

- New \`--input-attestation <path>\` flag (repeatable) on \`receipt verify\`
- URI scheme: \`cub-scout-receipt://<12-char-short-fingerprint>\`
- Each referenced receipt's fingerprint is verified at chain-construction time; **tampered receipts are refused** — silently chaining bad evidence would break the chain's trust property
- The downstream fingerprint covers the \`inputAttestations[]\` field by construction (tampering an upstream digest invalidates the downstream's fingerprint)
- The aggregate-with-discovery half (\`--scope namespace/<ns>\` auto-discovery + \`synthetic-aggregate://\` subject + max-severity verdict synthesis) is **deferred to a follow-up PR** — honest scope; the explicit-construction primitive is what's reviewable here

### `#449` — `watch --emit-receipt-on <event-types>`

Event-driven receipt emission. Pilot or similar acceptance tooling can subscribe to the watch stream and consume receipts inline; one streaming command, every matching event becomes a typed evidence artifact.

- Event-type support matrix (v1 of this flag):
  - \`drift.detected\` → \`applied-matches-spec\` auto-detected
  - \`ownership.changed\` → \`applied-matches-spec\` auto-detected
  - \`resource.discovered\` → **passes through silently** (would flood on first poll)
  - \`scan.finding\` → **passes through silently** (deferred)
  - \`all\` → sugar for the four known event types
- **Lenient on type, strict on build**: forward-compatible with future event types; receipt-build failures are non-fatal (event still emits with \`receipt: null\` + stderr warning)
- Existing webhook / file sinks unchanged — \`receipt\` is just an optional field on the event JSON
- Backpressure / batching for high-frequency events is **intentionally deferred** to a follow-up (issue's open question 3)

## What ships

| Surface | New code | New tests |
|---------|----------|-----------|
| \`pkg/agent/receipt_inputattestations.go\` | \`AttestationURIScheme\`, \`BuildAttestationRef\`, \`BuildAttestationRefsFromPaths\` | 8 unit tests |
| \`pkg/agent/receipt_build.go\` | \`BuildReceiptInput.InputAttestations\` field; nil → empty array contract | — |
| \`cmd/cub-scout/receipt.go\` | \`--fail-on\` + \`--input-attestation\` flags; \`parseReceiptFailOn\`; chain-construction wiring | 12 + 3 CLI integration tests |
| \`cmd/cub-scout/watch.go\` | \`--emit-receipt-on\` flag; \`watchEvent.Receipt\` field; attach loop in both \`--once\` and long-running paths | — |
| \`cmd/cub-scout/watch_receipt.go\` | \`parseWatchEmitReceiptOn\`, \`attachReceiptsIfRequested\`, \`watchBuildReceiptForEvent\`, two test seams | 10 tests |

**33 new tests** total; all green. Existing batch-1 / batch-2 / batch-3 / Codex-round-5 tests continue to pass.

## Docs

- \`docs/reference/json-contracts.md\` § Receipt Contract gains a new "**v2 Extensions**" subsection covering all three additions with sample JSON shapes
- \`docs/reference/commands.md\` § \`receipt verify\` flag table: new rows for \`--fail-on\` + \`--input-attestation\`; § \`watch\` flag table: new row for \`--emit-receipt-on\`
- \`skills/scout-verify/SKILL.md\` "v2 deferred" section replaced with "v2 surface (CI/agent shaped)" + worked-example CLI snippets + a clear "v2 still deferred" subsection

## Read-only triad still holds

- \`TestReceiptPackageReadOnlyClient\` passes — none of the new code introduces a mutating K8s client call
- \`FilterNextSteps\` still drops mutating actionType / nextCommand at emit time
- The watch-receipt path goes through the same \`BuildReceipt\` → \`FilterNextSteps\` pipeline as the standalone verify path

## What's deferred (for separate PRs after Codex review)

- **\`#448\` aggregate-with-discovery half**: \`--scope namespace/<ns>\` discovery, \`synthetic-aggregate://\` subject construction, max-severity verdict synthesis
- **\`#449\` backpressure**: high-frequency event batching, plus the \`resource.discovered\` / \`scan.finding\` event-type support that's gated on the backpressure design
- **MCP \`compare_source_truth\` enum drift**: 4 strategies in MCP schema, 9 in CLI — small follow-up
- **Source-truth receipt precedence tests** (Codex round-5 P3 leftover)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./pkg/agent/... ./cmd/cub-scout/...\` clean
- [x] \`go test ./pkg/agent/... ./cmd/cub-scout/...\` all green (existing + 33 new tests)
- [x] All three CI parity scripts pass locally
- [x] Read-only-triad guards still pass

## Request for Codex review

Per the user's instruction. Particularly want eyes on:

1. **The trust property of chained receipts** — does \`BuildAttestationRef\` refusing to chain a tampered upstream actually prevent the bad-evidence-propagation it's designed for? Any path where a chained receipt could be built without that integrity check firing?
2. **Watch receipt-build resilience** — is the "non-fatal warning + event still emits" path the right call vs. "drop event on receipt-build failure"?
3. **Event-type opinionation** — should \`resource.discovered\` / \`scan.finding\` get receipts in v1 of this flag, or is the current "pass through silently" right?
4. **\`--fail-on\` PASS rejection** — any case where gating on PASS would actually be the right behavior, or is the upfront rejection correct?
5. **The deferral list** — agree that aggregate-with-discovery + backpressure are the right things to defer to follow-up PRs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)