### PR TITLE
docs(skills): #444 batch B — 4 governance Pilot scenarios; closes #444

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -50,9 +50,11 @@ Each covers a real operator / agent workflow that spans multiple verbs. Compose 
 - [`operator-incident-evidence/`](operator-incident-evidence/SKILL.md) — postmortem evidence package: trace + compare + bundle + history + audit + fingerprinted receipts
 - [`confighub-source-truth/`](confighub-source-truth/SKILL.md) — strategy-typed `compare source-truth` verdicts (one of 9 strategies; cub-scout never infers); Pilot-acceptance-shaped output
 
-### Pilot–cub-scout integration scenarios (`#444` batch A)
+### Pilot–cub-scout integration scenarios (`#444`)
 
 The consumer-side complement to the verb-grouped + workflow skills above. Same cub-scout verbs, framed around **Pilot** (the acceptance judge) reading cub-scout's evidence and rendering verdicts that downstream consumers (CI/CD, dashboards, audit tickets, postmortems) act on. cub-scout produces evidence with documented `omissions[]`; Pilot decides. Pilot mutates via `cub` / Argo / Flux / kubectl — never via cub-scout.
+
+Batch A (CD / observability / event-driven; 5 scenarios — shipped in `#466` + Codex round-7 cleanup in `#467`):
 
 - [`pilot-cd-gate/`](pilot-cd-gate/SKILL.md) — pre-deploy gate in a CD pipeline; consumes `compare source-truth --strategy <s>` (+ optional `receipt verify --fail-on any-non-pass`); renders PASS / WATCH / ASK / BLOCK on the release
 - [`pilot-fleet-conformance/`](pilot-fleet-conformance/SKILL.md) — fleet-wide conformance verdict (View / namespace / cluster scope) composing `compare three-way --view` + per-resource `compare source-truth` + `fleet outliers`; judge-driven counterpart to `audit-fleet-conformance`
@@ -60,7 +62,12 @@ The consumer-side complement to the verb-grouped + workflow skills above. Same c
 - [`pilot-watch-alert-response/`](pilot-watch-alert-response/SKILL.md) — real-time event-driven response; consumes the `cub-scout watch` event stream with inline receipts via `--emit-receipt-on` (shipped in `#463`); the only event-driven skill in the pilot-* batch
 - [`pilot-incident-evidence/`](pilot-incident-evidence/SKILL.md) — incident close-out evidence pack with **chained receipts** (`--input-attestation` from `#463`) for multi-stage incidents; judge-driven counterpart to `operator-incident-evidence`
 
