### PR TITLE
feat(receipts #476): workloads-converged predicate (status-aware readiness)

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -33,6 +33,7 @@ var (
 	receiptSaveDir           string
 	receiptFailOn            string
 	receiptInputAttestations []string
+	receiptGraceWindow       string
 )
 
 // runReceiptVerifyDispatch is the shared entry point for the receipt
@@ -49,6 +50,9 @@ func runReceiptVerifyDispatch(cmd *cobra.Command, args []string) error {
 	}
 
 	if strings.TrimSpace(receiptObjectSetFile) != "" {
+		if agent.PredicateName(strings.TrimSpace(receiptPredicate)) == agent.PredicateWorkloadsConverged {
+			return runReceiptVerifyWorkloadsConverged(cmd, args)
+		}
 		return runReceiptVerifyObjectSet(cmd, args)
 	}
 
@@ -112,6 +116,7 @@ v1 predicates:
   source-truth-pass       compare source-truth returned PASS under --strategy
   no-manual-edits-since   no kubectl-* writer touched managedFields after --since
   object-set-matches      rendered manifest objects are present live and authored fields match
+  workloads-converged     desired workloads reached a ready/converged runtime state (reads status)
 
 Subject is usually a positional argument in the form <kind>/<name>.
 For install/object-set receipts, pass --file <manifest.yaml|dir> and scope
@@ -131,6 +136,7 @@ Examples:
   cub-scout receipt verify deploy/api -n prod --since 2026-05-22T00:00:00Z
   cub-scout receipt verify deploy/api -n prod --predicate applied-matches-spec --format json --out api.receipt.json
   cub-scout receipt verify --file out/manifests --scope namespace/redis --format json --out install.receipt.json
+  cub-scout receipt verify --file out/manifests --scope namespace/redis --predicate workloads-converged --fail-on any-non-pass
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runReceiptVerifyDispatch,
@@ -141,8 +147,9 @@ func init() {
 	receiptCmd.AddCommand(receiptVerifyCmd)
 
 	receiptVerifyCmd.Flags().StringVarP(&receiptNamespace, "namespace", "n", "", "Namespace of the resource (required for namespaced kinds)")
-	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 supports applied-matches-spec, source-truth-pass, no-manual-edits-since, object-set-matches.")
-	receiptVerifyCmd.Flags().StringVar(&receiptObjectSetFile, "file", "", "YAML file or directory containing rendered desired objects for object-set-matches install receipts.")
+	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 supports applied-matches-spec, source-truth-pass, no-manual-edits-since, object-set-matches, workloads-converged.")
+	receiptVerifyCmd.Flags().StringVar(&receiptObjectSetFile, "file", "", "YAML file or directory containing rendered desired objects for object-set-matches / workloads-converged install receipts.")
+	receiptVerifyCmd.Flags().StringVar(&receiptGraceWindow, "grace-window", "", "For --predicate workloads-converged: how long a workload may stay InProgress before it counts as failed (BLOCK) rather than progressing (WATCH), e.g. 5m. Empty means no deadline (InProgress is WATCH).")
 	receiptVerifyCmd.Flags().StringVar(&receiptAtCommit, "at-commit", "", "Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence.")
 	receiptVerifyCmd.Flags().StringVar(&receiptStrategy, "strategy", "", "Source-truth strategy for source-truth-pass (e.g. git-argo). cub-scout does not infer the strategy.")
 	receiptVerifyCmd.Flags().StringVar(&receiptSince, "since", "", "RFC 3339 cutoff for no-manual-edits-since (e.g. 2026-05-22T00:00:00Z).")

--- a/cmd/cub-scout/receipt_render.go
+++ b/cmd/cub-scout/receipt_render.go
@@ -127,6 +127,38 @@ func renderReceiptASCII(stmt agent.Statement) string {
 		}
 	}
 
+	if pred.Evidence.Workloads != nil {
+		w := pred.Evidence.Workloads
+		b.WriteString("\nEvidence (workloads converged)\n")
+		fmt.Fprintf(&b, "  source:      %s %s\n", w.DesiredSource.Type, w.DesiredSource.Ref)
+		if w.GraceWindow != "" {
+			fmt.Fprintf(&b, "  graceWindow: %s\n", w.GraceWindow)
+		}
+		fmt.Fprintf(&b, "  observedAt:  %s\n", w.ObservedAt)
+		fmt.Fprintf(&b, "  desired:     %d\n", w.Summary.Desired)
+		fmt.Fprintf(&b, "  converged:   %d\n", w.Summary.Converged)
+		fmt.Fprintf(&b, "  progressing: %d\n", w.Summary.Progressing)
+		fmt.Fprintf(&b, "  failed:      %d\n", w.Summary.Failed)
+		fmt.Fprintf(&b, "  missing:     %d\n", w.Summary.Missing)
+		fmt.Fprintf(&b, "  inconclusive:%d\n", w.Summary.Inconclusive)
+		for _, obj := range w.Workloads {
+			if obj.Status == agent.WorkloadConvergedConverged {
+				continue
+			}
+			fmt.Fprintf(&b, "  - %s: %s", obj.ID.String(), obj.Status)
+			if obj.KstatusStatus != "" {
+				fmt.Fprintf(&b, " (kstatus: %s)", obj.KstatusStatus)
+			}
+			b.WriteString("\n")
+			if obj.Error != "" {
+				fmt.Fprintf(&b, "      error: %s\n", obj.Error)
+			}
+			for _, pr := range obj.PodReasons {
+				fmt.Fprintf(&b, "      pod %s: %s\n", pr.Pod, pr.Reason)
+			}
+		}
+	}
+
 	// Omissions are critical — they convert silent PASS into honest PASS.
 	if len(pred.Omissions) > 0 {
 		b.WriteString("\nOmissions (deliberate non-claims)\n")

--- a/cmd/cub-scout/receipt_workloads.go
+++ b/cmd/cub-scout/receipt_workloads.go
@@ -1,0 +1,261 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+)
+
+// loadWorkloadsConvergedLiveFn is the function-variable seam for tests.
+// Production reads the cluster; tests swap in prefab observed objects.
+var loadWorkloadsConvergedLiveFn = loadWorkloadsConvergedLiveObjects
+
+func runReceiptVerifyWorkloadsConverged(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("--file workloads-converged receipt mode does not accept a positional subject; scope the install with --scope namespace/<ns> or -n <ns>")
+	}
+
+	format := strings.ToLower(strings.TrimSpace(receiptFormat))
+	if format != "ascii" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json)", receiptFormat)
+	}
+
+	// Parse --grace-window UPFRONT so a bad value rejects before any side
+	// effect (stdout, --out, --save).
+	var grace time.Duration
+	if raw := strings.TrimSpace(receiptGraceWindow); raw != "" {
+		parsed, perr := time.ParseDuration(raw)
+		if perr != nil {
+			return fmt.Errorf("invalid --grace-window %q (expected a Go duration like 5m or 90s): %w", raw, perr)
+		}
+		if parsed < 0 {
+			return fmt.Errorf("invalid --grace-window %q (must not be negative)", raw)
+		}
+		grace = parsed
+	}
+
+	var failOnSet map[agent.ReceiptVerdict]bool
+	failOnRaw := strings.TrimSpace(receiptFailOn)
+	if failOnRaw != "" {
+		parsed, parseErr := parseReceiptFailOn(failOnRaw)
+		if parseErr != nil {
+			return parseErr
+		}
+		failOnSet = parsed
+	}
+
+	scope, defaultNamespace, err := resolveObjectSetScope(receiptScope, receiptNamespace)
+	if err != nil {
+		return err
+	}
+
+	desired, source, err := loadObjectSetDesiredManifests(receiptObjectSetFile)
+	if err != nil {
+		return err
+	}
+	if len(desired) == 0 {
+		return fmt.Errorf("--file %q contained no Kubernetes objects", receiptObjectSetFile)
+	}
+
+	observed, err := loadWorkloadsConvergedLiveFn(cmd.Context(), desired, defaultNamespace)
+	if err != nil {
+		return err
+	}
+	evidence, err := agent.BuildWorkloadsConvergedEvidence(source, scope, grace, observed, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+
+	var inputAttestations []agent.VerifiedAttestationRef
+	if len(receiptInputAttestations) > 0 {
+		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
+		if refErr != nil {
+			return fmt.Errorf("build input-attestations: %w", refErr)
+		}
+		inputAttestations = refs
+	}
+
+	stmt, err := agent.BuildWorkloadsConvergedReceipt(agent.BuildWorkloadsConvergedReceiptInput{
+		Evidence:          evidence,
+		Verifier:          agent.Verifier{Tool: "cub-scout", Version: BuildTag},
+		VerifiedAt:        time.Now().UTC(),
+		InputAttestations: inputAttestations,
+	})
+	if err != nil {
+		return fmt.Errorf("build workloads-converged receipt: %w", err)
+	}
+
+	var out []byte
+	switch format {
+	case "json":
+		buf, mErr := json.MarshalIndent(stmt, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal receipt: %w", mErr)
+		}
+		out = buf
+	case "ascii":
+		out = []byte(renderReceiptASCII(stmt))
+	}
+	fmt.Println(string(out))
+
+	if outPath := strings.TrimSpace(receiptOut); outPath != "" {
+		jsonBytes, mErr := json.MarshalIndent(stmt, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal receipt for --out: %w", mErr)
+		}
+		if err := writeReceiptOutFile(outPath, jsonBytes); err != nil {
+			return err
+		}
+	}
+
+	if receiptSave {
+		if err := saveOneReceipt(cmd, stmt); err != nil {
+			return fmt.Errorf("save receipt: %w", err)
+		}
+	}
+
+	if failOnSet != nil && failOnSet[stmt.Predicate.Verdict] {
+		return newExitCodeError(
+			fmt.Errorf("receipt verdict %q matches --fail-on %q", stmt.Predicate.Verdict, failOnRaw),
+			2,
+		)
+	}
+	return nil
+}
+
+// loadWorkloadsConvergedLiveObjects fetches each desired object live and, for
+// workloads with a pod selector, the pods that belong to them — so pod-level
+// failure reasons (CreateContainerConfigError, CrashLoopBackOff, …) can be
+// surfaced even when the workload's own status only says "not ready".
+func loadWorkloadsConvergedLiveObjects(ctx context.Context, desired []*unstructured.Unstructured, defaultNamespace string) ([]agent.WorkloadConvergedObservedObject, error) {
+	cfg, err := buildConfig()
+	if err != nil {
+		return nil, fmt.Errorf("build kubernetes config: %w", err)
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build dynamic client: %w", err)
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build discovery client: %w", err)
+	}
+	groupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
+	if err != nil {
+		return nil, fmt.Errorf("discover API resources: %w", err)
+	}
+	mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
+
+	podsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	podsByNamespace := map[string][]*unstructured.Unstructured{}
+	listPods := func(ns string) []*unstructured.Unstructured {
+		if ns == "" {
+			return nil
+		}
+		if cached, ok := podsByNamespace[ns]; ok {
+			return cached
+		}
+		var pods []*unstructured.Unstructured
+		if list, lErr := dynClient.Resource(podsGVR).Namespace(ns).List(ctx, metav1.ListOptions{}); lErr == nil {
+			for i := range list.Items {
+				item := list.Items[i]
+				pods = append(pods, &item)
+			}
+		}
+		podsByNamespace[ns] = pods
+		return pods
+	}
+
+	out := make([]agent.WorkloadConvergedObservedObject, 0, len(desired))
+	for _, obj := range desired {
+		normalized := obj.DeepCopy()
+		mapping, mapErr := objectSetRESTMapping(mapper, normalized)
+		if mapErr != nil {
+			out = append(out, agent.WorkloadConvergedObservedObject{Desired: normalized, Error: mapErr.Error(), Inconclusive: true})
+			continue
+		}
+
+		ns := ""
+		var live *unstructured.Unstructured
+		var getErr error
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+			ns = strings.TrimSpace(normalized.GetNamespace())
+			if ns == "" {
+				ns = strings.TrimSpace(defaultNamespace)
+			}
+			if ns == "" {
+				ns = "default"
+			}
+			normalized.SetNamespace(ns)
+			live, getErr = dynClient.Resource(mapping.Resource).Namespace(ns).Get(ctx, normalized.GetName(), metav1.GetOptions{})
+		} else {
+			normalized.SetNamespace("")
+			live, getErr = dynClient.Resource(mapping.Resource).Get(ctx, normalized.GetName(), metav1.GetOptions{})
+		}
+		if getErr != nil {
+			obs := agent.WorkloadConvergedObservedObject{Desired: normalized, Error: getErr.Error()}
+			if !apierrors.IsNotFound(getErr) {
+				obs.Inconclusive = true
+			}
+			out = append(out, obs)
+			continue
+		}
+
+		obs := agent.WorkloadConvergedObservedObject{Desired: normalized, Live: live}
+		if selector := workloadSelectorMatchLabels(live); len(selector) > 0 && ns != "" {
+			obs.Pods = matchPodsBySelector(listPods(ns), selector)
+		}
+		out = append(out, obs)
+	}
+	return out, nil
+}
+
+// workloadSelectorMatchLabels reads spec.selector.matchLabels from a
+// controller workload (Deployment/StatefulSet/DaemonSet/ReplicaSet/Job).
+// Returns nil for kinds without a selector (Pod, PVC, …).
+func workloadSelectorMatchLabels(obj *unstructured.Unstructured) map[string]string {
+	if obj == nil {
+		return nil
+	}
+	raw, found, err := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels")
+	if err != nil || !found {
+		return nil
+	}
+	return raw
+}
+
+// matchPodsBySelector returns pods whose labels are a superset of every
+// selector key/value pair.
+func matchPodsBySelector(pods []*unstructured.Unstructured, selector map[string]string) []*unstructured.Unstructured {
+	var out []*unstructured.Unstructured
+	for _, pod := range pods {
+		labels := pod.GetLabels()
+		match := true
+		for k, v := range selector {
+			if labels[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			out = append(out, pod)
+		}
+	}
+	return out
+}

--- a/cmd/cub-scout/receipt_workloads_test.go
+++ b/cmd/cub-scout/receipt_workloads_test.go
@@ -1,0 +1,153 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func withFakeWorkloadsLoader(t *testing.T, fn func(context.Context, []*unstructured.Unstructured, string) ([]agent.WorkloadConvergedObservedObject, error)) {
+	t.Helper()
+	prev := loadWorkloadsConvergedLiveFn
+	loadWorkloadsConvergedLiveFn = fn
+	t.Cleanup(func() { loadWorkloadsConvergedLiveFn = prev })
+}
+
+// notReadyDeployment returns a live Deployment whose status drives kstatus
+// InProgress (availableReplicas below the spec).
+func notReadyDeployment(desired *unstructured.Unstructured) *unstructured.Unstructured {
+	live := desired.DeepCopy()
+	live.SetNamespace("helm-expt-demo")
+	_ = unstructured.SetNestedField(live.Object, int64(1), "metadata", "generation")
+	_ = unstructured.SetNestedField(live.Object, int64(1), "status", "observedGeneration")
+	_ = unstructured.SetNestedField(live.Object, int64(1), "status", "replicas")
+	_ = unstructured.SetNestedField(live.Object, int64(1), "status", "updatedReplicas")
+	_ = unstructured.SetNestedField(live.Object, int64(0), "status", "readyReplicas")
+	_ = unstructured.SetNestedField(live.Object, int64(0), "status", "availableReplicas")
+	return live
+}
+
+func configErrorPod(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": name, "namespace": "helm-expt-demo", "labels": map[string]interface{}{"app": "web"}},
+		"status": map[string]interface{}{
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name":  "web",
+					"state": map[string]interface{}{"waiting": map[string]interface{}{"reason": "CreateContainerConfigError"}},
+				},
+			},
+		},
+	}}
+}
+
+// The F3 reproduction at the CLI layer: object-set-matches would PASS, but
+// workloads-converged must BLOCK because the pod is wedged.
+func TestReceiptVerifyWorkloads_BLOCKOnCreateContainerConfigError(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: helm-expt-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+`)
+	withFakeWorkloadsLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.WorkloadConvergedObservedObject, error) {
+		return []agent.WorkloadConvergedObservedObject{{
+			Desired: desired[0],
+			Live:    notReadyDeployment(desired[0]),
+			Pods:    []*unstructured.Unstructured{configErrorPod("web-abc")},
+		}}, nil
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "--file", path, "--scope", "namespace/helm-expt-demo", "--predicate", "workloads-converged", "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt verify workloads-converged returned error: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal statement: %v\n%s", err, out)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateWorkloadsConverged) {
+		t.Fatalf("predicate = %s", stmt.Predicate.PredicateName)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.Workloads == nil {
+		t.Fatal("workloads evidence missing")
+	}
+	w := stmt.Predicate.Evidence.Workloads.Workloads[0]
+	if len(w.PodReasons) == 0 || w.PodReasons[0].Reason != "CreateContainerConfigError" {
+		t.Fatalf("expected CreateContainerConfigError pod reason, got %+v", w.PodReasons)
+	}
+}
+
+func TestReceiptVerifyWorkloads_FailOnExit2WhenMissing(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: helm-expt-demo
+spec:
+  replicas: 1
+`)
+	withFakeWorkloadsLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.WorkloadConvergedObservedObject, error) {
+		return []agent.WorkloadConvergedObservedObject{{Desired: desired[0], Live: nil}}, nil
+	})
+
+	rootCmd.SetArgs([]string{"receipt", "verify", "--file", path, "--scope", "namespace/helm-expt-demo", "--predicate", "workloads-converged", "--format", "json", "--fail-on", "any-non-pass"})
+	captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("missing workload with --fail-on any-non-pass must error")
+		}
+		var ec interface{ ExitCode() int }
+		if !errors.As(err, &ec) || ec.ExitCode() != 2 {
+			t.Fatalf("expected exit code 2 wrapper; got %v", err)
+		}
+	})
+}
+
+func TestReceiptVerifyWorkloads_RejectsBadGraceWindow(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: helm-expt-demo
+spec:
+  replicas: 1
+`)
+	rootCmd.SetArgs([]string{"receipt", "verify", "--file", path, "--scope", "namespace/helm-expt-demo", "--predicate", "workloads-converged", "--grace-window", "notaduration"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("invalid --grace-window must error")
+	}
+}

--- a/pkg/agent/kstatus_wrapper.go
+++ b/pkg/agent/kstatus_wrapper.go
@@ -109,6 +109,22 @@ func WorkloadStatus(obj runtime.Object, kind string) (status.Status, string) {
 	return res.Status, res.Message
 }
 
+// WorkloadConvergence returns the kstatus verdict and message for any
+// unstructured object. Unlike WorkloadStatus it does not re-seed the GVK
+// (the object already carries it) and accepts any kind kstatus classifies —
+// Deployment, StatefulSet, DaemonSet, Job, PersistentVolumeClaim, Pod.
+// Returns UnknownStatus when the object is nil or cannot be classified.
+func WorkloadConvergence(u *unstructured.Unstructured) (status.Status, string) {
+	if u == nil {
+		return status.UnknownStatus, ""
+	}
+	res, err := status.Compute(u)
+	if err != nil || res == nil {
+		return status.UnknownStatus, ""
+	}
+	return res.Status, res.Message
+}
+
 // computeStatus is the shared helper. Returns UnknownStatus on any error.
 func computeStatus(obj runtime.Object, apiVersion, kind string) status.Status {
 	u, err := toUnstructured(obj, apiVersion, kind)

--- a/pkg/agent/receipt.go
+++ b/pkg/agent/receipt.go
@@ -70,6 +70,12 @@ const (
 	//   k8s-live-object-set://namespace/redis
 	// or k8s-live-object-set://cluster.
 	SubjectSchemeK8sLiveObjectSet = "k8s-live-object-set://"
+
+	// SubjectSchemeK8sLiveWorkloads identifies the live workload set a
+	// workloads-converged receipt evaluated readiness over. Names look
+	// like k8s-live-workloads://namespace/redis or
+	// k8s-live-workloads://cluster.
+	SubjectSchemeK8sLiveWorkloads = "k8s-live-workloads://"
 )
 
 // Statement is the in-toto Statement v1 envelope wrapping a cub-scout
@@ -227,11 +233,12 @@ const (
 // pkg/agent layer (the structured compareResourceResult lives in
 // cmd/cub-scout) so it's an interface{}; the CLI populates it.
 type Evidence struct {
-	CompareThreeWay interface{}               `json:"compareThreeWay,omitempty"`
-	Attribution     *FieldMutationAttribution `json:"attribution,omitempty"`
-	SourceTruth     *SourceTruthEvidence      `json:"sourceTruth,omitempty"`
-	GitSource       *GitSourceAnchor          `json:"gitSource,omitempty"`
-	ObjectSet       *ObjectSetEvidence        `json:"objectSet,omitempty"`
+	CompareThreeWay interface{}                 `json:"compareThreeWay,omitempty"`
+	Attribution     *FieldMutationAttribution   `json:"attribution,omitempty"`
+	SourceTruth     *SourceTruthEvidence        `json:"sourceTruth,omitempty"`
+	GitSource       *GitSourceAnchor            `json:"gitSource,omitempty"`
+	ObjectSet       *ObjectSetEvidence          `json:"objectSet,omitempty"`
+	Workloads       *WorkloadsConvergedEvidence `json:"workloads,omitempty"`
 }
 
 // Omission is one structured gap the receipt does not claim. The
@@ -326,4 +333,14 @@ const (
 	// one or more desired objects could not be checked because the API
 	// mapping or live read was inconclusive.
 	OmissionObjectSetCoverage = "object-set-coverage"
+
+	// OmissionWorkloadConvergence is recorded by workloads-converged
+	// receipts to mark that readiness was observed at verifiedAt; the
+	// receipt does not prove the workloads stay converged afterward.
+	OmissionWorkloadConvergence = "workload-convergence-snapshot"
+
+	// OmissionWorkloadConvergenceCoverage is recorded by workloads-
+	// converged receipts when one or more desired workloads could not be
+	// classified because the live read or API mapping was inconclusive.
+	OmissionWorkloadConvergenceCoverage = "workload-convergence-coverage"
 )

--- a/pkg/agent/receipt_build.go
+++ b/pkg/agent/receipt_build.go
@@ -185,6 +185,8 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 		result = EvaluateNoManualEditsSince(predicateInput)
 	case PredicateObjectSetMatches:
 		return Statement{}, fmt.Errorf("build-receipt: predicate %q requires object-set evidence; use BuildObjectSetReceipt or `cub-scout receipt verify --file <manifests>`", predName)
+	case PredicateWorkloadsConverged:
+		return Statement{}, fmt.Errorf("build-receipt: predicate %q requires workload evidence; use BuildWorkloadsConvergedReceipt or `cub-scout receipt verify --file <manifests> --predicate workloads-converged`", predName)
 	case "":
 		// Auto-detect failed. The omission entry was already appended
 		// above; the predicate evaluation produces INCONCLUSIVE.

--- a/pkg/agent/receipt_predicates.go
+++ b/pkg/agent/receipt_predicates.go
@@ -35,6 +35,15 @@ const (
 	// that set still matches live. Kubernetes server defaults and
 	// controller-populated status are deliberately outside this claim.
 	PredicateObjectSetMatches PredicateName = "object-set-matches"
+
+	// PredicateWorkloadsConverged verifies that every desired workload in
+	// the rendered manifest set reached a ready/converged runtime state
+	// (Deployments/StatefulSets/DaemonSets rolled out, Jobs Succeeded,
+	// PVCs Bound, pods not wedged in CreateContainerConfigError /
+	// CrashLoopBackOff / ImagePullBackOff). Unlike object-set-matches,
+	// this predicate reads status. It is --file-routed and evaluated by
+	// BuildWorkloadsConvergedReceipt, not the BuildReceipt switch.
+	PredicateWorkloadsConverged PredicateName = "workloads-converged"
 )
 
 // AllPredicates returns the list of v1 predicate names cub-scout knows
@@ -46,6 +55,7 @@ func AllPredicates() []PredicateName {
 		PredicateSourceTruthPass,
 		PredicateNoManualEditsSince,
 		PredicateObjectSetMatches,
+		PredicateWorkloadsConverged,
 	}
 }
 

--- a/pkg/agent/receipt_workloads.go
+++ b/pkg/agent/receipt_workloads.go
@@ -1,0 +1,401 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+// Workload convergence per-object status values.
+const (
+	WorkloadConvergedConverged    = "converged"
+	WorkloadConvergedProgressing  = "progressing"
+	WorkloadConvergedFailed       = "failed"
+	WorkloadConvergedMissing      = "missing"
+	WorkloadConvergedInconclusive = "inconclusive"
+)
+
+// WorkloadsConvergedEvidence is attached under predicate.evidence.workloads
+// for workloads-converged receipts. Where object-set-matches proves presence
+// + authored-field match and deliberately strips status, this predicate
+// reads status to prove the desired workloads actually became usable —
+// closing the "receipt PASS while the pod is in CreateContainerConfigError"
+// false green (helm-expt finding F3, confighub/cub-scout#476).
+type WorkloadsConvergedEvidence struct {
+	DesiredSource ObjectSetSource                  `json:"desiredSource"`
+	Scope         ObjectSetScope                   `json:"scope"`
+	GraceWindow   string                           `json:"graceWindow,omitempty"`
+	ObservedAt    string                           `json:"observedAt"`
+	DesiredDigest string                           `json:"desiredDigest"`
+	LiveDigest    string                           `json:"liveDigest"`
+	Summary       WorkloadsConvergedSummary        `json:"summary"`
+	Workloads     []WorkloadConvergedObjectSummary `json:"workloads"`
+}
+
+type WorkloadsConvergedSummary struct {
+	Desired      int `json:"desired"`
+	Converged    int `json:"converged"`
+	Progressing  int `json:"progressing"`
+	Failed       int `json:"failed"`
+	Missing      int `json:"missing"`
+	Inconclusive int `json:"inconclusive"`
+}
+
+type WorkloadConvergedObjectSummary struct {
+	ID             ObjectSetObjectID   `json:"id"`
+	Status         string              `json:"status"`
+	KstatusStatus  string              `json:"kstatusStatus,omitempty"`
+	KstatusMessage string              `json:"kstatusMessage,omitempty"`
+	AgeSeconds     int64               `json:"ageSeconds,omitempty"`
+	PodReasons     []WorkloadPodReason `json:"podReasons,omitempty"`
+	Error          string              `json:"error,omitempty"`
+}
+
+// WorkloadPodReason is a pod-level failure reason surfaced for a not-ready
+// workload, classified by the shared podWaitingFailure helper.
+type WorkloadPodReason struct {
+	Pod       string `json:"pod"`
+	Container string `json:"container,omitempty"`
+	Reason    string `json:"reason"`
+	Message   string `json:"message,omitempty"`
+}
+
+// WorkloadConvergedObservedObject is one desired workload plus the live
+// object observed for that identity and (optionally) the pods that belong to
+// it. Error is interpreted as missing unless Inconclusive is true, in which
+// case the object could not be classified.
+type WorkloadConvergedObservedObject struct {
+	Desired      *unstructured.Unstructured
+	Live         *unstructured.Unstructured
+	Pods         []*unstructured.Unstructured
+	Error        string
+	Inconclusive bool
+}
+
+// BuildWorkloadsConvergedEvidence classifies each desired workload's live
+// readiness using kstatus, enriches not-ready workloads with pod-level
+// failure reasons, and applies the grace window to distinguish "progressing"
+// (WATCH) from "failed" (BLOCK). It is pure: callers do the file and cluster
+// reads before invoking.
+func BuildWorkloadsConvergedEvidence(source ObjectSetSource, scope ObjectSetScope, graceWindow time.Duration, observed []WorkloadConvergedObservedObject, observedAt time.Time) (WorkloadsConvergedEvidence, error) {
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+
+	summaries := make([]WorkloadConvergedObjectSummary, 0, len(observed))
+	desiredSet := make([]interface{}, 0, len(observed))
+	liveSet := make([]interface{}, 0, len(observed))
+	seen := map[string]struct{}{}
+
+	for _, obs := range observed {
+		if obs.Desired == nil {
+			continue
+		}
+		id := NewObjectSetObjectID(obs.Desired)
+		if _, dup := seen[id.Key()]; dup {
+			return WorkloadsConvergedEvidence{}, fmt.Errorf("duplicate desired object identity %s", id.String())
+		}
+		seen[id.Key()] = struct{}{}
+
+		desiredSet = append(desiredSet, objectSetDigestEntry(id, ComparableObject(obs.Desired)))
+
+		summary := WorkloadConvergedObjectSummary{ID: id}
+		switch {
+		case obs.Inconclusive:
+			summary.Status = WorkloadConvergedInconclusive
+			summary.Error = obs.Error
+		case obs.Live == nil:
+			summary.Status = WorkloadConvergedMissing
+			if obs.Error != "" {
+				summary.Error = obs.Error
+			} else {
+				summary.Error = "live object not found"
+			}
+		default:
+			st, msg := WorkloadConvergence(obs.Live)
+			summary.KstatusStatus = st.String()
+			summary.KstatusMessage = msg
+			var age time.Duration
+			if a, ok := unstructuredAge(obs.Live, observedAt); ok {
+				age = a
+				summary.AgeSeconds = int64(a.Seconds())
+			}
+			for _, pod := range obs.Pods {
+				if _, container, _, reason, message, ok := podWaitingFailure(pod); ok {
+					summary.PodReasons = append(summary.PodReasons, WorkloadPodReason{
+						Pod:       pod.GetName(),
+						Container: container,
+						Reason:    reason,
+						Message:   clampReason(message, 160),
+					})
+				}
+			}
+			summary.Status = classifyConvergence(st, summary.PodReasons, age, graceWindow)
+		}
+
+		summaries = append(summaries, summary)
+		liveSet = append(liveSet, objectSetDigestEntry(id, map[string]interface{}{
+			"status":  summary.Status,
+			"kstatus": summary.KstatusStatus,
+		}))
+	}
+
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].ID.Key() < summaries[j].ID.Key() })
+	sort.Slice(desiredSet, func(i, j int) bool { return digestEntryKey(desiredSet[i]) < digestEntryKey(desiredSet[j]) })
+	sort.Slice(liveSet, func(i, j int) bool { return digestEntryKey(liveSet[i]) < digestEntryKey(liveSet[j]) })
+
+	desiredDigest, err := digestJSON(desiredSet)
+	if err != nil {
+		return WorkloadsConvergedEvidence{}, fmt.Errorf("digest desired workload set: %w", err)
+	}
+	liveDigest, err := digestJSON(liveSet)
+	if err != nil {
+		return WorkloadsConvergedEvidence{}, fmt.Errorf("digest live workload set: %w", err)
+	}
+
+	summary := WorkloadsConvergedSummary{Desired: len(summaries)}
+	for _, w := range summaries {
+		switch w.Status {
+		case WorkloadConvergedConverged:
+			summary.Converged++
+		case WorkloadConvergedProgressing:
+			summary.Progressing++
+		case WorkloadConvergedFailed:
+			summary.Failed++
+		case WorkloadConvergedMissing:
+			summary.Missing++
+		case WorkloadConvergedInconclusive:
+			summary.Inconclusive++
+		}
+	}
+	source.ObjectCount = summary.Desired
+
+	graceStr := ""
+	if graceWindow > 0 {
+		graceStr = graceWindow.String()
+	}
+
+	return WorkloadsConvergedEvidence{
+		DesiredSource: source,
+		Scope:         scope,
+		GraceWindow:   graceStr,
+		ObservedAt:    observedAt.UTC().Format(time.RFC3339),
+		DesiredDigest: desiredDigest,
+		LiveDigest:    liveDigest,
+		Summary:       summary,
+		Workloads:     summaries,
+	}, nil
+}
+
+// classifyConvergence maps a kstatus result (plus pod reasons, object age,
+// and the grace window) to a per-workload convergence status.
+//
+//   - A hard pod failure reason (CrashLoopBackOff / ImagePullBackOff /
+//     CreateContainerConfigError, etc.) will not resolve by waiting, so it
+//     is failed regardless of grace.
+//   - kstatus Current -> converged; Failed/Terminating -> failed;
+//     NotFound -> missing; Unknown -> inconclusive.
+//   - kstatus InProgress is progressing while within the grace window, and
+//     failed once it ages past the window (a stuck rollout).
+func classifyConvergence(st status.Status, podReasons []WorkloadPodReason, age, grace time.Duration) string {
+	if len(podReasons) > 0 {
+		return WorkloadConvergedFailed
+	}
+	switch st {
+	case status.CurrentStatus:
+		return WorkloadConvergedConverged
+	case status.FailedStatus, status.TerminatingStatus:
+		return WorkloadConvergedFailed
+	case status.NotFoundStatus:
+		return WorkloadConvergedMissing
+	case status.InProgressStatus:
+		if grace > 0 && age > grace {
+			return WorkloadConvergedFailed
+		}
+		return WorkloadConvergedProgressing
+	default:
+		return WorkloadConvergedInconclusive
+	}
+}
+
+// BuildWorkloadsConvergedReceiptInput is the input to
+// BuildWorkloadsConvergedReceipt.
+type BuildWorkloadsConvergedReceiptInput struct {
+	Evidence          WorkloadsConvergedEvidence
+	Verifier          Verifier
+	VerifiedAt        time.Time
+	InputAttestations []VerifiedAttestationRef
+}
+
+// BuildWorkloadsConvergedReceipt builds a single receipt asserting that the
+// desired workloads reached a ready/converged state in the live cluster. It
+// is pure: callers do file and cluster reads before invoking.
+//
+// Verdict (severity order BLOCK > INCONCLUSIVE > WATCH > PASS):
+//   - BLOCK        any workload failed or missing
+//   - INCONCLUSIVE else any workload could not be classified
+//   - WATCH        else any workload still progressing within grace
+//   - PASS         every desired workload converged
+func BuildWorkloadsConvergedReceipt(in BuildWorkloadsConvergedReceiptInput) (Statement, error) {
+	if in.Evidence.Summary.Desired == 0 {
+		return Statement{}, fmt.Errorf("workloads-converged receipt: no desired workloads")
+	}
+	if in.Evidence.DesiredDigest == "" {
+		return Statement{}, fmt.Errorf("workloads-converged receipt: missing desired digest")
+	}
+	if in.Evidence.LiveDigest == "" {
+		return Statement{}, fmt.Errorf("workloads-converged receipt: missing live digest")
+	}
+
+	verifiedAt := in.VerifiedAt
+	if verifiedAt.IsZero() {
+		verifiedAt = time.Now().UTC()
+	}
+
+	s := in.Evidence.Summary
+	verdict := VerdictPASS
+	switch {
+	case s.Failed > 0 || s.Missing > 0:
+		verdict = VerdictBLOCK
+	case s.Inconclusive > 0:
+		verdict = VerdictINCONCLUSIVE
+	case s.Progressing > 0:
+		verdict = VerdictWATCH
+	}
+
+	omissions := []Omission{
+		{
+			Missing:  OmissionWorkloadConvergence,
+			Reason:   "workloads-converged reflects readiness observed at verifiedAt; it does not prove the workloads stay converged afterward",
+			Severity: "info",
+		},
+	}
+	if s.Inconclusive > 0 {
+		omissions = append(omissions, Omission{
+			Missing:  OmissionWorkloadConvergenceCoverage,
+			Reason:   fmt.Sprintf("%d desired workload(s) could not be classified because live lookup or API mapping was inconclusive", s.Inconclusive),
+			Severity: "warning",
+		})
+	}
+
+	nextSteps := []ReceiptNextStep{}
+	switch verdict {
+	case VerdictPASS:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "every desired workload reached a ready/converged state",
+			NextCommand: "cub-scout doctor",
+			NextSurface: "cub-scout",
+		})
+	case VerdictWATCH:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "waiting",
+			Reason:      "one or more workloads are still rolling out within the grace window; re-verify after they settle",
+			NextCommand: "cub-scout map status",
+			NextSurface: "cub-scout",
+		})
+	case VerdictBLOCK:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "one or more desired workloads failed to converge (not ready past grace, missing, or wedged pods); inspect before accepting the install",
+			NextCommand: "cub-scout doctor",
+			NextSurface: "cub-scout",
+		})
+	case VerdictINCONCLUSIVE:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "one or more workloads could not be classified; verify API availability and object identity",
+			NextCommand: "cub-scout map list",
+			NextSurface: "cub-scout",
+		})
+	}
+	filteredSteps, stepOmissions := FilterNextSteps(nextSteps)
+	omissions = append(omissions, stepOmissions...)
+
+	inputAttestations := make([]AttestationRef, 0, len(in.InputAttestations))
+	for i, v := range in.InputAttestations {
+		if v.IsZero() {
+			return Statement{}, fmt.Errorf("workloads-converged receipt: inputAttestations[%d] is a zero-value VerifiedAttestationRef; construct via BuildAttestationRef or BuildAttestationRefsFromPaths", i)
+		}
+		inputAttestations = append(inputAttestations, v.Ref())
+	}
+
+	claim := "desired workloads converged to a ready state in the live cluster"
+	if in.Evidence.DesiredSource.Ref != "" {
+		claim = fmt.Sprintf("desired workloads from %s converged to a ready state in the live cluster", in.Evidence.DesiredSource.Ref)
+	}
+	scope := Scope{
+		Kind:      "WorkloadSet",
+		Name:      "rendered-install",
+		Namespace: in.Evidence.Scope.Namespace,
+	}
+
+	evidence := in.Evidence
+	stmt := Statement{
+		Type: StatementType,
+		Subject: []Subject{
+			BuildRenderedObjectSetSubject(in.Evidence.DesiredDigest),
+			BuildLiveWorkloadsSubject(in.Evidence.Scope, in.Evidence.LiveDigest),
+		},
+		PredicateType: PredicateTypeReceiptV1,
+		Predicate: Predicate{
+			Version:           PredicateVersion,
+			Claim:             claim,
+			Scope:             scope,
+			Verifier:          in.Verifier,
+			VerifiedAt:        verifiedAt.UTC().Format(time.RFC3339),
+			PredicateName:     string(PredicateWorkloadsConverged),
+			Verdict:           verdict,
+			Evidence:          Evidence{Workloads: &evidence},
+			Omissions:         omissions,
+			InputAttestations: inputAttestations,
+			NextSteps:         filteredSteps,
+		},
+	}
+
+	if err := StampFingerprint(&stmt); err != nil {
+		return Statement{}, fmt.Errorf("workloads-converged receipt: stamp fingerprint: %w", err)
+	}
+	return stmt, nil
+}
+
+// BuildLiveWorkloadsSubject builds the live-workloads subject for a
+// workloads-converged receipt.
+func BuildLiveWorkloadsSubject(scope ObjectSetScope, digest string) Subject {
+	name := SubjectSchemeK8sLiveWorkloads + "cluster"
+	if scope.Namespace != "" {
+		name = SubjectSchemeK8sLiveWorkloads + "namespace/" + scope.Namespace
+	}
+	return Subject{
+		Name:   name,
+		Digest: map[string]string{"sha256": digest},
+	}
+}
+
+func unstructuredAge(u *unstructured.Unstructured, now time.Time) (time.Duration, bool) {
+	if u == nil {
+		return 0, false
+	}
+	created := u.GetCreationTimestamp().Time
+	if created.IsZero() {
+		return 0, false
+	}
+	age := now.Sub(created)
+	if age < 0 {
+		return 0, true
+	}
+	return age, true
+}
+
+func clampReason(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/pkg/agent/receipt_workloads_test.go
+++ b/pkg/agent/receipt_workloads_test.go
@@ -1,0 +1,186 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var workloadsObservedAt = time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+
+func desiredDeployment(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "prod",
+		},
+		"spec": map[string]interface{}{"replicas": int64(1)},
+	}}
+}
+
+// liveDeployment builds a Deployment whose status drives kstatus: ready>0
+// yields Current (converged), ready==0 yields InProgress (availableReplicas
+// below updatedReplicas).
+func liveDeployment(name string, ready int64) *unstructured.Unstructured {
+	avail := "False"
+	if ready > 0 {
+		avail = "True"
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":       name,
+			"namespace":  "prod",
+			"generation": int64(1),
+		},
+		"spec": map[string]interface{}{"replicas": int64(1)},
+		"status": map[string]interface{}{
+			"observedGeneration": int64(1),
+			"replicas":           int64(1),
+			"updatedReplicas":    int64(1),
+			"readyReplicas":      ready,
+			"availableReplicas":  ready,
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Available", "status": avail},
+				map[string]interface{}{"type": "Progressing", "status": "True", "reason": "NewReplicaSetAvailable"},
+			},
+		},
+	}}
+}
+
+func waitingPod(name, reason string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": name, "namespace": "prod"},
+		"status": map[string]interface{}{
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name": "web",
+					"state": map[string]interface{}{
+						"waiting": map[string]interface{}{"reason": reason, "message": `secret "app-db-secret" not found`},
+					},
+				},
+			},
+		},
+	}}
+}
+
+func buildWorkloadsReceipt(t *testing.T, grace time.Duration, observed []WorkloadConvergedObservedObject) Statement {
+	t.Helper()
+	evidence, err := BuildWorkloadsConvergedEvidence(
+		ObjectSetSource{Type: "file", Ref: "rendered.yaml"},
+		ObjectSetScope{Kind: "namespace", Namespace: "prod"},
+		grace, observed, workloadsObservedAt,
+	)
+	if err != nil {
+		t.Fatalf("BuildWorkloadsConvergedEvidence: %v", err)
+	}
+	stmt, err := BuildWorkloadsConvergedReceipt(BuildWorkloadsConvergedReceiptInput{
+		Evidence:   evidence,
+		Verifier:   Verifier{Tool: "cub-scout", Version: "test"},
+		VerifiedAt: workloadsObservedAt,
+	})
+	if err != nil {
+		t.Fatalf("BuildWorkloadsConvergedReceipt: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(PredicateWorkloadsConverged) {
+		t.Fatalf("predicate = %s", stmt.Predicate.PredicateName)
+	}
+	if err := VerifyStatementFingerprint(stmt); err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	return stmt
+}
+
+func TestWorkloadsConverged_PASSWhenReady(t *testing.T) {
+	stmt := buildWorkloadsReceipt(t, 0, []WorkloadConvergedObservedObject{
+		{Desired: desiredDeployment("web"), Live: liveDeployment("web", 1)},
+	})
+	if stmt.Predicate.Verdict != VerdictPASS {
+		t.Fatalf("verdict = %s, want PASS", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.Workloads.Summary.Converged != 1 {
+		t.Fatalf("converged = %d, want 1", stmt.Predicate.Evidence.Workloads.Summary.Converged)
+	}
+}
+
+func TestWorkloadsConverged_WATCHWhileProgressingInGrace(t *testing.T) {
+	stmt := buildWorkloadsReceipt(t, 10*time.Minute, []WorkloadConvergedObservedObject{
+		{Desired: desiredDeployment("web"), Live: liveDeployment("web", 0)},
+	})
+	if stmt.Predicate.Verdict != VerdictWATCH {
+		t.Fatalf("verdict = %s, want WATCH (kstatus=%s)", stmt.Predicate.Verdict, stmt.Predicate.Evidence.Workloads.Workloads[0].KstatusStatus)
+	}
+}
+
+func TestWorkloadsConverged_BLOCKWhenStuckPastGrace(t *testing.T) {
+	live := liveDeployment("web", 0)
+	_ = unstructured.SetNestedField(live.Object, "2020-01-01T00:00:00Z", "metadata", "creationTimestamp")
+	stmt := buildWorkloadsReceipt(t, 1*time.Second, []WorkloadConvergedObservedObject{
+		{Desired: desiredDeployment("web"), Live: live},
+	})
+	if stmt.Predicate.Verdict != VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+}
+
+// The helm-expt F3 reproduction: the Deployment is present but its pod is
+// wedged in CreateContainerConfigError because a required Secret is absent.
+// object-set-matches would PASS; workloads-converged must BLOCK.
+func TestWorkloadsConverged_BLOCKOnCreateContainerConfigError(t *testing.T) {
+	stmt := buildWorkloadsReceipt(t, 10*time.Minute, []WorkloadConvergedObservedObject{
+		{
+			Desired: desiredDeployment("web"),
+			Live:    liveDeployment("web", 0),
+			Pods:    []*unstructured.Unstructured{waitingPod("web-abc", "CreateContainerConfigError")},
+		},
+	})
+	if stmt.Predicate.Verdict != VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+	w := stmt.Predicate.Evidence.Workloads.Workloads[0]
+	if w.Status != WorkloadConvergedFailed {
+		t.Fatalf("workload status = %s, want failed", w.Status)
+	}
+	if len(w.PodReasons) == 0 || w.PodReasons[0].Reason != "CreateContainerConfigError" {
+		t.Fatalf("expected CreateContainerConfigError pod reason, got %+v", w.PodReasons)
+	}
+}
+
+func TestWorkloadsConverged_BLOCKWhenMissing(t *testing.T) {
+	stmt := buildWorkloadsReceipt(t, 0, []WorkloadConvergedObservedObject{
+		{Desired: desiredDeployment("web"), Live: nil},
+	})
+	if stmt.Predicate.Verdict != VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.Workloads.Summary.Missing != 1 {
+		t.Fatalf("missing = %d, want 1", stmt.Predicate.Evidence.Workloads.Summary.Missing)
+	}
+}
+
+func TestWorkloadsConverged_INCONCLUSIVEOnLookupGap(t *testing.T) {
+	stmt := buildWorkloadsReceipt(t, 0, []WorkloadConvergedObservedObject{
+		{Desired: desiredDeployment("web"), Error: "no matches for kind FutureThing", Inconclusive: true},
+	})
+	if stmt.Predicate.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict = %s, want INCONCLUSIVE", stmt.Predicate.Verdict)
+	}
+	found := false
+	for _, o := range stmt.Predicate.Omissions {
+		if o.Missing == OmissionWorkloadConvergenceCoverage {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s omission", OmissionWorkloadConvergenceCoverage)
+	}
+}


### PR DESCRIPTION
## What

Implements the `workloads-converged` receipt predicate (#476) — the status-aware readiness companion to `object-set-matches`. It closes the headline false green: a receipt can say PASS while the workload is wedged in `CreateContainerConfigError` (helm-expt finding F3).

## How

- New predicate `workloads-converged`, registered + build-guarded, with a `Workloads` evidence shape, two omissions, and a `k8s-live-workloads://` subject. Cloned from `object-set-matches` so it reuses the same canonical-JSON / fingerprint / next-steps / `--fail-on` plumbing.
- **Readiness reuses existing logic, not re-derived:** `kstatus` (`status.Compute`) classifies Deployment/StatefulSet/DaemonSet rollout, Job `Complete`, PVC `Bound`, Pod state; the shared `podWaitingFailure` classifier surfaces wedged-pod reasons (`CreateContainerConfigError`, `CrashLoopBackOff`, `ImagePullBackOff`, …).
- **Verdict** (severity BLOCK > INCONCLUSIVE > WATCH > PASS): PASS = all Current; WATCH = InProgress within `--grace-window`; BLOCK = failed / missing / stuck past grace / hard pod reason; INCONCLUSIVE = unclassifiable.
- **CLI:** `receipt verify --file <manifests> --predicate workloads-converged [--grace-window 5m] [--fail-on any-non-pass]`. The cmd-side loader fetches each desired object live plus the pods that belong to each workload (matched by `spec.selector.matchLabels`).

## Verified end-to-end (kind, `examples/helm-expt` F3 fixture)

Same install, same file, same namespace:

| Predicate | Exit | Verdict | Detail |
|---|---|---|---|
| `object-set-matches` | 0 | **PASS** | desired:3, matched:3 |
| `workloads-converged` | 2 | **BLOCK** | converged:2, failed:1 → `Deployment/web` InProgress, pod reason `CreateContainerConfigError` |

## Tests

- `pkg/agent`: 6 table tests (PASS / WATCH / BLOCK-past-grace / BLOCK-pod-reason / missing / inconclusive), each fingerprint-verified.
- `cmd/cub-scout`: 3 CLI integration tests (F3 BLOCK, `--fail-on` exit 2, bad `--grace-window` rejection) via the fake-loader seam.
- Full `pkg/agent` + `cmd/cub-scout` suites green; no regressions.

## Scope

Code-only. Updating `examples/helm-expt/verify.sh` to run this predicate alongside `object-set-matches` (so its gap table flips from "readiness ABSENT" → real BLOCK) is a small follow-up.

Closes #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
