### PR TITLE
docs(skills): #444 batch A — 5 Pilot–cub-scout integration scenarios

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -50,6 +50,18 @@ Each covers a real operator / agent workflow that spans multiple verbs. Compose 
 - [`operator-incident-evidence/`](operator-incident-evidence/SKILL.md) — postmortem evidence package: trace + compare + bundle + history + audit + fingerprinted receipts
 - [`confighub-source-truth/`](confighub-source-truth/SKILL.md) — strategy-typed `compare source-truth` verdicts (one of 9 strategies; cub-scout never infers); Pilot-acceptance-shaped output
 
+### Pilot–cub-scout integration scenarios (`#444` batch A)
+
+The consumer-side complement to the verb-grouped + workflow skills above. Same cub-scout verbs, framed around **Pilot** (the acceptance judge) reading cub-scout's evidence and rendering verdicts that downstream consumers (CI/CD, dashboards, audit tickets, postmortems) act on. cub-scout produces evidence with documented `omissions[]`; Pilot decides. Pilot mutates via `cub` / Argo / Flux / kubectl — never via cub-scout.
+
+- [`pilot-cd-gate/`](pilot-cd-gate/SKILL.md) — pre-deploy gate in a CD pipeline; consumes `compare source-truth --strategy <s>` (+ optional `receipt verify --fail-on any-non-pass`); renders PASS / WATCH / ASK / BLOCK on the release
+- [`pilot-fleet-conformance/`](pilot-fleet-conformance/SKILL.md) — fleet-wide conformance verdict (View / namespace / cluster scope) composing `compare three-way --view` + per-resource `compare source-truth` + `fleet outliers`; judge-driven counterpart to `audit-fleet-conformance`
+- [`pilot-patch-and-drift/`](pilot-patch-and-drift/SKILL.md) — drift-classification + revert / quarantine / accept-as-canonical / ASK decision; consumes attribution layer (`cause` / `managerHint` / `gitSource` / `bindingSource`); judge-driven counterpart to `investigate-drift`
+- [`pilot-watch-alert-response/`](pilot-watch-alert-response/SKILL.md) — real-time event-driven response; consumes the `cub-scout watch` event stream with inline receipts via `--emit-receipt-on` (shipped in `#463`); the only event-driven skill in the pilot-* batch
+- [`pilot-incident-evidence/`](pilot-incident-evidence/SKILL.md) — incident close-out evidence pack with **chained receipts** (`--input-attestation` from `#463`) for multi-stage incidents; judge-driven counterpart to `operator-incident-evidence`
+
+Batch B (4 governance-shaped scenarios: `pilot-rollback-decision`, `pilot-promotion-gate`, `pilot-compliance-audit`, `pilot-release-verification`) is tracked as the remaining `#444` follow-on.
+
 ### Shared references
 
 | Reference | Purpose |
