### PR TITLE
docs(helm-expt): gap analysis + runnable object-set-matches example

### DIFF
--- a/docs/proposals/helm-expt-driven-gaps.md
+++ b/docs/proposals/helm-expt-driven-gaps.md
@@ -1,0 +1,278 @@
+# cub-scout gaps surfaced by the helm-expt use case
+
+**Status:** Proposal / issue drafts (from a cross-repo synthesis)
+**Driving use case:** `confighub/helm-expt` as cub-scout's first real "install verification" consumer
+**Runnable reproduction:** [`examples/helm-expt/verify.sh`](../../examples/helm-expt/verify.sh)
+**Last updated:** 2026-06-09
+
+## Why this exists
+
+helm-expt renders Helm charts to an explicit object set and wants cub-scout to be
+the **live witness** that closes the loop: "the objects we approved are present,
+matching, and actually working in the cluster." helm-expt's own docs already
+assign cub-scout a day-2 charter — *"post-install readiness, Job result, webhook
+health, PVC binding, drift"* (`helm-expt/docs/user/introduction-to-the-harness.md:125`)
+— and its pain-point CSV has a dedicated `cub_scout_answer` column.
+
+But when helm-expt actually needed to verify an install, it **did not call
+cub-scout** — it shipped its own kubectl verifier
+(`helm-expt/scripts/verify-install.mjs`) and its own receipt format. The reason is
+a **scope gap**: cub-scout's keystone install predicate `object-set-matches`
+proves *presence + authored-field match* and deliberately strips `status`, so it
+cannot prove the very things helm-expt's charter assigns to cub-scout.
+
+This document records that gap as prioritized, issue-ready write-ups. The
+`examples/helm-expt/` demo reproduces it against a real kind cluster so each gap
+is observable, not theoretical.
+
+## The reproduction (real output, 2026-06-09)
+
+The fixture applies a Deployment that references a Secret (`app-db-secret`) which
+is **not** part of the shipped object set — helm-expt finding **F3** (the
+"separated secret" / unmet prerequisite, `helm-expt/tests/findings.md:132`).
+
+```text
+receipt object-set-matches : PASS   (exit 0 under --fail-on any-non-pass)
+  evidence.summary         : { desired:3, matched:3, missing:0, mismatched:0, inconclusive:0 }
+  Deployment/web           : status "matched"  (authored fields equal live)
+  receipt.nextSteps        : "every desired rendered object was present and all authored fields matched live"
+
+cub-scout doctor           : { healthy:4, warning:1, error:0 }
+
+ACTUAL cluster reality     : pod web-… CreateContainerConfigError, Ready=False
+                             app-db-secret absent
+```
+
+So the governance-grade artifact (the receipt, the thing `--fail-on` gates CI on)
+says **PASS / exit 0**, and `doctor` reports **error: 0** — while the workload
+cannot start. This is exactly the helm-expt finding: *"Argo and cub-scout report
+`Synced` while the workload sits in `CreateContainerConfigError` … the failure is
+silent at the governance/diagnosis layer"* (`helm-expt/tests/findings.md:134,159`).
+
+Note `doctor` does emit one **warning** — cub-scout is not blind — but a warning
+is not a BLOCK and the receipt gate is still green. The lesson is about the
+**verdict that becomes a durable artifact**, not about whether a human reading
+`doctor` could eventually notice.
+
+Two structural observations from the receipt JSON, relevant below:
+
+1. The receipt carries only `verifiedAt` — **no freshness/TTL/expiry field**
+   (`grep -iE 'ttl|fresh|expire'` → nothing).
+2. Both subjects (`rendered-object-set://…` and `k8s-live-object-set://…`) carry
+   the **same digest**, because `matchMode: authored-fields` hashes the *projected
+   authored fields*, not an independent hash of live state. The "live" subject is
+   therefore not evidence about everything actually live (status, extra objects,
+   workload health) — only about the authored-field projection.
+
+---
+
+## Issue drafts
+
+Each block below is copy-paste ready for `gh issue create`. Priority is my
+recommendation; effort is rough.
+
+### P0 — `workloads-converged` predicate (status-aware readiness)
+
+**Suggested labels:** `enhancement`, `receipts`, `predicate`, `helm-expt`
+
+**Problem.** `object-set-matches` strips `status` by design, so a receipt can be
+PASS while Deployments are not Ready, Jobs have not Succeeded, and PVCs are not
+Bound. helm-expt's charter assigns "post-install readiness, Job result, webhook
+health, PVC binding" to cub-scout, and its own verifier re-implements PVC/PING
+checks precisely because the receipt can't. The result is a silent false green
+(see reproduction above and `helm-expt/tests/findings.md` F3).
+
+**Proposal.** Add a `workloads-converged` predicate (companion to, not a change
+of, `object-set-matches`) that reads `status` for the desired object set and
+asserts readiness: Deployment/Statefulset/DaemonSet rollout complete, Job
+Succeeded, PVC Bound, pods not in `CreateContainerConfigError` / `CrashLoopBackOff`
+/ `ImagePullBackOff` / `CreateContainerError`. Verdict BLOCK on any not-converged;
+WATCH while still progressing within a grace window; PASS when all converged.
+Pair it with `object-set-matches` via `--input-attestation` for a "present AND
+working" chain.
+
+**Secondary fix (same theme).** cub-scout's false-green detection should treat
+`CreateContainerConfigError` as an error-class pod reason, not a warning — helm-expt
+found the equivalent one-line gap in its own contradiction checker
+(`helm-expt/tests/findings.md` notes the scanner watched for `ImagePullBackOff` /
+`CrashLoopBackOff` / `Error` but **not** `CreateContainerConfigError`). In the
+reproduction, `doctor` rated this pod `warning`, not `error`.
+
+**Acceptance.** Re-run `examples/helm-expt/verify.sh`: `workloads-converged`
+returns BLOCK (exit 2 under `--fail-on any-non-pass`) for the F3 fixture; PASS
+once `app-db-secret` is created and the pod becomes Ready.
+
+**Non-goals.** Application-level health probes beyond Kubernetes readiness; SLO
+evaluation.
+
+**Effort.** Medium. Reuses kstatus-style readiness cub-scout already has for
+`map status` / `watch`; the new surface is the predicate envelope + per-object
+status evidence.
+
+---
+
+### P0 — `prerequisites-met` predicate (target facts)
+
+**Suggested labels:** `enhancement`, `receipts`, `predicate`, `helm-expt`
+
+**Problem.** helm-expt's load-bearing abstraction is **target facts**: cluster-state
+dependencies (required CRDs, Secrets/keys, StorageClass, IngressClass, namespace,
+kube version) lifted out of hidden Helm `lookup` into explicit, declared,
+*live-checkable* inputs (`helm-expt/packages/*/collector/target-facts.sh` already
+`kubectl get`s them). cub-scout knows CRDs/webhooks only as static-scan risk
+types, not as a verifiable predicate. The unmet prerequisite in the reproduction
+(absent `app-db-secret`) is invisible to every current predicate.
+
+**Proposal.** Add a `prerequisites-met` predicate that takes a declared set of
+required cluster facts and verifies them live: CRDs established (and serving),
+named Secrets/keys present, StorageClass/IngressClass exists, namespace exists,
+ValidatingWebhookConfiguration reachable with a non-empty CA bundle. Input shape
+should map directly onto helm-expt's `targetFacts.requiredCRDs` /
+`requiredSecrets`, so helm-expt can *delete* its kubectl logic and consume one
+receipt. Verdict BLOCK on any missing required fact.
+
+**Acceptance.** A receipt over the F3 fixture's declared prerequisites returns
+BLOCK naming `secret/app-db-secret` as the unmet fact; PASS once present.
+
+**Non-goals.** Inferring prerequisites from a chart (that is helm-expt's job at
+render time); cub-scout consumes a declared list.
+
+**Effort.** Medium. Mostly a new evidence collector + envelope; reuses the
+discovery/REST-mapper plumbing `object-set-matches` already uses.
+
+---
+
+### P1 — Observation freshness: stamp `observedAt` + `expiresAt` on receipts
+
+**Suggested labels:** `enhancement`, `receipts`, `helm-expt`
+
+**Problem.** helm-expt treats freshness as part of the claim — its observation
+receipts carry `observedAt` + `freshnessTTL: 1h`, and the model demands the UI
+show "Observed by cub-scout 4m ago / stale / no receipt yet"
+(`helm-expt/docs/reference/chart-recipe-manifest-flow.md`). cub-scout receipts
+carry only `verifiedAt`; there is no TTL/expiry, so a workerless ConfigHub
+ingesting the receipt cannot tell a fresh green from a stale one. This is the
+single most structural mismatch for the "submit observation receipts to a
+workerless server" model.
+
+**Important framing.** This does **not** contradict the receipts-immutability
+stance ("keep the receipt fresh is a category error",
+[`receipts-way-forward.md`](./receipts-way-forward.md)). The receipt stays
+immutable; we add an **immutable** `observedAt` (when the live read happened) and
+an **immutable** `expiresAt` (a stamped freshness boundary, optionally from a
+`--ttl` flag). Staleness is then computed by the *consumer* at read time against
+`now`; the artifact never mutates.
+
+**Acceptance.** `receipt verify … --ttl 1h` produces a receipt whose predicate
+includes `observedAt` and `expiresAt`; `examples/helm-expt/verify.sh` reports
+"freshness/TTL field on receipt: present".
+
+**Non-goals.** Re-verification scheduling; that is the consumer's loop.
+
+**Effort.** Low. Two fields + one flag; no envelope/wire-format change.
+
+---
+
+### P1 — Standalone git/file-as-DRY for `compare three-way`
+
+**Suggested labels:** `enhancement`, `compare`, `helm-expt`
+
+**Problem.** helm-expt's doctrine is that a true PASS = intended ↔ applied/synced
+↔ live agree with exact field proof, never just "Synced". cub-scout has
+`compare three-way`, but it requires ConfigHub for the DRY leg. helm-expt is
+exactly the case that breaks this: it already *has* the rendered desired object
+set on disk and no ConfigHub in the loop. cub-scout's own "what's coming next"
+already lists git-as-DRY; helm-expt is the motivating consumer to prioritize it.
+
+**Proposal.** Allow `compare three-way --git-path <dir>` / `--source-path <file>`
+to supply DRY from rendered YAML or a git checkout, so the three-way agreement
+view works standalone. (`object-set-matches` is the receipt sibling; this is the
+interactive/compare sibling.)
+
+**Acceptance.** `compare three-way --source-path fixtures/release-objects.yaml
+--scope namespace/helm-expt-demo` returns a DRY/WET/LIVE agreement summary with
+no ConfigHub connection.
+
+**Effort.** Medium–large. DRY-source abstraction + wiring into the existing
+three-way engine.
+
+---
+
+### P2 — Closed-world / pruning verdict (resolve `extra-live-object-coverage`)
+
+**Suggested labels:** `enhancement`, `receipts`, `predicate`
+
+**Problem.** `object-set-matches` carries a permanent self-declared omission:
+*"it does not prove that no extra live objects exist outside that desired set."*
+The reproduction plants a `drift-not-in-object-set` ConfigMap that the PASS
+receipt happily ignores. For an install-equivalence claim ("what we shipped is
+what is running, and nothing else"), present-but-not-complete is a real gap.
+Compounded by the digest observation above: the "live" subject digest is the
+authored-field projection, so it cannot reflect extras either.
+
+**Proposal.** Add an optional closed-world check (`--prune-scope` /
+`--no-extras`): enumerate live objects in scope, diff against the desired identity
+set, and emit a WATCH/BLOCK plus an `extraObjects[]` evidence list when live has
+objects the manifest does not. Resolves the standing omission when enabled.
+
+**Acceptance.** With the check on, the reproduction reports the
+`drift-not-in-object-set` ConfigMap as an extra; the omission is dropped from the
+receipt.
+
+**Effort.** Medium. Needs careful scoping (ownership/label filters) to avoid
+flagging controller-created children.
+
+---
+
+### P2 — Helm/Kustomize provenance back-resolution
+
+**Suggested labels:** `enhancement`, `attribution`, `helm-expt`
+
+**Problem.** The root-cause theme across helm-expt's 15 pain points is "where did
+this field value come from?". cub-scout's attribution `gitSource.file:line` works
+only for *raw* YAML and is explicitly deferred for templated sources — i.e. it
+degrades exactly where Helm/Kustomize (helm-expt's whole domain) lives.
+
+**Proposal.** Extend attribution back-resolution so a live field can be traced to
+the Helm template / values key or Kustomize overlay that produced it, not just a
+rendered raw-YAML line. Pairs naturally with helm-expt, which holds the
+chart→render mapping.
+
+**Effort.** Large. This is the deep one; track as an epic.
+
+---
+
+### P2 — Foreign-receipt bridge + shared digest convention
+
+**Suggested labels:** `enhancement`, `receipts`, `helm-expt`
+
+**Problem.** helm-expt and cub-scout compute their object-set SHAs differently, so
+their digests can't be cross-checked, and `--input-attestation` only chains
+cub-scout-fingerprinted receipts. helm-expt's README admits its receipts must sit
+"adjacent in the run directory until those upstream receipts are emitted or
+bridged." The render→package→live story is therefore not one verifiable thread.
+
+**Proposal.** (a) Document and share a canonical rendered-object-set digest
+convention both repos compute identically over the same bytes; (b) let
+`--input-attestation` (or a sibling `--reference-evidence`) ingest helm-expt's
+`InstallerPackageReceipt` / `UserInstallObservationReceipt` by its
+`renderedObjectSetSHA256`, so a cub-scout receipt can chain a non-cub-scout
+upstream receipt by digest equality.
+
+**Effort.** Medium. Digest convention is small; the bridge needs a foreign-receipt
+adapter with explicit trust boundaries (digest match, not fingerprint).
+
+---
+
+## Suggested sequencing
+
+1. **`workloads-converged` + `prerequisites-met`** (both P0) — these close the F3
+   false green and let helm-expt drop its parallel verifier. Highest proven value.
+2. **Observation freshness** (P1, low effort) — structurally required by the
+   workerless-observation model; cheap.
+3. **git/file-as-DRY three-way** (P1) — unlocks the entire no-ConfigHub path.
+4. Then closed-world, foreign-receipt bridge, and the Helm provenance epic.
+
+The fastest way to keep these honest is to wire `examples/helm-expt/verify.sh`
+into CI against an ephemeral kind cluster: today it asserts the false green; as
+each predicate lands, the script's gap table flips from ABSENT to a real verdict.

--- a/examples/helm-expt/.gitignore
+++ b/examples/helm-expt/.gitignore
@@ -1,0 +1,2 @@
+# verify.sh run output (receipts + command dumps); regenerated on every run
+out/

--- a/examples/helm-expt/AI_START_HERE.md
+++ b/examples/helm-expt/AI_START_HERE.md
@@ -1,0 +1,68 @@
+# AI Start Here
+
+Use this page to drive the `helm-expt` example safely with Claude, Codex, Cursor,
+or another AI assistant.
+
+## What this example is for
+
+It wires cub-scout's `object-set-matches` install receipt end-to-end against a
+real cluster, and then **shows where it falls short today** for the
+`confighub/helm-expt` use case. It is a self-contained reproduction of helm-expt
+finding **F3** (a workload whose required Secret is not in the shipped object set).
+
+It is a demonstration of a scope gap, not a passing demo. `verify.sh` is expected
+to report a "false green".
+
+## Self-contained — does NOT touch helm-expt
+
+This example ships its own fixture (`fixtures/release-objects.yaml`). It never
+reads, writes, or depends on a `helm-expt` checkout. `setup.sh` creates its own
+kind cluster named `cub-scout-helm-expt` and only `cleanup.sh` deletes it.
+
+## Read-only first
+
+```bash
+cd examples/helm-expt
+cat fixtures/release-objects.yaml   # read the fixture and its inline F3 comment
+./setup.sh --help                   # read what setup will do before running it
+```
+
+## Recommended path
+
+```bash
+./setup.sh      # creates kind cluster, applies the object set (no Secret -> F3)
+./verify.sh     # builds the object-set receipt, contrasts it with reality
+./cleanup.sh    # deletes the kind cluster
+```
+
+To run against your current context instead of a new kind cluster:
+
+```bash
+./setup.sh --no-cluster
+./verify.sh --no-cluster
+./cleanup.sh --no-cluster
+```
+
+## What to expect
+
+- `receipt object-set-matches` → **PASS**, exit 0
+- pod → **CreateContainerConfigError**, Ready=False
+- `verify.sh` gap table → "false green (PASS but unusable)?: yes"
+
+That contrast is the point. The gaps map to issue drafts in
+[`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md).
+
+## Important boundaries
+
+- `verify.sh` is read-only against the cluster; it writes only into `./out/`.
+- cub-scout never mutates the cluster.
+- The receipt PASS is correct *for the predicate's deliberate scope* (presence +
+  authored-field match). The example documents what that scope omits.
+
+## Related files
+
+- [README.md](./README.md) — the full integration narrative and runtime menu
+- [contracts.md](./contracts.md) — what each artifact does and does not prove
+- [prompts.md](./prompts.md) — copy-paste prompts for an AI assistant
+- [setup.sh](./setup.sh) / [verify.sh](./verify.sh) / [cleanup.sh](./cleanup.sh)
+- [fixtures/release-objects.yaml](./fixtures/release-objects.yaml)

--- a/examples/helm-expt/README.md
+++ b/examples/helm-expt/README.md
@@ -16,6 +16,26 @@ This is a general pattern for any chart/release that `helm-expt` can render
 and compare. Redis is the first worked value set, not the shape of the whole
 example.
 
+## Runnable Demo (Self-Contained)
+
+The rest of this page is the full integration narrative against a real
+helm-expt render. If you just want to run the `object-set-matches` path
+end-to-end with no helm-expt checkout, use the bundled scripts and fixture:
+
+```bash
+cd examples/helm-expt
+./setup.sh     # ephemeral kind cluster + fixtures/release-objects.yaml
+./verify.sh    # builds the receipt, then contrasts it with cluster reality
+./cleanup.sh   # tears the cluster down
+```
+
+The fixture intentionally reproduces helm-expt finding **F3**: the receipt comes
+back `PASS` while the workload sits in `CreateContainerConfigError`. That gap, and
+the issue drafts that would close it, are documented in
+[`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md).
+Start with [AI_START_HERE.md](./AI_START_HERE.md). The scripts never touch a
+helm-expt checkout.
+
 ## Why This Exists
 
 cub-scout already answers useful runtime questions:

--- a/examples/helm-expt/cleanup.sh
+++ b/examples/helm-expt/cleanup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# cleanup.sh — tear down whatever setup.sh created.
+
+set -euo pipefail
+
+CLUSTER="cub-scout-helm-expt"
+CONTEXT="kind-${CLUSTER}"
+NS="helm-expt-demo"
+NO_CLUSTER=false
+
+usage() {
+    cat <<'USAGE'
+Usage: ./cleanup.sh [--no-cluster]
+
+Options:
+  --no-cluster   Only delete the demo namespace from the current context;
+                 do not delete a kind cluster.
+  -h, --help     Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-cluster) NO_CLUSTER=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ "$NO_CLUSTER" == "true" ]]; then
+    CONTEXT="$(kubectl config current-context)"
+    echo "==> Deleting namespace '$NS' from context '$CONTEXT'"
+    kubectl --context "$CONTEXT" delete namespace "$NS" --ignore-not-found
+else
+    if kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+        echo "==> Deleting kind cluster '$CLUSTER'"
+        kind delete cluster --name "$CLUSTER"
+    else
+        echo "==> kind cluster '$CLUSTER' not present; nothing to delete"
+    fi
+fi
+
+echo "Cleanup complete."

