### PR TITLE
feat(receipts #477): prerequisites-met predicate (target-fact pre-flight)

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -34,6 +34,7 @@ var (
 	receiptFailOn            string
 	receiptInputAttestations []string
 	receiptGraceWindow       string
+	receiptPrerequisitesFile string
 )
 
 // runReceiptVerifyDispatch is the shared entry point for the receipt
@@ -47,6 +48,10 @@ func runReceiptVerifyDispatch(cmd *cobra.Command, args []string) error {
 	positional := ""
 	if len(args) > 0 {
 		positional = strings.TrimSpace(args[0])
+	}
+
+	if strings.TrimSpace(receiptPrerequisitesFile) != "" || agent.PredicateName(strings.TrimSpace(receiptPredicate)) == agent.PredicatePrerequisitesMet {
+		return runReceiptVerifyPrerequisites(cmd, args)
 	}
 
 	if strings.TrimSpace(receiptObjectSetFile) != "" {
@@ -117,6 +122,7 @@ v1 predicates:
   no-manual-edits-since   no kubectl-* writer touched managedFields after --since
   object-set-matches      rendered manifest objects are present live and authored fields match
   workloads-converged     desired workloads reached a ready/converged runtime state (reads status)
+  prerequisites-met       declared cluster facts (CRDs/Secrets/StorageClasses/namespaces) are present live
 
 Subject is usually a positional argument in the form <kind>/<name>.
 For install/object-set receipts, pass --file <manifest.yaml|dir> and scope
@@ -137,6 +143,7 @@ Examples:
   cub-scout receipt verify deploy/api -n prod --predicate applied-matches-spec --format json --out api.receipt.json
   cub-scout receipt verify --file out/manifests --scope namespace/redis --format json --out install.receipt.json
   cub-scout receipt verify --file out/manifests --scope namespace/redis --predicate workloads-converged --fail-on any-non-pass
+  cub-scout receipt verify --prerequisites prereqs.yaml --scope namespace/redis --fail-on any-non-pass
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runReceiptVerifyDispatch,
@@ -147,9 +154,10 @@ func init() {
 	receiptCmd.AddCommand(receiptVerifyCmd)
 
 	receiptVerifyCmd.Flags().StringVarP(&receiptNamespace, "namespace", "n", "", "Namespace of the resource (required for namespaced kinds)")
-	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 supports applied-matches-spec, source-truth-pass, no-manual-edits-since, object-set-matches, workloads-converged.")
+	receiptVerifyCmd.Flags().StringVar(&receiptPredicate, "predicate", "", "Predicate to evaluate (default: auto-detect). v1 supports applied-matches-spec, source-truth-pass, no-manual-edits-since, object-set-matches, workloads-converged, prerequisites-met.")
 	receiptVerifyCmd.Flags().StringVar(&receiptObjectSetFile, "file", "", "YAML file or directory containing rendered desired objects for object-set-matches / workloads-converged install receipts.")
 	receiptVerifyCmd.Flags().StringVar(&receiptGraceWindow, "grace-window", "", "For --predicate workloads-converged: how long a workload may stay InProgress before it counts as failed (BLOCK) rather than progressing (WATCH), e.g. 5m. Empty means no deadline (InProgress is WATCH).")
+	receiptVerifyCmd.Flags().StringVar(&receiptPrerequisitesFile, "prerequisites", "", "YAML/JSON file declaring required cluster facts (requiredCRDs, requiredSecrets, requiredNamespaces, requiredStorageClasses, requiredIngressClasses) for a prerequisites-met receipt.")
 	receiptVerifyCmd.Flags().StringVar(&receiptAtCommit, "at-commit", "", "Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence.")
 	receiptVerifyCmd.Flags().StringVar(&receiptStrategy, "strategy", "", "Source-truth strategy for source-truth-pass (e.g. git-argo). cub-scout does not infer the strategy.")
 	receiptVerifyCmd.Flags().StringVar(&receiptSince, "since", "", "RFC 3339 cutoff for no-manual-edits-since (e.g. 2026-05-22T00:00:00Z).")

--- a/cmd/cub-scout/receipt_prerequisites.go
+++ b/cmd/cub-scout/receipt_prerequisites.go
@@ -1,0 +1,289 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
+)
+
+// prerequisiteSpec is the declared set of required cluster facts (the
+// "target facts" helm-expt models). cub-scout consumes this list; it does
+// not infer prerequisites from a chart.
+type prerequisiteSpec struct {
+	RequiredCRDs           []string         `json:"requiredCRDs"`
+	RequiredSecrets        []requiredSecret `json:"requiredSecrets"`
+	RequiredNamespaces     []string         `json:"requiredNamespaces"`
+	RequiredStorageClasses []string         `json:"requiredStorageClasses"`
+	RequiredIngressClasses []string         `json:"requiredIngressClasses"`
+}
+
+type requiredSecret struct {
+	Name      string   `json:"name"`
+	Namespace string   `json:"namespace"`
+	Keys      []string `json:"keys"`
+}
+
+func (s prerequisiteSpec) count() int {
+	return len(s.RequiredCRDs) + len(s.RequiredSecrets) + len(s.RequiredNamespaces) +
+		len(s.RequiredStorageClasses) + len(s.RequiredIngressClasses)
+}
+
+var (
+	prereqCRDGVR          = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
+	prereqSecretGVR       = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	prereqNamespaceGVR    = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	prereqStorageClassGVR = schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"}
+	prereqIngressClassGVR = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"}
+)
+
+// loadPrerequisitesLiveFn is the function-variable seam for tests.
+var loadPrerequisitesLiveFn = loadPrerequisitesLive
+
+func runReceiptVerifyPrerequisites(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("--prerequisites receipt mode does not accept a positional subject; scope with --scope namespace/<ns> or -n <ns>")
+	}
+	if strings.TrimSpace(receiptObjectSetFile) != "" {
+		return fmt.Errorf("--prerequisites cannot be combined with --file (object-set / workloads-converged); run prerequisites-met as its own receipt")
+	}
+	if strings.TrimSpace(receiptPrerequisitesFile) == "" {
+		return fmt.Errorf("--predicate prerequisites-met requires --prerequisites <file>")
+	}
+
+	format := strings.ToLower(strings.TrimSpace(receiptFormat))
+	if format != "ascii" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json)", receiptFormat)
+	}
+
+	var failOnSet map[agent.ReceiptVerdict]bool
+	failOnRaw := strings.TrimSpace(receiptFailOn)
+	if failOnRaw != "" {
+		parsed, parseErr := parseReceiptFailOn(failOnRaw)
+		if parseErr != nil {
+			return parseErr
+		}
+		failOnSet = parsed
+	}
+
+	scope, defaultNamespace, err := resolveObjectSetScope(receiptScope, receiptNamespace)
+	if err != nil {
+		return err
+	}
+
+	spec, source, err := loadPrerequisitesSpec(receiptPrerequisitesFile)
+	if err != nil {
+		return err
+	}
+	if spec.count() == 0 {
+		return fmt.Errorf("--prerequisites %q declared no required facts (requiredCRDs / requiredSecrets / requiredNamespaces / requiredStorageClasses / requiredIngressClasses)", receiptPrerequisitesFile)
+	}
+
+	facts, err := loadPrerequisitesLiveFn(cmd.Context(), spec, defaultNamespace)
+	if err != nil {
+		return err
+	}
+	evidence, err := agent.BuildPrerequisitesEvidence(source, scope, facts)
+	if err != nil {
+		return err
+	}
+
+	var inputAttestations []agent.VerifiedAttestationRef
+	if len(receiptInputAttestations) > 0 {
+		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
+		if refErr != nil {
+			return fmt.Errorf("build input-attestations: %w", refErr)
+		}
+		inputAttestations = refs
+	}
+
+	stmt, err := agent.BuildPrerequisitesReceipt(agent.BuildPrerequisitesReceiptInput{
+		Evidence:          evidence,
+		Verifier:          agent.Verifier{Tool: "cub-scout", Version: BuildTag},
+		VerifiedAt:        time.Now().UTC(),
+		InputAttestations: inputAttestations,
+	})
+	if err != nil {
+		return fmt.Errorf("build prerequisites receipt: %w", err)
+	}
+
+	var out []byte
+	switch format {
+	case "json":
+		buf, mErr := json.MarshalIndent(stmt, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal receipt: %w", mErr)
+		}
+		out = buf
+	case "ascii":
+		out = []byte(renderReceiptASCII(stmt))
+	}
+	fmt.Println(string(out))
+
+	if outPath := strings.TrimSpace(receiptOut); outPath != "" {
+		jsonBytes, mErr := json.MarshalIndent(stmt, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal receipt for --out: %w", mErr)
+		}
+		if err := writeReceiptOutFile(outPath, jsonBytes); err != nil {
+			return err
+		}
+	}
+
+	if receiptSave {
+		if err := saveOneReceipt(cmd, stmt); err != nil {
+			return fmt.Errorf("save receipt: %w", err)
+		}
+	}
+
+	if failOnSet != nil && failOnSet[stmt.Predicate.Verdict] {
+		return newExitCodeError(
+			fmt.Errorf("receipt verdict %q matches --fail-on %q", stmt.Predicate.Verdict, failOnRaw),
+			2,
+		)
+	}
+	return nil
+}
+
+func loadPrerequisitesSpec(path string) (prerequisiteSpec, agent.ObjectSetSource, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return prerequisiteSpec{}, agent.ObjectSetSource{}, fmt.Errorf("read --prerequisites %s: %w", path, err)
+	}
+	var spec prerequisiteSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return prerequisiteSpec{}, agent.ObjectSetSource{}, fmt.Errorf("parse --prerequisites %s: %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	source := agent.ObjectSetSource{Type: "file", Ref: path, Digest: hex.EncodeToString(sum[:])}
+	return spec, source, nil
+}
+
+// loadPrerequisitesLive checks each declared fact against the live cluster.
+func loadPrerequisitesLive(ctx context.Context, spec prerequisiteSpec, defaultNamespace string) ([]agent.PrerequisiteFactResult, error) {
+	cfg, err := buildConfig()
+	if err != nil {
+		return nil, fmt.Errorf("build kubernetes config: %w", err)
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build dynamic client: %w", err)
+	}
+
+	clusterPresence := func(kind, name string, gvr schema.GroupVersionResource, detail string) agent.PrerequisiteFactResult {
+		f := agent.PrerequisiteFactResult{Kind: kind, Name: name}
+		obj, gErr := dyn.Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case gErr == nil:
+			f.Status = agent.PrerequisitePresent
+			if detail == "crd" {
+				if crdEstablished(obj) {
+					f.Detail = "established"
+				} else {
+					f.Status = agent.PrerequisiteMissing
+					f.Detail = "exists but not Established"
+				}
+			}
+		case apierrors.IsNotFound(gErr):
+			f.Status = agent.PrerequisiteMissing
+			f.Error = gErr.Error()
+		default:
+			f.Status = agent.PrerequisiteInconclusive
+			f.Error = gErr.Error()
+		}
+		return f
+	}
+
+	var facts []agent.PrerequisiteFactResult
+	for _, name := range spec.RequiredCRDs {
+		facts = append(facts, clusterPresence(agent.PrerequisiteKindCRD, name, prereqCRDGVR, "crd"))
+	}
+	for _, rs := range spec.RequiredSecrets {
+		ns := strings.TrimSpace(rs.Namespace)
+		if ns == "" {
+			ns = strings.TrimSpace(defaultNamespace)
+		}
+		if ns == "" {
+			ns = "default"
+		}
+		f := agent.PrerequisiteFactResult{Kind: agent.PrerequisiteKindSecret, Name: rs.Name, Namespace: ns}
+		obj, gErr := dyn.Resource(prereqSecretGVR).Namespace(ns).Get(ctx, rs.Name, metav1.GetOptions{})
+		switch {
+		case gErr == nil:
+			missingKeys := secretMissingKeys(obj, rs.Keys)
+			if len(missingKeys) == 0 {
+				f.Status = agent.PrerequisitePresent
+				if len(rs.Keys) > 0 {
+					f.Detail = "keys: " + strings.Join(rs.Keys, ",")
+				}
+			} else {
+				f.Status = agent.PrerequisiteMissing
+				f.Detail = "missing keys: " + strings.Join(missingKeys, ",")
+			}
+		case apierrors.IsNotFound(gErr):
+			f.Status = agent.PrerequisiteMissing
+			f.Error = gErr.Error()
+		default:
+			f.Status = agent.PrerequisiteInconclusive
+			f.Error = gErr.Error()
+		}
+		facts = append(facts, f)
+	}
+	for _, name := range spec.RequiredNamespaces {
+		facts = append(facts, clusterPresence(agent.PrerequisiteKindNamespace, name, prereqNamespaceGVR, ""))
+	}
+	for _, name := range spec.RequiredStorageClasses {
+		facts = append(facts, clusterPresence(agent.PrerequisiteKindStorageClass, name, prereqStorageClassGVR, ""))
+	}
+	for _, name := range spec.RequiredIngressClasses {
+		facts = append(facts, clusterPresence(agent.PrerequisiteKindIngressClass, name, prereqIngressClassGVR, ""))
+	}
+	return facts, nil
+}
+
+func crdEstablished(crd *unstructured.Unstructured) bool {
+	conditions, found, _ := unstructured.NestedSlice(crd.Object, "status", "conditions")
+	if !found {
+		return false
+	}
+	for _, raw := range conditions {
+		cond, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if fmt.Sprintf("%v", cond["type"]) == "Established" && fmt.Sprintf("%v", cond["status"]) == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+func secretMissingKeys(secret *unstructured.Unstructured, keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	data, _, _ := unstructured.NestedMap(secret.Object, "data")
+	var missing []string
+	for _, k := range keys {
+		if _, ok := data[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	return missing
+}

--- a/cmd/cub-scout/receipt_prerequisites_test.go
+++ b/cmd/cub-scout/receipt_prerequisites_test.go
@@ -1,0 +1,123 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+)
+
+func withFakePrerequisitesLoader(t *testing.T, fn func(context.Context, prerequisiteSpec, string) ([]agent.PrerequisiteFactResult, error)) {
+	t.Helper()
+	prev := loadPrerequisitesLiveFn
+	loadPrerequisitesLiveFn = fn
+	t.Cleanup(func() { loadPrerequisitesLiveFn = prev })
+}
+
+func writePrereqsFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prereqs.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write prereqs: %v", err)
+	}
+	return path
+}
+
+// F3 root cause as a pre-flight check: the required Secret is absent.
+func TestReceiptVerifyPrerequisites_BLOCKOnMissingSecretFailOnExit2(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	path := writePrereqsFile(t, `
+requiredNamespaces:
+  - helm-expt-demo
+requiredSecrets:
+  - name: app-db-secret
+    namespace: helm-expt-demo
+    keys: [password]
+`)
+	withFakePrerequisitesLoader(t, func(_ context.Context, spec prerequisiteSpec, _ string) ([]agent.PrerequisiteFactResult, error) {
+		if len(spec.RequiredSecrets) != 1 || spec.RequiredSecrets[0].Name != "app-db-secret" {
+			t.Fatalf("spec not parsed: %+v", spec)
+		}
+		return []agent.PrerequisiteFactResult{
+			{Kind: agent.PrerequisiteKindNamespace, Name: "helm-expt-demo", Status: agent.PrerequisitePresent},
+			{Kind: agent.PrerequisiteKindSecret, Name: "app-db-secret", Namespace: "helm-expt-demo", Status: agent.PrerequisiteMissing, Error: "secrets \"app-db-secret\" not found"},
+		}, nil
+	})
+
+	rootCmd.SetArgs([]string{"receipt", "verify", "--prerequisites", path, "--scope", "namespace/helm-expt-demo", "--format", "json", "--fail-on", "any-non-pass"})
+	out := captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("missing prerequisite with --fail-on any-non-pass must error")
+		}
+		var ec interface{ ExitCode() int }
+		if !errors.As(err, &ec) || ec.ExitCode() != 2 {
+			t.Fatalf("expected exit code 2 wrapper; got %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal statement: %v\n%s", err, out)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicatePrerequisitesMet) {
+		t.Fatalf("predicate = %s", stmt.Predicate.PredicateName)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.Prerequisites == nil || stmt.Predicate.Evidence.Prerequisites.Summary.Missing != 1 {
+		t.Fatalf("expected 1 missing prerequisite, got %+v", stmt.Predicate.Evidence.Prerequisites)
+	}
+}
+
+func TestReceiptVerifyPrerequisites_PASSWhenAllPresent(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	path := writePrereqsFile(t, `
+requiredNamespaces:
+  - helm-expt-demo
+`)
+	withFakePrerequisitesLoader(t, func(_ context.Context, _ prerequisiteSpec, _ string) ([]agent.PrerequisiteFactResult, error) {
+		return []agent.PrerequisiteFactResult{
+			{Kind: agent.PrerequisiteKindNamespace, Name: "helm-expt-demo", Status: agent.PrerequisitePresent},
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "--prerequisites", path, "--scope", "namespace/helm-expt-demo", "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if stmt.Predicate.Verdict != agent.VerdictPASS {
+		t.Fatalf("verdict = %s, want PASS", stmt.Predicate.Verdict)
+	}
+}
+
+func TestReceiptVerifyPrerequisites_RequiresFile(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	rootCmd.SetArgs([]string{"receipt", "verify", "--predicate", "prerequisites-met"})
+	err := rootCmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires --prerequisites") {
+		t.Fatalf("expected requires --prerequisites error, got %v", err)
+	}
+}

--- a/cmd/cub-scout/receipt_render.go
+++ b/cmd/cub-scout/receipt_render.go
@@ -159,6 +159,30 @@ func renderReceiptASCII(stmt agent.Statement) string {
 		}
 	}
 
+	if pred.Evidence.Prerequisites != nil {
+		p := pred.Evidence.Prerequisites
+		b.WriteString("\nEvidence (prerequisites)\n")
+		fmt.Fprintf(&b, "  source:      %s %s\n", p.Source.Type, p.Source.Ref)
+		fmt.Fprintf(&b, "  required:    %d\n", p.Summary.Required)
+		fmt.Fprintf(&b, "  present:     %d\n", p.Summary.Present)
+		fmt.Fprintf(&b, "  missing:     %d\n", p.Summary.Missing)
+		fmt.Fprintf(&b, "  inconclusive:%d\n", p.Summary.Inconclusive)
+		for _, f := range p.Facts {
+			if f.Status == agent.PrerequisitePresent {
+				continue
+			}
+			fmt.Fprintf(&b, "  - %s %s", f.Kind, f.Name)
+			if f.Namespace != "" {
+				fmt.Fprintf(&b, " (ns %s)", f.Namespace)
+			}
+			fmt.Fprintf(&b, ": %s", f.Status)
+			if f.Detail != "" {
+				fmt.Fprintf(&b, " — %s", f.Detail)
+			}
+			b.WriteString("\n")
+		}
+	}
+
 	// Omissions are critical — they convert silent PASS into honest PASS.
 	if len(pred.Omissions) > 0 {
 		b.WriteString("\nOmissions (deliberate non-claims)\n")

--- a/cmd/cub-scout/receipt_test.go
+++ b/cmd/cub-scout/receipt_test.go
@@ -61,8 +61,8 @@ func withFakeReceiptLoader(t *testing.T, obj *unstructured.Unstructured) {
 func resetReceiptFlags(t *testing.T) {
 	t.Helper()
 	prev := struct {
-		ns, pred, at, fmt, out, file, scope string
-	}{receiptNamespace, receiptPredicate, receiptAtCommit, receiptFormat, receiptOut, receiptObjectSetFile, receiptScope}
+		ns, pred, at, fmt, out, file, scope, grace, prereq string
+	}{receiptNamespace, receiptPredicate, receiptAtCommit, receiptFormat, receiptOut, receiptObjectSetFile, receiptScope, receiptGraceWindow, receiptPrerequisitesFile}
 	receiptNamespace = ""
 	receiptPredicate = ""
 	receiptAtCommit = ""
@@ -70,6 +70,8 @@ func resetReceiptFlags(t *testing.T) {
 	receiptOut = ""
 	receiptObjectSetFile = ""
 	receiptScope = ""
+	receiptGraceWindow = ""
+	receiptPrerequisitesFile = ""
 	t.Cleanup(func() {
 		receiptNamespace = prev.ns
 		receiptPredicate = prev.pred
@@ -78,6 +80,8 @@ func resetReceiptFlags(t *testing.T) {
 		receiptOut = prev.out
 		receiptObjectSetFile = prev.file
 		receiptScope = prev.scope
+		receiptGraceWindow = prev.grace
+		receiptPrerequisitesFile = prev.prereq
 	})
 }
 

--- a/pkg/agent/receipt.go
+++ b/pkg/agent/receipt.go
@@ -76,6 +76,17 @@ const (
 	// like k8s-live-workloads://namespace/redis or
 	// k8s-live-workloads://cluster.
 	SubjectSchemeK8sLiveWorkloads = "k8s-live-workloads://"
+
+	// SubjectSchemeDeclaredPrerequisites identifies the declared set of
+	// required cluster facts a prerequisites-met receipt evaluated. Names
+	// look like declared-prerequisites://sha256/<short-digest>.
+	SubjectSchemeDeclaredPrerequisites = "declared-prerequisites://"
+
+	// SubjectSchemeK8sLivePrerequisites identifies the live cluster the
+	// prerequisites were checked against. Names look like
+	// k8s-live-prerequisites://namespace/redis or
+	// k8s-live-prerequisites://cluster.
+	SubjectSchemeK8sLivePrerequisites = "k8s-live-prerequisites://"
 )
 
 // Statement is the in-toto Statement v1 envelope wrapping a cub-scout
@@ -239,6 +250,7 @@ type Evidence struct {
 	GitSource       *GitSourceAnchor            `json:"gitSource,omitempty"`
 	ObjectSet       *ObjectSetEvidence          `json:"objectSet,omitempty"`
 	Workloads       *WorkloadsConvergedEvidence `json:"workloads,omitempty"`
+	Prerequisites   *PrerequisitesEvidence      `json:"prerequisites,omitempty"`
 }
 
 // Omission is one structured gap the receipt does not claim. The
@@ -343,4 +355,14 @@ const (
 	// converged receipts when one or more desired workloads could not be
 	// classified because the live read or API mapping was inconclusive.
 	OmissionWorkloadConvergenceCoverage = "workload-convergence-coverage"
+
+	// OmissionPrerequisitesSnapshot is recorded by prerequisites-met
+	// receipts to mark that the facts were checked at verifiedAt; the
+	// receipt does not prove they remain present afterward.
+	OmissionPrerequisitesSnapshot = "prerequisites-snapshot"
+
+	// OmissionPrerequisitesCoverage is recorded by prerequisites-met
+	// receipts when one or more declared facts could not be checked
+	// because the live read failed.
+	OmissionPrerequisitesCoverage = "prerequisites-coverage"
 )

--- a/pkg/agent/receipt_build.go
+++ b/pkg/agent/receipt_build.go
@@ -187,6 +187,8 @@ func BuildReceipt(in BuildReceiptInput) (Statement, error) {
 		return Statement{}, fmt.Errorf("build-receipt: predicate %q requires object-set evidence; use BuildObjectSetReceipt or `cub-scout receipt verify --file <manifests>`", predName)
 	case PredicateWorkloadsConverged:
 		return Statement{}, fmt.Errorf("build-receipt: predicate %q requires workload evidence; use BuildWorkloadsConvergedReceipt or `cub-scout receipt verify --file <manifests> --predicate workloads-converged`", predName)
+	case PredicatePrerequisitesMet:
+		return Statement{}, fmt.Errorf("build-receipt: predicate %q requires declared prerequisites; use BuildPrerequisitesReceipt or `cub-scout receipt verify --prerequisites <file>`", predName)
 	case "":
 		// Auto-detect failed. The omission entry was already appended
 		// above; the predicate evaluation produces INCONCLUSIVE.

--- a/pkg/agent/receipt_predicates.go
+++ b/pkg/agent/receipt_predicates.go
@@ -44,6 +44,15 @@ const (
 	// this predicate reads status. It is --file-routed and evaluated by
 	// BuildWorkloadsConvergedReceipt, not the BuildReceipt switch.
 	PredicateWorkloadsConverged PredicateName = "workloads-converged"
+
+	// PredicatePrerequisitesMet verifies that a declared set of required
+	// cluster-state facts (CRDs established, Secrets present with the named
+	// keys, StorageClasses / IngressClasses / namespaces existing) are
+	// present live before an install is applied. cub-scout consumes the
+	// declared list (the "target facts"); it does not infer prerequisites
+	// from a chart. --prerequisites-routed; evaluated by
+	// BuildPrerequisitesReceipt, not the BuildReceipt switch.
+	PredicatePrerequisitesMet PredicateName = "prerequisites-met"
 )
 
 // AllPredicates returns the list of v1 predicate names cub-scout knows
@@ -56,6 +65,7 @@ func AllPredicates() []PredicateName {
 		PredicateNoManualEditsSince,
 		PredicateObjectSetMatches,
 		PredicateWorkloadsConverged,
+		PredicatePrerequisitesMet,
 	}
 }
 

--- a/pkg/agent/receipt_prerequisites.go
+++ b/pkg/agent/receipt_prerequisites.go
@@ -1,0 +1,265 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Prerequisite fact kinds.
+const (
+	PrerequisiteKindCRD          = "CRD"
+	PrerequisiteKindSecret       = "Secret"
+	PrerequisiteKindNamespace    = "Namespace"
+	PrerequisiteKindStorageClass = "StorageClass"
+	PrerequisiteKindIngressClass = "IngressClass"
+)
+
+// Prerequisite fact statuses.
+const (
+	PrerequisitePresent      = "present"
+	PrerequisiteMissing      = "missing"
+	PrerequisiteInconclusive = "inconclusive"
+)
+
+// PrerequisitesEvidence is attached under predicate.evidence.prerequisites
+// for prerequisites-met receipts. It records, for each declared cluster-state
+// dependency (a "target fact" in helm-expt terms — required CRDs, Secrets,
+// StorageClasses, namespaces, IngressClasses), whether it is present live.
+// This is the pre-flight complement to workloads-converged: it catches an
+// unmet prerequisite (e.g. an absent Secret) before the workload tries to
+// start (helm-expt finding F3, confighub/cub-scout#477).
+type PrerequisitesEvidence struct {
+	Source         ObjectSetSource          `json:"source"`
+	Scope          ObjectSetScope           `json:"scope"`
+	DeclaredDigest string                   `json:"declaredDigest"`
+	LiveDigest     string                   `json:"liveDigest"`
+	Summary        PrerequisitesSummary     `json:"summary"`
+	Facts          []PrerequisiteFactResult `json:"facts"`
+}
+
+type PrerequisitesSummary struct {
+	Required     int `json:"required"`
+	Present      int `json:"present"`
+	Missing      int `json:"missing"`
+	Inconclusive int `json:"inconclusive"`
+}
+
+// PrerequisiteFactResult is the observed live state of one declared fact.
+type PrerequisiteFactResult struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+	Status    string `json:"status"`
+	Error     string `json:"error,omitempty"`
+}
+
+func prerequisiteFactKey(f PrerequisiteFactResult) string {
+	return f.Kind + "|" + f.Namespace + "|" + f.Name
+}
+
+// BuildPrerequisitesEvidence summarizes per-fact observations into the
+// evidence body and computes the declared/live digests. It is pure: callers
+// run the live checks before invoking.
+func BuildPrerequisitesEvidence(source ObjectSetSource, scope ObjectSetScope, facts []PrerequisiteFactResult) (PrerequisitesEvidence, error) {
+	if len(facts) == 0 {
+		return PrerequisitesEvidence{}, fmt.Errorf("prerequisites receipt: no declared prerequisites")
+	}
+
+	sorted := append([]PrerequisiteFactResult(nil), facts...)
+	sort.Slice(sorted, func(i, j int) bool { return prerequisiteFactKey(sorted[i]) < prerequisiteFactKey(sorted[j]) })
+
+	declaredSet := make([]interface{}, 0, len(sorted))
+	liveSet := make([]interface{}, 0, len(sorted))
+	summary := PrerequisitesSummary{Required: len(sorted)}
+	for _, f := range sorted {
+		declaredSet = append(declaredSet, map[string]interface{}{
+			"key": prerequisiteFactKey(f), "kind": f.Kind, "name": f.Name, "namespace": f.Namespace, "detail": f.Detail,
+		})
+		liveSet = append(liveSet, map[string]interface{}{
+			"key": prerequisiteFactKey(f), "status": f.Status,
+		})
+		switch f.Status {
+		case PrerequisitePresent:
+			summary.Present++
+		case PrerequisiteMissing:
+			summary.Missing++
+		default:
+			summary.Inconclusive++
+		}
+	}
+
+	declaredDigest, err := digestJSON(declaredSet)
+	if err != nil {
+		return PrerequisitesEvidence{}, fmt.Errorf("digest declared prerequisites: %w", err)
+	}
+	liveDigest, err := digestJSON(liveSet)
+	if err != nil {
+		return PrerequisitesEvidence{}, fmt.Errorf("digest live prerequisites: %w", err)
+	}
+	source.ObjectCount = summary.Required
+
+	return PrerequisitesEvidence{
+		Source:         source,
+		Scope:          scope,
+		DeclaredDigest: declaredDigest,
+		LiveDigest:     liveDigest,
+		Summary:        summary,
+		Facts:          sorted,
+	}, nil
+}
+
+// BuildPrerequisitesReceiptInput is the input to BuildPrerequisitesReceipt.
+type BuildPrerequisitesReceiptInput struct {
+	Evidence          PrerequisitesEvidence
+	Verifier          Verifier
+	VerifiedAt        time.Time
+	InputAttestations []VerifiedAttestationRef
+}
+
+// BuildPrerequisitesReceipt builds a single receipt asserting that the
+// declared cluster-state prerequisites are present live. It is pure.
+//
+// Verdict: BLOCK if any required fact is missing; else INCONCLUSIVE if any
+// fact could not be checked; else PASS.
+func BuildPrerequisitesReceipt(in BuildPrerequisitesReceiptInput) (Statement, error) {
+	if in.Evidence.Summary.Required == 0 {
+		return Statement{}, fmt.Errorf("prerequisites receipt: no declared prerequisites")
+	}
+	if in.Evidence.DeclaredDigest == "" {
+		return Statement{}, fmt.Errorf("prerequisites receipt: missing declared digest")
+	}
+	if in.Evidence.LiveDigest == "" {
+		return Statement{}, fmt.Errorf("prerequisites receipt: missing live digest")
+	}
+
+	verifiedAt := in.VerifiedAt
+	if verifiedAt.IsZero() {
+		verifiedAt = time.Now().UTC()
+	}
+
+	s := in.Evidence.Summary
+	verdict := VerdictPASS
+	switch {
+	case s.Missing > 0:
+		verdict = VerdictBLOCK
+	case s.Inconclusive > 0:
+		verdict = VerdictINCONCLUSIVE
+	}
+
+	omissions := []Omission{
+		{
+			Missing:  OmissionPrerequisitesSnapshot,
+			Reason:   "prerequisites-met reflects the cluster facts observed at verifiedAt; it does not prove they remain present afterward",
+			Severity: "info",
+		},
+	}
+	if s.Inconclusive > 0 {
+		omissions = append(omissions, Omission{
+			Missing:  OmissionPrerequisitesCoverage,
+			Reason:   fmt.Sprintf("%d declared prerequisite(s) could not be checked because the live read failed", s.Inconclusive),
+			Severity: "warning",
+		})
+	}
+
+	nextSteps := []ReceiptNextStep{}
+	switch verdict {
+	case VerdictPASS:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "every declared prerequisite is present in the live cluster",
+			NextCommand: "cub-scout doctor",
+			NextSurface: "cub-scout",
+		})
+	case VerdictBLOCK:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "human-decision",
+			Reason:      "one or more required cluster facts (CRD / Secret / StorageClass / namespace) are missing; provide them before applying the install",
+			NextCommand: "cub-scout map list",
+			NextSurface: "cub-scout",
+		})
+	case VerdictINCONCLUSIVE:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "one or more prerequisites could not be checked; verify API availability and permissions",
+			NextCommand: "cub-scout doctor",
+			NextSurface: "cub-scout",
+		})
+	}
+	filteredSteps, stepOmissions := FilterNextSteps(nextSteps)
+	omissions = append(omissions, stepOmissions...)
+
+	inputAttestations := make([]AttestationRef, 0, len(in.InputAttestations))
+	for i, v := range in.InputAttestations {
+		if v.IsZero() {
+			return Statement{}, fmt.Errorf("prerequisites receipt: inputAttestations[%d] is a zero-value VerifiedAttestationRef; construct via BuildAttestationRef or BuildAttestationRefsFromPaths", i)
+		}
+		inputAttestations = append(inputAttestations, v.Ref())
+	}
+
+	claim := "declared prerequisites are present in the live cluster"
+	if in.Evidence.Source.Ref != "" {
+		claim = fmt.Sprintf("declared prerequisites from %s are present in the live cluster", in.Evidence.Source.Ref)
+	}
+	scope := Scope{
+		Kind:      "Prerequisites",
+		Name:      "install-prerequisites",
+		Namespace: in.Evidence.Scope.Namespace,
+	}
+
+	evidence := in.Evidence
+	stmt := Statement{
+		Type: StatementType,
+		Subject: []Subject{
+			BuildDeclaredPrerequisitesSubject(in.Evidence.DeclaredDigest),
+			BuildLivePrerequisitesSubject(in.Evidence.Scope, in.Evidence.LiveDigest),
+		},
+		PredicateType: PredicateTypeReceiptV1,
+		Predicate: Predicate{
+			Version:           PredicateVersion,
+			Claim:             claim,
+			Scope:             scope,
+			Verifier:          in.Verifier,
+			VerifiedAt:        verifiedAt.UTC().Format(time.RFC3339),
+			PredicateName:     string(PredicatePrerequisitesMet),
+			Verdict:           verdict,
+			Evidence:          Evidence{Prerequisites: &evidence},
+			Omissions:         omissions,
+			InputAttestations: inputAttestations,
+			NextSteps:         filteredSteps,
+		},
+	}
+
+	if err := StampFingerprint(&stmt); err != nil {
+		return Statement{}, fmt.Errorf("prerequisites receipt: stamp fingerprint: %w", err)
+	}
+	return stmt, nil
+}
+
+// BuildDeclaredPrerequisitesSubject builds the declared-prerequisites subject.
+func BuildDeclaredPrerequisitesSubject(digest string) Subject {
+	short := digest
+	if len(short) > 16 {
+		short = short[:16]
+	}
+	return Subject{
+		Name:   SubjectSchemeDeclaredPrerequisites + "sha256/" + short,
+		Digest: map[string]string{"sha256": digest},
+	}
+}
+
+// BuildLivePrerequisitesSubject builds the live-prerequisites subject.
+func BuildLivePrerequisitesSubject(scope ObjectSetScope, digest string) Subject {
+	name := SubjectSchemeK8sLivePrerequisites + "cluster"
+	if scope.Namespace != "" {
+		name = SubjectSchemeK8sLivePrerequisites + "namespace/" + scope.Namespace
+	}
+	return Subject{
+		Name:   name,
+		Digest: map[string]string{"sha256": digest},
+	}
+}

