### PR TITLE
feat(#446 v2 / #449): expand --emit-receipt-on + per-poll backpressure cap; closes #449

### DIFF
--- a/cmd/cub-scout/watch.go
+++ b/cmd/cub-scout/watch.go
@@ -26,15 +26,16 @@ import (
 )
 
 var (
-	watchWebhookURL      string
-	watchOutputFile      string
-	watchInterval        time.Duration
-	watchNamespace       string
-	watchOwner           string
-	watchSeverity        string
-	watchOnce            bool
-	watchMaxQueuedEvents int
-	watchEmitReceiptOn   string
+	watchWebhookURL          string
+	watchOutputFile          string
+	watchInterval            time.Duration
+	watchNamespace           string
+	watchOwner               string
+	watchSeverity            string
+	watchOnce                bool
+	watchMaxQueuedEvents     int
+	watchEmitReceiptOn       string
+	watchEmitReceiptBatchCap int
 )
 
 type watchEvent struct {
@@ -169,7 +170,8 @@ func init() {
 	watchCmd.Flags().StringVar(&watchSeverity, "severity", "", "Filter finding/drift events by severity (comma-separated: critical,warning,info)")
 	watchCmd.Flags().BoolVar(&watchOnce, "once", false, "Run one collection cycle and exit")
 	watchCmd.Flags().IntVar(&watchMaxQueuedEvents, "max-queued-events", 1000, "Maximum buffered events when webhook is unavailable")
-	watchCmd.Flags().StringVar(&watchEmitReceiptOn, "emit-receipt-on", "", "Comma-separated watch event types to attach a cub-scout receipt to (e.g. 'drift.detected,ownership.changed' or 'all' for all four). Receipt-build failures are non-fatal — the underlying event still emits with receipt=null and a stderr warning. #449 v1 builds receipts only for 'drift.detected' and 'ownership.changed' to avoid flooding on first-poll discovery; other event types pass through silently.")
+	watchCmd.Flags().StringVar(&watchEmitReceiptOn, "emit-receipt-on", "", "Comma-separated watch event types to attach a cub-scout receipt to (e.g. 'drift.detected,ownership.changed' or 'all' for all four). Receipt-build failures are non-fatal — the underlying event still emits but the receipt key is omitted (omitempty) and a stderr warning fires. All four known event types build receipts in v2 (#449): drift.detected, ownership.changed, resource.discovered, scan.finding. Per-poll cap controlled by --emit-receipt-batch-cap.")
+	watchCmd.Flags().IntVar(&watchEmitReceiptBatchCap, "emit-receipt-batch-cap", 10, "Per-poll cap on receipt-build attempts (#449 backpressure). When a single poll produces more receipt-eligible events than the cap, the first N get receipts attached and the rest emit with the receipt key omitted plus a single stderr summary line. Set to 0 to disable receipt-build entirely while keeping the flag explicit; set to a large value (e.g. 1000) to effectively disable the cap. Default 10.")
 }
 
 func runWatch(cmd *cobra.Command, args []string) error {
@@ -192,21 +194,27 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Apply the per-poll backpressure cap (#449). 0 disables receipt-
+	// build entirely while keeping the --emit-receipt-on flag explicit;
+	// >0 is the cap.
+	if watchEmitReceiptBatchCap < 0 {
+		return fmt.Errorf("--emit-receipt-batch-cap must be >= 0 (got %d)", watchEmitReceiptBatchCap)
+	}
+	watchReceiptBatchCap = watchEmitReceiptBatchCap
+
 	// Codex round-6 P2 fix (#463): emit a one-time startup warning when
-	// --emit-receipt-on includes event types that the v1 mapping does
-	// NOT actually build receipts for. The flag is "lenient on type,
-	// strict on receipt-build" (so `all` is forward-compatible), but a
-	// user who asks for `scan.finding` thinking they'll get receipts
-	// gets silent skipping. The warning makes that expectation gap
-	// visible up front rather than as a "why aren't my receipts firing"
-	// debug session later.
+	// --emit-receipt-on includes event types that the mapping does NOT
+	// build receipts for. As of #449 all four known event types are
+	// supported; this block is retained for forward-compat — if a
+	// future event type is added without receipt-build support, the
+	// warning fires automatically.
 	if len(emitReceiptOn) > 0 {
 		unsupported := unsupportedEmitReceiptTypes(emitReceiptOn)
 		if len(unsupported) > 0 {
 			fmt.Fprintf(os.Stderr,
-				"Warning: --emit-receipt-on includes event types that don't yet build a receipt (#449 v1): %s. "+
+				"Warning: --emit-receipt-on includes event types that don't yet build a receipt: %s. "+
 					"The flag accepts these for forward-compat (so `--emit-receipt-on all` keeps working as new types land), "+
-					"but receipt-build is skipped for them. Supported in v1: %s.\n",
+					"but receipt-build is skipped for them. Currently supported: %s.\n",
 				strings.Join(unsupported, ", "),
 				strings.Join(supportedEmitReceiptTypesSorted(), ", "),
 			)

--- a/cmd/cub-scout/watch_receipt.go
+++ b/cmd/cub-scout/watch_receipt.go
@@ -54,12 +54,29 @@ var watchKnownEventTypes = []string{
 }
 
 // watchEventTypesWithReceiptSupport names the subset of event types for
-// which #449 v1 actually builds a receipt. The flag accepts other
-// types for forward-compat, but receipt-build is a no-op for them in
-// v1 — the rationale lives in watch_receipt.go's package doc.
+// which `--emit-receipt-on` actually builds a receipt. v1 of the flag
+// (#463) shipped with `drift.detected` and `ownership.changed`; the
+// #449 follow-up adds `resource.discovered` and `scan.finding` once
+// the per-poll backpressure cap (watchReceiptBatchCap below) makes
+// them safe on first-poll bursts.
+//
+// Per-event-type predicate mapping:
+//
+//	drift.detected      → applied-matches-spec (auto-detected from owner)
+//	ownership.changed   → applied-matches-spec
+//	resource.discovered → applied-matches-spec (the discovery moment captures the live state at first observation)
+//	scan.finding        → applied-matches-spec (the receipt records the resource state at finding time; the finding itself lives on the event's details)
+//
+// All four use auto-detect → applied-matches-spec via BuildReceipt's
+// existing AutoDetectPredicate flow. Source-truth-pass requires a
+// caller-declared --strategy that the watch loop doesn't take; no-
+// manual-edits-since requires a --since cutoff that's likewise out
+// of scope for event-driven emission.
 var watchEventTypesWithReceiptSupport = map[string]bool{
-	"drift.detected":    true,
-	"ownership.changed": true,
+	"drift.detected":      true,
+	"ownership.changed":   true,
+	"resource.discovered": true,
+	"scan.finding":        true,
 }
 
 // parseWatchEmitReceiptOn parses the --emit-receipt-on flag value into
@@ -191,6 +208,32 @@ func supportedEmitReceiptTypesSorted() []string {
 	return out
 }
 
+// watchReceiptBatchCap is the per-poll cap on receipt-build attempts
+// (#449 backpressure). When a single poll produces more than this many
+// receipt-eligible events (the intersection of emitOn and
+// watchEventTypesWithReceiptSupport), the cap kicks in:
+//
+//   - The first `cap` events get their receipt built and attached.
+//   - The remaining events still emit (the watch stream is preserved
+//     — backpressure is about receipt-build cost, not event drop) but
+//     their `receipt` key is omitted (omitempty).
+//   - A single stderr warning per poll summarizes the suppression
+//     ("backpressure: suppressed receipt-build for X events of N
+//     eligible; raise --emit-receipt-batch-cap if expected").
+//
+// This pattern parallels the rate-limited warnings in makeReceiptWarnFn:
+// the first N pass through; the rest is summarized. It's per-poll
+// rather than across-poll because event-discovery bursts are typically
+// transient (first-poll resource.discovered flood, initial scan.finding
+// burst) and once the catch-up window passes, subsequent polls see
+// normal volumes.
+//
+// Default cap = 10. Set to 0 via --emit-receipt-batch-cap to disable
+// receipt-build entirely (matches --emit-receipt-on being unset for
+// suppression behaviour while keeping the flag explicit). Set to a
+// large value (e.g., 1000) to effectively disable the cap.
+var watchReceiptBatchCap = 10
+
 // attachReceiptsIfRequested walks events and, for each one whose type
 // is in `emitOn` AND whose type has receipt-build support
 // (watchEventTypesWithReceiptSupport), builds a receipt and attaches
@@ -198,8 +241,15 @@ func supportedEmitReceiptTypesSorted() []string {
 // loadReceiptLiveFn seam tests already swap; production hits the
 // dynamic client.
 //
+// Per-poll backpressure cap (#449): when the receipt-eligible event
+// count exceeds watchReceiptBatchCap, the first `cap` get their
+// receipts built; the rest are skipped (receipt key omitted per
+// omitempty) and a single stderr summary fires. The cap is per-call
+// (one watch poll = one call), so a long-running watch with quiet
+// polls between bursts doesn't accumulate suppression state.
+//
 // Failures are logged to stderr (`warnFn`) and non-fatal — the
-// underlying event still emits with Receipt=nil.
+// underlying event still emits with the receipt key omitted.
 func attachReceiptsIfRequested(
 	ctx context.Context,
 	events []watchEvent,
@@ -211,14 +261,36 @@ func attachReceiptsIfRequested(
 	if len(emitOn) == 0 || len(events) == 0 {
 		return events
 	}
+
+	// First pass: count the receipt-eligible events so the cap warning
+	// can report the suppression accurately.
+	eligibleCount := 0
+	for _, ev := range events {
+		if emitOn[ev.Type] && watchEventTypesWithReceiptSupport[ev.Type] {
+			eligibleCount++
+		}
+	}
+
+	cap := watchReceiptBatchCap
+	if cap < 0 {
+		cap = 0
+	}
+
+	built := 0
+	suppressed := 0
 	for i := range events {
 		if !emitOn[events[i].Type] {
 			continue
 		}
 		if !watchEventTypesWithReceiptSupport[events[i].Type] {
-			// Caller asked us to consider this event type, but v1
-			// support is narrow; skip with no warning (the doc on
-			// --emit-receipt-on tells the user this is expected).
+			// Caller asked us to consider this event type, but it's
+			// not in the supported set (closed enumeration). Skip
+			// with no warning; the startup-time warning already lists
+			// unsupported types.
+			continue
+		}
+		if built >= cap {
+			suppressed++
 			continue
 		}
 		stmt, err := watchBuildReceiptForEventFn(ctx, events[i], dynClient, connected)
@@ -231,7 +303,16 @@ func attachReceiptsIfRequested(
 			continue
 		}
 		events[i].Receipt = stmt
+		built++
 	}
+
+	if suppressed > 0 && warnFn != nil {
+		warnFn(
+			"backpressure: suppressed receipt-build for %d event(s) of %d eligible (cap=%d); raise --emit-receipt-batch-cap to enable, or set 0 to disable entirely",
+			suppressed, eligibleCount, cap,
+		)
+	}
+
 	return events
 }
 

--- a/cmd/cub-scout/watch_receipt_test.go
+++ b/cmd/cub-scout/watch_receipt_test.go
@@ -65,20 +65,9 @@ func TestParseWatchEmitReceiptOn_RejectsUnknown(t *testing.T) {
 // --- unsupportedEmitReceiptTypes startup-warning helper -------------
 
 func TestUnsupportedEmitReceiptTypes_AllSupported(t *testing.T) {
-	emitOn := map[string]bool{
-		"drift.detected":    true,
-		"ownership.changed": true,
-	}
-	got := unsupportedEmitReceiptTypes(emitOn)
-	if len(got) != 0 {
-		t.Errorf("all-supported emit set must return empty unsupported list; got %v", got)
-	}
-}
-
-func TestUnsupportedEmitReceiptTypes_SomeUnsupported(t *testing.T) {
-	// `all` includes resource.discovered + scan.finding which v1 does
-	// not build receipts for. Codex round-6 P2: surface this gap up
-	// front so the user isn't surprised later.
+	// As of #449, all four known event types are supported. The
+	// startup-warning helper returns empty when every requested type
+	// has receipt-build support.
 	emitOn := map[string]bool{
 		"drift.detected":      true,
 		"ownership.changed":   true,
@@ -86,23 +75,27 @@ func TestUnsupportedEmitReceiptTypes_SomeUnsupported(t *testing.T) {
 		"scan.finding":        true,
 	}
 	got := unsupportedEmitReceiptTypes(emitOn)
-	wantSet := map[string]bool{
-		"resource.discovered": true,
-		"scan.finding":        true,
+	if len(got) != 0 {
+		t.Errorf("all-supported emit set must return empty unsupported list; got %v", got)
 	}
-	if len(got) != len(wantSet) {
-		t.Fatalf("expected %d unsupported types; got %d (%v)", len(wantSet), len(got), got)
+}
+
+func TestUnsupportedEmitReceiptTypes_ForwardCompatSyntheticType(t *testing.T) {
+	// The helper is kept as a forward-compat safety net: if a future
+	// event type is added without receipt-build support, the warning
+	// fires automatically. Simulate that by adding a synthetic type to
+	// the emit-on set that doesn't exist in
+	// watchEventTypesWithReceiptSupport.
+	emitOn := map[string]bool{
+		"drift.detected":            true,
+		"hypothetical.future.event": true, // not in watchEventTypesWithReceiptSupport
 	}
-	for _, t2 := range got {
-		if !wantSet[t2] {
-			t.Errorf("unexpected unsupported type %q", t2)
-		}
+	got := unsupportedEmitReceiptTypes(emitOn)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 unsupported type; got %d (%v)", len(got), got)
 	}
-	// Output must be sorted for stable warning text across runs.
-	for i := 1; i < len(got); i++ {
-		if got[i-1] >= got[i] {
-			t.Errorf("unsupportedEmitReceiptTypes must return sorted output; got %v", got)
-		}
+	if got[0] != "hypothetical.future.event" {
+		t.Errorf("expected the synthetic type to be flagged; got %v", got)
 	}
 }
 
@@ -249,9 +242,11 @@ func TestAttachReceiptsIfRequested_DriftDetectedGetsReceipt(t *testing.T) {
 }
 
 func TestAttachReceiptsIfRequested_UnsupportedEventTypeSkipsSilently(t *testing.T) {
-	// scan.finding is in the emitOn set but NOT in
-	// watchEventTypesWithReceiptSupport — should pass through silently
-	// (no warning, no receipt).
+	// An event type that's NOT in watchEventTypesWithReceiptSupport
+	// passes through silently (no warning, no receipt). As of #449 all
+	// four known event types are supported, so this test uses a
+	// synthetic forward-compat type that doesn't exist in the map.
+	// Mirrors the startup-warning forward-compat behaviour.
 	var warnings []string
 	warnFn := func(format string, args ...interface{}) {
 		warnings = append(warnings, format)
@@ -264,12 +259,12 @@ func TestAttachReceiptsIfRequested_UnsupportedEventTypeSkipsSilently(t *testing.
 	defer func() { watchBuildReceiptForEventFn = prev }()
 
 	events := []watchEvent{
-		{Type: "scan.finding", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+		{Type: "hypothetical.future.event", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
 	}
-	emitOn := map[string]bool{"scan.finding": true}
+	emitOn := map[string]bool{"hypothetical.future.event": true}
 	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, warnFn)
 	if out[0].Receipt != nil {
-		t.Error("scan.finding should not get a receipt in #449 v1")
+		t.Error("synthetic-future event should not get a receipt")
 	}
 	if len(warnings) != 0 {
 		t.Errorf("unsupported event type should pass through silently; got warnings: %v", warnings)
@@ -309,6 +304,207 @@ func TestAttachReceiptsIfRequested_BuildFailureNonFatal(t *testing.T) {
 type simulatedErr struct{ msg string }
 
 func (e *simulatedErr) Error() string { return e.msg }
+
+// --- #449: per-poll backpressure cap + new event types ---------------
+
+// withWatchReceiptBatchCap temporarily replaces the package-level cap
+// for the test's duration. The cap is a package variable (mutated by
+// the --emit-receipt-batch-cap flag at startup), so tests can swap it
+// directly.
+func withWatchReceiptBatchCap(t *testing.T, cap int) {
+	t.Helper()
+	prev := watchReceiptBatchCap
+	watchReceiptBatchCap = cap
+	t.Cleanup(func() { watchReceiptBatchCap = prev })
+}
+
+// TestAttachReceiptsIfRequested_ResourceDiscoveredGetsReceipt is the
+// #449 expansion: resource.discovered events now build receipts (cap
+// permitting). Previously they passed through silently.
+func TestAttachReceiptsIfRequested_ResourceDiscoveredGetsReceipt(t *testing.T) {
+	stmt := &agent.Statement{
+		Type:          agent.StatementType,
+		PredicateType: agent.PredicateTypeReceiptV1,
+		Predicate:     agent.Predicate{Version: agent.PredicateVersion, Verdict: agent.VerdictPASS},
+	}
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		return stmt, nil
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+	withWatchReceiptBatchCap(t, 10)
+
+	events := []watchEvent{
+		{Type: "resource.discovered", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+	}
+	emitOn := map[string]bool{"resource.discovered": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, nil)
+	if out[0].Receipt == nil {
+		t.Fatalf("resource.discovered should get a receipt in #449; got nil")
+	}
+}
+
+// TestAttachReceiptsIfRequested_ScanFindingGetsReceipt is the #449
+// expansion: scan.finding events now build receipts.
+func TestAttachReceiptsIfRequested_ScanFindingGetsReceipt(t *testing.T) {
+	stmt := &agent.Statement{
+		Type:          agent.StatementType,
+		PredicateType: agent.PredicateTypeReceiptV1,
+		Predicate:     agent.Predicate{Version: agent.PredicateVersion, Verdict: agent.VerdictWATCH},
+	}
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		return stmt, nil
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+	withWatchReceiptBatchCap(t, 10)
+
+	events := []watchEvent{
+		{Type: "scan.finding", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+	}
+	emitOn := map[string]bool{"scan.finding": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, nil)
+	if out[0].Receipt == nil {
+		t.Fatalf("scan.finding should get a receipt in #449; got nil")
+	}
+}
+
+// TestAttachReceiptsIfRequested_BackpressureCap is the load-bearing
+// #449 regression: when a single poll produces more receipt-eligible
+// events than the cap, the first N get receipts and the rest are
+// skipped with the receipt key omitted plus a stderr summary line.
+func TestAttachReceiptsIfRequested_BackpressureCap(t *testing.T) {
+	stmt := &agent.Statement{
+		Type:          agent.StatementType,
+		PredicateType: agent.PredicateTypeReceiptV1,
+		Predicate:     agent.Predicate{Version: agent.PredicateVersion, Verdict: agent.VerdictPASS},
+	}
+	buildCalls := 0
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		buildCalls++
+		return stmt, nil
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+
+	// Cap = 3; feed 7 eligible events. Expect 3 receipts attached and
+	// 4 skipped, with exactly one summary warning fired.
+	withWatchReceiptBatchCap(t, 3)
+	var warnings []string
+	warnFn := func(format string, args ...interface{}) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+
+	events := make([]watchEvent, 7)
+	for i := range events {
+		events[i] = watchEvent{
+			Type:     "drift.detected",
+			Resource: watchEventResource{Kind: "Deployment", Name: fmt.Sprintf("api-%d", i), Namespace: "prod"},
+		}
+	}
+	emitOn := map[string]bool{"drift.detected": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, warnFn)
+
+	if buildCalls != 3 {
+		t.Errorf("expected exactly 3 receipt builds (cap); got %d", buildCalls)
+	}
+	attached := 0
+	for _, ev := range out {
+		if ev.Receipt != nil {
+			attached++
+		}
+	}
+	if attached != 3 {
+		t.Errorf("expected 3 attached receipts; got %d", attached)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one backpressure summary; got %d (%v)", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "backpressure") {
+		t.Errorf("summary should mention backpressure; got %q", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "suppressed receipt-build for 4") {
+		t.Errorf("summary should report 4 suppressed; got %q", warnings[0])
+	}
+}
+
+// TestAttachReceiptsIfRequested_BackpressureCapZero disables receipt-
+// build entirely. With --emit-receipt-batch-cap 0, the cap kicks in
+// on the very first eligible event; no receipts are built.
+func TestAttachReceiptsIfRequested_BackpressureCapZero(t *testing.T) {
+	buildCalls := 0
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		buildCalls++
+		return &agent.Statement{}, nil
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+	withWatchReceiptBatchCap(t, 0)
+
+	var warnings []string
+	warnFn := func(format string, args ...interface{}) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+
+	events := []watchEvent{
+		{Type: "drift.detected", Resource: watchEventResource{Kind: "Deployment", Name: "api", Namespace: "prod"}},
+		{Type: "ownership.changed", Resource: watchEventResource{Kind: "Deployment", Name: "worker", Namespace: "prod"}},
+	}
+	emitOn := map[string]bool{"drift.detected": true, "ownership.changed": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, warnFn)
+
+	if buildCalls != 0 {
+		t.Errorf("cap=0 must suppress all receipt builds; got %d", buildCalls)
+	}
+	for _, ev := range out {
+		if ev.Receipt != nil {
+			t.Errorf("cap=0 must leave Receipt=nil; got %+v", ev.Receipt)
+		}
+	}
+	if len(warnings) != 1 {
+		t.Errorf("expected exactly one backpressure summary at cap=0; got %d", len(warnings))
+	}
+}
+
+// TestAttachReceiptsIfRequested_BackpressureCapNoTrigger confirms the
+// cap doesn't fire when the receipt-eligible count is at or below the
+// cap (no spurious warnings).
+func TestAttachReceiptsIfRequested_BackpressureCapNoTrigger(t *testing.T) {
+	stmt := &agent.Statement{Predicate: agent.Predicate{Verdict: agent.VerdictPASS}}
+	prev := watchBuildReceiptForEventFn
+	watchBuildReceiptForEventFn = func(_ context.Context, _ watchEvent, _ dynamic.Interface, _ bool) (*agent.Statement, error) {
+		return stmt, nil
+	}
+	defer func() { watchBuildReceiptForEventFn = prev }()
+	withWatchReceiptBatchCap(t, 5)
+
+	var warnings []string
+	warnFn := func(format string, args ...interface{}) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+
+	// 3 eligible events; cap is 5 — no suppression should fire.
+	events := []watchEvent{
+		{Type: "drift.detected", Resource: watchEventResource{Kind: "Deployment", Name: "a", Namespace: "p"}},
+		{Type: "drift.detected", Resource: watchEventResource{Kind: "Deployment", Name: "b", Namespace: "p"}},
+		{Type: "drift.detected", Resource: watchEventResource{Kind: "Deployment", Name: "c", Namespace: "p"}},
+	}
+	emitOn := map[string]bool{"drift.detected": true}
+	out := attachReceiptsIfRequested(context.Background(), events, emitOn, nil, false, warnFn)
+
+	attached := 0
+	for _, ev := range out {
+		if ev.Receipt != nil {
+			attached++
+		}
+	}
+	if attached != 3 {
+		t.Errorf("under cap, all 3 events should get receipts; got %d", attached)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("under-cap polls should fire no backpressure warning; got %v", warnings)
+	}
+}
 
 // --- watchBuildReceiptForEvent end-to-end ----------------------------
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -836,7 +836,8 @@ At least one destination is required: `--webhook` and/or `--output-file`.
 | `--severity` | Finding severity filter (`critical,warning,info`) |
 | `--once` | Run one collection cycle and exit |
 | `--max-queued-events` | Max buffered events while webhook is unreachable |
-| `--emit-receipt-on` | Comma-separated watch event types to attach a `cub-scout receipt` to (`drift.detected`, `ownership.changed`, or sugar `all`). Receipt-build failures are non-fatal: the watch event still emits but the JSON `receipt` key is **omitted** (the field uses `omitempty`; consumers should check key presence, not null-ness), with a stderr warning. (#449 v1: only `drift.detected` and `ownership.changed` actually build a receipt; other types pass through silently.) |
+| `--emit-receipt-on` | Comma-separated watch event types to attach a `cub-scout receipt` to. As of `#449` all four known types build receipts: `drift.detected`, `ownership.changed`, `resource.discovered`, `scan.finding` (plus the sugar `all`). Receipt-build failures are non-fatal: the watch event still emits but the JSON `receipt` key is **omitted** (the field uses `omitempty`; consumers should check key presence, not null-ness), with a stderr warning. Per-poll backpressure controlled by `--emit-receipt-batch-cap`. |
+| `--emit-receipt-batch-cap` | Per-poll cap on receipt-build attempts (`#449` backpressure). When a single poll produces more receipt-eligible events than the cap, the first N get receipts attached and the rest emit with the receipt key omitted plus a single stderr summary line. Set to 0 to disable receipt-build entirely while keeping the flag explicit; set to a large value (e.g. 1000) to effectively disable the cap. Default 10. |
 
 ### Event Types
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -978,29 +978,41 @@ Implementation: `pkg/agent/receipt_aggregate.go`
 (`runReceiptVerifyScoped`, `discoverNamespaceWorkloads`,
 `parseAggregateScope`).
 
-#### `watch --emit-receipt-on <event-types>` (`#449`)
+#### `watch --emit-receipt-on <event-types>` + `--emit-receipt-batch-cap` (`#449`)
 
 `cub-scout watch` accepts a new flag that attaches a receipt to each
 matching event payload inline. The watch event shape gains an optional
 `receipt` field carrying the full in-toto Statement.
 
-Event-type set (v1 of this flag):
+Event-type set (current; all four supported as of #449):
 
 | Event type | Receipt-build? | Notes |
 |------------|---------------|-------|
 | `drift.detected` | Yes — `applied-matches-spec` auto-detected | Highest signal: drift event already implies a verdict question |
 | `ownership.changed` | Yes — `applied-matches-spec` auto-detected | Owner shifts often indicate a delivery-chain change worth attesting |
-| `resource.discovered` | No (passes through silently) | Would flood on first poll; deferred to future iterations |
-| `scan.finding` | No (passes through silently) | Would flood on initial scan burst; deferred |
-| `all` | Sugar — accepts every known event type, but the build set is the supported subset above |
+| `resource.discovered` | Yes — `applied-matches-spec` auto-detected | The discovery moment captures the live state at first observation; backpressure-gated via `--emit-receipt-batch-cap` |
+| `scan.finding` | Yes — `applied-matches-spec` auto-detected | The receipt records the resource state at finding time; the finding detail lives on the event's `details` field; backpressure-gated |
+| `all` | Sugar — accepts every known event type |
+
+**Backpressure (`--emit-receipt-batch-cap N`, default 10):** when a
+single poll produces more receipt-eligible events than the cap, the
+first N get receipts built; the remaining events still emit but with
+the `receipt` key **omitted** (omitempty) and a single stderr summary
+line ("backpressure: suppressed receipt-build for X events of N
+eligible"). The cap is per-poll (one watch poll = one call), so a
+long-running watch with quiet polls between bursts doesn't accumulate
+suppression state. Set to 0 to disable receipt-build entirely while
+keeping the flag explicit; set to a large value (e.g. 1000) to
+effectively disable the cap.
 
 The flag is **lenient on type, strict on receipt-build**: unsupported event
 types pass through without a warning (so `--emit-receipt-on all` is
-forward-compatible as new event types land). Build failures on
-supported types emit a stderr warning and continue — the underlying
-watch event still emits, but with the `receipt` key **omitted** from
-the JSON (the field uses `omitempty`; consumers should check for key
-presence rather than null-ness):
+forward-compatible as new event types land — if a future type lands
+without receipt-build support, the startup warning fires automatically).
+Build failures on supported types emit a stderr warning and continue —
+the underlying watch event still emits, but with the `receipt` key
+**omitted** from the JSON (the field uses `omitempty`; consumers should
+check for key presence rather than null-ness):
 
 ```python
 # correct


### PR DESCRIPTION
## Summary

The remaining v2 work on `#449`. v1 of `--emit-receipt-on` shipped in [`#463`](https://github.com/confighub/cub-scout/pull/463) with only `drift.detected` and `ownership.changed` building receipts; `resource.discovered` and `scan.finding` were gated on the backpressure design (would flood on first-poll bursts). **This PR ships both: the backpressure cap and the expanded event-type set together.**

Closes `#449`.

## Two changes

### 1. All four event types now build receipts

| Event type | Before | After |
|---|---|---|
| `drift.detected` | builds receipt | (unchanged) |
| `ownership.changed` | builds receipt | (unchanged) |
| `resource.discovered` | passes through silently | **builds receipt** (auto-detect → `applied-matches-spec`) |
| `scan.finding` | passes through silently | **builds receipt** (auto-detect → `applied-matches-spec`) |

### 2. Per-poll backpressure cap

```
--emit-receipt-batch-cap N    (default 10)
```

When a single poll produces more receipt-eligible events than the cap:

- The first N get receipts built and attached
- The remaining events still emit (the watch stream is preserved — backpressure is about receipt-build *cost*, NOT event drop) but their `receipt` key is omitted (omitempty)
- A single stderr summary fires per poll:
  > `backpressure: suppressed receipt-build for X events of N eligible (cap=N); raise --emit-receipt-batch-cap to enable, or set 0 to disable entirely`

The cap is **per-poll** (one watch poll = one call), so a long-running watch with quiet polls between bursts doesn't accumulate suppression state. This mirrors `makeReceiptWarnFn`'s pattern from Codex round-6 P2 (`#463`) — first N pass through, summary at the boundary — applied to receipt-build attempts rather than warning lines.

| Value | Behaviour |
|---|---|
| `--emit-receipt-batch-cap 0` | Disables receipt-build entirely while keeping the flag explicit |
| `--emit-receipt-batch-cap 1000` | Effectively disables the cap |
| Negative | Rejected upfront |

## Why these ship together

The `#449` issue explicitly gated `resource.discovered` + `scan.finding` on the backpressure design: *"Would flood on first poll; deferred to future iterations."* With the per-poll cap in place, the flood is bounded (default 10 receipt-builds per poll) and the operator gets a clear suppression summary.

- Shipping the cap *without* the new event types would leave the original deferral in place
- Shipping the new event types *without* the cap would risk a first-poll receipt-build storm

## Forward-compat warning preserved

The Codex round-6 P2 (`#463`) startup warning helper (`unsupportedEmitReceiptTypes`) previously fired for `resource.discovered` and `scan.finding`. Now that all four event types are supported, that warning no longer fires for the known set — but the helper is **kept as a forward-compat safety net**: if a future event type lands in `watchKnownEventTypes` without receipt-build support, the warning fires automatically. Test coverage swapped from "`scan.finding` is unsupported" to a synthetic `hypothetical.future.event` forward-compat case.

## Test coverage

**Updated:**
- `TestUnsupportedEmitReceiptTypes_AllSupported` now includes all 4 types
- `TestUnsupportedEmitReceiptTypes_ForwardCompatSyntheticType` (renamed from `_SomeUnsupported`) verifies the forward-compat warning still works
- `TestAttachReceiptsIfRequested_UnsupportedEventTypeSkipsSilently` uses synthetic future event type

**New (`#449` specific):**
- `TestAttachReceiptsIfRequested_ResourceDiscoveredGetsReceipt`
- `TestAttachReceiptsIfRequested_ScanFindingGetsReceipt`
- `TestAttachReceiptsIfRequested_BackpressureCap` (cap=3, 7 events → 3 attached + 4 suppressed + 1 summary warning)
- `TestAttachReceiptsIfRequested_BackpressureCapZero` (cap=0 disables receipt-build)
- `TestAttachReceiptsIfRequested_BackpressureCapNoTrigger` (under-cap polls fire no summary)

**5 new tests + 3 updated.** All green.

## Docs

- `docs/reference/json-contracts.md` § Receipt Contract → `watch --emit-receipt-on` subsection:
  - Event-type table updated: all 4 types show "Yes" with backpressure-gating note for the new pair
  - New "Backpressure" paragraph documenting `--emit-receipt-batch-cap`
  - "Lenient on type, strict on receipt-build" wording reframed to forward-compat (warning fires only for future unsupported types)
- `docs/reference/commands.md` § `watch` flag table:
  - `--emit-receipt-on` row reflects the full 4-type support
  - New `--emit-receipt-batch-cap` row

## Read-only triad invariant

All new code stays inside the read-only triad. The per-poll cap is purely about receipt-build *cost*; the watch loop's only cluster operations remain `Get` / `List` / `Watch`. `TestReceiptPackageReadOnlyClient` continues to scan `watch_receipt.go` (via the `#463` round-6 substring glob fix) and passes.

## Verification

- [x] `go build ./...` clean
- [x] `bash scripts/check-readonly.sh` passes
- [x] `bash scripts/check-doc-freshness.sh` passes
- [x] `bash scripts/check-cli-guide-parity.sh` passes
- [x] `go test ./cmd/cub-scout/... ./pkg/agent/...` all green (existing + 5 new tests; 3 updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)