@@ -96,3 +108,5 @@ That's **~33 skill files** plus 9 references — the full scope from `#442`.
 - [`#458`](https://github.com/confighub/cub-scout/pull/458) — batch 3 controller-observer skills
 - [`#459`](https://github.com/confighub/cub-scout/pull/459) — batch 4 workflow scenario skills
 - batch 5 — this PR (closes `#442`)
+
+**`#444` batch A in progress**: 5 Pilot–cub-scout integration scenario skills (consumer-side complement to the `#442` set) — `pilot-cd-gate`, `pilot-fleet-conformance`, `pilot-patch-and-drift`, `pilot-watch-alert-response`, `pilot-incident-evidence`. Each frames the same cub-scout verbs from Pilot's perspective (acceptance judge reading evidence, rendering verdicts), with worked CLI examples + verdict-mapping tables. The watch-alert-response skill consumes the v2 `--emit-receipt-on` surface (shipped in `#463`); the incident-evidence skill consumes the v2 chained-receipts surface (`--input-attestation`, also `#463`). Batch B (4 governance-shaped scenarios) is the remaining `#444` work.

--- a/skills/cub-scout/SKILL.md
+++ b/skills/cub-scout/SKILL.md
@@ -46,6 +46,20 @@ This skill is the cross-cutting entry point. It picks the right verb-grouped ski
 
 See [`skills/README.md`](../README.md) for the full plan including controller observer skills (`observe-argocd`, `observe-flux`, `observe-helm`, `observe-crossplane`, `observe-kro`), workflow scenario skills (`triage-unhealthy-workload`, `investigate-drift`, `audit-fleet-conformance`, etc.), and shared references.
 
+### Pilot–cub-scout integration scenarios (`#444` batch A)
+
+The consumer-side complement: same cub-scout verbs framed around **Pilot** (the acceptance judge) rendering verdicts from cub-scout's evidence. Load one of these instead of a `scout-*` skill when the user's prompt is shaped as "Pilot, decide ..." or "render the verdict ...".
+
+| Scenario | Skill | Pilot consumes | Pilot decides |
+|---|---|---|---|
+| Pre-deploy CD gate | [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) | `compare source-truth --strategy <s>` + optional `receipt verify --fail-on any-non-pass` | PASS / WATCH / ASK / BLOCK on the release |
+| Fleet-wide conformance | [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md) | `compare three-way --view` + per-resource source-truth + `fleet outliers` | Fleet verdict + per-resource breakdown |
+| Drift classification | [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md) | attribution evidence (`cause` / `managerHint` / `gitSource` / `bindingSource`) | revert / quarantine / accept-as-canonical / ASK |
+| Real-time watch response | [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) | `cub-scout watch` event stream with `--emit-receipt-on` inline receipts (v2 #463) | Per-event PASS / WATCH / ASK / BLOCK |
+| Incident close-out | [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md) | trace + explain + compare + bundle + history + audit + chained receipts (`--input-attestation`, v2 #463) | Incident verdict + immutable evidence pack |
+
+Batch B (governance-shaped: `pilot-rollback-decision`, `pilot-promotion-gate`, `pilot-compliance-audit`, `pilot-release-verification`) is the open `#444` follow-on.
+
 ## Product value in one breath
 
 **cub scout observes and explains; it never decides.** It is the read-only Kubernetes and GitOps observer — it surfaces evidence about ownership, health, drift, and provenance, but it never mutates the cluster and never makes authority calls about what *should* be true. ConfigHub (driven by `cub`) is the authority; cub-scout is the witness.

--- a/skills/pilot-cd-gate/SKILL.md
+++ b/skills/pilot-cd-gate/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: pilot-cd-gate
+description: 'Use when Pilot (or another acceptance-judge tool) is making a PRE-DEPLOY GATE DECISION in a CD pipeline using cub-scout''s structured evidence. Natural phrasings the operator brings to Pilot: "should this deploy go?", "is this release safe to promote?", "what does cub-scout say about this strategy?", "Pilot, gate the apply", "block the deploy if source-truth disagrees", "PASS/WATCH/ASK/BLOCK on payments-api release". Pilot consumes cub-scout''s `compare source-truth --strategy <s>` (with optional `receipt verify --strategy <s> --fail-on any-non-pass` for typed evidence + exit-2 CI gate) and renders a verdict. cub-scout NEVER decides PASS/BLOCK — it produces evidence; Pilot makes the call. Do NOT load for: a Pilot post-deploy verification (use pilot-release-verification — coming in batch B), a real-time event-driven response (use pilot-watch-alert-response), a multi-cluster periodic audit (use pilot-fleet-conformance), or any cub-scout authoring command. Pilot mutates via `cub` / Argo / Flux — never via cub-scout.'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout compare source-truth *) Bash(cub-scout compare source-truth *) Bash(cub scout compare source-truth *) Bash(./cub-scout compare three-way *) Bash(cub-scout compare three-way *) Bash(cub scout compare three-way *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout explain *) Bash(cub-scout explain *) Bash(cub scout explain *) Bash(./cub-scout trace *) Bash(cub-scout trace *) Bash(cub scout trace *) Bash(./cub-scout doctor *) Bash(cub-scout doctor *) Bash(cub scout doctor *) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub unit get *) Bash(cub link list *) Bash(argocd app get *) Bash(flux get *)
+
+---
+
+# pilot-cd-gate
+
+The pre-deploy CD-gate scenario from **Pilot's** side. A release pipeline asks Pilot: *should this deploy go?* Pilot consumes cub-scout's structured evidence — specifically `compare source-truth --strategy <s>` plus (optionally) a typed `cub-scout receipt verify --strategy <s>` — and renders a verdict that the pipeline gates on.
+
+cub-scout is the **witness**. Pilot is the **judge**. ConfigHub (via `cub`) is the authority. cub-scout never decides PASS / BLOCK — it produces evidence with documented `omissions[]` where evidence is missing, and Pilot makes the call. This skill is about how Pilot reads that evidence; it is NOT about how Pilot itself mutates.
+
+## When to use
+
+Explicit phrasings the user brings to Pilot (which Pilot then satisfies by calling cub-scout):
+
+- "Should this deploy go?"
+- "Pilot, gate the apply"
+- "Is `payments-api@v1.4.3` safe to promote to prod?"
+- "Block the deploy if source-truth disagrees"
+- "Run the pre-deploy gate against `git-argo`"
+- "PASS/WATCH/ASK/BLOCK on the release ticket"
+- "Should we promote this PR's branch?"
+
+Implicit intents:
+
+- The user is **about to deploy** (pre-deploy, not post-deploy)
+- The evidence needs to feed a **gate** — a decision that turns into a CD pipeline exit code, a PR check, or a release-ticket field
+- The decision should be **strategy-anchored** — the user has declared what the source of truth is (one of the 9 source-truth strategies), and Pilot is checking conformance against that
+- The result needs to be **auditable** later — Pilot may want a fingerprinted receipt to attach to the release record
+
+## Do not load for
+
+- A **post-deploy** verification (release just shipped; did it land per Git?) — `pilot-release-verification` (batch B)
+- A **real-time** event-driven response (Pilot subscribing to `cub-scout watch`) — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- A **multi-cluster periodic conformance audit** (not tied to one release event) — [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md)
+- A **drift-classification** question after the gate already passed — [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md)
+- **Postmortem** evidence assembly — [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md)
+- Anything that **mutates** the cluster or ConfigHub. The gate decision is Pilot's; the mutation is `cub` / Argo / Flux's. cub-scout never mutates.
+
+## The Pilot ↔ cub-scout loop
+
+```
+   release pipeline
+        │
+        ▼
+   Pilot (acceptance judge)
+        │  "should this deploy go?"
+        │
+        ▼
+   cub-scout compare source-truth <subject> --strategy <s> --format json
+        │
+        │  ──────────────────────────────────────────────────────────
+        │  status:       PASS | WATCH | BLOCK | ASK
+        │  sourceTruth:  AGREED | MISMATCH | INCOMPLETE | BLOCKED | UNKNOWN
+        │  proofGaps:    [] (or list of structured missing-evidence entries)
+        │  attribution:  cause, managerHint, gitSource per field
+        │  ──────────────────────────────────────────────────────────
+        │
+        ▼
+   (optional) cub-scout receipt verify <subject> --strategy <s>
+                                --save --out release.receipt.json
+        │
+        │  fingerprinted in-toto Statement v1 artifact for the release record
+        │
+        ▼
+   Pilot's verdict: PASS / WATCH / ASK / BLOCK
+        │
+        ▼
+   release pipeline reads the verdict
+        │  PASS  → continue
+        │  WATCH → continue, attach the receipt to the release, alert
+        │  ASK   → block, ask a human
+        │  BLOCK → halt, alert, halt the promotion
+        └──────────────────────────────────────────────────────────
+```
+
+## Strategy required upfront
+
+cub-scout **never infers** the source-truth strategy. Pilot's gate must declare one of the 9 — pass it explicitly via `--strategy`:
+
+| Strategy | What it asserts |
+|----------|-----------------|
+| `git-argo`        | Argo CD application reading from a Git source; cluster matches the git tree |
+| `git-flux`        | Flux reading from a Git source; cluster matches the git tree |
+| `git-helm`        | Helm release from a Git-hosted chart; cluster matches the rendered chart |
+| `oci-argo`        | Argo CD reading from an OCI registry; cluster matches the OCI image |
+| `oci-flux`        | Flux reading from an OCI registry; cluster matches the OCI image |
+| `oci-helm`        | Helm chart published to OCI; cluster matches the rendered chart |
+| `kustomize-flux`  | Flux Kustomization; cluster matches the rendered kustomize tree |
+| `helm-flux`       | Flux HelmRelease; cluster matches the rendered chart |
+| `confighub-oci-argo` | ConfigHub authoring + OCI publish + Argo CD apply; cluster matches the unit revision via OCI |
+
+See [`source-truth-strategies`](../references/source-truth-strategies.md) for the full reference. If the user can't name a strategy, the gate is premature — Pilot should ask before evaluating.
+
+## Two-tier evidence: `compare source-truth` vs. `receipt verify`
+
+Pilot has two tiers of evidence available, and the choice is a quality / durability trade-off:
+
+| Tier | Verb | Output | When to use |
+|------|------|--------|-------------|
+| **Live evidence** | `cub-scout compare source-truth <kind>/<name> -n <ns> --strategy <s> --format json` | Ephemeral JSON the pipeline reads once | Most gate decisions. Pilot reads `status` + `sourceTruth` + `proofGaps`, renders a verdict, and the JSON is discarded after the decision. |
+| **Typed evidence** | `cub-scout receipt verify <kind>/<name> -n <ns> --strategy <s> --save --out release.receipt.json --fail-on any-non-pass` | Persistent in-toto Statement v1 envelope with SHA-256 fingerprint | When the release record needs an immutable receipt attached (audit, compliance, postmortem). `--fail-on any-non-pass` doubles as the exit-2 CI gate. |
+
+The receipt path is **preferred for production gates** because:
+
+1. The artifact is durable — the release record carries the evidence the gate decision was made on, fingerprint-verifiable later.
+2. `--fail-on any-non-pass` gives Pilot a native CI exit code (0/2/1) without per-pipeline glue.
+3. The receipt is preserved **even if the gate fires** — exit-2 happens AFTER stdout/`--out`/`--save`, so the failure case still produces evidence. (See `examples/receipts/ci-gate/README.md` for the full walkthrough.)
+4. The receipt can be re-validated later: `cub-scout receipt validate release.receipt.json` exits 0 (OK) / 1 (mismatch) / 2 (I/O).
+
+## Verdict mapping (cub-scout status → Pilot verdict)
+
+The source-truth contract has **two** enums:
+
+- **`status`** — evidence-quality verdict: `PASS` / `WATCH` / `BLOCK` / `ASK`
+- **`sourceTruth`** — cross-surface agreement: `AGREED` / `MISMATCH` / `INCOMPLETE` / `BLOCKED` / `UNKNOWN`
+
+Pilot's gate verdict typically tracks `status`, with `sourceTruth` available for drill-down:
+
+| cub-scout `status` | cub-scout `sourceTruth` (typical) | Pilot gate verdict | Pipeline action |
+|--------------------|-----------------------------------|--------------------|-----------------|
+| PASS  | AGREED      | **PASS** | continue |
+| WATCH | INCOMPLETE  | **WATCH** | continue but attach receipt; alert release channel |
+| ASK   | UNKNOWN     | **ASK** | block; ask human (proof gaps the user can fill) |
+| BLOCK | MISMATCH    | **BLOCK** | halt; alert |
+| BLOCK | BLOCKED     | **BLOCK** | halt; the evidence itself was unreachable (cluster down, ConfigHub down) |
+
+When wrapped in a receipt, `ASK` maps to receipt verdict `WATCH` per the locked synthesis in `docs/proposals/receipts-way-forward.md`. The receipt-level `INCONCLUSIVE` verdict is reserved for receipts that themselves couldn't be built (missing predicate inputs, e.g., source-truth-pass without `--strategy`); it does NOT appear in `compare source-truth`'s own `status`.
+
+## Worked example
+
+A release pipeline is gating on `payments-api@v1.4.3` going to `prod`. The team's declared strategy is `git-argo` (Argo CD reading from the org's Git repo).
+
+```bash
+# Step 1 — Pilot asks cub-scout for live evidence
+$ cub-scout compare source-truth deploy/payments-api -n prod \
+    --strategy git-argo \
+    --format json
+```
+
+```json
+{
+  "scope": "resource:Deployment/payments-api/prod",
+  "strategy": "git-argo",
+  "status": "WATCH",
+  "sourceTruth": "INCOMPLETE",
+  "proofGaps": [
+    {
+      "missing": "git-source-anchor",
+      "reason": "argocd CLI not installed; tracer fell back to label-only ownership",
+      "severity": "warning"
+    }
+  ],
+  "attribution": {
+    "Deployment/payments-api": {
+      "cause": "controller-drift",
+      "managerHint": "argocd-controller"
+    }
+  }
+}
+```
+
+Pilot reads this:
+- `status: WATCH` → not a hard PASS; gate fires WATCH (continue but flag).
+- `proofGaps[0].missing: git-source-anchor` → the operator can fix this by installing argocd CLI in the pipeline container.
+- `attribution.cause: controller-drift` → no manual-edit signal; Argo is in control.
+
+Pilot's CD pipeline policy says WATCH is non-blocking but must attach a receipt to the release ticket. So Pilot escalates the call to:
+
+```bash
+# Step 2 — Pilot generates a typed receipt to attach to the release
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --save \
+    --out release.receipt.json \
+    --fail-on BLOCK
+# exit 0 because verdict is WATCH (not in --fail-on BLOCK set)
+# stdout shows the JSON; release.receipt.json is on disk; the local store has the artifact too
+```
+
+The release ticket gets the WATCH verdict + the `release.receipt.json` artifact attached. Later, an audit query can:
+
+```bash
+$ cub-scout receipt validate ./release.receipt.json
+# exit 0 — fingerprint still matches
+$ cub-scout receipt show ./release.receipt.json --format ascii
+# renders the same evidence Pilot read
+```
+
+The receipt is **fingerprint-stable** — the same release.receipt.json can be archived for years and validated indefinitely (subject to the underlying evidence sources still existing for cross-checks).
+
+## Standalone vs connected
+
+Pilot's CD gate runs in two flavors:
+
+| Flavor | Verbs available | Notes |
+|--------|-----------------|-------|
+| **Standalone** (cluster only, no ConfigHub auth) | `receipt verify --predicate applied-matches-spec`, `receipt verify --predicate no-manual-edits-since` | Limited — cannot use `source-truth-pass`. Useful for non-ConfigHub-managed deployments. |
+| **Connected** (cluster + `cub auth login`) | All of the above + `receipt verify --strategy <s>` (source-truth-pass), `compare source-truth`, `compare three-way`, `confighub-unit://` subject in receipt | Full surface. Recommended for production gates. |
+
+A standalone gate is still valuable but produces an INCOMPLETE receipt (missing `confighub-unit://` subject) with a documented `OmissionConfigHubUnitSubject` entry. Pilot can still consume it, but the verdict ceiling is WATCH (the receipt is honest about what's missing).
+
+Run `cub-scout status` in the pipeline preamble to confirm the mode; if standalone and the gate requires a strategy, Pilot's policy should escalate to ASK rather than proceed.
+
+## CI integration shapes
+
+```yaml
+# GitHub Actions — Pilot calls cub-scout, Pilot decides
+- name: cub-scout evidence
+  id: evidence
+  run: |
+    cub-scout compare source-truth deploy/payments-api -n prod \
+      --strategy git-argo \
+      --format json > evidence.json
+- name: Pilot verdict
+  id: verdict
+  run: |
+    # Pilot's policy engine consumes evidence.json
+    verdict=$(pilot decide --evidence ./evidence.json --release ${{ env.RELEASE }})
+    echo "verdict=$verdict" >> $GITHUB_OUTPUT
+- name: Halt on BLOCK or ASK
+  if: steps.verdict.outputs.verdict == 'BLOCK' || steps.verdict.outputs.verdict == 'ASK'
+  run: exit 1
+```
+
+```yaml
+# Simpler: skip Pilot, use the receipt --fail-on path directly
+- name: cub-scout receipt gate
+  run: |
+    cub-scout receipt verify deploy/payments-api -n prod \
+      --strategy git-argo \
+      --fail-on any-non-pass \
+      --save \
+      --out release.receipt.json
+    # exit 0 → continue; exit 2 → gate fired (release.receipt.json is still on disk)
+- name: Upload receipt (always)
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: release-receipt
+    path: release.receipt.json
+```
+
+See [`examples/receipts/ci-gate/README.md`](../../examples/receipts/ci-gate/README.md) for the full GitHub Actions / GitLab CI / Jenkins walkthrough.
+
+## Tool boundary
+
+- **Allowed (cub-scout side):** `compare source-truth`, `compare three-way`, `receipt verify` / `show` / `validate`, `explain`, `trace`, `doctor`. All read-only.
+- **Allowed (cluster side):** `kubectl get/describe`. **NOT** `kubectl apply/edit/patch/delete`.
+- **Allowed (ConfigHub side, connected):** `cub * get / list`, `cub unit get`, `cub link list`. **NOT** any `cub * create / update / delete`.
+- **Allowed (controller side):** `argocd app get`, `flux get`. **NOT** `argocd app sync`, `flux reconcile`.
+- **Pilot itself may mutate** — but through `cub` / Argo / Flux / whatever, not through cub-scout. This skill's allowed-tools list is what cub-scout authorizes for Pilot's evidence-gathering calls.
+
+## References
+
+- [`scout-compare`](../scout-compare/SKILL.md) — the four Compare verbs (cub-scout side)
+- [`scout-verify`](../scout-verify/SKILL.md) — the receipt verbs (cub-scout side)
+- [`confighub-source-truth`](../confighub-source-truth/SKILL.md) — strategy-typed verdict workflow
+- [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) — real-time companion (event-driven, this skill is query-driven)
+- [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md) — drift classification after the gate passes
+- [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md) — evidence assembly when the gate didn't catch it
+- Source-truth contract: `#393`, `#418` (Phase 2 strategies), `#409` (Phase 3 deferred)
+- Receipts: `#446` (v1), `#463` (v2: `--fail-on`, chained, watch emit)
+- Worked CI walkthrough: [`examples/receipts/ci-gate/README.md`](../../examples/receipts/ci-gate/README.md)
+
+## Constraints
+
+- Connected mode (`cub auth login`) is **required** for `--strategy source-truth-pass`. Standalone gates fall back to `applied-matches-spec` or `no-manual-edits-since`, which are narrower.
+- The strategy is **caller-declared**, never inferred. If the team can't name one, the gate is premature.
+- The gate decision is Pilot's, but cub-scout's `--fail-on` flag implements the same shape (exit 2 = non-PASS) for gateways that don't want a Pilot dependency.
+- Receipts are **immutable** — once persisted to the store, `SaveStatement` uses `O_EXCL` and refuses to overwrite. Re-running the gate produces a new receipt with a new fingerprint.
+- The receipt-level verdict `INCONCLUSIVE` is distinct from `compare source-truth`'s `status: ASK`. INCONCLUSIVE means the receipt itself couldn't be built; ASK means the receipt was built but the evidence quality couldn't reach PASS.

--- a/skills/pilot-fleet-conformance/SKILL.md
+++ b/skills/pilot-fleet-conformance/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: pilot-fleet-conformance
+description: 'Use when Pilot (or another acceptance-judge tool) is rendering a FLEET-WIDE CONFORMANCE VERDICT across multiple clusters / namespaces / a ConfigHub View. Natural phrasings: "Pilot, give me the fleet verdict for prod", "is the payments fleet conformant against `git-argo`?", "render the conformance report Pilot can attach to the compliance ticket", "what does Pilot say across all 12 clusters?", "per-cluster PASS/WATCH/ASK/BLOCK rolled up to a fleet verdict". Pilot consumes cub-scout''s `compare three-way --view` + per-resource `compare source-truth --strategy` + `fleet outliers --view`, optionally persisting per-resource receipts via `receipt verify --save`, then synthesizes a fleet-level verdict. Differs from `audit-fleet-conformance` which is the OPERATOR-DRIVEN audit loop; this skill is the JUDGE-DRIVEN companion (Pilot reading the same surfaces but framing the output as a verdict, not a checklist). Do NOT load for: a single-resource pre-deploy gate (use pilot-cd-gate), real-time event-driven response (use pilot-watch-alert-response), or any mutating action.'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout compare three-way *) Bash(cub-scout compare three-way *) Bash(cub scout compare three-way *) Bash(./cub-scout compare source-truth *) Bash(cub-scout compare source-truth *) Bash(cub scout compare source-truth *) Bash(./cub-scout fleet outliers *) Bash(cub-scout fleet outliers *) Bash(cub scout fleet outliers *) Bash(./cub-scout views resolve *) Bash(cub-scout views resolve *) Bash(cub scout views resolve *) Bash(./cub-scout views project *) Bash(cub-scout views project *) Bash(cub scout views project *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout map *) Bash(cub-scout map *) Bash(cub scout map *) Bash(./cub-scout scan *) Bash(cub-scout scan *) Bash(cub scout scan *) Bash(./cub-scout summary *) Bash(cub-scout summary *) Bash(cub scout summary *) Bash(kubectl get *) Bash(cub * get) Bash(cub * list) Bash(cub view get *) Bash(cub view list)
+
+---
+
+# pilot-fleet-conformance
+
+The fleet-wide conformance scenario from **Pilot's** side. Pilot is asked for a verdict across a fleet — multiple clusters, multiple namespaces, or a ConfigHub View scope — and synthesizes a single fleet-level PASS / WATCH / ASK / BLOCK from per-resource cub-scout evidence.
+
+This is the **judge-driven** companion to [`audit-fleet-conformance`](../audit-fleet-conformance/SKILL.md) (the operator-driven audit loop). Same cub-scout verbs feed both; the difference is framing: an operator runs an audit to find what's wrong; Pilot renders a verdict that downstream consumers (compliance dashboards, governance tickets, release boards) act on.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot, give me the fleet verdict for prod"
+- "Is the payments fleet conformant against `git-argo`?"
+- "Render the conformance report Pilot can attach to the compliance ticket"
+- "What does Pilot say across all 12 clusters?"
+- "Per-cluster PASS/WATCH/ASK/BLOCK rolled up to a fleet verdict"
+- "Fleet conformance check on Hub View `monthly-spend-by-team`"
+- "Which clusters are out of conformance with their declared strategy?"
+
+Implicit intents:
+
+- The user is **operating across many resources** — namespace, View, or full fleet
+- The output needs to be a **single verdict** with structured drill-down, not a per-resource checklist
+- The judgment is **strategy-anchored** — the user has declared what the source of truth should be
+- The result feeds a **dashboard / ticket / compliance flow**, not an interactive triage
+
+## Do not load for
+
+- A **single-resource pre-deploy gate** — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- An **operator-driven** audit checklist (same verbs, different framing) — [`audit-fleet-conformance`](../audit-fleet-conformance/SKILL.md)
+- A **real-time event-driven** fleet response (Pilot subscribes to a watch stream) — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- A **postmortem evidence assembly** — [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md)
+- A **drift classification** per resource — [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md)
+- Anything that **mutates** the fleet. Pilot's mutation path is `cub` / Argo / Flux, never cub-scout.
+
+## The Pilot ↔ cub-scout fleet loop
+
+```
+   compliance dashboard / release board / governance ticket
+        │
+        ▼
+   Pilot (acceptance judge)
+        │  "render the fleet verdict for view:monthly-spend-by-team"
+        │
+        ├──► cub-scout views resolve <url-or-uuid>          # confirm scope
+        │
+        ├──► cub-scout fleet outliers --view <uuid>         # cross-cluster outliers
+        │
+        ├──► cub-scout compare three-way --view <uuid>      # per-resource DRY/WET/LIVE
+        │     --format json
+        │
+        ├──► for each resource in scope:
+        │      cub-scout compare source-truth <r> --strategy <s>
+        │     --format json                                  # per-resource verdict
+        │
+        └──► (optional, for audit attachment)
+              for each resource in scope:
+                cub-scout receipt verify <r> --strategy <s>
+                  --save                                    # fingerprinted artifact
+              cub-scout receipt list --format json          # the artifact inventory
+        │
+        ▼
+   Pilot's fleet verdict = max-severity over per-resource verdicts
+        │
+        ▼
+   downstream consumer reads the verdict
+        │  PASS  → conformant fleet, no action needed
+        │  WATCH → conformant with caveats; attach receipts; review at next sync
+        │  ASK   → human-needed; the per-resource ASKs surface proof gaps
+        │  BLOCK → halt promotion / release; quarantine the divergent resources
+        └────────────────────────────────────────────────────
+```
+
+## Scope sources
+
+Pilot's fleet verdict needs a defined scope. cub-scout exposes three scope shapes:
+
+| Scope | Verb path | Use when |
+|-------|-----------|----------|
+| **View** | `views resolve <url-or-uuid>` → `--view <uuid>` on the audit verbs | The team declared the scope in ConfigHub (preferred for governance) |
+| **Namespace** | `--scope namespace/<ns>` | One namespace's workloads |
+| **Cluster** | `--scope cluster` | Entire kubeconfig context |
+| **Multi-cluster** | `fleet outliers --view <uuid>` | Cross-cluster comparison against a View baseline (connected mode only) |
+
+Views are declared via `cub view create` (out of cub-scout's scope — `cub` operation). cub-scout reads them via `views resolve`. If the team doesn't have a View, Pilot can still render a fleet verdict over a namespace or cluster scope; the scope is just less semantically anchored.
+
+## Verdict synthesis (per-resource → fleet)
+
+Pilot's synthesis policy is **max-severity** by default:
+
+| Per-resource verdicts | Fleet verdict |
+|-----------------------|---------------|
+| All PASS | **PASS** |
+| Some WATCH, rest PASS | **WATCH** |
+| Some ASK, rest PASS/WATCH | **ASK** (humans needed for the proof gaps) |
+| Any BLOCK | **BLOCK** (one divergent resource halts the fleet verdict) |
+
+`fleet outliers` adds a cross-cluster dimension: if all per-cluster resource counts match the View baseline, the fleet is **outlier-free**; if one cluster diverges, Pilot's verdict downgrades to at least WATCH and may escalate to BLOCK depending on the missing resource's role.
+
+This skill does NOT prescribe the synthesis policy beyond max-severity — Pilot may want a different aggregation (majority, weighted by criticality). The cub-scout side is verdict-producing per resource; the fleet roll-up is Pilot's call.
+
+## Step-by-step
+
+### Step 1 — resolve the scope
+
+```bash
+$ cub-scout views resolve https://hub.confighub.com/views/payments-prod-conformance
+View: payments-prod-conformance
+  scope: cluster
+  columns: [team, service, replicas, source_truth_strategy]
+  resolved at: 2026-05-22T10:30:00Z
+```
+
+If no View applies, fall back to a namespace scope; the rest of the loop is identical except `--scope namespace/<ns>` replaces `--view <uuid>`.
+
+### Step 2 — outliers (true fleet shape)
+
+```bash
+$ cub-scout fleet outliers --view payments-prod-conformance
+View: payments-prod-conformance
+Clusters: 12
+
+  payments-api   EXPECTED 3 deploys / cluster   prod-euw1: 2 (outlier: missing payments-api-worker)
+  payments-db    EXPECTED 1 deploy / cluster    ALL match
+  payments-cron  EXPECTED 4 deploys / cluster   staging-use2: 3 (outlier: missing payments-cron-billing)
+```
+
+`fleet outliers` emits per-row mismatches. Each outlier is at minimum a **WATCH** for Pilot's fleet verdict (the per-cluster resource count doesn't match the View baseline); it escalates to **BLOCK** if the missing resource is in the View's critical-set (a separate policy Pilot enforces).
+
+### Step 3 — per-resource three-way + source-truth
+
+```bash
+# Three-way conformance across the View (DRY/WET/LIVE per resource)
+$ cub-scout compare three-way --view payments-prod-conformance --format json \
+    | jq '.summary'
+{
+  "agreement": "partial",
+  "agreed": 18,
+  "converging": 1,
+  "diverged": 3,
+  "scope": "view:payments-prod-conformance"
+}
+
+# Strategy-anchored source-truth per resource
+$ for r in $(cub-scout views project --view payments-prod-conformance --format json \
+              | jq -r '.[] | "\(.kind)/\(.name) -n \(.namespace)"'); do
+    cub-scout compare source-truth $r --strategy git-argo --format json \
+      | jq '{resource: "'"$r"'", status: .status, sourceTruth: .sourceTruth}'
+  done
+```
+
+Each per-resource output has `status` (PASS/WATCH/BLOCK/ASK) + `sourceTruth` (AGREED/MISMATCH/INCOMPLETE/BLOCKED/UNKNOWN). Pilot collects these into the synthesis matrix.
+
+### Step 4 — persist fleet evidence as receipts (audit-quality)
+
+```bash
+# Per-resource receipts, saved to the immutable local store
+$ for r in $(cub-scout views project --view payments-prod-conformance --format json \
+              | jq -r '.[] | "\(.kind)/\(.name) -n \(.namespace)"'); do
+    cub-scout receipt verify $r --strategy git-argo --save
+  done
+
+# Audit inventory: every fleet receipt with verdict BLOCK or WATCH
+$ cub-scout receipt list --format json \
+    | jq '[.[] | select(.verdict == "BLOCK" or .verdict == "WATCH")]'
+```
+
+The receipt store is **immutable** (each filename is canonical and `O_EXCL`-protected; duplicate saves return `os.ErrExist` and never overwrite). The fleet audit produces a fingerprint-stable evidence pack that can be archived for compliance review.
+
+## Worked example
+
+Pilot is asked for the daily fleet verdict on View `payments-prod-conformance`, strategy `git-argo`:
+
+```bash
+$ cub-scout fleet outliers --view payments-prod-conformance
+View: payments-prod-conformance
+Clusters: 12
+
+  payments-api   EXPECTED 3 deploys / cluster   prod-euw1: 2 (outlier)
+  payments-cron  EXPECTED 4 deploys / cluster   staging-use2: 3 (outlier)
+
+$ cub-scout compare three-way --view payments-prod-conformance --format json \
+    | jq '.summary'
+{
+  "agreement": "partial",
+  "agreed": 18,
+  "converging": 1,
+  "diverged": 3
+}
+
+$ # per-resource source-truth (abbreviated)
+$ ... 18 PASS, 1 WATCH, 3 BLOCK
+```
+
+Pilot's synthesis:
+- 22 resources in scope
+- 18 PASS + 1 WATCH + 3 BLOCK per source-truth
+- 2 cluster-level outliers (counted as WATCH)
+- Max-severity verdict → **BLOCK**
+
+Pilot's verdict surface to the compliance dashboard:
+
+```json
+{
+  "fleet": "payments-prod",
+  "view": "payments-prod-conformance",
+  "strategy": "git-argo",
+  "verdict": "BLOCK",
+  "rollup": {
+    "PASS": 18,
+    "WATCH": 1,
+    "ASK": 0,
+    "BLOCK": 3,
+    "outliers": 2
+  },
+  "blockers": [
+    "Deployment/payments-api in prod-use1 (sourceTruth=MISMATCH)",
+    "Deployment/payments-worker in prod-use1 (sourceTruth=MISMATCH)",
+    "Deployment/payments-db in prod-euw1 (sourceTruth=MISMATCH)"
+  ],
+  "evidence_path": "/path/to/audit/receipts/2026-05-22/",
+  "next_step": "investigate the 3 BLOCK resources via pilot-patch-and-drift"
+}
+```
+
+Downstream consumer (compliance dashboard) reads the verdict, halts promotion, escalates to the team with the per-resource breakdown.
+
+## Standalone vs connected
+
+Most of this skill **requires connected mode** (`cub auth login`):
+
+- `compare three-way` (DRY layer needs ConfigHub) — connected
+- `compare source-truth` — connected (the contract is meaningless without all 3 surfaces)
+- `views resolve` / `views project` — connected
+- `fleet outliers` — connected (cross-cluster snapshots live in ConfigHub)
+- `receipt verify --strategy <s>` — connected (source-truth-pass predicate requires it)
+
+Standalone-mode fleet conformance is narrower:
+- Per-resource `compare drift` against files (no DRY layer)
+- `receipt verify --predicate applied-matches-spec` (cluster-only)
+- No View scope; falls back to namespace / cluster scope
+
+Pilot should run `cub-scout status` in the pipeline preamble; if standalone and the fleet verdict requires `--strategy`, escalate to ASK with a "connected mode required" message.
+
+## CI / dashboard integration
+
+For periodic fleet audits, the verbs are CI-shaped:
+
+```bash
+# Daily cron — render the fleet verdict, exit non-zero if BLOCK
+$ cub-scout compare three-way --view payments-prod-conformance --fail-on warning
+# exit 2 if any resource in the View has a hard mismatch
+```
+
+For receipts-attached audits (preferred for compliance):
+
+```bash
+# Per-resource receipt save + collect into audit branch
+$ ./fleet-audit.sh > audit-results.txt
+$ cub-scout receipt list --format json > audit-receipts.json
+$ git add audit-receipts.json && git commit -m "fleet audit $(date -u +%F)"
+```
+
+Pilot's typical batch shape: run per-resource `receipt verify --strategy <s> --save` overnight; in the morning, walk `cub-scout receipt list --format json` for the verdict roll-up.
+
+## Tool boundary
+
+- **Allowed (cub-scout):** Compare verbs; `fleet outliers`; `views resolve` / `project`; `receipt verify` / `show` / `validate` / `list`; `scan`; `map`; `summary list`. All read-only.
+- **Allowed (cluster):** `kubectl get`. NOT `kubectl apply/edit/patch/delete`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub view get / list`. NOT `cub * create / update / delete / sync`.
+- **Pilot itself may mutate** via `cub` or controller verbs, but the fleet-conformance verdict is Pilot's evidence-driven judgment; cub-scout never decides on Pilot's behalf.
+
+## References
+
+- [`audit-fleet-conformance`](../audit-fleet-conformance/SKILL.md) — operator-side counterpart (same verbs, different framing)
+- [`scout-compare`](../scout-compare/SKILL.md) — the four Compare verbs (cub-scout side)
+- [`scout-govern`](../scout-govern/SKILL.md) — fleet outliers, views, summary
+- [`scout-verify`](../scout-verify/SKILL.md) — receipt persistence
+- [`confighub-source-truth`](../confighub-source-truth/SKILL.md) — strategy-typed verdict
+- [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) — single-resource pre-deploy gate companion
+- [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md) — drill-down for the BLOCK resources Pilot flags
+- [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) — event-driven companion (this skill is periodic-driven)
+- Views integration: `#391` (parent), `#414` (compare three-way --view), `#403` (views resolve), `#420` (views project --with-reality)
+- Source-truth contract: `#393`, `#418` (Phase 2 strategies)
+
+## Constraints
+
+- Connected mode is required for the View + ConfigHub + fleet surfaces.
+- The strategy is **caller-declared** per resource (or uniform across the View when the team declares fleet-wide policy). cub-scout never infers it.
+- Synthesis policy (max-severity, majority, weighted, etc.) is **Pilot's** choice. cub-scout provides per-resource verdicts; the roll-up shape is Pilot-side.
+- `fleet outliers` requires the View to be **declared with cluster scope** (`cub view create --scope cluster`). Namespace-scoped Views can't be cross-clustered.
+- Per-resource receipts in a fleet audit can be high-volume. The local receipt store handles large-N writes (each filename is canonical so collisions are predictable), but downstream consumers should expect `receipt list` to return many entries.

--- a/skills/pilot-incident-evidence/SKILL.md
+++ b/skills/pilot-incident-evidence/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: pilot-incident-evidence
+description: 'Use when Pilot is ASSEMBLING THE INCIDENT EVIDENCE PACK during incident close-out — Pilot renders a structured, fingerprinted evidence package the postmortem and the audit ticket both consume. Natural phrasings: "Pilot, build the evidence pack for last night''s outage", "render the incident verdict + evidence for the SEV-2", "Pilot, what does cub-scout have on this incident?", "freeze the evidence before the cluster moves on", "assemble the postmortem inputs from cub-scout". Pilot composes `trace` + `explain` + attribution + recent K8s events + `bundle` + `history` + (crucially) per-affected-resource `receipt verify --save` with chained `--input-attestation` for multi-stage incidents. Differs from `operator-incident-evidence` which is OPERATOR-DRIVEN (the SRE assembling for their own postmortem); this skill is JUDGE-DRIVEN (Pilot rendering an evidence pack + verdict for downstream consumption). Do NOT load for: pager-active triage (use triage-unhealthy-workload), a real-time event-driven response (use pilot-watch-alert-response), a periodic fleet audit (use pilot-fleet-conformance), or any mutating remediation. cub-scout never mutates; Pilot''s mutation path is `cub` / Argo / Flux.'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout trace *) Bash(cub-scout trace *) Bash(cub scout trace *) Bash(./cub-scout explain *) Bash(cub-scout explain *) Bash(cub scout explain *) Bash(./cub-scout compare *) Bash(cub-scout compare *) Bash(cub scout compare *) Bash(./cub-scout doctor *) Bash(cub-scout doctor *) Bash(cub scout doctor *) Bash(./cub-scout bundle *) Bash(cub-scout bundle *) Bash(cub scout bundle *) Bash(./cub-scout history *) Bash(cub-scout history *) Bash(cub scout history *) Bash(./cub-scout audit *) Bash(cub-scout audit *) Bash(cub scout audit *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout snapshot *) Bash(cub-scout snapshot *) Bash(cub scout snapshot *) Bash(./cub-scout map *) Bash(cub-scout map *) Bash(cub scout map *) Bash(kubectl get *) Bash(kubectl describe *) Bash(kubectl get events *) Bash(kubectl logs *) Bash(cub * get) Bash(cub * list) Bash(cub history *) Bash(cub link list *) Bash(cub unit get *) Bash(argocd app get *) Bash(flux get *)
+
+---
+
+# pilot-incident-evidence
+
+The incident-evidence scenario from **Pilot's** side. After the incident is past peak (pager no longer firing), Pilot is asked to **render an evidence pack + verdict** that downstream consumers — the postmortem doc, the release-engineering meeting, the audit ticket, the compliance review — all consume.
+
+This is the **judge-driven** companion to [`operator-incident-evidence`](../operator-incident-evidence/SKILL.md) (the SRE-driven postmortem assembly). Same cub-scout verbs feed both; the difference is framing: the operator wants to understand the incident; Pilot wants to render a verdict + a fingerprinted evidence pack on the incident's close-out.
+
+The receipts v2 chained-attestation surface (`--input-attestation`, shipped in `#463`) is load-bearing here: a multi-stage incident produces a **chain** of per-stage receipts, each referencing the prior, and the final verdict receipt has the full chain inline. cub-scout never mutates; Pilot's "what should we change" recommendation is its own surface, not cub-scout's.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot, build the evidence pack for last night's outage"
+- "Render the incident verdict + evidence for the SEV-2"
+- "Pilot, what does cub-scout have on this incident?"
+- "Freeze the evidence before the cluster moves on"
+- "Assemble the postmortem inputs from cub-scout"
+- "Pilot, attach the verdict + fingerprinted receipts to the audit ticket"
+- "Chain the receipts so the postmortem has the full delivery path"
+
+Implicit intents:
+
+- The incident is **past peak** (pager no longer firing); time pressure has eased
+- Pilot is rendering for an **audience** — postmortem doc, release-engineering meeting, compliance audit
+- The evidence needs to be **immutable** (fingerprinted) — it shouldn't shift if someone fixes the cluster afterwards
+- The output is a **verdict + an evidence pack**, not just a description
+- Multi-stage incidents (deploy → reconciliation → drift → revert) want **chained receipts**, not isolated artifacts
+
+## Do not load for
+
+- **Pager-active triage** (the incident is still firing) — [`triage-unhealthy-workload`](../triage-unhealthy-workload/SKILL.md)
+- A **real-time event-driven response** as the incident unfolds — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- A **single-resource pre-deploy gate** that would have prevented the incident — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- A **periodic fleet audit** — [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md)
+- A **drift-classification deep-dive** in isolation — [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md)
+- An **operator-driven** evidence assembly (SRE writing their own postmortem) — [`operator-incident-evidence`](../operator-incident-evidence/SKILL.md)
+- Any **mutating action**. cub-scout doesn't revert / fix / restart. Pilot's mutation path is `cub` / Argo / Flux / kubectl.
+
+## The Pilot ↔ cub-scout incident-evidence loop
+
+```
+   incident SEV-2 fired at 14:00, resolved at 16:00 — close-out at 16:30
+        │
+        ▼
+   Pilot (acceptance judge)
+        │  "render the evidence pack + verdict for incident-2026-05-22-001"
+        │
+        ├──► Per affected resource:
+        │      cub-scout trace <r> -n <ns> --format json     # owner + lineage
+        │      cub-scout explain <r> -n <ns> --presentation ai
+        │      cub-scout compare three-way <r> -n <ns>      # DRY/WET/LIVE + attribution
+        │        --format json
+        │      cub-scout history <r> -n <ns> --since 4h     # ChangeSet timeline
+        │      cub-scout receipt verify <r> -n <ns>
+        │        --predicate no-manual-edits-since
+        │        --since <pre-incident timestamp>
+        │        --save                                      # was a manual edit involved?
+        │
+        ├──► Cluster-level capture:
+        │      cub-scout bundle --since 4h                   # debug-bundle archive (replay-able)
+        │      cub-scout snapshot                            # GSF JSON snapshot (offline)
+        │      cub-scout audit list --since 4h               # ConfigHub audit entries
+        │
+        ├──► (multi-stage) Chain the receipts:
+        │      # Stage 1: pre-incident receipt
+        │      cub-scout receipt verify <r> ... --out stage1.receipt.json
+        │      # Stage 2: at-incident receipt, chained to stage 1
+        │      cub-scout receipt verify <r> ... \
+        │        --input-attestation stage1.receipt.json \
+        │        --out stage2.receipt.json
+        │      # Stage 3: post-resolution receipt, chained to stage 2
+        │      cub-scout receipt verify <r> ... \
+        │        --input-attestation stage2.receipt.json \
+        │        --out stage3.receipt.json
+        │
+        └──► (optional) cub-scout receipt list --format json > incident-receipt-inventory.json
+        │
+        ▼
+   Pilot's evidence pack + verdict:
+        │
+        │  evidence_pack = {
+        │    incident_id: "incident-2026-05-22-001",
+        │    verdict: <max-severity over all receipts>,
+        │    timeline: [
+        │      {stage: "pre", receipt: "stage1.receipt.json"},
+        │      {stage: "at", receipt: "stage2.receipt.json"},
+        │      {stage: "post", receipt: "stage3.receipt.json"}
+        │    ],
+        │    bundle: "incident-bundle.tar.gz",
+        │    snapshot: "incident-snapshot.json",
+        │    audit_entries: [...],
+        │    next_step: "<Pilot's recommendation, e.g., open Git PR to remove kubectl-edit access>"
+        │  }
+        │
+        ▼
+   downstream consumer (postmortem / audit / compliance) reads the pack
+        └────────────────────────────────────────────────────
+```
+
+## The four-tier evidence shape
+
+Pilot's incident pack composes four tiers of cub-scout evidence, in increasing audit durability:
+
+| Tier | Verb | Durability | Shape |
+|------|------|------------|-------|
+| **1. Ephemeral** | `compare three-way`, `explain`, `trace`, `history` | One-shot JSON; valid at this moment | Live evidence — the cluster state at incident close-out |
+| **2. Bundle snapshot** | `bundle`, `snapshot` | Tar / JSON archive replay-able offline | Cluster-wide state freeze; survives the cluster being rolled |
+| **3. Fingerprinted receipt** | `receipt verify --save` | Immutable per-resource artifact; SHA-256 fingerprint over RFC 8785 canonical JSON | Typed evidence; verdict per predicate; verifiable later via `receipt validate` |
+| **4. Chained receipts** | `receipt verify --input-attestation <prior>` | Per-stage receipts linked by `inputAttestations[]`; each ref's fingerprint verified at chain construction | Multi-stage incident timeline as a tamper-evident DAG |
+
+Pilot uses tier-1 + tier-2 for the narrative; tier-3 + tier-4 for the **immutable** part of the pack. The chained-receipts tier is what makes a multi-stage incident's evidence trustworthy: tampering with any upstream receipt invalidates every downstream receipt's fingerprint.
+
+## Step-by-step
+
+### Step 1 — define scope and timeline
+
+- What resources were involved? (`deploy/payments-api`, maybe `deploy/payments-worker`, the upstream `service/payments`)
+- What time window? (incident fired 14:00, resolved 16:00; capture from 13:00 to 16:30 to cover pre-and-post state)
+- Was there a **deploy** during the window? a **manual edit**? a **controller reconciliation flap**?
+
+### Step 2 — resource-level evidence (per affected resource)
+
+```bash
+# Owner + lineage
+$ cub-scout trace deploy/payments-api -n prod --format json > payments-api-trace.json
+$ cub-scout explain deploy/payments-api -n prod --presentation ai > payments-api-explain.txt
+
+# DRY/WET/LIVE + per-field attribution
+$ cub-scout compare three-way deploy/payments-api -n prod --format json > payments-api-3way.json
+
+# ChangeSet timeline
+$ cub-scout history deploy/payments-api -n prod --since 4h --format json > payments-api-history.json
+
+# Manual-edits check
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --predicate no-manual-edits-since \
+    --since 2026-05-22T13:00:00Z \
+    --save \
+    --out payments-api-manual-edits.receipt.json
+```
+
+The four outputs together answer: who owns it, how is it diverging now, what changed recently, and was a kubectl-* writer involved.
+
+### Step 3 — cluster-level capture (offline-replay-able)
+
+```bash
+$ cub-scout bundle --since 4h > incident-bundle.tar.gz
+$ cub-scout snapshot > incident-snapshot.json
+$ cub-scout audit list --since 4h --format json > incident-audit.json
+```
+
+The bundle archives enough cluster state to replay offline (`cub-scout bundle replay` later). The snapshot is GSF JSON for tooling. `audit list` collects connected-mode ConfigHub audit entries.
+
+### Step 4 — multi-stage chained receipts (the load-bearing piece)
+
+For a multi-stage incident (e.g., deploy at 13:50 → drift at 14:00 → revert at 15:30), capture per-stage receipts and chain them:
+
+```bash
+# Stage 1: pre-incident baseline
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --at-commit <pre-incident-sha> \
+    --save \
+    --out incident/stage1-pre.receipt.json
+
+# Stage 2: at peak (during the incident)
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --input-attestation incident/stage1-pre.receipt.json \
+    --save \
+    --out incident/stage2-at.receipt.json
+
+# Stage 3: post-resolution
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --input-attestation incident/stage2-at.receipt.json \
+    --save \
+    --out incident/stage3-post.receipt.json
+```
+
+The chain forms a tamper-evident DAG: `stage3` references `stage2` references `stage1`, and each parent's fingerprint is verified at chain construction time. Tampering with `stage1.receipt.json` after the fact would refuse to chain into `stage2` — chain construction errors out upfront rather than silently propagating bad evidence.
+
+The verify step inside `cub-scout receipt verify --input-attestation` is enforced **at the API boundary** via the `VerifiedAttestationRef` typed wrapper (#463 Codex round-6 P1 fix). Programmatic callers cannot bypass the verify step; the chain integrity property is locked in code.
+
+### Step 5 — Pilot's verdict synthesis
+
+Pilot's verdict for the incident pack is **max-severity over the chained receipts**:
+
+| Stage receipts' verdicts | Pilot's incident verdict |
+|--------------------------|--------------------------|
+| All PASS | **PASS** (no incident; close as no-op) |
+| At least one WATCH, rest PASS | **WATCH** (close with a flag) |
+| At least one ASK | **ASK** (postmortem owners need to fill proof gaps) |
+| Any BLOCK | **BLOCK** (real incident; write a postmortem) |
+
+The chained shape encodes the timeline: PASS → BLOCK → PASS reads as "we had a manual-edit episode that we recovered from"; PASS → BLOCK → BLOCK reads as "we never recovered intent; the live state is still divergent."
+
+### Step 6 — assemble the pack for downstream consumption
+
+```json
+{
+  "incident_id": "incident-2026-05-22-001",
+  "scope": "Deployment/payments-api in prod",
+  "window": "13:00–16:30",
+  "verdict": "BLOCK",
+  "timeline": [
+    {"stage": "pre",  "at": "13:00", "receipt": "stage1-pre.receipt.json",  "verdict": "PASS"},
+    {"stage": "at",   "at": "14:00", "receipt": "stage2-at.receipt.json",   "verdict": "BLOCK"},
+    {"stage": "post", "at": "16:30", "receipt": "stage3-post.receipt.json", "verdict": "PASS"}
+  ],
+  "bundle": "incident-bundle.tar.gz",
+  "snapshot": "incident-snapshot.json",
+  "audit_entries": "incident-audit.json",
+  "narrative": "explain + trace + 3way outputs (txt + json)",
+  "root_cause_hypothesis": "manual-edit on image during pager-active triage (kubectl-edit; verified manager string)",
+  "recommendation": "open Git PR amending apps/prod/payments-api/deployment.yaml; remove ad-hoc kubectl-edit access from on-call IAM"
+}
+```
+
+The downstream consumer (postmortem author, audit reviewer) reads the verdict + the chained timeline + the cluster-state artifacts. Every receipt is fingerprint-verifiable; `cub-scout receipt validate` exit-coded for CI.
+
+## Worked example
+
+Incident `incident-2026-05-22-001`: `deploy/payments-api` in prod fired SEV-2 at 14:00. Resolved by 16:00. Pilot is rendering the close-out pack.
+
+```bash
+# Pre-incident baseline (the controller said this was good at 13:00)
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --at-commit 9e7d12fa \
+    --save \
+    --out incident/stage1-pre.receipt.json
+# verdict: PASS, fingerprint: sha256:abc...
+
+# At incident peak (14:00)
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --input-attestation incident/stage1-pre.receipt.json \
+    --save \
+    --out incident/stage2-at.receipt.json
+# verdict: BLOCK, evidence shows manual-edit on container image; fingerprint: sha256:def...
+
+# Post-resolution (16:30)
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --input-attestation incident/stage2-at.receipt.json \
+    --save \
+    --out incident/stage3-post.receipt.json
+# verdict: PASS, the post-resolution Git revision matches LIVE; fingerprint: sha256:789...
+
+# Bundle + snapshot for offline replay
+$ cub-scout bundle --since 4h > incident/bundle.tar.gz
+$ cub-scout snapshot > incident/snapshot.json
+
+# Connected-mode timeline
+$ cub-scout history deploy/payments-api -n prod --since 4h --format json > incident/history.json
+$ cub-scout audit list --since 4h --format json > incident/audit.json
+
+# Receipt inventory for the incident namespace
+$ cub-scout receipt list --format json > incident/receipt-inventory.json
+```
+
+Pilot's verdict pack (rendered as JSON for the audit ticket):
+
+```json
+{
+  "incident_id": "incident-2026-05-22-001",
+  "verdict": "BLOCK",
+  "scope": "Deployment/payments-api in prod",
+  "window": "13:00–16:30",
+  "chain": ["stage1-pre", "stage2-at", "stage3-post"],
+  "verdict_per_stage": ["PASS", "BLOCK", "PASS"],
+  "root_cause": "manual-edit on container image during pager triage",
+  "verified_manager": "kubectl-edit",
+  "recovered_at": "16:00",
+  "evidence_paths": {
+    "receipts": "incident/stage{1,2,3}-*.receipt.json",
+    "bundle": "incident/bundle.tar.gz",
+    "snapshot": "incident/snapshot.json",
+    "history": "incident/history.json",
+    "audit": "incident/audit.json"
+  },
+  "recommended_follow_ups": [
+    "Open Git PR codifying the image bump as intent",
+    "Review on-call IAM (remove kubectl-edit on prod deployments)",
+    "Open issue against #449 — investigate whether watch alert fired pre-pager"
+  ]
+}
+```
+
+The audit ticket gets the verdict + the chained-receipts manifest. Six months later, an auditor can:
+
+```bash
+$ cub-scout receipt validate incident/stage1-pre.receipt.json   # exit 0 — fingerprint intact
+$ cub-scout receipt validate incident/stage2-at.receipt.json    # exit 0 — fingerprint intact
+$ cub-scout receipt validate incident/stage3-post.receipt.json  # exit 0 — fingerprint intact
+$ cub-scout receipt show incident/stage2-at.receipt.json --format ascii
+# Same evidence Pilot rendered the verdict from; tamper-evident.
+```
+
+If any of the receipts had been tampered with between then and now, `receipt validate` would exit 1 — the audit would immediately know the chain was untrustworthy.
+
+## Standalone vs connected
+
+Most of this skill works in **both modes**:
+
+- Standalone: tier-1 + tier-2 + tier-3 (with `--predicate applied-matches-spec` and `--predicate no-manual-edits-since`); chained receipts work. Receipts will carry an `OmissionConfigHubUnitSubject` entry.
+- Connected: adds `--strategy source-truth-pass` (tier-3 quality boost), `cub-scout audit list`, `cub-scout history`, `bindingSource` in attribution. Recommended for production incident packs.
+
+Pilot should run `cub-scout status` in the pack-assembly preamble; if standalone, Pilot's pack records the limitation explicitly (the receipts themselves already record it via omissions).
+
+## Tool boundary
+
+- **Allowed (cub-scout):** `trace`, `explain`, all Compare verbs, `doctor`, `bundle`, `history`, `audit`, `receipt verify` / `show` / `validate` / `list`, `snapshot`, `map`. All read-only.
+- **Allowed (cluster):** `kubectl get/describe`, `kubectl get events`, `kubectl logs`. NOT `kubectl apply / edit / patch / delete` / `rollout undo`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub history`, `cub link list`, `cub unit get`. NOT `cub * create / update / delete`.
+- **Allowed (controllers):** `argocd app get`, `flux get`. NOT `argocd app sync`, `flux reconcile`.
+- **Pilot's recommendation** ("open a Git PR", "remove kubectl-edit access") is **a recommendation only**. cub-scout doesn't implement the recommendation; Pilot's mutation path is `cub` / Argo / kubectl. This skill produces evidence and a verdict, not a remediation.
+
+## References
+
+- [`operator-incident-evidence`](../operator-incident-evidence/SKILL.md) — operator-driven counterpart (SRE writing their own postmortem)
+- [`scout-verify`](../scout-verify/SKILL.md) — receipts + chained `--input-attestation`
+- [`scout-observe`](../scout-observe/SKILL.md) — `bundle`, `snapshot`, `watch` (the source of replay-able evidence)
+- [`scout-attribute`](../scout-attribute/SKILL.md) — `cause` / `managerHint` / `gitSource` per field
+- [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md) — drift-classification companion (per-field, not per-incident)
+- [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) — real-time companion (the events that may have fired during the incident; this skill replays them in the bundle)
+- [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) — what should have caught the incident pre-deploy (postmortem may recommend tightening this)
+- Chained receipts: `#448` (issue), `#463` (chained-half shipped); `VerifiedAttestationRef` typed wrapper enforces verify at API boundary
+- in-toto Statement v1, RFC 8785 canonical JSON, SHA-256 fingerprint: [`docs/reference/json-contracts.md`](../../docs/reference/json-contracts.md) § Receipt Contract
+
+## Constraints
+
+- The incident pack's **immutability** depends on the receipt store's `O_EXCL` atomic file create (cub-scout side). The store at `$XDG_DATA_HOME/cub-scout/receipts` is per-host; Pilot should archive receipts to a durable store (S3, ConfigHub bundle catalog) for long-term audit retention.
+- Chained receipts ONLY verify chain integrity at construction time — `cub-scout receipt validate` checks one receipt's fingerprint; verifying a multi-stage chain requires walking each `inputAttestations[]` entry and validating it independently. A future helper may automate this; today it's a manual loop.
+- `--input-attestation` requires the **upstream receipt to be a valid in-toto Statement v1 envelope with a verifiable fingerprint**. Tampered upstreams refuse to chain at the verify-time API boundary (`VerifiedAttestationRef` typed wrapper); Pilot must capture pristine receipts at each stage.
+- `bundle` archives can be large for high-resource clusters. Pilot may want to scope `bundle --namespace <ns>` to the affected namespace rather than the whole cluster.
+- The verdict is **per-incident**, not per-resource. A multi-resource incident produces N chains, and Pilot's incident-level verdict is the max-severity over all chains.

--- a/skills/pilot-patch-and-drift/SKILL.md
+++ b/skills/pilot-patch-and-drift/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: pilot-patch-and-drift
+description: 'Use when Pilot is CLASSIFYING DRIFT and DECIDING WHAT TO DO ABOUT IT after a divergence between intended state and live state is detected. Natural phrasings: "Pilot, classify this drift", "is this manual edit or controller drift?", "should Pilot revert this patch?", "quarantine or accept-as-canonical?", "what does cub-scout say about who touched this field?", "render a drift verdict for the audit". Pilot consumes cub-scout''s attribution evidence (`cause: manual-edit` / `controller-drift` / `unknown` + `managerHint` + `gitSource` + `bindingSource`) and decides revert / quarantine / accept-as-canonical / ASK-human. The decision shape matches the attribution layer''s evidence shape — cub-scout produces deterministic classification; Pilot picks the policy action. Do NOT load for: a single-resource pre-deploy gate (use pilot-cd-gate), a real-time event response (use pilot-watch-alert-response), a fleet roll-up (use pilot-fleet-conformance), or any mutating action. Pilot mutates via `cub` / Argo / kubectl — never via cub-scout.'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout compare *) Bash(cub-scout compare *) Bash(cub scout compare *) Bash(./cub-scout explain *) Bash(cub-scout explain *) Bash(cub scout explain *) Bash(./cub-scout trace *) Bash(cub-scout trace *) Bash(cub scout trace *) Bash(./cub-scout history *) Bash(cub-scout history *) Bash(cub scout history *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(kubectl get *) Bash(kubectl describe *) Bash(kubectl get --show-managed-fields *) Bash(cub * get) Bash(cub * list) Bash(cub link list *) Bash(cub unit get *) Bash(argocd app get *) Bash(flux get *)
+
+---
+
+# pilot-patch-and-drift
+
+The drift-classification scenario from **Pilot's** side. A field has diverged from its intended value; Pilot needs to decide what to do — revert, quarantine, accept-as-canonical, or ASK a human. The decision depends on **who** changed the field and **what kind** of change it was, which is exactly what cub-scout's attribution layer (#435) produces.
+
+cub-scout's attribution surface is deterministic: every `compareFieldMismatch` carries `cause` (`controller-drift` / `manual-edit` / `unknown`) + `managerHint` (the verified manager-string from `managedFields`) + `gitSource` (where the intended value came from) + `bindingSource` (which ConfigHub Link supplied it, when connected). Pilot reads that triple and picks an action.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot, classify this drift"
+- "Is this manual edit or controller drift?"
+- "Should Pilot revert this patch?"
+- "Quarantine or accept-as-canonical?"
+- "What does cub-scout say about who touched this field?"
+- "Render a drift verdict for the audit"
+- "Decision: is this an emergency manual fix we accept, or noise we revert?"
+- "Argo and kubectl both wrote this field — who actually owns it?"
+
+Implicit intents:
+
+- A **divergence is already known** (an audit found it, a watch event surfaced it, a gate failed) — this isn't the discovery skill
+- The user wants a **classification + action**, not just a description
+- The action is the **operator's call** but informed by deterministic attribution evidence
+- The result may persist as a **fingerprinted receipt** if the action needs an audit trail
+
+## Do not load for
+
+- A **pre-deploy gate** (drift hasn't happened yet) — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- A **real-time event-driven** drift response — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- A **fleet roll-up verdict** — [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md)
+- **Postmortem evidence assembly** — [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md)
+- Pure **investigation** without a Pilot policy decision (operator wants to understand, not decide) — [`investigate-drift`](../investigate-drift/SKILL.md)
+- The **first-pass discovery** of drift — [`scout-attribute`](../scout-attribute/SKILL.md) (the underlying capability) or [`scout-compare`](../scout-compare/SKILL.md)
+- Any **mutating action**. cub-scout doesn't revert, quarantine, or apply. Pilot's mutation path is `cub` / Argo / Flux / kubectl.
+
+## The Pilot ↔ cub-scout drift loop
+
+```
+   alert: drift detected on deploy/payments-api spec.replicas
+        │
+        ▼
+   Pilot (acceptance judge)
+        │  "classify this drift, decide an action"
+        │
+        ├──► cub-scout compare three-way deploy/payments-api -n prod
+        │     --format json
+        │     │
+        │     │   per-field fieldMismatches[] with:
+        │     │     cause          (controller-drift / manual-edit / unknown)
+        │     │     managerHint    (verified manager string)
+        │     │     gitSource      (repoUrl / revision / path / file / line)
+        │     │     bindingSource  (upstream unit + binding path + link, connected)
+        │     │     compareThreeWay (DRY/WET/LIVE values per field)
+        │     ▼
+        │
+        ├──► (optional) cub-scout history deploy/payments-api -n prod
+        │     # ConfigHub ChangeSet timeline for the past 24h
+        │
+        ├──► (optional) cub-scout explain deploy/payments-api -n prod --presentation ai
+        │     # narrative ownership + lineage (AI-shaped output)
+        │
+        └──► (optional, for audit) cub-scout receipt verify deploy/payments-api -n prod
+              --predicate no-manual-edits-since --since <timestamp> --save
+        │
+        ▼
+   Pilot's drift verdict, by field:
+        │
+        │  cause: controller-drift   → ACCEPT (controller is reconciling; transient)
+        │  cause: manual-edit + Argo-owned → INVESTIGATE → likely REVERT or QUARANTINE
+        │  cause: manual-edit + Flux-owned → same
+        │  cause: manual-edit + unmanaged   → ACCEPT-AS-CANONICAL or QUARANTINE
+        │  cause: unknown                   → ASK (managedFields incomplete)
+        │
+        ▼
+   downstream consumer reads the action
+        │  ACCEPT             → no-op
+        │  REVERT             → trigger `argocd app sync` / `flux reconcile` / `cub unit update`
+        │  QUARANTINE         → tag the resource, alert the owner
+        │  ACCEPT-AS-CANONICAL → update intent (Git PR / `cub unit update`)
+        │  ASK                → page a human
+        └────────────────────────────────────────────────────
+```
+
+## The five `cause` outcomes
+
+cub-scout's attribution layer produces one of five `cause` values per field. Pilot's policy maps each to an action:
+
+| `cause` | Meaning | Typical Pilot action |
+|---------|---------|----------------------|
+| `controller-drift` | The detected owner's controller wrote the field. The drift is the controller doing its job (e.g., HPA scaled replicas; the controller will re-converge). | **ACCEPT** — no action; the controller is reconciling. |
+| `manual-edit` (Argo/Flux/ConfigHub owner) | A `kubectl-*` writer touched the field on a controller-owned resource. This is a real divergence — the controller will fight the manual edit on next sync. | **INVESTIGATE** — read the gitSource / bindingSource; usually **REVERT** (let the controller win) or **QUARANTINE** if the manual edit was an emergency fix. |
+| `manual-edit` (no controller owner) | A `kubectl-*` writer on an unmanaged resource. There's no controller to fight back. | **ACCEPT-AS-CANONICAL** (update intent to match) or **QUARANTINE** if the resource shouldn't be unmanaged. |
+| `controller-drift` (verified manager unknown / wrong) | A controller wrote it, but the manager string isn't in the verified enumeration (or is from a different controller than the detected owner — Argo wrote on a Flux-owned resource). | **ASK** — possible controller-on-controller conflict; cub-scout doesn't guess which is canonical. |
+| `unknown` | `managedFields` is missing or the field-path resolution failed. | **ASK** — Pilot doesn't have enough evidence. |
+
+The verified manager-string enumeration ([`verified-manager-strings`](../references/verified-manager-strings.md)) covers Argo CD, Flux (kustomize/helm/source controllers), Helm direct, Crossplane (composite/composed/claim/MRD/refs), kro (applyset/parent/labeller), and `kubectl-*`. Strings not in the enumeration return `unknown` rather than misclassifying — same `parse, don't guess` rule used by ownership detection.
+
+## Step-by-step
+
+### Step 1 — get the structured evidence
+
+```bash
+$ cub-scout compare three-way deploy/payments-api -n prod --format json
+```
+
+The output's `fieldMismatches[]` is per-field. Each entry has:
+
+```json
+{
+  "path": "spec.template.spec.containers[0].image",
+  "compareThreeWay": {
+    "dry": "ghcr.io/org/payments-api:v1.4.2",
+    "wet": "ghcr.io/org/payments-api:v1.4.2",
+    "live": "ghcr.io/org/payments-api:v1.4.3-hotfix"
+  },
+  "cause": "manual-edit",
+  "managerHint": "kubectl-edit",
+  "gitSource": {
+    "repoUrl": "https://github.com/org/payments",
+    "revision": "abc123",
+    "path": "apps/prod/payments-api/deployment.yaml",
+    "file": "apps/prod/payments-api/deployment.yaml",
+    "line": 42
+  },
+  "bindingSource": null
+}
+```
+
+This is the canonical evidence shape Pilot reads. The triple `(cause, managerHint, gitSource)` carries the deterministic classification; the four values (`dry`, `wet`, `live`, plus the resolved `gitSource`) carry the divergence shape.
+
+### Step 2 — (connected) check the binding source
+
+When connected, the same output includes a `bindingSource` per field that the field came from an upstream ConfigHub Link:
+
+```json
+{
+  "bindingSource": {
+    "unit": "payments-base",
+    "path": ".spec.image",
+    "link": "lnk-2024-prod-image-bump"
+  }
+}
+```
+
+Reading: the live `image` field was supposed to come from upstream unit `payments-base` via Link `lnk-2024-prod-image-bump`. Pilot can:
+
+- `cub unit get payments-base` to see the canonical value
+- `cub link list payments-api` to see all incoming bindings
+- Decide whether the divergence is in the downstream resource or the upstream unit
+
+When standalone or the resource isn't ConfigHub-linked, `bindingSource: null` and Pilot drops back to the `cause` + `managerHint` evidence.
+
+### Step 3 — (optional) get the change timeline
+
+```bash
+$ cub-scout history deploy/payments-api -n prod --since 24h --format json
+```
+
+The history surface produces the ConfigHub ChangeSet timeline (connected only). Useful when:
+- The drift might be a recent intentional change Pilot should reconcile to
+- The audit needs a "who changed what when" entry
+
+### Step 4 — render the verdict
+
+Pilot's verdict per field is the action from the table above. For the worked-example field (manual-edit on an Argo-owned image field):
+
+```json
+{
+  "resource": "Deployment/payments-api in prod",
+  "field": "spec.template.spec.containers[0].image",
+  "cause": "manual-edit",
+  "managerHint": "kubectl-edit",
+  "owner": "argo",
+  "action": "INVESTIGATE",
+  "recommendation": "Likely emergency hotfix — verify with on-call before reverting. If intentional, update intent (Git PR to apps/prod/payments-api/deployment.yaml line 42); if not, let Argo sync revert it.",
+  "evidence_path": null
+}
+```
+
+### Step 5 — (optional) persist a receipt
+
+If the verdict needs an audit trail (e.g., for compliance review later):
+
+```bash
+# Predicate "no-manual-edits-since": BLOCK if any kubectl-* writer touched the resource
+# after the cutoff. The cutoff is typically the last known intentional change.
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --predicate no-manual-edits-since \
+    --since 2026-05-22T00:00:00Z \
+    --save \
+    --out drift.receipt.json
+```
+
+The receipt records what cub-scout observed at this moment + the verdict (BLOCK if a kubectl-* writer touched it after the cutoff). Pilot attaches `drift.receipt.json` to the drift ticket.
+
+### Step 6 — invoke the action (Pilot's surface, not cub-scout's)
+
+Pilot's mutation choices, by action:
+
+| Action | Pilot's mutation path |
+|--------|----------------------|
+| ACCEPT | none (no-op) |
+| REVERT | `argocd app sync <app>` (Argo); `flux reconcile kustomization <ks>` (Flux); `cub unit apply <unit>` (ConfigHub) |
+| QUARANTINE | label/annotate the resource (out-of-scope for cub-scout); page the owner |
+| ACCEPT-AS-CANONICAL | Open a Git PR amending the intended state; `cub unit update <unit>` to update ConfigHub intent |
+| ASK | escalate to the on-call human |
+
+cub-scout participates **only in evidence**. The mutation paths above are all out-of-scope for this skill.
+
+## Worked example
+
+A drift alert fires on `deploy/payments-api` in prod — `spec.template.spec.containers[0].image` has diverged.
+
+```bash
+$ cub-scout compare three-way deploy/payments-api -n prod --format json \
+    | jq '.fieldMismatches[] | select(.path | contains("image"))'
+{
+  "path": "spec.template.spec.containers[0].image",
+  "compareThreeWay": {
+    "dry": "ghcr.io/org/payments-api:v1.4.2",
+    "wet": "ghcr.io/org/payments-api:v1.4.2",
+    "live": "ghcr.io/org/payments-api:v1.4.3-hotfix"
+  },
+  "cause": "manual-edit",
+  "managerHint": "kubectl-edit",
+  "gitSource": {
+    "repoUrl": "https://github.com/org/payments",
+    "revision": "abc123",
+    "path": "apps/prod/payments-api/deployment.yaml",
+    "file": "apps/prod/payments-api/deployment.yaml",
+    "line": 42
+  },
+  "bindingSource": null
+}
+```
+
+Pilot's reading:
+- DRY=WET (`v1.4.2`) but LIVE=`v1.4.3-hotfix` — manual-edit
+- `cause: manual-edit` + `managerHint: kubectl-edit` confirms a human ran `kubectl edit` or `kubectl set image`
+- Owner (from `cub-scout explain`): Argo CD application `payments-api`
+- `gitSource.file:line` points at the canonical declaration
+
+Pilot's verdict:
+- **Action**: INVESTIGATE
+- **Recommendation**: Likely an emergency hotfix (suffix `-hotfix` is a strong hint). Verify with on-call:
+  - If intentional → open Git PR amending `apps/prod/payments-api/deployment.yaml:42` to `v1.4.3-hotfix` and merge; Argo will sync.
+  - If accidental → trigger `argocd app sync payments-api --prune` to let Argo revert.
+
+Pilot's downstream system records the verdict + the cub-scout evidence ID + a link to the on-call ticket.
+
+## Edge cases the attribution layer handles
+
+- **Argo CD CSA migration default and `kubectl apply --client-side` write the same manager string** — the classifier reads `pkg/agent/ownership.go` first; Argo-owned resources resolve as `controller-drift`, non-Argo as `manual-edit`. (See [`verified-manager-strings`](../references/verified-manager-strings.md) for the full enumeration.)
+- **Crossplane composed children use prefix match** — `apiextensions.crossplane.io/composed-<hash>` varies per XR. The classifier matches by prefix, not exact string.
+- **Per-field rollup degrades cleanly to resource-level** — when `FieldsV1` is missing (older K8s, stripped), classification is resource-level. When present, per-field. List-key fields (e.g., `spec.template.spec.containers[name="api"].image`) currently fall back to resource-level pending list-key selector support — `pilot-patch-and-drift` should treat resource-level `cause` as authoritative for those fields.
+- **`gitSource.file:line` is opt-in via `--source-path <local-checkout>`** — the resource-level `gitSource` (repoUrl/revision/path) is automatic; raw-YAML back-resolution to `file:line` requires the CI pipeline (or Pilot's runtime) to have a local checkout available. Helm/Kustomize templating explicitly deferred.
+
+## Tool boundary
+
+- **Allowed (cub-scout):** Compare verbs (read-only attribution); `explain`, `trace`, `history`; `receipt verify` / `show` / `validate` / `list`. All read-only.
+- **Allowed (cluster):** `kubectl get/describe`, `kubectl get --show-managed-fields` (Pilot may want to inspect the raw `managedFields` to verify cub-scout's classification). NOT `kubectl apply / edit / patch / delete`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub unit get`, `cub link list`. NOT `cub * create / update / delete`.
+- **Allowed (controllers):** `argocd app get`, `flux get`. NOT `argocd app sync`, `flux reconcile` (those are Pilot's REVERT path, not cub-scout's).
+- **Pilot's mutation paths** (REVERT, QUARANTINE, ACCEPT-AS-CANONICAL) are out-of-scope for this skill. cub-scout produces the classification; Pilot decides; the mutation lives in `cub` / Argo / Flux.
+
+## References
+
+- [`scout-attribute`](../scout-attribute/SKILL.md) — the underlying attribution capability (cub-scout side)
+- [`scout-compare`](../scout-compare/SKILL.md) — the Compare verbs that surface attribution
+- [`scout-verify`](../scout-verify/SKILL.md) — receipt persistence
+- [`investigate-drift`](../investigate-drift/SKILL.md) — operator-driven counterpart (same evidence, different framing)
+- [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) — pre-deploy companion
+- [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) — real-time companion
+- [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md) — postmortem companion
+- [`verified-manager-strings`](../references/verified-manager-strings.md) — the canonical manager-string list
+- [`kubernetes-managedfields`](../references/kubernetes-managedfields.md) — `managedFields` mechanics
+- Attribution layer: `#435` (parent), `#437` (A1+A1.5+A2 classifier + manager strings + git anchor), `#438` (C1 incoming binding), `#439` (C2 per-field binding source), `#440` (B raw-YAML file:line)
+
+## Constraints
+
+- Per-field `cause` classification requires `managedFields` present on the resource (K8s ≥ 1.18 default; some controllers strip it). When missing, classification degrades to resource-level.
+- The verified manager-string enumeration is a **whitelist**, not a heuristic. New controllers' manager strings need to be added to `pkg/agent/manager_strings.go` (a `cub-scout` core change, not a Pilot-side patch).
+- `bindingSource` requires connected mode AND the resource being ConfigHub-linked via `cub link create`. Without that, `bindingSource: null` and Pilot drops to `cause` + `managerHint` alone.
+- `gitSource.file:line` requires `--source-path <local-checkout>` to be passed AND the source to be raw YAML (not Helm/Kustomize templated). Templated sources only get the resource-level `repoUrl/revision/path` anchor.
+- Pilot's action policy (revert vs quarantine vs accept-as-canonical) is **Pilot's call**. cub-scout produces the classification; the action mapping above is illustrative, not normative.

--- a/skills/pilot-watch-alert-response/SKILL.md
+++ b/skills/pilot-watch-alert-response/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: pilot-watch-alert-response
+description: 'Use when Pilot is RESPONDING TO REAL-TIME CLUSTER EVENTS surfaced by `cub-scout watch`. Natural phrasings: "Pilot subscribes to the watch stream", "render verdicts on each drift event as they fire", "real-time acceptance kernel for cluster changes", "Pilot, decide on this drift.detected event", "what does Pilot say about the ownership.changed alert", "stream PASS/WATCH/ASK/BLOCK per event from cub-scout watch". Pilot consumes the `cub-scout watch` event stream (webhook or file sink, optionally with inline receipts via `--emit-receipt-on`) and renders a verdict per event, calling back into cub-scout (`explain`, `compare three-way`, `trace`) for context when needed. This is the ONLY event-driven skill in the pilot-* batch — others are query-driven. Do NOT load for: a single-resource pre-deploy gate (use pilot-cd-gate), a periodic fleet roll-up (use pilot-fleet-conformance), a drift-classification deep-dive (use pilot-patch-and-drift), a postmortem evidence pack (use pilot-incident-evidence), or any mutating action.'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout watch *) Bash(cub-scout watch *) Bash(cub scout watch *) Bash(./cub-scout explain *) Bash(cub-scout explain *) Bash(cub scout explain *) Bash(./cub-scout compare *) Bash(cub-scout compare *) Bash(cub scout compare *) Bash(./cub-scout trace *) Bash(cub-scout trace *) Bash(cub scout trace *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout doctor *) Bash(cub-scout doctor *) Bash(cub scout doctor *) Bash(./cub-scout map *) Bash(cub-scout map *) Bash(cub scout map *) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub link list *) Bash(cub unit get *) Bash(argocd app get *) Bash(flux get *)
+
+---
+
+# pilot-watch-alert-response
+
+The real-time event-driven scenario from **Pilot's** side. Pilot subscribes to `cub-scout watch` (which already exposes webhook / file sinks) and, for each event, decides PASS / WATCH / ASK / BLOCK — calling back into cub-scout for context as needed. This is the **only event-driven skill in the pilot-* batch**; the other four are query-driven.
+
+With the receipts v2 surface shipped (#463), Pilot can ask `cub-scout watch` to **inline a receipt** with each matching event via `--emit-receipt-on drift.detected,ownership.changed`. That delivers a fingerprinted in-toto Statement v1 per event in the same JSONL line — Pilot reads the verdict + receipt in one shot, no synchronous call-back required for the common case.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot subscribes to the watch stream"
+- "Render verdicts on each drift event as they fire"
+- "Real-time acceptance kernel for cluster changes"
+- "Pilot, decide on this `drift.detected` event"
+- "What does Pilot say about the `ownership.changed` alert"
+- "Stream PASS/WATCH/ASK/BLOCK per event from cub-scout watch"
+- "Pilot reads receipts inline from the watch event stream"
+- "Trigger Pilot on any cub-scout drift event"
+
+Implicit intents:
+
+- The flow is **event-driven**, not query-driven (Pilot reacts to a stream, not a polling job)
+- The decision needs to **fire fast** — a Pilot verdict per event, ideally inline
+- The receipt-attached path (v2 `--emit-receipt-on`) is preferred when audit durability matters
+- Backpressure is a real concern when events fire fast (e.g., ApplicationSet expansion)
+
+## Do not load for
+
+- A **single-resource pre-deploy gate** — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- A **periodic fleet roll-up verdict** — [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md)
+- A **drift-classification deep-dive** for one resource — [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md)
+- A **postmortem evidence pack** — [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md)
+- Pure **observation** without a Pilot policy decision — [`scout-observe`](../scout-observe/SKILL.md) covers the `watch` surface from the operator side
+- Any **mutating action**. Pilot's mutation path is `cub` / Argo / Flux / kubectl — never cub-scout.
+
+## The Pilot ↔ cub-scout watch loop
+
+```
+   cub-scout watch -n prod \
+     --webhook https://pilot.acme/cub-scout-events \
+     --emit-receipt-on drift.detected,ownership.changed \
+     --output-file /var/log/cub-scout-watch.jsonl
+        │
+        │  ▼ JSONL event stream (one event per line)
+        │  {
+        │    "type": "drift.detected",
+        │    "timestamp": "2026-05-22T11:00:00Z",
+        │    "resource": {"kind": "Deployment", "name": "api", "namespace": "prod"},
+        │    "owner": {"type": "argo", "name": "payments-api"},
+        │    "severity": "warning",
+        │    "details": {"category": "DRIFT"},
+        │    "receipt": { in-toto Statement v1 with applied-matches-spec verdict }
+        │  }
+        ▼
+   Pilot's event handler
+        │  fast path: the event already carries a receipt
+        │    │
+        │    └► Pilot reads receipt.predicate.verdict → render verdict
+        │
+        │  slow path: the event doesn't carry a receipt
+        │    │  (event type isn't in --emit-receipt-on, OR receipt-build failed)
+        │    │
+        │    ├──► cub-scout compare three-way <r> -n <ns> --format json
+        │    ├──► cub-scout explain <r> -n <ns> --presentation ai
+        │    └──► cub-scout receipt verify <r> -n <ns> --strategy <s> --out event-receipt.json
+        │
+        ▼
+   Pilot's per-event verdict
+        │  PASS  → log + continue
+        │  WATCH → alert + log + (optional) attach receipt to a ticket
+        │  ASK   → page on-call; the proof gap is structured in the receipt
+        │  BLOCK → halt promotion / trigger Pilot's escalation policy
+        └────────────────────────────────────────────────────
+```
+
+## Event types (`cub-scout watch` v1 + receipts v2)
+
+`cub-scout watch` emits four event types today; `--emit-receipt-on` v1 attaches receipts to two of them:
+
+| Event type | When it fires | Receipt-built in v1? | Pilot's typical reaction |
+|------------|---------------|----------------------|--------------------------|
+| `resource.discovered` | First poll sees a resource cub-scout hadn't seen before | No (would flood on initial poll burst; pass-through silently) | Log; no verdict needed. |
+| `ownership.changed` | A resource's ownership controller changed (Argo → Flux, Flux → kubectl, etc.) | **Yes** — `applied-matches-spec` auto-detected. Receipt verdict reflects whether the new owner has a resolved git anchor. | WATCH (often a transient state during migration); ASK if `applied-matches-spec` returns INCONCLUSIVE. |
+| `drift.detected` | `compare three-way` finds a divergence on a resource cub-scout watched into | **Yes** — `applied-matches-spec` auto-detected. Receipt verdict reflects whether the drift is controller-drift (PASS / reconciling) or manual-edit (BLOCK). | Drives [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md) shape: PASS = ACCEPT; WATCH = INVESTIGATE; BLOCK = REVERT/QUARANTINE. |
+| `scan.finding` | A risk pattern matched on a resource (CVE, expiring cert, etc.) | No (would flood on initial scan burst; pass-through silently) | Severity-driven; route to security/SRE escalation policy. |
+
+The `--emit-receipt-on all` sugar accepts every known event type for forward-compat, but cub-scout emits a one-time **startup warning** listing the event types it doesn't actually build receipts for (so the operator isn't surprised). Receipt-build failures are non-fatal — the underlying event still emits, just without the `receipt` key (uses `omitempty`; consumers should check key presence, not null-ness).
+
+```python
+# Idiomatic Python consumer
+for line in stream:
+    event = json.loads(line)
+    if "receipt" in event:        # key-present check, NOT `is not None`
+        verdict = pilot.decide_from_receipt(event["receipt"])
+    else:
+        verdict = pilot.fallback_decide(event)  # slow path
+    handle(verdict)
+```
+
+## Wire shape
+
+A `drift.detected` event with an attached receipt (one JSONL line, pretty-printed here):
+
+```json
+{
+  "type": "drift.detected",
+  "timestamp": "2026-05-22T11:00:00Z",
+  "resource": {
+    "kind": "Deployment",
+    "name": "payments-api",
+    "namespace": "prod"
+  },
+  "owner": {
+    "type": "argo",
+    "name": "payments-api"
+  },
+  "severity": "warning",
+  "details": {
+    "category": "DRIFT"
+  },
+  "receipt": {
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [
+      {
+        "name": "k8s-live://apps/v1/Deployment/prod/payments-api",
+        "digest": {"sha256": "abc..."}
+      }
+    ],
+    "predicateType": "https://cub-scout.dev/receipt/v1",
+    "predicate": {
+      "version": "1",
+      "predicateName": "applied-matches-spec",
+      "verdict": "BLOCK",
+      "claim": "applied matches spec at apps/prod/payments-api",
+      "scope": {"kind": "Deployment", "name": "payments-api", "namespace": "prod"},
+      "evidence": {
+        "attribution": {"cause": "manual-edit", "managerHint": "kubectl-edit"},
+        "gitSource": {"repoUrl": "https://github.com/org/payments", "revision": "abc123", "path": "apps/prod/payments-api"}
+      },
+      "omissions": [],
+      "inputAttestations": [],
+      "nextSteps": [],
+      "verifier": {"tool": "cub-scout", "version": "v2.2.1"},
+      "verifiedAt": "2026-05-22T11:00:00Z",
+      "fingerprint": "sha256:1a2b3c..."
+    }
+  }
+}
+```
+
+Pilot reads `receipt.predicate.verdict` directly: `BLOCK` → halt; `WATCH` → alert; `PASS` → log + continue; `INCONCLUSIVE` → ASK.
+
+## Step-by-step
+
+### Step 1 — confirm the watch stream is shaped for Pilot
+
+```bash
+# Pre-flight: doctor + status
+$ cub-scout doctor
+$ cub-scout status
+
+# Confirm the event taxonomy Pilot expects
+$ cub-scout watch --help | grep -A 3 '\-\-emit-receipt-on'
+```
+
+If standalone (no ConfigHub auth), the receipts in the stream will have an `OmissionConfigHubUnitSubject` entry — Pilot can still consume but the verdict ceiling is WATCH for receipts that need the connected subject.
+
+### Step 2 — start the watch stream
+
+```bash
+$ cub-scout watch -n prod \
+    --webhook https://pilot.acme/cub-scout-events \
+    --emit-receipt-on drift.detected,ownership.changed \
+    --output-file /var/log/cub-scout-watch.jsonl \
+    --severity warning,critical
+```
+
+- `--webhook` is Pilot's listener (POST per event).
+- `--output-file` keeps a local JSONL log (useful for replay during postmortems; see [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md)).
+- `--emit-receipt-on` attaches receipts to the two event types where it's meaningful.
+- `--severity` filters scan-finding events to the actionable subset.
+
+The watch loop is **read-only by design**. cub-scout's only cluster operations are `Get` / `List` / `Watch`; `--emit-receipt-on` adds an in-process `BuildReceipt` per matching event, which is also pure (the receipts code path is statically guarded by `TestReceiptPackageReadOnlyClient`).
+
+### Step 3 — Pilot's per-event handler
+
+Pilot's logic, per event:
+
+```python
+def handle_event(event: dict) -> Verdict:
+    # Fast path: event carries an inline receipt
+    if "receipt" in event:
+        receipt = event["receipt"]
+        verdict_str = receipt["predicate"]["verdict"]  # PASS|WATCH|BLOCK|INCONCLUSIVE
+        # The receipt also carries omissions[], attribution, gitSource — Pilot can drill in
+        if verdict_str == "PASS":
+            return Verdict.PASS
+        elif verdict_str == "WATCH":
+            attach_receipt_to_ticket(receipt)
+            return Verdict.WATCH
+        elif verdict_str == "BLOCK":
+            escalate(event, receipt)
+            return Verdict.BLOCK
+        elif verdict_str == "INCONCLUSIVE":
+            return Verdict.ASK
+
+    # Slow path: no inline receipt (event type not in --emit-receipt-on, OR receipt-build failed)
+    return synchronous_evidence_gathering(event)
+```
+
+The slow path calls back into cub-scout synchronously:
+
+```bash
+$ cub-scout compare three-way deploy/payments-api -n prod --format json > evidence.json
+$ cub-scout receipt verify deploy/payments-api -n prod --save --out event.receipt.json
+```
+
+### Step 4 — verify the receipt fingerprint (optional but recommended)
+
+Pilot may want to verify that the inline receipt's fingerprint is intact — particularly when the event arrived via a webhook that traversed network boundaries. cub-scout's receipt validate path is exit-coded:
+
+```bash
+$ echo "$event" | jq '.receipt' > event-receipt.json
+$ cub-scout receipt validate event-receipt.json
+# exit 0 = fingerprint matches; 1 = mismatch (refuse to act on it); 2 = I/O
+```
+
+## Operational defaults Pilot should know
+
+- **Receipt-build failures are non-fatal**: the event still emits, the `receipt` key is omitted (omitempty), and cub-scout logs a stderr warning. Pilot's handler must check for key presence, not null-ness.
+- **Warnings are rate-limited** (Codex round-6 P2 fix in #463): the first 10 receipt-build warnings pass through verbatim; afterwards, a summary line fires every 100 suppressed warnings. A long-running watch with transient cluster-read failures won't spam stderr.
+- **Unsupported event types pass through silently**: `resource.discovered` and `scan.finding` accept the flag (so `--emit-receipt-on all` works) but cub-scout skips receipt-build for them in v1. A startup warning lists them.
+- **Backpressure is not yet handled** (open in `#449`): if events fire faster than the consumer drains, the watch can queue up to `--max-queued-events` and then drops oldest. ApplicationSet expansion is the canonical "events fire fast" scenario.
+- **Connected vs standalone**: receipts attached to events include the `confighub-unit://` subject only when connected. Standalone-mode receipts carry an `OmissionConfigHubUnitSubject` entry — Pilot should treat verdict ceiling as WATCH for those (the receipt is honest about what's missing).
+
+## Worked example: drift event triggers Pilot
+
+A `drift.detected` event fires for `deploy/payments-api` in prod. Pilot's webhook receives:
+
+```json
+{
+  "type": "drift.detected",
+  "timestamp": "2026-05-22T11:00:00Z",
+  "resource": {"kind": "Deployment", "name": "payments-api", "namespace": "prod"},
+  "owner": {"type": "argo", "name": "payments-api"},
+  "severity": "warning",
+  "details": {"category": "DRIFT"},
+  "receipt": {
+    "_type": "https://in-toto.io/Statement/v1",
+    "predicateType": "https://cub-scout.dev/receipt/v1",
+    "predicate": {
+      "predicateName": "applied-matches-spec",
+      "verdict": "BLOCK",
+      "evidence": {
+        "attribution": {"cause": "manual-edit", "managerHint": "kubectl-edit"}
+      },
+      "fingerprint": "sha256:1a2b3c..."
+    }
+  }
+}
+```
+
+Pilot's handler:
+1. Sees `"receipt" in event` → fast path.
+2. Reads `receipt.predicate.verdict: "BLOCK"`.
+3. Reads `receipt.predicate.evidence.attribution: {cause: manual-edit, managerHint: kubectl-edit}` → confirms human kubectl-edited an Argo-owned resource.
+4. Renders Pilot verdict: **BLOCK**.
+5. Escalates: opens a ticket, attaches the receipt, pages the on-call.
+
+Total round-trip: one webhook POST, zero synchronous cub-scout calls. The receipt is fingerprint-verifiable later if the ticket is audited.
+
+If the same event had arrived without an inline receipt (e.g., `--emit-receipt-on` wasn't set), Pilot would call `cub-scout compare three-way deploy/payments-api -n prod --format json` to get the same evidence on the slow path.
+
+## Open scope on the cub-scout side (issue `#449`)
+
+This skill calls out gaps that may surface during real deployment. They live in the open scope of `#449`, not this skill:
+
+- **More event types**: `attribution.cause-flipped` (a resource's `cause` changes from `controller-drift` → `manual-edit`); `source-truth.verdict-changed` (a `compare source-truth` verdict flips PASS → WATCH); `bindingSource.changed` (a Link now resolves to a different upstream). All v2+ scope.
+- **Backpressure / batching**: high-frequency events from ApplicationSet expansion need a documented drop / batch policy. Currently `--max-queued-events` controls in-process queue depth; downstream filtering is Pilot's call.
+- **Pilot-shaped emit format**: a `--format pilot` or `--shape acceptance-event` that bundles enough context per event for Pilot to verdict-render without any synchronous call-back. Receipts inline already cover the common case, but a fuller shape could include `compareThreeWay` per event.
+- **`resource.discovered` / `scan.finding` receipt support**: gated on the backpressure design (would flood on initial poll burst). Open in `#449`.
+
+Filing these is a non-goal of this skill; surfacing them during real-deployment authoring is a goal.
+
+## Tool boundary
+
+- **Allowed (cub-scout):** `watch`, Compare verbs, `explain`, `trace`, `doctor`, `map`, `receipt verify / show / validate / list`. All read-only.
+- **Allowed (cluster):** `kubectl get/describe`. NOT `kubectl apply / edit / patch / delete`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub unit get`, `cub link list`. NOT `cub * create / update / delete`.
+- **Allowed (controllers):** `argocd app get`, `flux get`. NOT `argocd app sync`, `flux reconcile`.
+- **Pilot's mutation path** (REVERT, QUARANTINE, escalation) is out-of-scope for this skill.
+
+## References
+
+- [`scout-observe`](../scout-observe/SKILL.md) — the `watch` surface from the operator side
+- [`scout-verify`](../scout-verify/SKILL.md) — receipt-emit (the `--emit-receipt-on` flag wiring)
+- [`scout-compare`](../scout-compare/SKILL.md) — Compare verbs Pilot falls back to on the slow path
+- [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) — pre-deploy companion (query-driven)
+- [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md) — periodic fleet companion (query-driven)
+- [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md) — drill-down for BLOCK / WATCH events
+- [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md) — replay watch logs during postmortems
+- Wire format: [`docs/reference/json-contracts.md`](../../docs/reference/json-contracts.md) § Receipt Contract — Watch event emission (v2.2)
+- Receipts v1+v2: `#446` (v1), `#449` (this flag), `#463` (the shipping merge)
+- Read-only triad: [`scout-observe`](../scout-observe/SKILL.md), [`scout-attribute`](../scout-attribute/SKILL.md), [`scout-compare`](../scout-compare/SKILL.md), [`scout-verify`](../scout-verify/SKILL.md)
+
+## Constraints
+
+- Receipts on `resource.discovered` and `scan.finding` events are **not** built in v1 of `--emit-receipt-on`. Both fire on initial poll bursts and would flood without backpressure. Pilot's policy should treat those events as low-signal until v2 expands the set.
+- The `receipt` key uses `omitempty` — consumers MUST check key presence, not null-ness. `event["receipt"]` raising `KeyError` is the correct empty signal; `if event["receipt"] is None` is the wrong pattern.
+- The wire format is the **in-toto Statement v1 envelope** wrapping `https://cub-scout.dev/receipt/v1`. Pilot's receipt parser should be schema-aware to handle future envelope additions (e.g., signing layer).
+- `--emit-receipt-on` requires the v2.2+ cub-scout binary (the flag shipped in `#463`). Older binaries don't have the flag and the watch event payload won't include a `receipt` field.
+- Backpressure / batching is **deferred** — high-throughput environments should expect events to queue (`--max-queued-events`) and drop on overflow. Filing follow-on issues for batched emit shapes is a real outcome of this skill's authoring; this skill itself doesn't implement them.


### PR DESCRIPTION
## Summary

The consumer-side complement to the `#442` verb-grouped + workflow skills: same cub-scout verbs, framed around **Pilot** (the acceptance judge) reading cub-scout's evidence and rendering verdicts that downstream consumers (CI/CD, dashboards, audit tickets, postmortems) act on.

**cub-scout produces evidence with documented `omissions[]`; Pilot decides.** Pilot mutates via `cub` / Argo / Flux / kubectl — never via cub-scout. The read-only-triad invariant (#410 / #428) is preserved across all 5 allowed-tools lines; 0 mutating verbs.

Per the `#444` issue plan, batch A is the most load-bearing 5 scenarios (CD / observability / event-driven). Batch B (4 governance-shaped scenarios) is the remaining follow-on.

## New skills

| Skill | Lines | Pilot consumes | Pilot decides |
|---|---|---|---|
| [`pilot-cd-gate`](skills/pilot-cd-gate/SKILL.md) | 275 | `compare source-truth --strategy <s>` + optional `receipt verify --fail-on any-non-pass` | PASS / WATCH / ASK / BLOCK on the release |
| [`pilot-fleet-conformance`](skills/pilot-fleet-conformance/SKILL.md) | 299 | `compare three-way --view` + per-resource source-truth + `fleet outliers` | Fleet verdict + per-resource breakdown |
| [`pilot-patch-and-drift`](skills/pilot-patch-and-drift/SKILL.md) | 294 | attribution layer (`cause` / `managerHint` / `gitSource` / `bindingSource`) | revert / quarantine / accept-as-canonical / ASK |
| [`pilot-watch-alert-response`](skills/pilot-watch-alert-response/SKILL.md) | 320 | `cub-scout watch` event stream with inline receipts via `--emit-receipt-on` (v2 `#463`) | Per-event PASS / WATCH / ASK / BLOCK |
| [`pilot-incident-evidence`](skills/pilot-incident-evidence/SKILL.md) | 346 | trace + explain + compare + bundle + history + audit + **chained receipts** via `--input-attestation` (v2 `#463`) | Incident verdict + immutable evidence pack |

Each skill is ~200–350 lines following the structure used by existing scenario skills (`audit-fleet-conformance`, `operator-incident-evidence`, `investigate-drift`): rich frontmatter description, "When to use" + "Do not load for" cross-refs, "The loop" diagram, step-by-step with example outputs, worked example, standalone vs connected applicability, tool boundary, references, and constraints.

## How this lands on the v2 receipts surface

Two of the batch-A skills consume capabilities that just shipped in `#463`:

- **`pilot-watch-alert-response`** documents the `--emit-receipt-on drift.detected,ownership.changed` flow, including the rate-limited stderr warnings (Codex round-6 P2 fix), the `omitempty` wire shape (consumers must check for key presence, not null-ness), and the open scope on backpressure (`#449` follow-on).
- **`pilot-incident-evidence`** documents the chained-receipt workflow (`--input-attestation` per stage; `VerifiedAttestationRef` typed wrapper enforces verify at the API boundary) and how a multi-stage incident produces a tamper-evident DAG of per-stage receipts.

If `#463` hadn't shipped, both skills would have had to caveat the surface as deferred. Now they document it as the current product.

## Cross-references

- `skills/README.md`: new "Pilot–cub-scout integration scenarios (`#444` batch A)" subsection between the workflow scenarios and the shared references; status block updated.
- `skills/cub-scout/SKILL.md` (umbrella router): new "Pilot–cub-scout integration scenarios" table after the existing capability map, so the router picks the pilot-* skill instead of a `scout-*` skill when the user's prompt is shaped as "Pilot, decide ..." or "render the verdict ...".
- Every skill carries explicit "Do not load for" cross-refs to the other four `pilot-*` skills + the relevant `scout-*` and workflow skills (so the router decision is loud, not silent).

## Allowed-tools audit

- **0 mutating verbs** across all 5 skills (verified via grep for `apply` / `edit` / `patch` / `delete` / `sync` / `reconcile` / `refresh` / `create` / `update`). Every skill's allowed-tools stays strictly inside the read-only triad.
- **No broad `Bash(cub-scout *)` / `Bash(./cub-scout *)` wildcards** (the Codex round-5 `#461` leak class). Every allowed-tools entry is verb-prefixed.

## Test plan

- [x] `bash scripts/check-readonly.sh` passes
- [x] `bash scripts/check-doc-freshness.sh` passes
- [x] `bash scripts/check-cli-guide-parity.sh` passes
- [x] Static grep for mutating verbs in allowed-tools across `skills/pilot-*/SKILL.md` returns 0 hits
- [x] Static grep for broad `*` wildcards in allowed-tools returns 0 hits
- [x] No code changed; existing test suite continues to pass

## What's deferred to batch B

Per the issue plan, the four governance-shaped scenarios are the remaining `#444` work:

- `pilot-rollback-decision` — when and which revision to roll back to
- `pilot-promotion-gate` — variant A → variant B promotion safety
- `pilot-compliance-audit` — periodic policy conformance check
- `pilot-release-verification` — post-deploy validation

`#444` stays open for batch B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)