--- a/examples/helm-expt/contracts.md
+++ b/examples/helm-expt/contracts.md
@@ -1,0 +1,39 @@
+# Contracts: what each artifact does and does not prove
+
+This example is precise about claim strength, in the spirit of helm-expt's
+"narrowest true claim" discipline. Do not collapse these into "verified".
+
+| Artifact | Proves | Does NOT prove |
+|---|---|---|
+| `object-set-matches` receipt | Every desired object identity in `fixtures/release-objects.yaml` is present live, and every **authored field** matches. | That the workload is **running** (status is stripped); that **prerequisites** (the Secret) exist; that **no extra** live objects exist; freshness. |
+| `cub-scout doctor` | A human-readable health summary; surfaces the broken pod as a **warning**. | A gating verdict — `error: 0` here despite a dead pod. |
+| `cub-scout compare drift --file` | Whether supported workload fields (e.g. replicas, images) drifted. | Full authored-field equivalence; readiness; prerequisites. |
+| The fixture's missing Secret | (by design) reproduces F3 — the unmet prerequisite. | n/a |
+
+## The deliberate scope line
+
+`object-set-matches` is honest about its own boundary. The receipt carries this
+omission verbatim:
+
+> object-set-matches verifies desired object identities and authored fields from
+> the rendered manifests; it does not prove that no extra live objects exist
+> outside that desired set.
+
+And it strips `status`, so readiness is out of scope **by construction**, not by
+oversight. The PASS verdict is therefore *correct for what it claims*. The
+example exists to document the distance between "what it claims" and "the install
+actually worked".
+
+## Subject digest caveat
+
+Both receipt subjects (`rendered-object-set://…` and `k8s-live-object-set://…`)
+carry the same SHA-256 because `matchMode: authored-fields` hashes the projected
+authored fields, not an independent snapshot of live state. Read the "live"
+subject as "the authored-field projection of live", not "everything that is live".
+
+## What would make the claim complete
+
+See [`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md):
+a `workloads-converged` predicate (readiness), a `prerequisites-met` predicate
+(target facts), observation freshness (`observedAt` + `expiresAt`), and an
+optional closed-world check.

--- a/examples/helm-expt/fixtures/release-objects.yaml
+++ b/examples/helm-expt/fixtures/release-objects.yaml
@@ -1,0 +1,76 @@
+# Rendered object set fixture for the cub-scout <-> helm-expt example.
+#
+# This is a SELF-CONTAINED stand-in for a helm-expt "rendered/release-objects.yaml".
+# It does not require a helm-expt checkout. It deliberately reproduces helm-expt
+# finding F3 (helm-expt tests/findings.md): a workload that depends on a Secret
+# which is NOT part of the shipped object set ("separated secret" / unmet
+# prerequisite).
+#
+# When this exact file is applied and then verified:
+#   - every authored field of every object below is present and matches live,
+#     so `receipt verify --file ... object-set-matches` returns PASS;
+#   - but the Deployment's pod is stuck in CreateContainerConfigError because
+#     `app-db-secret` does not exist.
+#
+# That PASS-while-broken is the "silent false green" the example exists to expose.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-config
+  namespace: helm-expt-demo
+  labels:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/managed-by: helm-expt-example
+data:
+  GREETING: "hello from the helm-expt object-set demo"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: helm-expt-demo
+  labels:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/managed-by: helm-expt-example
+spec:
+  selector:
+    app.kubernetes.io/name: web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: helm-expt-demo
+  labels:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/managed-by: helm-expt-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: web
+    spec:
+      containers:
+        - name: web
+          image: busybox:1.36
+          command: ["sh", "-c", "echo \"$GREETING\"; sleep 3600"]
+          envFrom:
+            - configMapRef:
+                name: web-config
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  # app-db-secret is intentionally NOT shipped in this object set.
+                  # This is the unmet prerequisite that object-set-matches cannot see.
+                  name: app-db-secret
+                  key: password
+                  optional: false

--- a/examples/helm-expt/prompts.md
+++ b/examples/helm-expt/prompts.md
@@ -1,0 +1,38 @@
+# Prompts
+
+Copy-paste starting points for driving this example with an AI assistant.
+
+## Run the reproduction
+
+```
+Run ./setup.sh then ./verify.sh in examples/helm-expt. Read the gap table in the
+verify output. Explain, in two sentences, why the object-set-matches receipt is
+PASS while the pod is in CreateContainerConfigError. Then run ./cleanup.sh.
+```
+
+## Inspect the receipt
+
+```
+Read examples/helm-expt/out/object-set.receipt.json. Confirm: the verdict, that
+status is not in the evidence, that there is no freshness/TTL field, and quote the
+self-declared omission. Map each finding to an issue in
+docs/proposals/helm-expt-driven-gaps.md.
+```
+
+## Use it as a spec for a new predicate
+
+```
+Using docs/proposals/helm-expt-driven-gaps.md as the spec, sketch the evidence
+shape for a workloads-converged predicate: which kinds it reads status for, the
+PASS/WATCH/BLOCK rules, and how it chains to an object-set-matches receipt via
+--input-attestation. Do not change object-set-matches.
+```
+
+## Point it at a real helm-expt render (optional, read-only)
+
+```
+I have a helm-expt checkout at $HELM_EXPT. Without modifying that repo, run:
+./cub-scout receipt verify --file "$HELM_EXPT/recipes/bitnami/redis/25.5.3/revisions/default/r001/rendered/release-objects.yaml" \
+  --scope namespace/redis --format json --out /tmp/redis.receipt.json --fail-on any-non-pass
+against a cluster where that render was applied, and summarize the verdict and any omissions.
+```

--- a/examples/helm-expt/setup.sh
+++ b/examples/helm-expt/setup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# setup.sh — stand up a self-contained cluster state that reproduces helm-expt
+# finding F3, so verify.sh can show where object-set-matches falls short today.
+#
+# Self-contained: uses only the fixture in this directory. It never reads or
+# touches a helm-expt checkout.
+#
+# Default: create an ephemeral kind cluster named cub-scout-helm-expt.
+#   --no-cluster : skip kind, apply into your CURRENT kube-context instead.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER="cub-scout-helm-expt"
+CONTEXT="kind-${CLUSTER}"
+NS="helm-expt-demo"
+MANIFESTS="$SCRIPT_DIR/fixtures/release-objects.yaml"
+NO_CLUSTER=false
+
+usage() {
+    cat <<'USAGE'
+Usage: ./setup.sh [--no-cluster]
+
+Options:
+  --no-cluster   Apply the fixture into your current kube-context instead of
+                 creating an ephemeral kind cluster.
+  -h, --help     Show this help.
+
+What it does (read it before running):
+  - creates kind cluster "cub-scout-helm-expt" (unless --no-cluster)
+  - creates namespace "helm-expt-demo"
+  - applies fixtures/release-objects.yaml (a ConfigMap, Service, Deployment)
+  - does NOT create the Secret the Deployment requires -> pod will sit in
+    CreateContainerConfigError. That is intentional.
+  - creates one extra ConfigMap that is NOT in the object set, to exercise the
+    closed-world / extra-live-object coverage gap.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-cluster) NO_CLUSTER=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ "$NO_CLUSTER" == "true" ]]; then
+    CONTEXT="$(kubectl config current-context)"
+    echo "==> Using current kube-context: $CONTEXT"
+else
+    command -v kind >/dev/null 2>&1 || { echo "kind is required (or pass --no-cluster)" >&2; exit 1; }
+    if kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+        echo "==> kind cluster '$CLUSTER' already exists; reusing it"
+    else
+        echo "==> Creating kind cluster '$CLUSTER'"
+        kind create cluster --name "$CLUSTER"
+    fi
+fi
+
+echo "==> Ensuring namespace '$NS'"
+kubectl --context "$CONTEXT" create namespace "$NS" --dry-run=client -o yaml | kubectl --context "$CONTEXT" apply -f -
+
+echo "==> Applying the rendered object set (no Secret -> intentional F3 reproduction)"
+kubectl --context "$CONTEXT" apply -f "$MANIFESTS"
+
+echo "==> Planting one extra live ConfigMap that is NOT in the object set"
+kubectl --context "$CONTEXT" create configmap drift-not-in-object-set \
+    -n "$NS" --from-literal=note="object-set-matches will not notice me" \
+    --dry-run=client -o yaml | kubectl --context "$CONTEXT" apply -f -
+
+echo "==> Waiting a few seconds for the pod to reach its (failed) steady state"
+kubectl --context "$CONTEXT" -n "$NS" wait --for=condition=Available deployment/web --timeout=20s || true
+
+echo
+echo "Setup complete. Pod state:"
+kubectl --context "$CONTEXT" -n "$NS" get pods -o wide || true
+echo
+echo "Now run:  ./verify.sh"

--- a/examples/helm-expt/verify.sh
+++ b/examples/helm-expt/verify.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# verify.sh — run the real cub-scout object-set-matches path end-to-end against
+# the fixture cluster state, then contrast the receipt verdict with the actual
+# workload reality. The point of this script is to make the current gaps
+# OBSERVABLE, not to hide them.
+#
+# Read-only against the cluster. Writes only into ./out/ in this directory.
+# Self-contained: never reads a helm-expt checkout.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+NS="helm-expt-demo"
+CLUSTER="cub-scout-helm-expt"
+CONTEXT="kind-${CLUSTER}"
+MANIFESTS="$SCRIPT_DIR/fixtures/release-objects.yaml"
+RUN_DIR="$SCRIPT_DIR/out"
+RECEIPT="$RUN_DIR/object-set.receipt.json"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --context) CONTEXT="$2"; shift 2 ;;
+        --context=*) CONTEXT="${1#*=}"; shift ;;
+        --no-cluster) CONTEXT="$(kubectl config current-context)"; shift ;;
+        -h|--help) echo "Usage: ./verify.sh [--context <ctx> | --no-cluster]"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+
+resolve_cub_scout() {
+    if [[ -n "${CUB_SCOUT_BIN:-}" ]]; then printf '%s\n' "$CUB_SCOUT_BIN"; return; fi
+    if [[ -x "$REPO_ROOT/cub-scout" ]]; then printf '%s\n' "$REPO_ROOT/cub-scout"; return; fi
+    command -v cub-scout 2>/dev/null || echo ""
+}
+CUB_SCOUT="$(resolve_cub_scout)"
+[[ -n "$CUB_SCOUT" ]] || { echo "cub-scout binary not found (build ./cmd/cub-scout or set CUB_SCOUT_BIN)" >&2; exit 1; }
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+kubectl --context "$CONTEXT" get ns "$NS" >/dev/null 2>&1 || {
+    echo "namespace '$NS' not found in context '$CONTEXT' — run ./setup.sh first" >&2; exit 1; }
+
+mkdir -p "$RUN_DIR"
+rule() { printf '\n========== %s ==========\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+rule "1. object-set-matches receipt (the keystone integration the READMEs promise)"
+# cub-scout reads the live cluster via the current context, so point it there.
+( kubectl config use-context "$CONTEXT" >/dev/null 2>&1 || true )
+set +e
+"$CUB_SCOUT" receipt verify \
+    --file "$MANIFESTS" \
+    --scope "namespace/$NS" \
+    --format json \
+    --out "$RECEIPT" \
+    --fail-on any-non-pass >"$RUN_DIR/object-set.stdout.json" 2>"$RUN_DIR/object-set.stderr.txt"
+RECEIPT_RC=$?
+set -e
+[[ -s "$RECEIPT" ]] || RECEIPT="$RUN_DIR/object-set.stdout.json"
+
+VERDICT="$(jq -r '.predicate.verdict // .predicate.result // .verdict // "UNKNOWN"' "$RECEIPT" 2>/dev/null || echo UNKNOWN)"
+MATCHED="$(jq -r '[.. | objects | .matched? // empty] | add // "?"' "$RECEIPT" 2>/dev/null || echo '?')"
+echo "receipt verdict         : $VERDICT"
+echo "receipt exit code       : $RECEIPT_RC   (--fail-on any-non-pass; 0 means cub-scout considers this a clean install)"
+echo "receipt written to      : ${RECEIPT/#$SCRIPT_DIR\//}"
+
+# ---------------------------------------------------------------------------
+rule "2. what is ACTUALLY happening in the cluster"
+kubectl --context "$CONTEXT" -n "$NS" get deploy,pods -o wide || true
+POD_JSON="$(kubectl --context "$CONTEXT" -n "$NS" get pods -o json 2>/dev/null || echo '{}')"
+WAIT_REASONS="$(echo "$POD_JSON" | jq -r '[.items[]?.status.containerStatuses[]?.state.waiting.reason] | map(select(. != null)) | unique | join(",")')"
+READY="$(echo "$POD_JSON" | jq -r '[.items[]?.status.conditions[]? | select(.type=="Ready") | .status] | join(",")')"
+SECRET_PRESENT="$(kubectl --context "$CONTEXT" -n "$NS" get secret app-db-secret >/dev/null 2>&1 && echo yes || echo no)"
+echo
+echo "pod waiting reason      : ${WAIT_REASONS:-<none>}"
+echo "pod Ready condition     : ${READY:-<none>}"
+echo "required Secret present : $SECRET_PRESENT  (app-db-secret — the unmet prerequisite)"
+
+# ---------------------------------------------------------------------------
+rule "3. receipt vs reality — where object-set-matches falls short"
+FALSE_GREEN="no"
+if [[ "$VERDICT" == "PASS" && ( "$WAIT_REASONS" == *CreateContainerConfigError* || "$READY" != *True* ) ]]; then
+    FALSE_GREEN="yes"
+fi
+
+# Probe the receipt envelope for the fields helm-expt expects but cub-scout
+# does not emit yet.
+HAS_FRESHNESS="$(grep -iEc 'ttl|fresh|expire' "$RECEIPT" 2>/dev/null || true)"
+HAS_READINESS="$(grep -iEc 'prerequisite|createcontainer|"ready"|isReady|readyReplicas' "$RECEIPT" 2>/dev/null || true)"
+OMISSIONS="$(jq -r '[.. | objects | .omissions? // empty] | add // [] | map(.id // .reason // tostring) | join(", ")' "$RECEIPT" 2>/dev/null || echo '')"
+
+printf '%-42s | %s\n' "claim / capability" "observed"
+printf -- '-------------------------------------------+----------------------------------\n'
+printf '%-42s | %s\n' "object-set-matches verdict"            "$VERDICT"
+printf '%-42s | %s\n' "workload actually usable?"             "$([[ "$READY" == *True* ]] && echo yes || echo NO)"
+printf '%-42s | %s\n' "=> false green (PASS but unusable)?"   "$FALSE_GREEN"
+printf '%-42s | %s\n' "readiness / Job / PVC status in claim" "$([[ "$HAS_READINESS" -gt 0 ]] && echo present || echo ABSENT)"
+printf '%-42s | %s\n' "prerequisite (required Secret) checked" "ABSENT"
+printf '%-42s | %s\n' "freshness / TTL field on receipt"      "$([[ "$HAS_FRESHNESS" -gt 0 ]] && echo present || echo ABSENT)"
+printf '%-42s | %s\n' "self-declared coverage omission(s)"    "${OMISSIONS:-<none>}"
+
+# ---------------------------------------------------------------------------
+rule "4. the rest of the runtime menu (informational)"
+for desc_cmd in \
+    "doctor|doctor --namespace $NS --format json" \
+    "map status|map status --namespace $NS --json" \
+    "compare drift|compare drift --file $MANIFESTS -n $NS --format json"; do
+    desc="${desc_cmd%%|*}"; args="${desc_cmd#*|}"
+    echo "--- cub-scout $desc ---"
+    # shellcheck disable=SC2086
+    "$CUB_SCOUT" $args >"$RUN_DIR/${desc// /-}.json" 2>/dev/null \
+        && echo "  saved out/${desc// /-}.json" \
+        || echo "  (command returned non-zero or unsupported in this build; see out/)"
+done
+
+# ---------------------------------------------------------------------------
+rule "verdict for this example"
+if [[ "$FALSE_GREEN" == "yes" ]]; then
+cat <<EOF
+object-set-matches returned ${VERDICT} and exit ${RECEIPT_RC}, yet the workload is
+not usable (${WAIT_REASONS:-not ready}) because the prerequisite Secret is absent.
+
+This is the helm-expt F3 "silent false green", reproduced against a real cluster.
+It is not a bug in object-set-matches — that predicate proves presence + authored
+field match by design — it is the SCOPE gap this example exists to document:
+
+  * no readiness/Job/PVC predicate     -> see issue: workloads-converged
+  * no prerequisite predicate          -> see issue: prerequisites-met
+  * no freshness/TTL on the receipt    -> see issue: receipt observation freshness
+  * extra live objects not covered     -> see issue: closed-world object-set
+
+See docs/proposals/helm-expt-driven-gaps.md for the write-ups.
+EOF
+else
+cat <<EOF
+Expected a false-green reproduction but did not detect one. Inspect:
+  receipt verdict = $VERDICT, pod waiting = ${WAIT_REASONS:-none}, ready = ${READY:-none}
+Did ./setup.sh run, and was the Secret accidentally created?
+EOF
+fi
+echo
+echo "Receipt and command output saved under: ${RUN_DIR/#$REPO_ROOT\//}"


### PR DESCRIPTION
## What

Adds the helm-expt-driven gap analysis and a **self-contained, runnable** example that wires cub-scout's `object-set-matches` path end-to-end and demonstrates where it falls short today.

- `docs/proposals/helm-expt-driven-gaps.md` — design note + 7 prioritized, issue-ready write-ups (now filed as #476–#482).
- `examples/helm-expt/` — `setup.sh` / `verify.sh` / `cleanup.sh` + a `fixtures/release-objects.yaml` that reproduces helm-expt finding **F3** on an ephemeral kind cluster, plus the repo's AI-first bundle (`AI_START_HERE.md`, `contracts.md`, `prompts.md`) and a README pointer.

## Why

helm-expt is cub-scout's first real install-verification consumer. Its docs assign cub-scout a day-2 charter (readiness, prerequisites, drift, freshness), but the keystone `object-set-matches` predicate strips `status` and only proves presence + authored-field match — so a receipt can be `PASS` while the workload can't start.

## Reproduced (2026-06-09, real kind cluster)

```
object-set-matches : PASS (exit 0)   { desired:3, matched:3, missing:0, mismatched:0 }
doctor             : { healthy:4, warning:1, error:0 }
ACTUAL             : pod CreateContainerConfigError, Ready=False, required Secret absent
```

The example is **self-contained**: it ships its own fixture and never reads or modifies a helm-expt checkout.

## Gap issues this documents

- #476 `workloads-converged` predicate (P0) · #477 `prerequisites-met` predicate (P0)
- #478 receipt observation freshness (P1) · #479 standalone git/file-as-DRY three-way (P1)
- #480 closed-world verdict · #481 Helm/Kustomize provenance · #482 foreign-receipt bridge

Companion policy issue in helm-expt: confighub/helm-expt#261.

## Note

Docs + example only — no code or behavior change. `examples/helm-expt/out/` is gitignored.