--- a/pkg/agent/receipt_prerequisites_test.go
+++ b/pkg/agent/receipt_prerequisites_test.go
@@ -1,0 +1,81 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func buildPrereqReceipt(t *testing.T, facts []PrerequisiteFactResult) Statement {
+	t.Helper()
+	ev, err := BuildPrerequisitesEvidence(
+		ObjectSetSource{Type: "file", Ref: "prereqs.yaml"},
+		ObjectSetScope{Kind: "namespace", Namespace: "helm-expt-demo"},
+		facts,
+	)
+	if err != nil {
+		t.Fatalf("BuildPrerequisitesEvidence: %v", err)
+	}
+	stmt, err := BuildPrerequisitesReceipt(BuildPrerequisitesReceiptInput{
+		Evidence:   ev,
+		Verifier:   Verifier{Tool: "cub-scout", Version: "test"},
+		VerifiedAt: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("BuildPrerequisitesReceipt: %v", err)
+	}
+	if stmt.Predicate.PredicateName != string(PredicatePrerequisitesMet) {
+		t.Fatalf("predicate = %s", stmt.Predicate.PredicateName)
+	}
+	if err := VerifyStatementFingerprint(stmt); err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	return stmt
+}
+
+func TestPrerequisites_PASSWhenAllPresent(t *testing.T) {
+	stmt := buildPrereqReceipt(t, []PrerequisiteFactResult{
+		{Kind: PrerequisiteKindNamespace, Name: "helm-expt-demo", Status: PrerequisitePresent},
+		{Kind: PrerequisiteKindSecret, Name: "app-db-secret", Namespace: "helm-expt-demo", Detail: "keys: password", Status: PrerequisitePresent},
+	})
+	if stmt.Predicate.Verdict != VerdictPASS {
+		t.Fatalf("verdict = %s, want PASS", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.Prerequisites.Summary.Present != 2 {
+		t.Fatalf("present = %d, want 2", stmt.Predicate.Evidence.Prerequisites.Summary.Present)
+	}
+}
+
+// The F3 root cause as a pre-flight check: the required Secret is absent.
+func TestPrerequisites_BLOCKOnMissingSecret(t *testing.T) {
+	stmt := buildPrereqReceipt(t, []PrerequisiteFactResult{
+		{Kind: PrerequisiteKindNamespace, Name: "helm-expt-demo", Status: PrerequisitePresent},
+		{Kind: PrerequisiteKindSecret, Name: "app-db-secret", Namespace: "helm-expt-demo", Status: PrerequisiteMissing, Error: "secrets \"app-db-secret\" not found"},
+	})
+	if stmt.Predicate.Verdict != VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+	if stmt.Predicate.Evidence.Prerequisites.Summary.Missing != 1 {
+		t.Fatalf("missing = %d, want 1", stmt.Predicate.Evidence.Prerequisites.Summary.Missing)
+	}
+}
+
+func TestPrerequisites_INCONCLUSIVEOnCheckGap(t *testing.T) {
+	stmt := buildPrereqReceipt(t, []PrerequisiteFactResult{
+		{Kind: PrerequisiteKindCRD, Name: "servicemonitors.monitoring.coreos.com", Status: PrerequisiteInconclusive, Error: "the server could not find the requested resource"},
+	})
+	if stmt.Predicate.Verdict != VerdictINCONCLUSIVE {
+		t.Fatalf("verdict = %s, want INCONCLUSIVE", stmt.Predicate.Verdict)
+	}
+	found := false
+	for _, o := range stmt.Predicate.Omissions {
+		if o.Missing == OmissionPrerequisitesCoverage {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s omission", OmissionPrerequisitesCoverage)
+	}
+}


### PR DESCRIPTION
## What

Implements the `prerequisites-met` receipt predicate (#477) — the pre-flight complement to `workloads-converged` (#476). It verifies a declared set of required cluster facts (helm-expt's "target facts") are present before an install is applied, catching the **root cause** of F3 (the absent Secret) *before* the workload even tries to start.

## How

- New predicate `prerequisites-met`, registered + build-guarded, with a `Prerequisites` evidence shape, two omissions, and `declared-prerequisites://` + `k8s-live-prerequisites://` subjects.
- **Input:** `--prerequisites <file>` (YAML/JSON) declaring `requiredCRDs`, `requiredSecrets` (name/namespace/keys), `requiredNamespaces`, `requiredStorageClasses`, `requiredIngressClasses`. cub-scout consumes the declared list; it does not infer prerequisites from a chart.
- **Live checks:** CRD established (`status.conditions[Established]=True`), Secret present with all named keys, namespace / StorageClass / IngressClass existing.
- **Verdict:** BLOCK if any required fact is missing; INCONCLUSIVE if a check could not run; else PASS.
- Same emit / `--out` / `--save` / `--fail-on` plumbing and ASCII render style as the other receipts.

## Verified end-to-end (kind, `examples/helm-expt` F3 fixture)

| State | Exit | Verdict | Detail |
|---|---|---|---|
| `app-db-secret` absent | 2 | **BLOCK** | required:3, present:2, missing:1 → `Secret/app-db-secret` (namespace + StorageClass present) |
| after creating the secret | 0 | **PASS** | required:3, present:3, missing:0 |

## Tests

- `pkg/agent`: 3 table tests (PASS / BLOCK-missing-secret / INCONCLUSIVE), each fingerprint-verified.
- `cmd/cub-scout`: 3 CLI tests (BLOCK + `--fail-on` exit 2, PASS, requires-`--prerequisites`) via the fake-loader seam. Also extends `resetReceiptFlags` to clear the new `--grace-window` / `--prerequisites` flags (fixes latent cross-test flag leakage).
- Full `pkg/agent` + `cmd/cub-scout` suites green; no regressions.

Together **#476** (runtime readiness) + **#477** (pre-flight prerequisites) close helm-expt finding F3 from both ends.

Closes #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