-Batch B (4 governance-shaped scenarios: `pilot-rollback-decision`, `pilot-promotion-gate`, `pilot-compliance-audit`, `pilot-release-verification`) is tracked as the remaining `#444` follow-on.
+Batch B (governance-shaped; 4 scenarios):
+
+- [`pilot-rollback-decision/`](pilot-rollback-decision/SKILL.md) — choose the rollback target SHA + render a safety verdict; consumes `history` + `impact` + per-candidate `receipt verify --at-commit <sha>`; chains candidate receipts into a chosen-target receipt
+- [`pilot-promotion-gate/`](pilot-promotion-gate/SKILL.md) — cross-variant promotion-safety verdict (staging → prod; canary 5% → 50%; blue → green; cell-A → cell-B); consumes `compare three-way` per variant + `bindingSource` graph diff; chains variant-A receipt into the promotion-target receipt
+- [`pilot-compliance-audit/`](pilot-compliance-audit/SKILL.md) — periodic policy-conformance report (quarterly / monthly) with fingerprinted evidence inventory; consumes scope-wide `compare source-truth` + `scan` + `audit list`; compliance-vocabulary translation layer over receipt verdicts
+- [`pilot-release-verification/`](pilot-release-verification/SKILL.md) — post-deploy validation gate (companion to `pilot-cd-gate`'s pre-deploy half); consumes `compare three-way` + `history --since <deploy-time>` + `receipt verify --at-commit <release-sha>`; `summary.agreement` field drives the convergence signal
 
 ### Shared references
 
@@ -109,4 +116,11 @@ That's **~33 skill files** plus 9 references — the full scope from `#442`.
 - [`#459`](https://github.com/confighub/cub-scout/pull/459) — batch 4 workflow scenario skills
 - batch 5 — this PR (closes `#442`)
 
-**`#444` batch A shipped** ([`#466`](https://github.com/confighub/cub-scout/pull/466)): 5 Pilot–cub-scout integration scenario skills (consumer-side complement to the `#442` set) — `pilot-cd-gate`, `pilot-fleet-conformance`, `pilot-patch-and-drift`, `pilot-watch-alert-response`, `pilot-incident-evidence`. Each frames the same cub-scout verbs from Pilot's perspective (acceptance judge reading evidence, rendering verdicts), with worked CLI examples + verdict-mapping tables. The watch-alert-response skill consumes the v2 `--emit-receipt-on` surface (shipped in `#463`); the incident-evidence skill consumes the v2 chained-receipts surface (`--input-attestation`, also `#463`). Codex round-7 P1/P2 follow-ups (broad `compare *` allowed-tools, source-truth JSON shape drift, strategy-enum gap, etc.) landed shortly after in a follow-up PR. **Batch B (4 governance-shaped scenarios: `pilot-rollback-decision`, `pilot-promotion-gate`, `pilot-compliance-audit`, `pilot-release-verification`) is the remaining `#444` work.**
+**`#444` complete**: 9 Pilot–cub-scout integration scenario skills shipped across two batches. Each frames the same cub-scout verbs from Pilot's perspective (acceptance judge reading evidence, rendering verdicts), with worked CLI examples + verdict-mapping tables. The watch-alert-response skill consumes the v2 `--emit-receipt-on` surface (shipped in `#463`); the incident-evidence + rollback-decision + promotion-gate skills consume the v2 chained-receipts surface (`--input-attestation`, also `#463`).
+
+PRs:
+- [`#466`](https://github.com/confighub/cub-scout/pull/466) — batch A (5 scenarios: CD / observability / event-driven)
+- [`#467`](https://github.com/confighub/cub-scout/pull/467) — batch A Codex round-7 fixes (enumerated `compare *` allowed-tools; snake_case source-truth JSON shape; strategy enum corrected; etc.)
+- batch B (this PR) — 4 governance scenarios: rollback-decision / promotion-gate / compliance-audit / release-verification
+
+Codex round-7 learnings applied upfront in batch B: enumerated `compare three-way / compare drift / compare source-truth` allowed-tools (no broad `compare *`); snake_case source-truth fields (`declared_strategy` / `source_truth` / `proof_gaps`); no invented Pilot CLI surfaces; abstract mutation paths; receipt verdicts only PASS/WATCH/BLOCK/INCONCLUSIVE (ASK is source-truth `status`, maps to receipt `WATCH` when wrapped).

--- a/skills/cub-scout/SKILL.md
+++ b/skills/cub-scout/SKILL.md
@@ -46,9 +46,9 @@ This skill is the cross-cutting entry point. It picks the right verb-grouped ski
 
 See [`skills/README.md`](../README.md) for the full plan including controller observer skills (`observe-argocd`, `observe-flux`, `observe-helm`, `observe-crossplane`, `observe-kro`), workflow scenario skills (`triage-unhealthy-workload`, `investigate-drift`, `audit-fleet-conformance`, etc.), and shared references.
 
-### Pilot–cub-scout integration scenarios (`#444` batch A)
+### Pilot–cub-scout integration scenarios (`#444`)
 
-The consumer-side complement: same cub-scout verbs framed around **Pilot** (the acceptance judge) rendering verdicts from cub-scout's evidence. Load one of these instead of a `scout-*` skill when the user's prompt is shaped as "Pilot, decide ..." or "render the verdict ...".
+The consumer-side complement: same cub-scout verbs framed around **Pilot** (the acceptance judge) rendering verdicts from cub-scout's evidence. Load one of these instead of a `scout-*` skill when the user's prompt is shaped as "Pilot, decide ..." or "render the verdict ...". `#444` is complete: 9 scenarios shipped across batches A and B.
 
 | Scenario | Skill | Pilot consumes | Pilot decides |
 |---|---|---|---|
@@ -57,8 +57,10 @@ The consumer-side complement: same cub-scout verbs framed around **Pilot** (the 
 | Drift classification | [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md) | attribution evidence (`cause` / `managerHint` / `gitSource` / `bindingSource`) | revert / quarantine / accept-as-canonical / ASK |
 | Real-time watch response | [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) | `cub-scout watch` event stream with `--emit-receipt-on` inline receipts (v2 #463) | Per-event PASS / WATCH / ASK / BLOCK |
 | Incident close-out | [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md) | trace + explain + compare + bundle + history + audit + chained receipts (`--input-attestation`, v2 #463) | Incident verdict + immutable evidence pack |
-
-Batch B (governance-shaped: `pilot-rollback-decision`, `pilot-promotion-gate`, `pilot-compliance-audit`, `pilot-release-verification`) is the open `#444` follow-on.
+| Rollback decision | [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md) | `history` + `impact` + per-candidate `receipt verify --at-commit <sha>` chained into chosen-target receipt | Rollback target SHA + safety verdict |
+| Promotion gate | [`pilot-promotion-gate`](../pilot-promotion-gate/SKILL.md) | `compare three-way` per variant + `bindingSource` graph diff + chained variant-A receipt | Cross-variant PASS / WATCH / ASK / BLOCK with diff reasons |
+| Compliance audit | [`pilot-compliance-audit`](../pilot-compliance-audit/SKILL.md) | scope-wide source-truth + `scan` + `audit list` + per-resource saved receipts | Compliance report (Compliant / with-caveats / Non-compliant / Insufficient-evidence) + fingerprinted evidence inventory |
+| Release verification | [`pilot-release-verification`](../pilot-release-verification/SKILL.md) | `compare three-way` + `history --since <deploy-time>` + `receipt verify --at-commit <release-sha>`; `summary.agreement` drives convergence signal | Post-deploy PASS / WATCH (wait) / BLOCK / ASK |
 
 ## Product value in one breath
 

--- a/skills/pilot-compliance-audit/SKILL.md
+++ b/skills/pilot-compliance-audit/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: pilot-compliance-audit
+description: 'Use when Pilot is RENDERING A PERIODIC POLICY-CONFORMANCE REPORT for a compliance audit. Natural phrasings: "Pilot, run the quarterly compliance audit", "render the conformance report against policy", "audit our prod fleet against the security baseline", "produce the compliance evidence pack for the auditor", "Pilot, what are this quarter''s policy violations + their evidence?". Pilot consumes cub-scout''s scope-wide `compare source-truth` (per-resource verdicts under the declared strategy) + `scan` findings (risk-pattern matches) + (optional) per-resource receipts persisted to the local store, then synthesizes a compliance-shaped report with violations table + fingerprinted evidence inventory. Differs from `pilot-fleet-conformance` which is the SAME-VERBS-SAME-DAY operational verdict; this skill is the LONGER-CYCLE compliance shape — the output is a quarterly/monthly report with attached evidence inventory, not a real-time gate. Do NOT load for: a single-resource pre-deploy gate (use pilot-cd-gate), real-time event response (use pilot-watch-alert-response), incident close-out evidence (use pilot-incident-evidence), or a rollback decision (use pilot-rollback-decision).'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout compare three-way *) Bash(cub-scout compare three-way *) Bash(cub scout compare three-way *) Bash(./cub-scout compare source-truth *) Bash(cub-scout compare source-truth *) Bash(cub scout compare source-truth *) Bash(./cub-scout compare drift *) Bash(cub-scout compare drift *) Bash(cub scout compare drift *) Bash(./cub-scout scan *) Bash(cub-scout scan *) Bash(cub scout scan *) Bash(./cub-scout patterns *) Bash(cub-scout patterns *) Bash(cub scout patterns *) Bash(./cub-scout fleet outliers *) Bash(cub-scout fleet outliers *) Bash(cub scout fleet outliers *) Bash(./cub-scout views resolve *) Bash(cub-scout views resolve *) Bash(cub scout views resolve *) Bash(./cub-scout views project *) Bash(cub-scout views project *) Bash(cub scout views project *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout map *) Bash(cub-scout map *) Bash(cub scout map *) Bash(./cub-scout audit *) Bash(cub-scout audit *) Bash(cub scout audit *) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub view get *) Bash(cub view list)
+
+---
+
+# pilot-compliance-audit
+
+The periodic compliance-audit scenario from **Pilot's** side. A quarterly/monthly audit window opens; Pilot is asked to render a structured **compliance report** with per-resource violations + their fingerprinted evidence. The downstream consumer is the auditor (internal security/compliance team, external auditor, SOC 2 reviewer, regulator) — not the SRE team running the cluster.
+
+Same cub-scout verbs as `pilot-fleet-conformance`, different framing: that skill is the *operational* verdict (today's snapshot, today's decision); this skill is the *compliance* shape (last quarter's evidence, an auditor's report). The output cadence is longer; the evidence-attachment requirement is stricter.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot, run the quarterly compliance audit"
+- "Render the conformance report against policy"
+- "Audit our prod fleet against the security baseline"
+- "Produce the compliance evidence pack for the auditor"
+- "Pilot, what are this quarter's policy violations + their evidence?"
+- "Generate the SOC 2 evidence inventory from cub-scout"
+- "Compliance run for {policy/baseline name}"
+
+Implicit intents:
+
+- The cadence is **periodic** (quarterly, monthly), not real-time
+- The audience is the **auditor** — an external or compliance-team reviewer who wants structured violations + fingerprinted evidence per violation
+- The report needs to be **fingerprint-stable** — the auditor may re-validate any receipt months later
+- The report rolls up across **scope** (View / namespace / cluster / fleet) — not a single resource
+- Pilot's verdict per resource maps to a **compliance category** (Compliant / Compliant with caveats / Non-compliant / Insufficient evidence) — slightly different vocabulary from PASS/WATCH/ASK/BLOCK
+
+## Do not load for
+
+- A **single-resource pre-deploy gate** — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- The **operational** version of the same audit (same-day; not for the auditor) — [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md). Same verbs; different framing.
+- A **real-time event-driven** response — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- An **incident close-out** evidence pack — [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md)
+- A **rollback decision** — [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md)
+- A **promotion safety check** — [`pilot-promotion-gate`](../pilot-promotion-gate/SKILL.md)
+- Any **mutating action**. Compliance audits are read-only by design.
+
+## The Pilot ↔ cub-scout compliance loop
+
+```
+   quarterly compliance window opens (cron / manual trigger)
+        │
+        ▼
+   Pilot (acceptance judge in compliance-report mode)
+        │  "render Q2 2026 compliance report for view:prod-baseline"
+        │
+        ├──► cub-scout views resolve <baseline-view>   # scope confirmation
+        │
+        ├──► For each resource in scope:
+        │      cub-scout compare source-truth <r> -n <ns> --strategy <s> --format json
+        │      cub-scout scan -n <ns> --format json   # risk-pattern matches per resource
+        │      cub-scout receipt verify <r> -n <ns> --strategy <s> \
+        │        --save                              # fingerprinted, persisted to local store
+        │
+        ├──► Cross-cluster (if View has cluster scope):
+        │      cub-scout fleet outliers --view <baseline-view> --format json
+        │
+        ├──► Audit-trail layer:
+        │      cub-scout audit list --since 90d --format json    # ConfigHub audit entries
+        │      cub-scout receipt list --format json              # full receipt inventory
+        │
+        └──► (optional) chain ALL per-resource receipts under one aggregate:
+              # When #448 aggregate-with-discovery half ships, this collapses to one call.
+              # Until then: produce one receipt per resource; the report inventory links each.
+        │
+        ▼
+   Pilot's compliance report:
+        │  Compliant resources:               <list with PASS receipts>
+        │  Compliant-with-caveats resources:  <list with WATCH receipts + proof_gaps>
+        │  Non-compliant resources:           <list with BLOCK receipts + violation reason>
+        │  Insufficient-evidence resources:   <list with INCONCLUSIVE receipts + omissions>
+        │  Audit-trail (last 90d):            <ConfigHub change events that touched the scope>
+        │  Receipt inventory:                 <fingerprint-stable file paths per resource>
+        │
+        ▼
+   auditor reads the report
+        │  Auditor can `cub-scout receipt validate <path>` any individual entry to confirm tamper-free
+        └────────────────────────────────────────────────────
+```
+
+## Verdict mapping (cub-scout → compliance vocabulary)
+
+Auditors typically don't speak PASS / WATCH / ASK / BLOCK. Map cub-scout's receipt verdicts to compliance vocabulary at the report-rendering layer:
+
+| Receipt verdict | Compliance category | Auditor-facing meaning |
+|------------------|---------------------|------------------------|
+| `PASS` | **Compliant** | Evidence supports the claim against the declared strategy / baseline |
+| `WATCH` | **Compliant with caveats** | Evidence is ambiguous; proof_gaps listed; the auditor can decide whether the gaps invalidate compliance |
+| `BLOCK` | **Non-compliant** | Evidence contradicts the claim — a real violation |
+| `INCONCLUSIVE` | **Insufficient evidence** | The receipt couldn't be built (missing strategy, missing input); the auditor needs the cube-scout-side fix or a manual review |
+
+`ASK` is a source-truth `status` value, not a receipt verdict. When it surfaces during the audit, the wrapping receipt has verdict `WATCH` (per `pkg/agent/receipt_predicates.go:396-407`); Pilot's compliance report should list the auditor-facing meaning consistently.
+
+## Step-by-step
+
+### Step 1 — resolve the audit scope
+
+A **View** is the canonical compliance scope (declared in ConfigHub via `cub view create`):
+
+```bash
+$ cub-scout views resolve https://hub.confighub.com/views/prod-baseline-q2-2026
+View: prod-baseline-q2-2026
+  scope: cluster
+  columns: [team, service, source_truth_strategy, last_audited]
+  resolved at: 2026-05-22T22:00:00Z
+```
+
+Scope sources for compliance: ConfigHub Views (preferred — declared scope is auditable), namespace, cluster. Avoid ad-hoc resource lists for periodic compliance — they're harder to defend later.
+
+### Step 2 — per-resource source-truth + scan + receipt
+
+```bash
+# Per-resource source-truth verdict against the baseline's declared strategy
+$ for r in $(cub-scout views project --view prod-baseline-q2-2026 --format json \
+              | jq -r '.[] | "\(.kind)/\(.name) -n \(.namespace)"'); do
+    cub-scout compare source-truth $r --strategy git-argo --format json \
+      > evidence/$r-source-truth.json
+  done
+
+# Risk-pattern scan (CVE, expiring certs, dangling resources, etc.)
+$ cub-scout scan --format json > evidence/scan-findings.json
+
+# Fingerprinted per-resource receipts (immutable; survive the audit window)
+$ for r in $(cub-scout views project --view prod-baseline-q2-2026 --format json \
+              | jq -r '.[] | "\(.kind)/\(.name) -n \(.namespace)"'); do
+    cub-scout receipt verify $r --strategy git-argo --save
+  done
+```
+
+Each receipt lands in the immutable local store (`$CUB_SCOUT_RECEIPTS_DIR → $XDG_DATA_HOME → $HOME/.local/share/cub-scout/receipts`) with a canonical filename. Auditors can validate any receipt months later with `cub-scout receipt validate`.
+
+### Step 3 — connected-mode audit trail layer
+
+```bash
+$ cub-scout audit list --since 90d --format json > evidence/confighub-audit.json
+$ cub-scout fleet outliers --view prod-baseline-q2-2026 --format json > evidence/fleet-outliers.json
+```
+
+`audit list` (connected) captures break-glass accept/reject entries from ConfigHub — the human-decision audit trail that paired with the per-resource verdicts during the quarter. `fleet outliers` flags cross-cluster divergences against the baseline.
+
+### Step 4 — compose the report
+
+Pilot's compliance report shape:
+
+```json
+{
+  "report_type": "quarterly_compliance",
+  "audit_window": "Q2 2026 (2026-04-01 → 2026-06-30)",
+  "scope": "view:prod-baseline-q2-2026",
+  "declared_strategy": "git-argo",
+  "rollup": {
+    "compliant": 184,
+    "compliant_with_caveats": 12,
+    "non_compliant": 3,
+    "insufficient_evidence": 1
+  },
+  "non_compliant": [
+    {
+      "resource": "Deployment/payments-cron in prod-use1",
+      "verdict": "BLOCK",
+      "reason": "source_truth=MISMATCH; manual-edit detected on container image",
+      "receipt": "/path/to/receipts/2026-Q2/payments-cron.receipt.json"
+    },
+    {"resource": "Deployment/legacy-api in prod-euw1", "verdict": "BLOCK", "reason": "fleet outlier: missing per-cluster baseline", "receipt": "/path/to/..." }
+  ],
+  "compliant_with_caveats": [
+    {"resource": "Deployment/api in prod-use1", "verdict": "WATCH", "proof_gaps": ["git-source-anchor unresolved: argocd CLI not installed"], "receipt": "/path/to/..."}
+  ],
+  "insufficient_evidence": [
+    {"resource": "Deployment/legacy-tool in prod-use1", "verdict": "INCONCLUSIVE", "omissions": ["managedFields"], "receipt": "/path/to/..."}
+  ],
+  "audit_trail_entries": "evidence/confighub-audit.json (90 entries)",
+  "scan_findings": "evidence/scan-findings.json (4 critical, 12 warning, 31 info)",
+  "fleet_outliers": "evidence/fleet-outliers.json (2 outliers)",
+  "evidence_inventory": "evidence/receipt-list.json (200 receipts; all fingerprint-verifiable)"
+}
+```
+
+### Step 5 — handoff + later re-validation
+
+The auditor receives the report + the `evidence/` directory. To validate any individual receipt:
+
+```bash
+$ cub-scout receipt validate evidence/non-compliant/payments-cron.receipt.json
+# exit 0 = fingerprint intact; 1 = mismatch; 2 = I/O
+
+$ cub-scout receipt show evidence/non-compliant/payments-cron.receipt.json --format ascii
+# Renders the same evidence Pilot's report cited — tamper-evident
+```
+
+Pilot's report is **only as durable as the receipt store** — auditors typically want the evidence/ directory archived externally (S3, GitHub Release artifact, ConfigHub bundle catalog) for the retention period.
+
+## Worked example
+
+Q2 2026 compliance run; scope = `view:prod-baseline-q2-2026`; strategy = `git-argo`.
+
+```bash
+$ mkdir -p evidence/{non-compliant,with-caveats,inconclusive}
+
+# Per-resource receipts (saved to immutable store + linked into evidence/)
+$ for r in $(cub-scout views project --view prod-baseline-q2-2026 --format json \
+              | jq -r '.[] | "\(.kind)/\(.name) -n \(.namespace)"'); do
+    cub-scout receipt verify $r --strategy git-argo --save 2>/dev/null
+  done
+
+# Categorize by verdict
+$ cub-scout receipt list --format json \
+    | jq '[.[] | select(.verdict == "BLOCK")]' > evidence/non-compliant.json
+$ cub-scout receipt list --format json \
+    | jq '[.[] | select(.verdict == "WATCH")]' > evidence/with-caveats.json
+$ cub-scout receipt list --format json \
+    | jq '[.[] | select(.verdict == "INCONCLUSIVE")]' > evidence/inconclusive.json
+
+# Audit-trail + scan + fleet outliers
+$ cub-scout audit list --since 90d --format json > evidence/audit.json
+$ cub-scout scan --format json > evidence/scan.json
+$ cub-scout fleet outliers --view prod-baseline-q2-2026 --format json > evidence/outliers.json
+
+# Rollup
+$ jq 'length' evidence/{non-compliant,with-caveats,inconclusive}.json
+3
+12
+1
+```
+
+Pilot's report cites the 3 non-compliant resources by name + their receipts + their violation reasons; the WATCH/INCONCLUSIVE lists fill in the caveats; the audit-trail / scan / outliers layers give the auditor the cross-axis evidence. Total artifact count: 200 receipts (one per resource in scope) + 3 supporting JSON files. All fingerprint-verifiable.
+
+## Standalone vs connected
+
+**Connected mode is effectively required** for compliance audits:
+
+- `compare source-truth --strategy` — connected
+- `views resolve` / `views project` — connected
+- `fleet outliers` — connected
+- `audit list` — connected
+- `receipt verify --strategy source-truth-pass` — connected
+
+Standalone-mode compliance is *narrower* (no View scope; no ConfigHub audit trail; no fleet-outlier dimension) and rarely useful for an external auditor. If standalone is the only option, Pilot's report should call out the limitation explicitly so the auditor knows what's missing.
+
+## Tool boundary
+
+- **Allowed (cub-scout):** Compare verbs (read-only), `scan`, `patterns`, `fleet outliers`, `views resolve` / `project`, `receipt verify` / `show` / `validate` / `list`, `map`, `audit list`. All read-only.
+- **Allowed (cluster):** `kubectl get/describe`. NOT `kubectl apply / edit / patch / delete`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub view get / list`. NOT `cub * create / update / delete`.
+- **Compliance audits are read-only by design.** The audit produces evidence; remediation (re-aligning the non-compliant resources) is a separate operational decision, typically routed through `pilot-patch-and-drift` or `pilot-rollback-decision` — those skills handle Pilot's mutation path. This skill stops at the report.
+
+## References
+
+- [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md) — same verbs, operational (same-day) framing instead of compliance (periodic) framing
+- [`scout-compare`](../scout-compare/SKILL.md) — Compare verbs
+- [`scout-verify`](../scout-verify/SKILL.md) — receipt persistence + validation
+- [`scout-govern`](../scout-govern/SKILL.md) — fleet, views, audit, summary
+- [`audit-fleet-conformance`](../audit-fleet-conformance/SKILL.md) — operator-side counterpart
+- [`scout-attribute`](../scout-attribute/SKILL.md) — per-field attribution for violation explainability
+- Source-truth contract: `#393`, `#418` (Phase 2 strategies)
+- Receipts v1+v2: `#446` (v1), `#463` (v2 surface)
+- Read-only triad: [`references/read-only-triad.md`](../references/read-only-triad.md)
+
+## Constraints
+
+- The audit is **point-in-time**: the report reflects the cluster + ConfigHub state at evaluation. Compliance frameworks that require continuous monitoring should pair this skill with [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) for the event-driven side.
+- Receipts are **fingerprint-stable but not signed** in v1/v2 (`#463`); cryptographic signing is a future hardening direction. Auditors who require non-repudiation need the future signing layer — flag this in the report.
+- The local receipt store at `$XDG_DATA_HOME/cub-scout/receipts` is **per-host**. For multi-host compliance pipelines, Pilot should archive each run's `evidence/` directory externally (S3, ConfigHub bundle catalog, GitHub Release artifact) for the retention period.
+- `scan` covers ~46 built-in risk patterns; bespoke policies (custom CIS benchmarks, SOC 2 controls) need either custom patterns (out of cub-scout scope) or a policy engine (Kyverno, OPA Gatekeeper) that this skill doesn't replace.
+- Compliance vocabulary (Compliant / Non-compliant) is the report-layer translation of receipt verdicts (PASS / BLOCK). cub-scout doesn't speak compliance vocabulary natively; Pilot's report renders the translation.

--- a/skills/pilot-promotion-gate/SKILL.md
+++ b/skills/pilot-promotion-gate/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: pilot-promotion-gate
+description: 'Use when Pilot is GATING A VARIANT-TO-VARIANT PROMOTION between two intentional configurations (e.g., staging → prod; canary 5%% → 50%%; blue → green; cell-A → cell-B). Natural phrasings: "Pilot, gate the promotion from staging to prod", "is variant B safe to promote from variant A?", "render the cross-variant safety verdict", "what would change between cells if we promote?", "promotion gate for the canary rollout". Pilot consumes cub-scout''s `compare three-way` per variant + the per-variant `bindingSource` graph + `compare source-truth --strategy <s>` per variant to render a CROSS-VARIANT verdict — not a pre-deploy gate against a single resource (that''s pilot-cd-gate). Pilot picks promotion safety + the field-level diff reasons; the actual promotion execution lives in Pilot''s mutation path. Do NOT load for: a single-resource pre-deploy gate (use pilot-cd-gate), a rollback decision (use pilot-rollback-decision), a real-time event response (use pilot-watch-alert-response), or a post-deploy validation (use pilot-release-verification).'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout compare three-way *) Bash(cub-scout compare three-way *) Bash(cub scout compare three-way *) Bash(./cub-scout compare drift *) Bash(cub-scout compare drift *) Bash(cub scout compare drift *) Bash(./cub-scout compare source-truth *) Bash(cub-scout compare source-truth *) Bash(cub scout compare source-truth *) Bash(./cub-scout impact *) Bash(cub-scout impact *) Bash(cub scout impact *) Bash(./cub-scout views resolve *) Bash(cub-scout views resolve *) Bash(cub scout views resolve *) Bash(./cub-scout views project *) Bash(cub-scout views project *) Bash(cub scout views project *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout explain *) Bash(cub-scout explain *) Bash(cub scout explain *) Bash(./cub-scout trace *) Bash(cub-scout trace *) Bash(cub scout trace *) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub link list *) Bash(cub unit get *) Bash(argocd app get *) Bash(flux get *)
+
+---
+
+# pilot-promotion-gate
+
+The variant-to-variant promotion-safety scenario from **Pilot's** side. A pipeline (or a human) asks: *is variant B safe to promote from variant A?* — where A and B are two intentional configurations (staging → prod; canary 5% → 50%; blue → green; cell-A → cell-B). Pilot consumes cub-scout's evidence from **both** variants and renders a cross-variant safety verdict.
+
+This is **not** `pilot-cd-gate` — that's the single-resource pre-deploy gate. Promotion is the *cross-variant safety check*: variant A has been running successfully; variant B is the proposed next state; the diff between them needs structured evidence before promotion fires.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot, gate the promotion from staging to prod"
+- "Is variant B safe to promote from variant A?"
+- "Render the cross-variant safety verdict"
+- "What would change between cells if we promote?"
+- "Promotion gate for the canary rollout"
+- "Pilot, decide on the 5% → 50% canary increase"
+- "Show me the field-level diff between blue and green"
+
+Implicit intents:
+
+- A **promotion is being staged** (not a fresh deploy and not a rollback) — two variants are both real and Pilot is picking whether to advance
+- The decision is **cross-variant** — comparing variant A's evidence to variant B's, not just evaluating B alone
+- The result feeds a **promotion ticket / release gate** — the team needs structured evidence the promotion is safe, with field-level diff reasons
+- The actual promotion (Argo PromotionStrategy sync, Flux progressive rollout, ConfigHub variant flip) is Pilot's mutation path
+
+## Do not load for
+
+- A **single-resource pre-deploy gate** (no prior variant to compare against) — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- A **rollback decision** (backward direction; this skill is forward-direction) — [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md)
+- A **post-deploy validation** after the promotion already fired — [`pilot-release-verification`](../pilot-release-verification/SKILL.md)
+- A **real-time event-driven** drift response on either variant — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- A **fleet-wide conformance audit** across many variants — [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md)
+- A **compliance audit** across policies (not a variant decision) — [`pilot-compliance-audit`](../pilot-compliance-audit/SKILL.md)
+- Any **mutating action**. The promotion execution is Pilot's; cub-scout doesn't promote.
+
+## The Pilot ↔ cub-scout promotion loop
+
+```
+   release pipeline: variant A is running; variant B is the proposed promotion
+        │
+        ▼
+   Pilot (acceptance judge)
+        │  "is B safe to promote from A?"
+        │
+        ├──► For variant A (the current state):
+        │      cub-scout compare three-way <r> -n <ns-A> --format json
+        │      cub-scout compare source-truth <r> -n <ns-A> --strategy <s> --format json
+        │      cub-scout receipt verify <r> -n <ns-A> --strategy <s> \
+        │        --out variant-A.receipt.json
+        │
+        ├──► For variant B (the proposed state):
+        │      cub-scout compare three-way <r> -n <ns-B> --format json
+        │      cub-scout compare source-truth <r> -n <ns-B> --strategy <s> --format json
+        │      cub-scout receipt verify <r> -n <ns-B> --strategy <s> \
+        │        --out variant-B.receipt.json
+        │
+        ├──► Cross-variant binding diff:
+        │      cub-scout compare three-way <r> -n <ns-A> --format json \
+        │        | jq '.fieldMismatches[].bindingSource'
+        │      cub-scout compare three-way <r> -n <ns-B> --format json \
+        │        | jq '.fieldMismatches[].bindingSource'
+        │      # Pilot compares the bindingSource graphs field-by-field
+        │
+        └──► Cross-variant chained receipt:
+              cub-scout receipt verify <r> -n <ns-B> --strategy <s> \
+                --input-attestation variant-A.receipt.json \
+                --save \
+                --out promotion-target.receipt.json
+        │
+        ▼
+   Pilot's cross-variant verdict:
+        │  A=PASS AND B=PASS AND diff is clean    → PROMOTION PASS
+        │  A=PASS AND B=PASS but bindingSource    → PROMOTION WATCH (caveats)
+        │   shifts in unexpected ways
+        │  A=PASS AND B=WATCH                     → PROMOTION ASK (B isn't ready)
+        │  A=PASS AND B=BLOCK                     → PROMOTION BLOCK (don't promote)
+        │  A=BLOCK                                → PROMOTION BLOCK (fix A first)
+        │
+        ▼
+   release pipeline reads the verdict
+        │  PASS  → fire Pilot's promotion mutation path
+        │  WATCH → fire with caveats attached to the release ticket
+        │  ASK   → halt; the on-call decides
+        │  BLOCK → halt; alert; do not promote
+        └────────────────────────────────────────────────────
+```
+
+## What "variant" means here
+
+This skill handles three common variant shapes:
+
+| Variant shape | Variant A | Variant B | cub-scout reads |
+|---------------|-----------|-----------|------------------|
+| **Environment promotion** | `deploy/api -n staging` | `deploy/api -n prod` | Same kind/name, different namespaces |
+| **Canary progression** | `deploy/api -n prod` (HPA limit 5%) | `deploy/api -n prod` (HPA limit 50%) | Same resource, different Argo-Rollouts step |
+| **Blue-green flip** | `deploy/api-blue -n prod` | `deploy/api-green -n prod` | Different names, same role; Pilot compares both against the shared upstream Unit |
+| **Cell rollout** | `deploy/api -n prod-use1` | `deploy/api -n prod-euw1` | Same resource in different cluster cells |
+
+For each shape, Pilot's cross-variant call is structurally the same: read both variants' three-way + source-truth + bindingSource graphs; compute the diff; render a verdict. cub-scout doesn't model variants as a first-class concept — it reads the kind/name/namespace pair Pilot passes. The variant pairing is Pilot's job.
+
+## Why `bindingSource` matters for promotion
+
+The `bindingSource` per field (connected-mode only; from `#435` C2) records *which ConfigHub Link supplied this field's value*. Cross-variant safety often hinges on whether the same upstream Link feeds both variants:
+
+- **A and B reference the same upstream Unit at the same path** → safe; the promotion is just propagating an already-canonical value
+- **A and B reference different upstream Units** → caveat; the promotion is *also* a Link-graph shift, which may surprise the operator
+- **A has a bindingSource but B has `null`** → ASK; B might be unmanaged or the Link wasn't promoted alongside
+
+This is the load-bearing reason promotion-gate is distinct from `pilot-cd-gate`: a single-variant gate doesn't see the cross-variant Link-graph shift.
+
+## Step-by-step
+
+### Step 1 — per-variant evidence
+
+```bash
+# Variant A (current)
+$ cub-scout compare three-way deploy/api -n staging --format json > variant-A-3way.json
+$ cub-scout compare source-truth deploy/api -n staging --strategy git-argo --format json > variant-A-st.json
+$ cub-scout receipt verify deploy/api -n staging --strategy git-argo \
+    --save \
+    --out variant-A.receipt.json
+
+# Variant B (proposed)
+$ cub-scout compare three-way deploy/api -n prod --format json > variant-B-3way.json
+$ cub-scout compare source-truth deploy/api -n prod --strategy git-argo --format json > variant-B-st.json
+$ cub-scout receipt verify deploy/api -n prod --strategy git-argo \
+    --save \
+    --out variant-B.receipt.json
+```
+
+### Step 2 — extract field-level diff between variants
+
+```bash
+# Pilot's cross-variant diff — fieldMismatches by path
+$ jq -s '
+  {
+    A_fields: .[0].fieldMismatches | map({path, value: .compareThreeWay.live, bindingSource}),
+    B_fields: .[1].fieldMismatches | map({path, value: .compareThreeWay.live, bindingSource})
+  }
+' variant-A-3way.json variant-B-3way.json
+```
+
+Pilot reads:
+- Fields present in A but not B (deleted)
+- Fields present in B but not A (new)
+- Fields in both with different values (changed)
+- Fields where the `bindingSource` shifted (cross-variant Link-graph drift)
+
+The last category is the most important and the hardest to surface — only the cross-variant comparison can see it.
+
+### Step 3 — chained receipt records the cross-variant relationship
+
+```bash
+$ cub-scout receipt verify deploy/api -n prod \
+    --strategy git-argo \
+    --input-attestation variant-A.receipt.json \
+    --save \
+    --out promotion-target.receipt.json
+```
+
+The promotion-target receipt's `inputAttestations[]` records variant A's receipt — the audit trail says "promotion B was gated against the prior variant A's evidence." If A's receipt is later tampered with, the chain construction (`VerifiedAttestationRef` API-boundary verify) refuses.
+
+### Step 4 — Pilot's verdict synthesis
+
+| Variant A verdict | Variant B verdict | bindingSource diff | Pilot promotion verdict |
+|--------------------|--------------------|--------------------|-------------------------|
+| PASS | PASS | none | **PASS** |
+| PASS | PASS | shifted but explicable | **WATCH** |
+| PASS | PASS | shifted without rationale | **ASK** (human decides) |
+| PASS | WATCH | — | **ASK** (B isn't ready) |
+| PASS | BLOCK | — | **BLOCK** |
+| PASS | INCONCLUSIVE | — | **ASK** (B can't be evaluated) |
+| WATCH / BLOCK | any | — | **BLOCK** (fix A first; don't promote a sick variant) |
+| INCONCLUSIVE | any | — | **ASK** (A's evidence isn't reliable for the gate) |
+
+The decision is **cross-variant** — both variants' verdicts and the diff between them all feed the promotion verdict. cub-scout doesn't synthesize this; Pilot does.
+
+## Worked example
+
+Promotion: `deploy/payments-api` from `staging` to `prod`. Declared strategy: `git-argo`.
+
+```bash
+# Per-variant receipts
+$ cub-scout receipt verify deploy/payments-api -n staging \
+    --strategy git-argo --save --out staging.receipt.json
+# verdict: PASS
+
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo --save --out prod.receipt.json
+# verdict: WATCH; proof_gaps lists git-source-anchor missing for one container
+
+# Cross-variant chained receipt
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --input-attestation staging.receipt.json \
+    --save \
+    --out promotion-target.receipt.json
+```
+
+Pilot's verdict synthesis:
+- staging.verdict = PASS
+- prod.verdict = WATCH (a per-container source-anchor gap)
+- bindingSource diff: identical (same upstream Unit in both variants)
+- → Pilot promotion verdict: **ASK** (B isn't fully ready; missing source-anchor on one container)
+
+Pilot's verdict pack:
+
+```json
+{
+  "decision_type": "promotion",
+  "from_variant": "staging",
+  "to_variant": "prod",
+  "from_receipt": "staging.receipt.json",
+  "to_receipt": "prod.receipt.json",
+  "chained_target": "promotion-target.receipt.json",
+  "from_verdict": "PASS",
+  "to_verdict": "WATCH",
+  "binding_source_diff": "none",
+  "promotion_verdict": "ASK",
+  "rationale": "B (prod) has a WATCH verdict with proof_gaps; on-call should decide whether to proceed",
+  "next_step": "route to on-call; promotion mutation lives in Pilot's stack, not cub-scout"
+}
+```
+
+## Standalone vs connected
+
+**Connected mode strongly recommended** for promotion-gate:
+
+- `compare source-truth --strategy` — connected (per-variant strategy verdict)
+- `bindingSource` field on each mismatch — connected (Link-graph data)
+- `impact` for blast-radius — connected
+
+Standalone mode degrades:
+- Receipt verdicts can still be produced via `--predicate applied-matches-spec`
+- bindingSource is null per field; cross-variant Link-graph diff isn't available
+- The promotion-gate result is narrower; Pilot's policy should escalate to ASK when bindingSource isn't readable.
+
+## Tool boundary
+
+- **Allowed (cub-scout):** Compare verbs (read-only), `impact`, `views resolve` / `project`, `receipt verify` / `show` / `validate` / `list`, `explain`, `trace`. All read-only.
+- **Allowed (cluster):** `kubectl get/describe`. NOT `kubectl apply / edit / patch / delete`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub unit get`, `cub link list`. NOT any mutating `cub` verb.
+- **Allowed (controllers):** `argocd app get`, `flux get`. NOT `argocd app sync`, `flux reconcile`.
+- **Pilot's promotion execution** (Argo PromotionStrategy, Flux progressive rollout, ConfigHub variant flip, blue-green service swap) is Pilot's mutation path, deliberately not named here.
+
+## References
+
+- [`scout-compare`](../scout-compare/SKILL.md) — Compare verbs (cub-scout side)
+- [`scout-attribute`](../scout-attribute/SKILL.md) — `bindingSource` semantics
+- [`scout-verify`](../scout-verify/SKILL.md) — chained receipts via `--input-attestation`
+- [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) — single-resource pre-deploy companion
+- [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md) — backward direction
+- [`pilot-release-verification`](../pilot-release-verification/SKILL.md) — post-promotion validation
+- [`pilot-fleet-conformance`](../pilot-fleet-conformance/SKILL.md) — fleet-wide variant audit (related but different framing)
+- Attribution layer: `#435` (C1+C2 `bindingSource`)
+- Chained receipts: `#448` (parent), `#463` (chained-half shipped)
+
+## Constraints
+
+- cub-scout doesn't model variants as a first-class concept. The variant pairing (which two resources are being compared) is **Pilot's job**; cub-scout reads the kind/name/namespace pairs Pilot passes.
+- `bindingSource` requires connected mode AND both variants being ConfigHub-linked. Variants without Link coverage produce `null` bindingSource — the cross-variant Link-graph diff isn't surfaced. Pilot should escalate to ASK in that case.
+- The promotion-target receipt's `inputAttestations[]` typically references variant A's receipt. If multi-step promotion (A → A' → B), Pilot may chain multiple prior receipts. The chain ordering is **Pilot's choice** — cub-scout treats `inputAttestations[]` as a set (RFC 8785 canonical JSON orders the array, but the meaning is set-shaped).
+- Promotion mutation (the actual flip from A to B) is Pilot's mutation path. cub-scout's role ends at the promotion-target receipt; how Pilot fires the controller sync / variant flip is outside this skill.

--- a/skills/pilot-release-verification/SKILL.md
+++ b/skills/pilot-release-verification/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: pilot-release-verification
+description: 'Use when Pilot is RUNNING POST-DEPLOY VALIDATION after a release has shipped — confirming the release actually landed per declared intent. Natural phrasings: "Pilot, verify the release", "did `payments-api@v1.4.3` land cleanly?", "post-deploy verification gate", "Pilot, render the release-quality verdict", "confirm the deploy matches Git", "did everything reconcile after the apply?". Pilot consumes cub-scout''s `compare three-way` (DRY/WET/LIVE per resource in the release scope) + `bindingSource` graph (did Links propagate correctly?) + `history` since the deploy timestamp (what changed in the last N minutes?) + `gitSource` anchor (does the live state match the release SHA?). Pilot renders a release-quality verdict per resource and a release-level rollup. Distinct from `pilot-cd-gate` which fires BEFORE the deploy; this skill fires AFTER. Do NOT load for: pre-deploy gate (use pilot-cd-gate), real-time event response (use pilot-watch-alert-response), rollback decision when verification fails (use pilot-rollback-decision), or incident close-out evidence (use pilot-incident-evidence).'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout compare three-way *) Bash(cub-scout compare three-way *) Bash(cub scout compare three-way *) Bash(./cub-scout compare drift *) Bash(cub-scout compare drift *) Bash(cub scout compare drift *) Bash(./cub-scout compare source-truth *) Bash(cub-scout compare source-truth *) Bash(cub scout compare source-truth *) Bash(./cub-scout history *) Bash(cub-scout history *) Bash(cub scout history *) Bash(./cub-scout doctor *) Bash(cub-scout doctor *) Bash(cub scout doctor *) Bash(./cub-scout explain *) Bash(cub-scout explain *) Bash(cub scout explain *) Bash(./cub-scout trace *) Bash(cub-scout trace *) Bash(cub scout trace *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout watch *) Bash(cub-scout watch *) Bash(cub scout watch *) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub history *) Bash(cub link list *) Bash(cub unit get *) Bash(argocd app get *) Bash(flux get *)
+
+---
+
+# pilot-release-verification
+
+The post-deploy validation scenario from **Pilot's** side. A release has just shipped (Argo synced, Flux reconciled, Helm applied, ConfigHub unit fired). Pilot is asked: *did it land cleanly?* Pilot consumes cub-scout's evidence at the post-deploy moment + the timeline since deploy + the binding graph + the source-truth anchor, then renders a release-quality verdict.
+
+This is the **after-the-fact** companion to `pilot-cd-gate`. The CD gate fires *before* the deploy and decides whether to proceed; release-verification fires *after* the deploy and confirms it actually landed. Both are query-driven; the timing is the differentiator.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot, verify the release"
+- "Did `payments-api@v1.4.3` land cleanly?"
+- "Post-deploy verification gate"
+- "Pilot, render the release-quality verdict"
+- "Confirm the deploy matches Git"
+- "Did everything reconcile after the apply?"
+- "Pilot, sign off on the release"
+- "Run the post-deploy gate against the release record"
+
+Implicit intents:
+
+- The deploy **already happened**; reconciliation may still be in flight
+- The user wants to **confirm the landing**, not pre-gate the next deploy
+- The result feeds a **release record** — typically a release ticket, a deploy webhook, a "did this work?" signal back to the CD pipeline
+- The audit-attached path (receipt-saved) is the preferred output — the release record carries the receipt
+
+## Do not load for
+
+- A **pre-deploy gate** (the deploy hasn't happened yet) — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- A **real-time event-driven** response on subsequent drift — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- A **rollback decision** when verification failed — [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md). This skill says "did the release land?"; rollback-decision picks what to do if it didn't.
+- A **postmortem evidence pack** for a broken release — [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md)
+- A **promotion safety check** between two variants — [`pilot-promotion-gate`](../pilot-promotion-gate/SKILL.md)
+- A **periodic compliance audit** — [`pilot-compliance-audit`](../pilot-compliance-audit/SKILL.md)
+- Any **mutating action**. Verification is read-only by design.
+
+## The Pilot ↔ cub-scout release-verification loop
+
+```
+   CD pipeline: argocd app sync / flux reconcile / cub unit apply just fired at <deploy-time>
+        │
+        ▼
+   (reconciliation in flight; allow a settle window — typically 30-180s)
+        │
+        ▼
+   Pilot (acceptance judge in post-deploy mode)
+        │  "did the release land cleanly?"
+        │
+        ├──► cub-scout doctor          # cluster-health sanity check
+        │
+        ├──► For each resource in the release scope:
+        │      cub-scout compare three-way <r> -n <ns> --format json
+        │      # DRY/WET/LIVE convergence check
+        │
+        │      cub-scout compare source-truth <r> -n <ns> --strategy <s> --format json
+        │      # strategy-typed verdict against the release SHA
+        │
+        │      cub-scout history <r> -n <ns> --since <deploy-time> --format json
+        │      # what changed since the deploy fired
+        │
+        │      cub-scout receipt verify <r> -n <ns> --strategy <s> \
+        │        --at-commit <release-sha> \
+        │        --save \
+        │        --out release-verify-<r>.receipt.json
+        │      # fingerprinted post-deploy verdict, pinned to the release SHA
+        │
+        └──► Convergence-still-in-flight detection:
+              cub-scout compare three-way <r> -n <ns> --format json \
+                | jq '.summary.agreement'
+              # "converging" = give it more time
+              # "diverged"   = the release did NOT land cleanly
+              # "agreed"     = clean landing
+        │
+        ▼
+   Pilot's release-quality verdict:
+        │  All PASS, summary.agreement = "agreed"        → RELEASE PASS
+        │  All PASS but summary.agreement = "converging" → RELEASE WATCH (wait + re-check)
+        │  Any WATCH                                     → RELEASE WATCH (note in release record)
+        │  Any BLOCK (manual-edit during deploy window)  → RELEASE BLOCK → escalate to rollback
+        │  Any INCONCLUSIVE                              → RELEASE ASK   → human checks
+        │
+        ▼
+   release record gets the verdict + per-resource receipts
+        │  PASS  → close the release ticket as Verified
+        │  WATCH → re-verify after another settle window; or close with caveats
+        │  BLOCK → route to pilot-rollback-decision
+        │  ASK   → page on-call; the proof gaps explain what's missing
+        └────────────────────────────────────────────────────
+```
+
+## Settle window — the load-bearing timing detail
+
+Reconciliation isn't instant. Argo CD application syncs typically converge in 10-60s for healthy resources; Flux Kustomizations in 20-180s; Helm in similar windows. Cron-style or autoscaled workloads can take longer.
+
+Pilot's verification policy MUST account for a settle window:
+
+| Resource type | Typical settle | Verification call timing |
+|---------------|----------------|--------------------------|
+| Deployment / ReplicaSet | 30-60s after sync | First verify after sync wait; retry on `converging` |
+| StatefulSet | 60-180s (per-pod rolling) | Same; longer retry window |
+| CronJob | next schedule (variable) | Don't verify until first job runs; or skip CronJobs from this gate |
+| Helm release | 30-120s for full chart converge | Wait for `helm status` Deployed; then verify |
+
+Pilot's policy choice: short-poll (re-verify every N seconds until `agreed` or timeout) vs single-shot (verify once after a fixed wait). cub-scout supports both — the verb is the same; the loop is Pilot's.
+
+## What `compare three-way`'s `summary.agreement` field tells you
+
+The post-deploy convergence signal:
+
+| `summary.agreement` | Meaning |
+|---------------------|---------|
+| `agreed` | All resources in scope have DRY=WET=LIVE for every field. **Release landed cleanly.** |
+| `converging` | Most resources agree; a small subset is in active reconciliation (`controller-drift` causes). **Release is in flight; wait and re-verify.** |
+| `diverged` | At least one resource has a hard mismatch with no `controller-drift` cause. **Release did NOT land cleanly; investigate or rollback.** |
+| `partial` | Mixed; the rollup couldn't pick a single label. **Read per-resource details.** |
+
+`converging` is the most important post-deploy state — it's the "wait, the controller is still working on it" signal. Pilot's verification policy should treat `converging` as "not done yet" rather than a soft pass.
+
+## Step-by-step
+
+### Step 1 — pre-flight health check
+
+```bash
+$ cub-scout doctor
+```
+
+If the cluster itself is unhealthy (API server flapping, controller flat-lined), the verification call won't be trustworthy. Doctor's output is a sanity signal — verify cluster is in a state where reconciliation *could* succeed before evaluating whether it *did*.
+
+### Step 2 — wait the settle window, then verify
+
+```bash
+# Adjust the sleep to your release type's typical settle
+$ sleep 60
+
+# Per-resource three-way + source-truth
+$ for r in <list-of-released-resources>; do
+    cub-scout compare three-way $r --format json > verify/$r-3way.json
+    cub-scout compare source-truth $r --strategy git-argo --format json > verify/$r-st.json
+  done
+```
+
+### Step 3 — pin to the release SHA via `--at-commit`
+
+```bash
+$ for r in <list>; do
+    cub-scout receipt verify $r --strategy git-argo \
+      --at-commit <release-sha> \
+      --save \
+      --out verify/$r.receipt.json
+  done
+```
+
+`--at-commit <sha>` pins the spec anchor to the release's SHA. A PASS verdict confirms the live state matches **this release**, not some other state. The receipt is fingerprint-stable and lands in the release record.
+
+### Step 4 — timeline check
+
+```bash
+$ cub-scout history deploy/payments-api -n prod --since "<deploy-time>" --format json
+```
+
+Reveals what ChangeSet entries fired in the deploy window. Should match the release's intent — if extra ChangeSets fired (manual edits during deploy, controller flaps), Pilot's verdict should downgrade.
+
+### Step 5 — Pilot's release-quality verdict synthesis
+
+| Per-resource verdicts | `summary.agreement` | Pilot release verdict | Pipeline action |
+|------------------------|---------------------|-----------------------|-----------------|
+| All PASS | `agreed` | **RELEASE PASS** | Close the release ticket as Verified |
+| All PASS | `converging` | **RELEASE WATCH (wait)** | Re-verify after another settle window |
+| Mix of PASS + WATCH | any | **RELEASE WATCH** | Note caveats in the release record; consider closing with caveats |
+| Any BLOCK | `diverged` | **RELEASE BLOCK** | Route to [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md) |
+| Any BLOCK | `converging` | **RELEASE ASK** | Wait; the controller may still resolve the divergence |
+| Any INCONCLUSIVE | any | **RELEASE ASK** | Page on-call; proof gaps explain what's missing |
+
+### Step 6 — attach receipts to the release record
+
+```bash
+# The receipt path each resource's verdict landed at
+$ cub-scout receipt list --format json \
+    | jq '[.[] | select(.verifiedAt > "<deploy-time>")]' \
+    > verify/release-receipts.json
+```
+
+The release record (release ticket, deploy webhook payload, change-management entry) gets the per-resource receipts attached. Six months later, an auditor can `cub-scout receipt validate` any individual receipt to confirm it's tamper-evident.
+
+## Worked example
+
+Release `payments-api@v1.4.3` (SHA `9e7d12fa`) just fired at `2026-05-22T14:30:00Z`. Strategy: `git-argo`. Settle window: 60s.
+
+```bash
+# Pre-flight
+$ cub-scout doctor 2>&1 | tail -3
+✓ API server reachable
+✓ All required controllers Ready
+✓ 2 namespaces selected for compare
+
+# Wait the settle window
+$ sleep 60
+
+# Per-resource three-way
+$ cub-scout compare three-way deploy/payments-api -n prod --format json \
+    | jq '.summary'
+{
+  "agreement": "agreed",
+  "agreed": 7,
+  "converging": 0,
+  "diverged": 0,
+  "scope": "resource:Deployment/payments-api/prod"
+}
+
+# Source-truth + receipt
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --at-commit 9e7d12fa \
+    --save \
+    --out release-v1.4.3.receipt.json
+# Verdict: PASS
+
+# Timeline check
+$ cub-scout history deploy/payments-api -n prod \
+    --since 2026-05-22T14:30:00Z --format json | jq 'length'
+1   # one ChangeSet entry (the release itself); no surprise edits
+```
+
+Pilot's release-quality verdict:
+
+```json
+{
+  "release_id": "release-2026-05-22-payments-api-v1.4.3",
+  "release_sha": "9e7d12fa",
+  "deploy_time": "2026-05-22T14:30:00Z",
+  "verify_time": "2026-05-22T14:31:00Z",
+  "settle_window_seconds": 60,
+  "release_verdict": "PASS",
+  "summary_agreement": "agreed",
+  "per_resource": [
+    {"resource": "Deployment/payments-api in prod", "verdict": "PASS", "receipt": "release-v1.4.3.receipt.json"}
+  ],
+  "post_deploy_changesets": 1,
+  "rationale": "DRY=WET=LIVE; source-truth PASS against release SHA; no surprise changes",
+  "next_step": "close release ticket as Verified; attach release-v1.4.3.receipt.json"
+}
+```
+
+The release ticket gets the verdict + the receipt. Six months later: `cub-scout receipt validate release-v1.4.3.receipt.json` exits 0 — fingerprint stable.
+
+## Standalone vs connected
+
+**Connected mode preferred** for full verification:
+
+- `compare source-truth --strategy` — connected
+- `history` — connected (ChangeSet timeline)
+- `bindingSource` field on `compare three-way` — connected
+- `cub link list` for Link-graph cross-check — connected
+- `receipt verify --strategy source-truth-pass` — connected
+
+Standalone mode is **partial**:
+- `compare three-way --git-path <local-checkout>` works without ConfigHub for raw-YAML comparison
+- `receipt verify --predicate applied-matches-spec --at-commit <sha>` produces a per-resource verdict
+- No `history` (no ChangeSet timeline) — Pilot has to supply deploy-time from elsewhere
+- No `bindingSource` — Link-graph verification skipped
+
+A standalone post-deploy gate is still valuable but narrower. Pilot's policy should call out the limitation in the release record.
+
+## Tool boundary
+
+- **Allowed (cub-scout):** Compare verbs (read-only), `history`, `doctor`, `explain`, `trace`, `receipt verify` / `show` / `validate` / `list`, `watch` (for the optional event-driven verification track). All read-only.
+- **Allowed (cluster):** `kubectl get/describe`. NOT `kubectl apply / edit / patch / delete / rollout undo`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub history`, `cub link list`, `cub unit get`. NOT mutating `cub` verbs.
+- **Allowed (controllers):** `argocd app get`, `flux get`. NOT `argocd app sync`, `flux reconcile` (those fired *before* this skill ran).
+- **Verification is read-only by design.** If the verdict is BLOCK, the rollback path is [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md) — and even there, cub-scout's role is evidence, not the controller sync.
+
+## References
+
+- [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) — pre-deploy companion (this skill is the post-deploy half)
+- [`pilot-rollback-decision`](../pilot-rollback-decision/SKILL.md) — when this skill returns BLOCK
+- [`pilot-promotion-gate`](../pilot-promotion-gate/SKILL.md) — cross-variant; this skill is single-release
+- [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md) — event-driven companion; useful as an alternative to short-poll re-verify
+- [`scout-compare`](../scout-compare/SKILL.md) — Compare verbs (cub-scout side)
+- [`scout-verify`](../scout-verify/SKILL.md) — receipts with `--at-commit`
+- [`scout-govern`](../scout-govern/SKILL.md) — `history`
+- Source-truth contract: `#393`, `#418` (Phase 2 strategies)
+- Receipts: `#446` (v1), `#463` (v2 surface)
+
+## Constraints
+
+- **Settle window** is mandatory. Verification too early returns `converging` and Pilot's policy has to re-verify. Pilot's choice between short-poll (every N seconds) vs single-shot (fixed wait) is Pilot-side; cub-scout exposes the verbs.
+- `--at-commit <sha>` pins the spec anchor revision; the rest of the predicate evaluation (attribution, source-truth derivation) runs against the **live** cluster state. Useful for "did we land *this specific* release?" rather than "is the live state plausible against *some* release?"
+- For CronJobs or workloads that don't materialize a Pod until their schedule fires, verification within minutes of deploy may not be meaningful. Pilot's policy should either skip those resources from the per-release gate or delay verification until the first execution.
+- The release-quality verdict is **per-release**, not per-resource. A single BLOCK resource flips the whole release to BLOCK by default; Pilot may pick a different roll-up policy (e.g., "ignore drift on `deploy/legacy-tool`") — that's Pilot-side.
+- Verification's `--at-commit` pinning is meaningful only against `source-truth-pass` predicate. `applied-matches-spec` doesn't strictly require it (the controller-resolved anchor is sufficient when present).

--- a/skills/pilot-rollback-decision/SKILL.md
+++ b/skills/pilot-rollback-decision/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: pilot-rollback-decision
+description: 'Use when Pilot is DECIDING WHEN AND WHICH REVISION TO ROLL BACK TO after an incident or a broken release. Natural phrasings: "Pilot, should we roll back?", "what revision should Pilot pick for the rollback?", "is the previous SHA safe to roll back to?", "render the rollback verdict + target", "Pilot, choose the rollback revision and explain why". Pilot consumes cub-scout''s `history` (ConfigHub ChangeSet timeline) + `impact` (blast-radius preview) + `compare source-truth --strategy <s>` (per-candidate-revision evidence) + `receipt verify --predicate applied-matches-spec --at-commit <sha>` (pin to a specific revision for fingerprinted evaluation). Pilot picks the rollback target and renders a safety verdict; the actual rollback is Pilot''s mutation path (controller sync to the chosen revision), not cub-scout''s. Do NOT load for: pre-deploy gate (use pilot-cd-gate), real-time event response (use pilot-watch-alert-response), drift-classification on the current state (use pilot-patch-and-drift), or incident close-out evidence assembly (use pilot-incident-evidence — which captures what happened; this skill picks where to go next).'
+phase: cross-cutting
+allowed-tools: Bash(./cub-scout history *) Bash(cub-scout history *) Bash(cub scout history *) Bash(./cub-scout impact *) Bash(cub-scout impact *) Bash(cub scout impact *) Bash(./cub-scout compare three-way *) Bash(cub-scout compare three-way *) Bash(cub scout compare three-way *) Bash(./cub-scout compare drift *) Bash(cub-scout compare drift *) Bash(cub scout compare drift *) Bash(./cub-scout compare source-truth *) Bash(cub-scout compare source-truth *) Bash(cub scout compare source-truth *) Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout explain *) Bash(cub-scout explain *) Bash(cub scout explain *) Bash(./cub-scout trace *) Bash(cub-scout trace *) Bash(cub scout trace *) Bash(kubectl get *) Bash(kubectl describe *) Bash(cub * get) Bash(cub * list) Bash(cub history *) Bash(cub unit get *) Bash(cub link list *) Bash(argocd app get *) Bash(flux get *)
+
+---
+
+# pilot-rollback-decision
+
+The rollback-decision scenario from **Pilot's** side. After an incident, a broken release, or a failed verification, Pilot is asked: *should we roll back, and to which revision?* Pilot consumes cub-scout's `history` + `impact` + per-candidate-revision evidence and picks the rollback target with a safety verdict.
+
+cub-scout is the **witness**; Pilot is the **judge**. ConfigHub (via `cub`) is the authority. cub-scout never picks a target or executes the rollback — it produces structured evidence per candidate revision, and Pilot decides. The mutation (controller sync to the chosen revision) is Pilot's surface, not cub-scout's.
+
+## When to use
+
+Explicit phrasings:
+
+- "Pilot, should we roll back?"
+- "What revision should Pilot pick for the rollback?"
+- "Is the previous SHA safe to roll back to?"
+- "Render the rollback verdict + target"
+- "Pilot, choose the rollback revision and explain why"
+- "How far back should the rollback go?"
+- "Show me the safety verdict for rolling back to `<sha>`"
+
+Implicit intents:
+
+- A **rollback is being considered** (not a forward fix); time pressure may still be active but the decision needs structured evidence, not heuristic
+- The user wants a **target revision** plus a safety verdict (not just "roll back somewhere")
+- The result feeds a **decision record** — postmortem, change ticket, release rollback approval
+- The mutation itself is Pilot's call; cub-scout's job is to make the safest target *legible*
+
+## Do not load for
+
+- A **pre-deploy gate** (the deploy hasn't happened yet) — [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md)
+- A **real-time event-driven** response — [`pilot-watch-alert-response`](../pilot-watch-alert-response/SKILL.md)
+- A **drift classification** on current state without a rollback decision — [`pilot-patch-and-drift`](../pilot-patch-and-drift/SKILL.md)
+- A **postmortem evidence pack** (what happened) — [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md). That skill captures the incident's evidence; **this** skill picks where to go next.
+- A **promotion** between two intentional variants (not a rollback) — [`pilot-promotion-gate`](../pilot-promotion-gate/SKILL.md)
+- A **post-deploy** validation that didn't fail (just confirming the release landed) — [`pilot-release-verification`](../pilot-release-verification/SKILL.md)
+- Any **mutating action**. The rollback execution path is Pilot's. cub-scout doesn't roll anything back.
+
+## The Pilot ↔ cub-scout rollback loop
+
+```
+   broken release at HEAD = <bad-sha>
+        │
+        ▼
+   Pilot (acceptance judge)
+        │  "should we roll back, and to which revision?"
+        │
+        ├──► cub-scout history <r> -n <ns> --since 7d --format json
+        │     # ConfigHub ChangeSet timeline — candidate prior SHAs
+        │
+        ├──► cub-scout impact <r> --format json
+        │     # blast-radius of the current state + each candidate
+        │
+        ├──► For each candidate revision (call it <candidate-sha>):
+        │      cub-scout receipt verify <r> -n <ns> \
+        │        --strategy <s> \
+        │        --at-commit <candidate-sha> \
+        │        --out candidate-<sha>.receipt.json
+        │      # fingerprinted, per-candidate verdict
+        │      cub-scout compare three-way <r> -n <ns> --format json
+        │        # what fields would change between current and candidate
+        │
+        └──► (optional) chain the candidates:
+              cub-scout receipt verify <r> -n <ns> \
+                --input-attestation candidate-<sha1>.receipt.json \
+                --input-attestation candidate-<sha2>.receipt.json \
+                --strategy <s> \
+                --at-commit <chosen-sha> \
+                --save                          # the chosen-target receipt
+        │
+        ▼
+   Pilot's rollback verdict, by candidate:
+        │
+        │  candidate.verdict == PASS    → safe candidate
+        │  candidate.verdict == WATCH   → safe but with caveats; check proof_gaps
+        │  candidate.verdict == BLOCK   → unsafe target (would re-introduce a divergence)
+        │  candidate.verdict == INCONCLUSIVE → can't evaluate; pick another candidate
+        │
+        ▼
+   Pilot picks the first PASS candidate (most recent prior SHA), records
+   the chosen-target receipt, and routes to Pilot's mutation path
+   (controller sync to <chosen-sha>; implementation lives outside cub-scout).
+        └────────────────────────────────────────────────────
+```
+
+## Candidate selection (most-recent-first PASS)
+
+Pilot's default policy is **most-recent-first**: walk the ChangeSet timeline backwards from the current HEAD, evaluate each candidate revision with `--at-commit`, pick the first one that produces a PASS receipt for the declared strategy.
+
+This is *not* "roll back to the last green build" — the last green build may have been green for the *wrong* reasons (cached evidence, fewer resources in scope, transient luck). cub-scout's per-candidate `receipt verify --at-commit <sha>` evaluates the candidate against the *current* cluster state with the *current* strategy. Pilot's verdict pack carries that exact pairing.
+
+Alternative policies (Pilot-side; cub-scout doesn't enforce):
+
+| Policy | When to use |
+|--------|-------------|
+| Most-recent PASS | Default; the smallest possible rollback to a verifiable state |
+| Most-recent PASS with no INCOMPLETE proof gaps | Stricter; useful when source-truth evidence quality matters |
+| Last release-tagged SHA | When the team distinguishes "release-tagged" SHAs from intermediate commits |
+| Operator-named SHA | Pilot's interface to a human decision — the operator passes `--at-commit <sha>` directly |
+
+Pilot's policy choice is *its* business; cub-scout's job is to make each candidate's safety legible via fingerprinted receipts.
+
+## Step-by-step
+
+### Step 1 — enumerate candidates from history
+
+```bash
+$ cub-scout history deploy/payments-api -n prod --since 7d --format json
+[
+  {"timestamp": "2026-05-22T14:00:00Z", "actor": "ci-bot", "change": "image: v1.4.2 → v1.4.3", "changeset": "CS-4821", "sha": "9e7d12fa"},
+  {"timestamp": "2026-05-22T09:30:00Z", "actor": "ci-bot", "change": "replicas: 2 → 3", "changeset": "CS-4818", "sha": "8b6c11e9"},
+  {"timestamp": "2026-05-21T17:15:00Z", "actor": "ci-bot", "change": "image: v1.4.1 → v1.4.2", "changeset": "CS-4815", "sha": "7a5b10d8"}
+]
+```
+
+The ChangeSet timeline lists candidate prior SHAs in reverse-chronological order. Pilot's candidate set is `[8b6c11e9, 7a5b10d8, …]` (skip the current HEAD `9e7d12fa` which is presumed broken). Connected mode required (`cub auth login`) for `history`.
+
+### Step 2 — per-candidate receipt with `--at-commit`
+
+```bash
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --at-commit 8b6c11e9 \
+    --save \
+    --out candidate-8b6c11e9.receipt.json
+# Pilot reads receipt.predicate.verdict directly
+```
+
+`--at-commit <sha>` overrides the controller-resolved revision in the spec anchor; the resulting receipt asserts "the live state at this moment matches the candidate revision per the declared strategy." A PASS verdict means rolling back to this SHA would NOT introduce drift; a BLOCK means it would.
+
+Repeat per candidate. Each receipt is fingerprint-stable; Pilot's verdict pack carries the full set.
+
+### Step 3 — blast radius per candidate
+
+```bash
+$ cub-scout impact deploy/payments-api --format json
+```
+
+`impact` is connected-mode only. It returns the blast-radius preview (downstream units, dependent workloads). Pilot weights candidates: a candidate that would change many downstream units is higher-risk than one that changes few — even if both verify PASS individually.
+
+### Step 4 — chain the candidates into the chosen-target receipt
+
+Once Pilot picks `<chosen-sha>`, the chosen-target receipt references each candidate evaluated:
+
+```bash
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --at-commit <chosen-sha> \
+    --input-attestation candidate-<sha1>.receipt.json \
+    --input-attestation candidate-<sha2>.receipt.json \
+    --save \
+    --out rollback-target.receipt.json
+```
+
+The chosen-target receipt's `inputAttestations[]` records every candidate Pilot considered — even the ones it rejected. The chain shape is **why Pilot picked this target**, not just **which target Pilot picked**. Audit later can walk the chain and confirm the decision process.
+
+### Step 5 — Pilot's verdict + handoff
+
+Pilot's verdict pack:
+
+```json
+{
+  "decision_type": "rollback",
+  "resource": "Deployment/payments-api in prod",
+  "current_sha": "9e7d12fa",
+  "candidates_evaluated": [
+    {"sha": "8b6c11e9", "verdict": "PASS", "receipt": "candidate-8b6c11e9.receipt.json"},
+    {"sha": "7a5b10d8", "verdict": "PASS", "receipt": "candidate-7a5b10d8.receipt.json"}
+  ],
+  "chosen_sha": "8b6c11e9",
+  "chosen_receipt": "rollback-target.receipt.json",
+  "rationale": "most-recent PASS; smallest possible rollback to a verifiable state",
+  "blast_radius": "1 unit affected (payments-api); no downstream Link impact",
+  "next_step": "route to Pilot's controller-sync path with target=8b6c11e9; cub-scout does not execute the sync"
+}
+```
+
+The downstream consumer (release rollback approver, change ticket) reads the verdict + chosen receipt. Pilot's mutation path (the controller sync to `8b6c11e9`) is **out of scope** for cub-scout — typically a `cub` / Argo / Flux operation in Pilot's stack.
+
+## Worked example
+
+Production `deploy/payments-api` at HEAD `9e7d12fa` is failing health checks. Pilot is asked to decide a rollback target.
+
+```bash
+# Step 1 — enumerate candidates
+$ cub-scout history deploy/payments-api -n prod --since 24h --format json \
+    | jq '.[].sha'
+"9e7d12fa"  # current; broken
+"8b6c11e9"  # 4h ago
+"7a5b10d8"  # 21h ago
+
+# Step 2 — verify each candidate
+$ for sha in 8b6c11e9 7a5b10d8; do
+    cub-scout receipt verify deploy/payments-api -n prod \
+      --strategy git-argo \
+      --at-commit $sha \
+      --save \
+      --out candidate-$sha.receipt.json
+  done
+
+# Step 3 — read verdicts
+$ for sha in 8b6c11e9 7a5b10d8; do
+    jq -r '.predicate.verdict' candidate-$sha.receipt.json
+  done
+PASS    # 8b6c11e9 → safe candidate
+PASS    # 7a5b10d8 → also safe (older)
+
+# Step 4 — chain candidates into chosen-target receipt
+$ cub-scout receipt verify deploy/payments-api -n prod \
+    --strategy git-argo \
+    --at-commit 8b6c11e9 \
+    --input-attestation candidate-8b6c11e9.receipt.json \
+    --input-attestation candidate-7a5b10d8.receipt.json \
+    --save \
+    --out rollback-target.receipt.json
+
+# Step 5 — blast radius
+$ cub-scout impact deploy/payments-api --format json | jq '.affected_units | length'
+1
+```
+
+Pilot's verdict: roll back to `8b6c11e9` (most-recent PASS), blast radius 1 unit, evidence chain attached. Routes to Pilot's controller-sync path with target SHA; cub-scout's role ends at the verdict.
+
+## Standalone vs connected
+
+Most of this skill **requires connected mode** (`cub auth login`):
+
+- `history` — connected (ChangeSet timeline lives in ConfigHub)
+- `impact` — connected (blast-radius needs the Link graph)
+- `receipt verify --strategy source-truth-pass` — connected
+- Per-candidate evaluation can still produce a per-candidate receipt in standalone mode using `--predicate applied-matches-spec`, but without the ChangeSet timeline, Pilot has to supply candidate SHAs from somewhere else (release tags, the operator's memory, git log).
+
+Run `cub-scout status` upfront; if standalone and `history` is needed, Pilot's policy should escalate to ASK ("operator must supply candidate SHAs").
+
+## Tool boundary
+
+- **Allowed (cub-scout):** `history`, `impact`, Compare verbs (read-only), `receipt verify` / `show` / `validate` / `list`, `explain`, `trace`. All read-only.
+- **Allowed (cluster):** `kubectl get/describe`. NOT `kubectl apply / edit / patch / delete / rollout undo`.
+- **Allowed (ConfigHub):** `cub * get / list`, `cub unit get`, `cub link list`, `cub history`. NOT `cub * create / update / delete`.
+- **Allowed (controllers):** `argocd app get`, `flux get`. NOT `argocd app sync`, `flux reconcile`.
+- **Pilot's rollback execution** (the controller sync, the unit revision update) is Pilot's mutation path, deliberately not enumerated here. cub-scout's role ends at the chosen-target receipt.
+
+## References
+
+- [`scout-govern`](../scout-govern/SKILL.md) — `history`, `impact` (cub-scout side)
+- [`scout-verify`](../scout-verify/SKILL.md) — receipts; `--at-commit` for revision-pinned evaluation; `--input-attestation` for chained candidates
+- [`scout-compare`](../scout-compare/SKILL.md) — Compare verbs
+- [`pilot-cd-gate`](../pilot-cd-gate/SKILL.md) — pre-deploy companion
+- [`pilot-incident-evidence`](../pilot-incident-evidence/SKILL.md) — captures *what happened*; this skill picks *where to go next*
+- [`pilot-promotion-gate`](../pilot-promotion-gate/SKILL.md) — variant-to-variant safety (forward direction)
+- [`pilot-release-verification`](../pilot-release-verification/SKILL.md) — post-deploy validation
+- Chained receipts: `#448` (parent), `#463` (chained-half shipped)
+- ConfigHub ChangeSet timeline: `cub-scout history` reference in commands.md
+
+## Constraints
+
+- `--at-commit <sha>` is the only knob for pinning the candidate-evaluation to a specific revision. It overrides the controller-resolved revision in the spec anchor; the rest of the predicate evaluation (attribution, source-truth derivation) runs against the **current** cluster state.
+- Candidate enumeration via `history` requires connected mode AND the resource being ConfigHub-tracked. Resources not in ConfigHub's ChangeSet timeline can't be candidate-walked through `history`; Pilot has to supply candidate SHAs another way.
+- The chosen-target receipt's `inputAttestations[]` is **not** ordered — RFC 8785 canonical JSON treats arrays as ordered, so Pilot should choose a deterministic order (e.g., evaluation order, or oldest-to-newest) for reproducibility.
+- `impact` blast-radius is a *snapshot* — it reflects the Link graph at evaluation time, which may shift after the rollback. Pilot's policy should treat it as a hint, not a guarantee.
+- cub-scout never executes the rollback. The chosen-target receipt is the handoff artifact; the controller sync (or unit revision update, or whatever Pilot's stack uses) is the mutation path Pilot owns.


### PR DESCRIPTION
## Summary

The remaining 4 Pilot–cub-scout integration scenarios from `#444`, all governance-shaped: **rollback / promotion / compliance / release verify**. Closes `#444` (5 batch A + 4 batch B = 9 Pilot scenarios).

Same template as batch A ([`#466`](https://github.com/confighub/cub-scout/pull/466) + Codex round-7 cleanup in [`#467`](https://github.com/confighub/cub-scout/pull/467)); same read-only-triad invariant; Codex round-7 learnings applied upfront so the same review cycle doesn't re-fire.

## New skills

| Skill | Lines | Pilot consumes | Pilot decides |
|---|---|---|---|
| [`pilot-rollback-decision`](skills/pilot-rollback-decision/SKILL.md) | 266 | `history` + `impact` + per-candidate `receipt verify --at-commit <sha>` chained into chosen-target receipt | Rollback target SHA + safety verdict |
| [`pilot-promotion-gate`](skills/pilot-promotion-gate/SKILL.md) | 271 | `compare three-way` per variant + `bindingSource` graph diff + chained variant-A receipt | Cross-variant PASS / WATCH / ASK / BLOCK with diff reasons |
| [`pilot-compliance-audit`](skills/pilot-compliance-audit/SKILL.md) | 272 | scope-wide source-truth + `scan` + `audit list` + per-resource saved receipts | Compliance report (Compliant / Compliant-with-caveats / Non-compliant / Insufficient-evidence) + fingerprinted evidence inventory |
| [`pilot-release-verification`](skills/pilot-release-verification/SKILL.md) | 298 | `compare three-way` + `history --since <deploy-time>` + `receipt verify --at-commit <release-sha>`; `summary.agreement` drives convergence signal | Post-deploy PASS / WATCH (wait) / BLOCK / ASK |

## Cross-references

- `skills/README.md`: § "Pilot–cub-scout integration scenarios" gains a Batch B subsection with the 4 new entries; status block flipped to **`#444` complete: 9 scenarios shipped**.
- `skills/cub-scout/SKILL.md` (umbrella router): capability table extended to 9 rows; subtitle updated from "batch A" to "`#444`".
- Every new skill carries "Do not load for" cross-refs to its siblings (the existing 5 batch-A skills + the 3 new sibling batch-B skills).

## Codex round-7 learnings applied upfront

The same correctness issues Codex flagged on batch A would have applied to batch B. Applied at authoring time:

| Round-7 learning | How batch B applies it |
|---|---|
| Broad `Bash(./cub-scout compare *)` silently allows `compare --suggest --apply` (mutating) | Allowed-tools enumerate `compare three-way *` / `compare drift *` / `compare source-truth *` only |
| `strategy` / `sourceTruth` / `proofGaps` camelCase doesn't match shipping JSON | All examples use snake_case `declared_strategy` / `source_truth` / `proof_gaps` / `safe_next_action` |
| Invented `pilot decide --` CLI surface | All Pilot-side decision code is abstracted as "Pilot consumes the evidence and writes a verdict" with shell placeholders |
| Specific mutation verbs (`argocd app sync` / `flux reconcile` / `cub unit apply`) | Mutation paths abstracted as "Pilot's REVERT path / intent-update path; mutation lives outside cub-scout" |
| Receipt verdicts conflated with source-truth `ASK` status | Verdict synthesis tables explicitly distinguish receipt verdicts (PASS/WATCH/BLOCK/INCONCLUSIVE) from source-truth `status` (PASS/WATCH/BLOCK/ASK), and note that ASK maps to receipt WATCH when wrapped |
| Receipt versioning + omitempty contracts | Worked examples (e.g., in `pilot-release-verification`) reference the same wire shape as batch A's corrected version |

## Verification

- [x] `bash scripts/check-readonly.sh` passes
- [x] `bash scripts/check-doc-freshness.sh` passes
- [x] `bash scripts/check-cli-guide-parity.sh` passes
- [x] Static grep: **0** mutating verbs (`apply`/`edit`/`patch`/`delete`/`sync`/`reconcile`/`refresh`/`create`/`update`) in any batch-B allowed-tools
- [x] Static grep: **0** broad `compare *` patterns
- [x] Static grep: **0** camelCase source-truth field references
- [x] No code changed; existing test suite continues to pass

**1107 new lines** across 4 skill files + 2 router updates (skills/README.md + skills/cub-scout/SKILL.md).

## What this closes

- `#444` (all 9 Pilot–cub-scout integration scenarios shipped)
- The "highest-leverage open track" per `HANDOVER.md`'s next-milestone framing — now batch B is in main, the next-priority track is the receipts v2 deferred halves (`#448` aggregate-with-discovery, `#449` backpressure / new event types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)