### PR TITLE
docs(concepts): define receipt and proof terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Honest gaps in the current capability map, with the leverage on filling them:
 | AI tool integration | [docs/howto/using-cub-scout-from-ai-tool.md](docs/howto/using-cub-scout-from-ai-tool.md) |
 | Examples and demos | [examples/README.md](examples/README.md) |
 | Receipts (typed evidence artifacts) | [examples/receipts/README.md](examples/receipts/README.md) + [docs/reference/json-contracts.md § Receipt Contract](docs/reference/json-contracts.md) |
+| Receipt and proof terminology (vs log / journal / record / ledger / provenance) | [docs/concepts/receipts-and-proofs.md](docs/concepts/receipts-and-proofs.md) |
 | Receipts end-to-end how-to (pre-deploy gate → audit chain → namespace aggregate → real-time emission) | [docs/howto/receipts-end-to-end.md](docs/howto/receipts-end-to-end.md) |
 | Watch event types + inline receipts + backpressure | [docs/reference/watch-events.md](docs/reference/watch-events.md) |
 | Security model | [SECURITY.md](SECURITY.md) |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Today, `compare three-way` and `compare source-truth` require ConfigHub. A stand
 
 ### Verify — typed, fingerprinted, immutable evidence artifacts
 
-cub-scout receipts (#446) are the **persistence** sibling of `compare`: where `compare` produces an ephemeral live picture, `receipt verify` wraps the same evidence into an in-toto Statement v1 envelope that CI/CD gates, audit trails, postmortems, and acceptance-judge tooling can attach to a decision and later prove the inputs were what they claim to be.
+cub-scout receipts (#446) are the **persistence** sibling of `compare`: where `compare` produces an ephemeral live picture, `receipt verify` wraps the same evidence into an in-toto Statement v1 envelope that CI/CD gates, audit trails, postmortems, and acceptance-judge tooling can attach to a decision and later re-check for tampering.
 
 | Command | What you get | Inputs |
 |---|---|---|

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -17,6 +17,7 @@ Then go deeper with:
 - [tui-vs-gui.md](tui-vs-gui.md) — Scope boundaries between cub-scout and ConfigHub
 - [clobbering-problem.md](clobbering-problem.md) — Why GitOps layering causes silent overrides
 - [alternatives.md](alternatives.md) — Where cub-scout fits vs adjacent tools
+- [receipts-and-proofs.md](receipts-and-proofs.md) — What "receipt" and "proof" mean, vs log / journal / record / ledger / provenance
 
 ## Doc Status
 
@@ -34,6 +35,7 @@ Then go deeper with:
 | [tui-vs-gui.md](tui-vs-gui.md) | Current (Deep Dive) | 2026-02-12 |
 | [clobbering-problem.md](clobbering-problem.md) | Current (Deep Dive) | 2026-02-12 |
 | [alternatives.md](alternatives.md) | Current (Deep Dive) | 2026-02-12 |
+| [receipts-and-proofs.md](receipts-and-proofs.md) | Current (Deep Dive) | 2026-05-25 |
 
 ## Notes
 

--- a/docs/concepts/receipts-and-proofs.md
+++ b/docs/concepts/receipts-and-proofs.md
@@ -1,0 +1,125 @@
+# Receipts and Proofs
+
+> Status: Current (Deep Dive)
+> Last reviewed: 2026-05-25
+> Concepts index: [README.md](README.md)
+
+"Receipt" and "proof" are loaded words. cub-scout uses both, and it's worth being precise about which sense we mean — both for users picking the right tool and for integrators choosing the right vocabulary in their own docs.
+
+This doc defines the two terms, places them inside the broader vocabulary they sit alongside (log, journal, record, ledger, provenance), and notes where the boundaries blur honestly.
+
+---
+
+## Receipt
+
+A **receipt** in cub-scout is a stamped, hand-offable record of a single verification — *who ran what check, on what subject, at what time, with what verdict and what supporting evidence.*
+
+Structurally it is an [in-toto Statement v1](https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md) envelope wrapping a predicate (verdict + evidence + optional pointers to upstream receipts). It is fingerprinted via SHA-256 over [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) canonical JSON, so any third party can recompute the fingerprint and detect tampering. Receipts are optionally chainable: the predicate carries `inputAttestations[]` referencing upstream receipts by digest.
+
+What lifts a receipt above a plain record:
+
+- **It is transactional, not passive.** A record describes an entity. A receipt describes a *check that ran* — there is a verb in it (`verify`, `aggregate`, `emit`).
+- **It is stamped.** Cryptographic integrity is intrinsic, not bolted on by the storage layer.
+- **It is hand-offable.** The in-toto envelope is a standard format meant to be passed to a third party who does not trust the issuer's database.
+- **It is contestable.** Anyone with the same inputs can re-run the verify and challenge the stamped verdict.
+
+Single-line definition:
+
+> **A receipt is a record-with-proof of one verification, in a hand-offable envelope.**
+
+The wire format is documented in [docs/reference/json-contracts.md § Receipt Contract](../reference/json-contracts.md). The operational lifecycle is documented in [docs/howto/receipts-end-to-end.md](../howto/receipts-end-to-end.md).
+
+---
+
+## Proof
+
+A **proof** in cub-scout is *the verifiable property of a receipt, not a separate artifact.*
+
+The proof is: you can recompute the fingerprint over the canonical JSON of the predicate, and if it matches the stamped value, the receipt has not been tampered with. For chained receipts the proof extends — you walk the chain, independently re-validate each upstream's fingerprint, and confirm the DAG is intact.
+
+cub-scout uses "proof" in the sense of **tamper-evidence of the attestation** — not in the strong sense of formal verification or zero-knowledge cryptography. The fingerprint shows that the receipt has not been edited since it was stamped; it does not, by itself, prove the underlying claim is *true* — it proves the issuer's claim has not been altered.
+
+Useful framing:
+
+> **A receipt without verifiable proof is a claim. A receipt with verifiable proof is evidence.**
+
+Validating the proof for a saved receipt:
+
+```bash
+cub-scout receipt validate path/to/receipt.json
+# exit 0 → fingerprint matches; receipt is intact
+# exit 1 → fingerprint mismatch; receipt has been tampered with
+# exit 2 → I/O error
+```
+
+---
+
+## The broader vocabulary
+
+"Receipt" and "proof" sit alongside five other terms that get reached for in similar territory. cub-scout's surface intentionally covers each of them at a different resolution, and being clear about which term applies to which surface helps avoid muddled vocabulary in handover docs and integrator code.
+
+| Term | Focus | cub-scout analog | Surface |
+|---|---|---|---|
+| **Log** | Time and sequence — an append-only chronological stream of events | Watch event stream | `cub-scout watch` |
+| **Journal** | The first, unaltered record of a transaction with full raw detail | Per-field diff trace | `cub-scout trace deploy/x -n y` |
+| **Record** | A complete, structured unit of data about a single entity or event | A single in-toto Statement (one receipt file) | `cub-scout receipt verify --save` |
+| **Ledger** | A master system-of-record that aggregates and categorizes — current state, not raw history | Aggregate receipt over a scope | `cub-scout receipt verify --scope namespace/<ns>` |
+| **Provenance** | Verifiable origin and chain of custody across the lifecycle | Chained-receipt DAG | `cub-scout receipt verify --input-attestation <upstream>` |
+
+The receipt sits at the **record** layer of this vocabulary, with attestation semantics added — a record-with-proof, hand-offable to a third party.
+
+- The **chain** (provenance) is built *from* receipts; each link inherits the receipt's proof property.
+- The **aggregate** (ledger) is built *from* receipts; the synthesized verdict inherits the proof property of the receipts it summarizes.
+- The **log** and **journal** sit *below* the receipt: lower-resolution surfaces that are not stamped by default. A watch event can be promoted to a receipt via `watch --emit-receipt-on`.
+
+---
+
+## Where the terms blur honestly
+
+Some of these distinctions matter more in marketing copy than in code. The honest edges:
+
+- **Receipt vs. attestation.** in-toto and SLSA call the artifact an "attestation"; the inner JSON we call a `predicate` is literally the in-toto `predicate` field. We chose "receipt" because it reads to a non-supply-chain audience without explanation. The trade is some industry-specificity for clarity — the two words refer to the same artifact in our case.
+
+- **Chain vs. provenance.** A cub-scout chain is provenance-*shaped* but discrete — a DAG of stamped checkpoints, not a continuous lineage of every field across every transformation. If you need that breadth, reach for OpenLineage or OpenTelemetry traces. cub-scout's chain is "evidence at gates," not "everything that ever happened."
+
+- **Aggregate vs. ledger.** A cub-scout aggregate is a single receipt synthesized from N input receipts via a policy (current: `max-severity`). It is ledger-shaped — rolled-up state over a category — but it is a snapshot, not a running balance. Running balances are built by composing chains of aggregates.
+
+- **Proof, weak sense vs. strong sense.** Already noted above: we mean tamper-evidence, not formal proof. The strong sense — "this verdict is mathematically correct" — would require an independent verifier to re-run the underlying observation against the live cluster. The receipt format carries enough state to support that re-verification, but the receipt itself does not perform it.
+
+- **Record vs. receipt.** Every receipt is a record; not every record is a receipt. A row in a `scan` output is a record. A row that has been stamped via `receipt verify` with a fingerprint over canonical JSON is a receipt.
+
+---
+
+## A single worked example
+
+You verify a deploy. cub-scout produces, at increasing resolution:
+
+```
+1. watch event              → log entry        (time + event type + subject)
+2. trace --format json      → journal entry    (per-field intent vs observed, raw)
+3. receipt verify           → record + proof   (in-toto Statement, fingerprint stamped)
+4. --input-attestation prev → provenance link  (this receipt references prior by digest)
+5. --scope namespace/prod   → ledger row       (synthesized aggregate over the scope)
+```
+
+The proof property is what lets you hand 3-5 to a third party — an auditor, a paranoid reviewer, an AI agent running a year later — and have them independently confirm: this verdict was produced by this binary, on this subject, at this time, and nothing has been edited since. They do not have to trust your storage; they recompute the fingerprint, and the answer is the same or it is not.
+
+---
+
+## Short answer for a slide
+
+- **Receipt** = a stamped, hand-offable record of one verification, in a standard envelope (in-toto v1).
+- **Proof** = the verifiable property of a receipt: recompute the fingerprint, compare to the stamped value.
+- **Chain** = receipts linked by digest → provenance.
+- **Aggregate** = receipts synthesized by policy → ledger.
+- **Log / journal** = lower-resolution surfaces (watch events / trace output); receipts are what get stamped at gates.
+
+---
+
+## See also
+
+- [docs/howto/receipts-end-to-end.md](../howto/receipts-end-to-end.md) — operational lifecycle (pre-deploy gate → audit chain → namespace aggregate → real-time emission → reading back)
+- [docs/reference/json-contracts.md § Receipt Contract](../reference/json-contracts.md) — wire format, fingerprint algorithm, predicate schemas
+- [docs/reference/watch-events.md](../reference/watch-events.md) — event taxonomy and `--emit-receipt-on` semantics
+- [examples/receipts/](../../examples/receipts/) — four worked example directories with paste-ready CI snippets
+- [skills/scout-verify/SKILL.md](../../skills/scout-verify/SKILL.md) — the Verify verb group for AI-agent loaders

--- a/docs/concepts/receipts-and-proofs.md
+++ b/docs/concepts/receipts-and-proofs.md
@@ -6,7 +6,7 @@
 
 ## TL;DR
 
-> A **receipt** is a stamped, hand-offable record of one verification — an in-toto Statement v1 envelope around a verdict and its evidence, fingerprinted via SHA-256 over RFC 8785 canonical JSON. The **proof** is that fingerprint: any third party can recompute it over the receipt's canonical bytes and confirm nothing has been edited since the receipt was stamped. A receipt without proof is a claim; a receipt with proof is evidence.
+> A **receipt** is a stamped, hand-offable record of one verification: an in-toto Statement v1 envelope around a verdict, evidence, omissions, and optional upstream receipt references. Its **proof** is the verifiable integrity property created by the fingerprint: SHA-256 over RFC 8785 canonical JSON of the full Statement, with only `predicate.fingerprint` removed before hashing. Any third party can recompute that fingerprint to confirm the receipt has not been edited since it was stamped. That is tamper-evidence, not producer authentication or formal proof of truth. A receipt without proof is a claim; a receipt with proof is evidence.
 
 The rest of this doc unpacks each term, places them inside the broader vocabulary they sit alongside (log, journal, record, ledger, provenance), and notes where the boundaries blur honestly.
 
@@ -22,7 +22,7 @@ The rest of this doc unpacks each term, places them inside the broader vocabular
 
 A **receipt** in cub-scout is a stamped, hand-offable record of a single verification — *who ran what check, on what subject, at what time, with what verdict and what supporting evidence.*
 
-Structurally it is an [in-toto Statement v1](https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md) envelope wrapping a predicate (verdict + evidence + optional pointers to upstream receipts). It is fingerprinted via SHA-256 over [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) canonical JSON, so any third party can recompute the fingerprint and detect tampering. Receipts are optionally chainable: the predicate carries `inputAttestations[]` referencing upstream receipts by digest.
+Structurally it is an [in-toto Statement v1](https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md) envelope wrapping a predicate (verdict + evidence + optional pointers to upstream receipts). It is fingerprinted via SHA-256 over [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) canonical JSON of the full Statement, with only `predicate.fingerprint` removed before hashing. That scope covers `_type`, `subject`, `predicateType`, and every predicate field except the fingerprint itself. Receipts are optionally chainable: the predicate carries `inputAttestations[]` referencing upstream receipts by digest.
 
 What lifts a receipt above a plain record:
 
@@ -41,11 +41,11 @@ The wire format is documented in [docs/reference/json-contracts.md § Receipt Co
 
 ## Proof
 
-A **proof** in cub-scout is *the verifiable property of a receipt, not a separate artifact.*
+A **proof** in cub-scout is *the verifiable integrity property of a receipt, not a separate artifact and not the fingerprint value by itself.*
 
-The proof is: you can recompute the fingerprint over the canonical JSON of the predicate, and if it matches the stamped value, the receipt has not been tampered with. For chained receipts the proof extends — you walk the chain, independently re-validate each upstream's fingerprint, and confirm the DAG is intact.
+The proof is: you can remove `predicate.fingerprint`, recompute the fingerprint over the canonical JSON of the full Statement, and compare it with the stamped value. If it matches, the receipt's envelope, subject, verdict, evidence, omissions, and upstream references have not been edited since the receipt was stamped. For chained receipts the proof extends by walking the chain: independently re-validate each upstream receipt's fingerprint, then compare each upstream digest to the downstream `inputAttestations[]` reference.
 
-cub-scout uses "proof" in the sense of **tamper-evidence of the attestation** — not in the strong sense of formal verification or zero-knowledge cryptography. The fingerprint shows that the receipt has not been edited since it was stamped; it does not, by itself, prove the underlying claim is *true* — it proves the issuer's claim has not been altered.
+cub-scout uses "proof" in the sense of **tamper-evidence of the attestation** — not in the strong sense of formal verification, zero-knowledge cryptography, or signature-backed producer identity. The fingerprint shows that the receipt has not been edited since it was stamped; it does not, by itself, prove the underlying claim is *true* or prove who controlled the binary that emitted it. It proves the stamped claim has not been altered.
 
 Useful framing:
 
@@ -69,7 +69,7 @@ cub-scout receipt validate path/to/receipt.json
 | Term | Focus | cub-scout analog | Surface |
 |---|---|---|---|
 | **Log** | Time and sequence — an append-only chronological stream of events | Watch event stream | `cub-scout watch` |
-| **Journal** | The first, unaltered record of a transaction with full raw detail | Per-field diff trace | `cub-scout trace deploy/x -n y` |
+| **Journal** | The first, unaltered record of a transaction with full raw detail | Field-level comparison / attribution output | `cub-scout compare three-way --scope deploy/x -n y --format json` |
 | **Record** | A complete, structured unit of data about a single entity or event | A single in-toto Statement (one receipt file) | `cub-scout receipt verify --save` |
 | **Ledger** | A master system-of-record that aggregates and categorizes — current state, not raw history | Aggregate receipt over a scope | `cub-scout receipt verify --scope namespace/<ns>` |
 | **Provenance** | Verifiable origin and chain of custody across the lifecycle | Chained-receipt DAG | `cub-scout receipt verify --input-attestation <upstream>` |
@@ -78,7 +78,7 @@ The receipt sits at the **record** layer of this vocabulary, with attestation se
 
 - The **chain** (provenance) is built *from* receipts; each link inherits the receipt's proof property.
 - The **aggregate** (ledger) is built *from* receipts; the synthesized verdict inherits the proof property of the receipts it summarizes.
-- The **log** and **journal** sit *below* the receipt: lower-resolution surfaces that are not stamped by default. A watch event can be promoted to a receipt via `watch --emit-receipt-on`.
+- The **log** and **journal** sit *below* the receipt: lower-level surfaces that are not stamped by default. A watch event can be promoted to a receipt via `watch --emit-receipt-on`; comparison evidence can be wrapped by `receipt verify`.
 
 ---
 
@@ -104,23 +104,24 @@ You verify a deploy. cub-scout produces, at increasing resolution:
 
 ```
 1. watch event              → log entry        (time + event type + subject)
-2. trace --format json      → journal entry    (per-field intent vs observed, raw)
+2. compare three-way --format json
+                             → journal entry    (per-field intended vs observed, raw)
 3. receipt verify           → record + proof   (in-toto Statement, fingerprint stamped)
 4. --input-attestation prev → provenance link  (this receipt references prior by digest)
 5. --scope namespace/prod   → ledger row       (synthesized aggregate over the scope)
 ```
 
-The proof property is what lets you hand 3-5 to a third party — an auditor, a paranoid reviewer, an AI agent running a year later — and have them independently confirm: this verdict was produced by this binary, on this subject, at this time, and nothing has been edited since. They do not have to trust your storage; they recompute the fingerprint, and the answer is the same or it is not.
+The proof property is what lets you hand 3-5 to a third party — an auditor, a paranoid reviewer, an AI agent running a year later — and have them independently confirm: this receipt says this verifier/version produced this verdict, for this subject, at this time, with this evidence, and none of those fields have been edited since stamping. They do not have to trust your storage; they recompute the fingerprint, and the answer is the same or it is not. They still do not get producer authentication from the fingerprint alone; that would require a signing layer.
 
 ---
 
 ## Short answer for a slide
 
 - **Receipt** = a stamped, hand-offable record of one verification, in a standard envelope (in-toto v1).
-- **Proof** = the verifiable property of a receipt: recompute the fingerprint, compare to the stamped value.
+- **Proof** = the verifiable integrity property of a receipt: remove `predicate.fingerprint`, recompute the full-Statement fingerprint, compare to the stamped value.
 - **Chain** = receipts linked by digest → provenance.
 - **Aggregate** = receipts synthesized by policy → ledger.
-- **Log / journal** = lower-resolution surfaces (watch events / trace output); receipts are what get stamped at gates.
+- **Log / journal** = lower-level surfaces (watch events / comparison output); receipts are what get stamped at gates.
 
 ---
 

--- a/docs/concepts/receipts-and-proofs.md
+++ b/docs/concepts/receipts-and-proofs.md
@@ -4,9 +4,17 @@
 > Last reviewed: 2026-05-25
 > Concepts index: [README.md](README.md)
 
-"Receipt" and "proof" are loaded words. cub-scout uses both, and it's worth being precise about which sense we mean — both for users picking the right tool and for integrators choosing the right vocabulary in their own docs.
+## TL;DR
 
-This doc defines the two terms, places them inside the broader vocabulary they sit alongside (log, journal, record, ledger, provenance), and notes where the boundaries blur honestly.
+> A **receipt** is a stamped, hand-offable record of one verification — an in-toto Statement v1 envelope around a verdict and its evidence, fingerprinted via SHA-256 over RFC 8785 canonical JSON. The **proof** is that fingerprint: any third party can recompute it over the receipt's canonical bytes and confirm nothing has been edited since the receipt was stamped. A receipt without proof is a claim; a receipt with proof is evidence.
+
+The rest of this doc unpacks each term, places them inside the broader vocabulary they sit alongside (log, journal, record, ledger, provenance), and notes where the boundaries blur honestly.
+
+---
+
+## Why this matters
+
+"Receipt" and "proof" are loaded words. cub-scout uses both, and it's worth being precise about which sense we mean — both for users picking the right tool and for integrators choosing the right vocabulary in their own docs.
 
 ---
 

--- a/docs/howto/receipts-end-to-end.md
+++ b/docs/howto/receipts-end-to-end.md
@@ -2,6 +2,8 @@
 
 cub-scout receipts are typed, fingerprinted, immutable evidence artifacts. This how-to walks through the **operational lifecycle** of a receipt in a real CD pipeline — from pre-deploy gate, through chained multi-stage delivery, through namespace-wide audit, through real-time event-driven emission.
 
+If you're new to the terminology — what does "receipt" mean here exactly, vs. "proof" / "log" / "ledger" / "provenance"? — start with [docs/concepts/receipts-and-proofs.md](../concepts/receipts-and-proofs.md). This how-to is operational; the concept doc is the vocabulary.
+
 For reference material, see:
 - [JSON Contracts § Receipt Contract](../reference/json-contracts.md)
 - [Command Reference § receipt verify](../reference/commands.md)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2446,8 +2446,7 @@ Create and verify typed, fingerprinted, immutable evidence receipts (`#446`).
 Receipts wrap cub-scout's existing field-level evidence (compareThreeWay,
 attribution, sourceTruth, gitSource) into a verifiable in-toto Statement v1
 envelope. CI/CD gates, audit trails, postmortems, and acceptance-judge
-tooling can attach a receipt to a decision and later prove the inputs
-were what they claim to be.
+tooling can attach a receipt to a decision and later re-check for tampering.
 
 Current shipping releases use fingerprint-only integrity (SHA-256 over
 RFC 8785 canonical JSON of the full Statement minus only

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -598,7 +598,7 @@ Source: `pkg/agent/event_timeline.go`, `internal/mapsvc/jsonout.go`
 
 ## Receipt Contract (`cub-scout receipt verify`)
 
-> A **receipt** is a stamped, hand-offable record of one verification — an in-toto Statement v1 envelope around a verdict and its evidence, fingerprinted via SHA-256 over RFC 8785 canonical JSON. The **proof** is that fingerprint: any third party can recompute it over the receipt's canonical bytes and confirm nothing has been edited since the receipt was stamped. A receipt without proof is a claim; a receipt with proof is evidence.
+> A **receipt** is a stamped, hand-offable record of one verification: an in-toto Statement v1 envelope around a verdict, evidence, omissions, and optional upstream receipt references. Its **proof** is the verifiable integrity property created by the fingerprint: SHA-256 over RFC 8785 canonical JSON of the full Statement, with only `predicate.fingerprint` removed before hashing. Any third party can recompute that fingerprint to confirm the receipt has not been edited since it was stamped. That is tamper-evidence, not producer authentication or formal proof of truth. A receipt without proof is a claim; a receipt with proof is evidence.
 
 For the *vocabulary* — what "receipt" and "proof" mean in cub-scout, and how they relate to log / journal / record / ledger / provenance — see [docs/concepts/receipts-and-proofs.md](../concepts/receipts-and-proofs.md). This section documents the *wire format* of the artifact itself.
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -598,6 +598,8 @@ Source: `pkg/agent/event_timeline.go`, `internal/mapsvc/jsonout.go`
 
 ## Receipt Contract (`cub-scout receipt verify`)
 
+For the *vocabulary* — what "receipt" and "proof" mean in cub-scout, and how they relate to log / journal / record / ledger / provenance — see [docs/concepts/receipts-and-proofs.md](../concepts/receipts-and-proofs.md). This section documents the *wire format* of the artifact itself.
+
 The receipt surface emits typed, fingerprinted, immutable evidence artifacts
 wrapping cub-scout's existing field-level evidence (compareThreeWay,
 attribution, sourceTruth, gitSource) into a verifiable record. Current

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -598,6 +598,8 @@ Source: `pkg/agent/event_timeline.go`, `internal/mapsvc/jsonout.go`
 
 ## Receipt Contract (`cub-scout receipt verify`)
 
+> A **receipt** is a stamped, hand-offable record of one verification — an in-toto Statement v1 envelope around a verdict and its evidence, fingerprinted via SHA-256 over RFC 8785 canonical JSON. The **proof** is that fingerprint: any third party can recompute it over the receipt's canonical bytes and confirm nothing has been edited since the receipt was stamped. A receipt without proof is a claim; a receipt with proof is evidence.
+
 For the *vocabulary* — what "receipt" and "proof" mean in cub-scout, and how they relate to log / journal / record / ledger / provenance — see [docs/concepts/receipts-and-proofs.md](../concepts/receipts-and-proofs.md). This section documents the *wire format* of the artifact itself.
 
 The receipt surface emits typed, fingerprinted, immutable evidence artifacts

--- a/skills/scout-verify/SKILL.md
+++ b/skills/scout-verify/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools: Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify 
 
 The Verify verb group of cub-scout. Produces typed, fingerprinted, immutable evidence artifacts — **receipts** — wrapping cub-scout's existing field-level evidence into a verifiable record CI/CD gates, audit trails, postmortems, and acceptance-judge tooling can attach to a decision and later prove the inputs were what they claim to be.
 
+> A **receipt** is a stamped, hand-offable record of one verification — an in-toto Statement v1 envelope around a verdict and its evidence, fingerprinted via SHA-256 over RFC 8785 canonical JSON. The **proof** is that fingerprint: any third party can recompute it over the receipt's canonical bytes and confirm nothing has been edited since the receipt was stamped. A receipt without proof is a claim; a receipt with proof is evidence.
+
 Receipts are HISTORICAL records. Updates produce new receipts; old ones never mutate.
 
 ## When to use

--- a/skills/scout-verify/SKILL.md
+++ b/skills/scout-verify/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: scout-verify
-description: 'Use when the user wants a TYPED, FINGERPRINTED, IMMUTABLE evidence artifact about a Kubernetes resource — the Verify verb group of cub-scout (the receipt capability shipped in #446). Natural phrasing: "produce a receipt that this is in compliance", "give me an attestation that the cluster matches Git", "I need a verifiable record for the audit trail", "build a receipt verifying no manual edits since deploy", "verify deploy/api against source-truth and save the artifact", "validate this receipt is authentic", "show me what receipts we have", "is this receipt tampered with?", "attach evidence to my CI gate". Load whenever intent is receipt / attestation / evidence-artifact / signed-evidence / verified-record / audit-trail / postmortem-evidence / acceptance-judge-input. Do NOT load for: a live comparison without a persisted artifact (use scout-compare), interpreting a single field''s provenance (use scout-attribute), or actually applying a fix (cub-scout never mutates — route to cub / argocd / kubectl with the user driving).'
+description: 'Use when the user wants a TYPED, FINGERPRINTED, IMMUTABLE evidence artifact about a Kubernetes resource — the Verify verb group of cub-scout (the receipt capability shipped in #446). Natural phrasing: "produce a receipt that this is in compliance", "give me an attestation that the cluster matches Git", "I need a verifiable record for the audit trail", "build a receipt verifying no manual edits since deploy", "verify deploy/api against source-truth and save the artifact", "validate this receipt has not been tampered with", "show me what receipts we have", "is this receipt tampered with?", "attach evidence to my CI gate". Load whenever intent is receipt / attestation / evidence-artifact / tamper-evident-record / verified-record / audit-trail / postmortem-evidence / acceptance-judge-input. Do NOT load for: a live comparison without a persisted artifact (use scout-compare), interpreting a single field''s provenance (use scout-attribute), or actually applying a fix (cub-scout never mutates — route to cub / argocd / kubectl with the user driving).'
 phase: verify
 allowed-tools: Bash(./cub-scout receipt verify *) Bash(cub-scout receipt verify *) Bash(cub scout receipt verify *) Bash(./cub-scout receipt show *) Bash(cub-scout receipt show *) Bash(cub scout receipt show *) Bash(./cub-scout receipt validate *) Bash(cub-scout receipt validate *) Bash(cub scout receipt validate *) Bash(./cub-scout receipt list *) Bash(cub-scout receipt list *) Bash(cub scout receipt list *) Bash(./cub-scout receipt list) Bash(cub-scout receipt list) Bash(cub scout receipt list) Bash(kubectl get *) Bash(kubectl describe *) Bash(kubectl get --show-managed-fields *) Bash(cub * get) Bash(cub * list) Bash(cub link list *) Bash(cub unit get *) Bash(argocd app get *) Bash(flux get *)
 ---
 
 # scout-verify
 
-The Verify verb group of cub-scout. Produces typed, fingerprinted, immutable evidence artifacts — **receipts** — wrapping cub-scout's existing field-level evidence into a verifiable record CI/CD gates, audit trails, postmortems, and acceptance-judge tooling can attach to a decision and later prove the inputs were what they claim to be.
+The Verify verb group of cub-scout. Produces typed, fingerprinted, immutable evidence artifacts — **receipts** — wrapping cub-scout's existing field-level evidence into a verifiable record CI/CD gates, audit trails, postmortems, and acceptance-judge tooling can attach to a decision and later re-check for tampering.
 
-> A **receipt** is a stamped, hand-offable record of one verification — an in-toto Statement v1 envelope around a verdict and its evidence, fingerprinted via SHA-256 over RFC 8785 canonical JSON. The **proof** is that fingerprint: any third party can recompute it over the receipt's canonical bytes and confirm nothing has been edited since the receipt was stamped. A receipt without proof is a claim; a receipt with proof is evidence.
+> A **receipt** is a stamped, hand-offable record of one verification: an in-toto Statement v1 envelope around a verdict, evidence, omissions, and optional upstream receipt references. Its **proof** is the verifiable integrity property created by the fingerprint: SHA-256 over RFC 8785 canonical JSON of the full Statement, with only `predicate.fingerprint` removed before hashing. Any third party can recompute that fingerprint to confirm the receipt has not been edited since it was stamped. That is tamper-evidence, not producer authentication or formal proof of truth. A receipt without proof is a claim; a receipt with proof is evidence.
 
 Receipts are HISTORICAL records. Updates produce new receipts; old ones never mutate.
 
@@ -22,7 +22,7 @@ Explicit phrasings:
 - "I need an evidence artifact for the audit trail"
 - "Build a receipt verifying no manual edits since the freeze started"
 - "Verify deploy/api against source-truth and save the artifact"
-- "Validate this receipt is authentic / hasn't been tampered with"
+- "Validate this receipt has not been tampered with"
 - "List the receipts I've generated locally"
 - "Show me yesterday's receipts where the verdict was BLOCK"
 - "Attach typed evidence to my CI gate / promotion gate / release ticket"
@@ -31,7 +31,7 @@ Implicit intents:
 
 - The user wants **persistence** of an evidence snapshot, not just an ephemeral comparison
 - The user is gating CI / promotion / acceptance on a verdict
-- The user needs to **prove later** that the inputs were what they claim to be (forensic / audit / postmortem)
+- The user needs to **show later** exactly what evidence was attached to a decision, with tamper-evidence (forensic / audit / postmortem)
 - The user is integrating with Pilot or a similar acceptance kernel that consumes receipt-shaped evidence
 - The user wants a tamper-evident artifact, not a log line
 
@@ -60,7 +60,7 @@ Implicit intents:
 |---|---|---|
 | "Produce a receipt about this resource" | `cub-scout receipt verify <kind>/<name> -n <ns>` | Auto-detects the predicate from owner + signals. Defaults to applied-matches-spec for Argo/Flux/ConfigHub-owned resources with a resolved git anchor. |
 | "Render a saved receipt" | `cub-scout receipt show <path>` | ASCII or JSON. Does NOT verify the fingerprint — works on tampered receipts for forensic inspection. |
-| "Is this receipt authentic?" | `cub-scout receipt validate <path>` | Recomputes the fingerprint and compares. Exit 0 OK / 1 mismatch / 2 I/O. JSON output for CI. |
+| "Has this receipt been tampered with?" | `cub-scout receipt validate <path>` | Recomputes the fingerprint and compares. Exit 0 OK / 1 mismatch / 2 I/O. JSON output for CI. |
 | "What receipts do I have locally?" | `cub-scout receipt list` | Walks `$CUB_SCOUT_RECEIPTS_DIR → $XDG_DATA_HOME/cub-scout/receipts → $HOME/.local/share/cub-scout/receipts`. Sortable, newest first. |
 
 ## The predicates

--- a/skills/scout-verify/SKILL.md
+++ b/skills/scout-verify/SKILL.md
@@ -292,6 +292,7 @@ Shipping releases use fingerprint-only integrity; future hardening is honest abo
 
 ## References
 
+- Terminology: [`docs/concepts/receipts-and-proofs.md`](../../docs/concepts/receipts-and-proofs.md) — what "receipt" and "proof" mean, vs log / journal / record / ledger / provenance
 - Contract: [`docs/reference/json-contracts.md`](../../docs/reference/json-contracts.md) § Receipt Contract
 - Locked design: [`docs/proposals/receipts-way-forward.md`](../../docs/proposals/receipts-way-forward.md)
 - Examples: [`examples/receipts/`](../../examples/receipts/) — 8 canonical receipts across the three predicates, generated deterministically by `tools/gen-receipt-examples`


### PR DESCRIPTION
## Summary

Adds `docs/concepts/receipts-and-proofs.md` — a focused conceptual doc that pins down what "receipt" and "proof" mean in cub-scout, and how they relate to the broader vocabulary they sit alongside (log, journal, record, ledger, provenance).

The doc grew out of a vocabulary-clarification question on the receipts surface: we use "receipt" and "proof" in our copy without ever defining them precisely against the surrounding terminology landscape. This pins both terms down with structural and semantic clarity, maps cub-scout's surface onto the broader 5-term vocabulary, and is honest about where the boundaries blur (receipt vs attestation, chain vs provenance, weak-sense proof vs strong-sense proof, etc.).

### What it says

- **Receipt** = a stamped, hand-offable record of one verification, in an in-toto Statement v1 envelope.
- **Proof** = the verifiable property of that record (recompute the fingerprint, compare to the stamped value) — tamper-evidence, not formal-proof.
- **Chain** = receipts linked by digest → provenance.
- **Aggregate** = receipts synthesized by policy → ledger.
- **Log / journal** = lower-resolution surfaces (`watch` / `trace`) that are not stamped by default.

### Cross-links wired

- `docs/concepts/README.md` — deep-dive list + status table
- `docs/howto/receipts-end-to-end.md` — top-of-file pointer (operational vs. vocabulary)
- `docs/reference/json-contracts.md` § Receipt Contract — vocabulary vs. wire-format split
- `README.md` Documentation Map — new row
- `skills/scout-verify/SKILL.md` § References — top of the list

## Test plan

- [x] `./scripts/check-doc-freshness.sh` — passes
- [x] `./scripts/check-readonly.sh` — passes
- [ ] Reviewer: read the new concept doc end-to-end, sanity-check that the five-term mapping table reads honestly
- [ ] Reviewer: check that the cross-links land on the right anchors (concepts README, howto opener, json-contracts § Receipt Contract, README Documentation Map, scout-verify References)

No code change. Pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)