### PR TITLE
docs(helm-expt): run all three install-receipt predicates in the example

### DIFF
--- a/examples/helm-expt/AI_START_HERE.md
+++ b/examples/helm-expt/AI_START_HERE.md
@@ -45,11 +45,15 @@ To run against your current context instead of a new kind cluster:
 
 ## What to expect
 
-- `receipt object-set-matches` → **PASS**, exit 0
-- pod → **CreateContainerConfigError**, Ready=False
-- `verify.sh` gap table → "false green (PASS but unusable)?: yes"
+`verify.sh` prints a scorecard for the same install:
 
-That contrast is the point. The gaps map to issue drafts in
+- `object-set-matches` → **PASS** (present + match) — a false green on its own
+- `prerequisites-met` (#477) → **BLOCK** — the required Secret is absent (pre-flight)
+- `workloads-converged` (#476) → **BLOCK** — the pod is in `CreateContainerConfigError` (runtime)
+- receipt freshness/TTL (#478) → **ABSENT** — still open
+
+The two BLOCKs catching the same F3 install from both ends is the point. The full
+set maps to
 [`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md).
 
 ## Important boundaries

--- a/examples/helm-expt/README.md
+++ b/examples/helm-expt/README.md
@@ -25,13 +25,17 @@ end-to-end with no helm-expt checkout, use the bundled scripts and fixture:
 ```bash
 cd examples/helm-expt
 ./setup.sh     # ephemeral kind cluster + fixtures/release-objects.yaml
-./verify.sh    # builds the receipt, then contrasts it with cluster reality
+./verify.sh    # runs object-set-matches + prerequisites-met + workloads-converged
 ./cleanup.sh   # tears the cluster down
 ```
 
-The fixture intentionally reproduces helm-expt finding **F3**: the receipt comes
-back `PASS` while the workload sits in `CreateContainerConfigError`. That gap, and
-the issue drafts that would close it, are documented in
+`verify.sh` runs all three install-receipt predicates against the same install and
+prints a scorecard. The fixture reproduces helm-expt finding **F3**, so
+`object-set-matches` is `PASS` (present + match) — a false green on its own — while
+`prerequisites-met` (#477) BLOCKs pre-flight (the required Secret is absent) and
+`workloads-converged` (#476) BLOCKs at runtime (the pod is in
+`CreateContainerConfigError`). The remaining gap, receipt freshness (#478), and the
+full set are in
 [`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md).
 Start with [AI_START_HERE.md](./AI_START_HERE.md). The scripts never touch a
 helm-expt checkout.

--- a/examples/helm-expt/contracts.md
+++ b/examples/helm-expt/contracts.md
@@ -33,7 +33,9 @@ subject as "the authored-field projection of live", not "everything that is live
 
 ## What would make the claim complete
 
-See [`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md):
-a `workloads-converged` predicate (readiness), a `prerequisites-met` predicate
-(target facts), observation freshness (`observedAt` + `expiresAt`), and an
-optional closed-world check.
+`workloads-converged` (#476, readiness) and `prerequisites-met` (#477, target
+facts) now ship and `verify.sh` runs them — `object-set-matches` PASS plus those
+two BLOCKs is the honest picture of this install. Still open in
+[`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md):
+observation freshness (`observedAt` + `expiresAt`, #478) and an optional
+closed-world check.

--- a/examples/helm-expt/fixtures/prerequisites.yaml
+++ b/examples/helm-expt/fixtures/prerequisites.yaml
@@ -1,0 +1,15 @@
+# Declared "target facts" for the demo install — the cluster-state dependencies
+# this install needs before it can work. Consumed by:
+#   cub-scout receipt verify --prerequisites prerequisites.yaml --predicate prerequisites-met
+#
+# app-db-secret is intentionally NOT created by setup.sh (it is the unmet
+# prerequisite from helm-expt finding F3), so prerequisites-met BLOCKs on it.
+requiredNamespaces:
+  - helm-expt-demo
+requiredStorageClasses:
+  - standard
+requiredSecrets:
+  - name: app-db-secret
+    namespace: helm-expt-demo
+    keys:
+      - password

--- a/examples/helm-expt/verify.sh
+++ b/examples/helm-expt/verify.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 #
-# verify.sh — run the real cub-scout object-set-matches path end-to-end against
-# the fixture cluster state, then contrast the receipt verdict with the actual
-# workload reality. The point of this script is to make the current gaps
-# OBSERVABLE, not to hide them.
+# verify.sh — run the three cub-scout install-receipt predicates end-to-end
+# against the fixture cluster state and show how object-set-matches ALONE is a
+# false green, while workloads-converged (#476) and prerequisites-met (#477)
+# catch helm-expt finding F3 from both ends:
+#
+#   object-set-matches   PASS   every desired object is present + fields match
+#   prerequisites-met    BLOCK  the required Secret is absent (pre-flight)
+#   workloads-converged  BLOCK  the pod is wedged in CreateContainerConfigError (runtime)
 #
 # Read-only against the cluster. Writes only into ./out/ in this directory.
 # Self-contained: never reads a helm-expt checkout.
@@ -16,8 +20,8 @@ NS="helm-expt-demo"
 CLUSTER="cub-scout-helm-expt"
 CONTEXT="kind-${CLUSTER}"
 MANIFESTS="$SCRIPT_DIR/fixtures/release-objects.yaml"
+PREREQS="$SCRIPT_DIR/fixtures/prerequisites.yaml"
 RUN_DIR="$SCRIPT_DIR/out"
-RECEIPT="$RUN_DIR/object-set.receipt.json"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -31,115 +35,97 @@ done
 
 command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
 
+# Resolve a cub-scout binary that supports the install-receipt predicates. The
+# prebuilt repo-root binary may predate them, so fall back to building fresh.
+supports_predicates() { "$1" receipt verify --help 2>/dev/null | grep -q workloads-converged; }
 resolve_cub_scout() {
-    if [[ -n "${CUB_SCOUT_BIN:-}" ]]; then printf '%s\n' "$CUB_SCOUT_BIN"; return; fi
-    if [[ -x "$REPO_ROOT/cub-scout" ]]; then printf '%s\n' "$REPO_ROOT/cub-scout"; return; fi
-    command -v cub-scout 2>/dev/null || echo ""
+    if [[ -n "${CUB_SCOUT_BIN:-}" ]] && supports_predicates "$CUB_SCOUT_BIN"; then printf '%s\n' "$CUB_SCOUT_BIN"; return; fi
+    if [[ -x "$REPO_ROOT/cub-scout" ]] && supports_predicates "$REPO_ROOT/cub-scout"; then printf '%s\n' "$REPO_ROOT/cub-scout"; return; fi
+    if command -v cub-scout >/dev/null 2>&1 && supports_predicates "$(command -v cub-scout)"; then command -v cub-scout; return; fi
+    echo "==> building a fresh cub-scout (the available binary predates the install-receipt predicates)" >&2
+    ( cd "$REPO_ROOT" && go build -o "$RUN_DIR/cub-scout" ./cmd/cub-scout ) >&2 || return 1
+    printf '%s\n' "$RUN_DIR/cub-scout"
 }
+mkdir -p "$RUN_DIR"
 CUB_SCOUT="$(resolve_cub_scout)"
-[[ -n "$CUB_SCOUT" ]] || { echo "cub-scout binary not found (build ./cmd/cub-scout or set CUB_SCOUT_BIN)" >&2; exit 1; }
+[[ -n "$CUB_SCOUT" ]] || { echo "cub-scout binary not found and could not be built" >&2; exit 1; }
 
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 kubectl --context "$CONTEXT" get ns "$NS" >/dev/null 2>&1 || {
     echo "namespace '$NS' not found in context '$CONTEXT' — run ./setup.sh first" >&2; exit 1; }
+( kubectl config use-context "$CONTEXT" >/dev/null 2>&1 || true )
 
-mkdir -p "$RUN_DIR"
 rule() { printf '\n========== %s ==========\n' "$1"; }
 
-# ---------------------------------------------------------------------------
-rule "1. object-set-matches receipt (the keystone integration the READMEs promise)"
-# cub-scout reads the live cluster via the current context, so point it there.
-( kubectl config use-context "$CONTEXT" >/dev/null 2>&1 || true )
-set +e
-"$CUB_SCOUT" receipt verify \
-    --file "$MANIFESTS" \
-    --scope "namespace/$NS" \
-    --format json \
-    --out "$RECEIPT" \
-    --fail-on any-non-pass >"$RUN_DIR/object-set.stdout.json" 2>"$RUN_DIR/object-set.stderr.txt"
-RECEIPT_RC=$?
-set -e
-[[ -s "$RECEIPT" ]] || RECEIPT="$RUN_DIR/object-set.stdout.json"
-
-VERDICT="$(jq -r '.predicate.verdict // .predicate.result // .verdict // "UNKNOWN"' "$RECEIPT" 2>/dev/null || echo UNKNOWN)"
-MATCHED="$(jq -r '[.. | objects | .matched? // empty] | add // "?"' "$RECEIPT" 2>/dev/null || echo '?')"
-echo "receipt verdict         : $VERDICT"
-echo "receipt exit code       : $RECEIPT_RC   (--fail-on any-non-pass; 0 means cub-scout considers this a clean install)"
-echo "receipt written to      : ${RECEIPT/#$SCRIPT_DIR\//}"
+# run_predicate <label> <verify args...> — runs a receipt, stores it in out/,
+# and sets LAST_VERDICT / LAST_RC.
+LAST_VERDICT=""; LAST_RC=0
+run_predicate() {
+    local label="$1"; shift
+    set +e
+    "$CUB_SCOUT" receipt verify "$@" --scope "namespace/$NS" --format json \
+        --out "$RUN_DIR/$label.receipt.json" --fail-on any-non-pass \
+        >"$RUN_DIR/$label.stdout.json" 2>"$RUN_DIR/$label.stderr.txt"
+    LAST_RC=$?
+    set -e
+    local f="$RUN_DIR/$label.receipt.json"; [[ -s "$f" ]] || f="$RUN_DIR/$label.stdout.json"
+    LAST_VERDICT="$(jq -r '.predicate.verdict // "UNKNOWN"' "$f" 2>/dev/null || echo UNKNOWN)"
+}
 
 # ---------------------------------------------------------------------------
-rule "2. what is ACTUALLY happening in the cluster"
+rule "1. object-set-matches — every desired object present + fields match"
+run_predicate object-set --file "$MANIFESTS" --predicate object-set-matches
+OS_VERDICT="$LAST_VERDICT"; OS_RC="$LAST_RC"
+echo "verdict: $OS_VERDICT  (exit $OS_RC)"
+jq -c '.predicate.evidence.objectSet.summary' "$RUN_DIR/object-set.receipt.json" 2>/dev/null | sed 's/^/  summary: /'
+
+# ---------------------------------------------------------------------------
+rule "2. prerequisites-met (#477) — are the declared target facts present?"
+run_predicate prerequisites --prerequisites "$PREREQS" --predicate prerequisites-met
+PQ_VERDICT="$LAST_VERDICT"; PQ_RC="$LAST_RC"
+echo "verdict: $PQ_VERDICT  (exit $PQ_RC)"
+jq -r '.predicate.evidence.prerequisites.facts[] | "  "+.kind+"/"+.name+" -> "+.status' "$RUN_DIR/prerequisites.receipt.json" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+rule "3. workloads-converged (#476) — did the workloads actually become usable?"
+run_predicate workloads --file "$MANIFESTS" --predicate workloads-converged
+WL_VERDICT="$LAST_VERDICT"; WL_RC="$LAST_RC"
+echo "verdict: $WL_VERDICT  (exit $WL_RC)"
+jq -r '.predicate.evidence.workloads.workloads[] | select(.status!="converged") | "  "+.id.kind+"/"+.id.name+" -> "+.status+" (kstatus "+.kstatusStatus+(if (.podReasons|length)>0 then ", pod "+.podReasons[0].reason else "" end)+")"' "$RUN_DIR/workloads.receipt.json" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+rule "4. what is ACTUALLY happening in the cluster"
 kubectl --context "$CONTEXT" -n "$NS" get deploy,pods -o wide || true
-POD_JSON="$(kubectl --context "$CONTEXT" -n "$NS" get pods -o json 2>/dev/null || echo '{}')"
-WAIT_REASONS="$(echo "$POD_JSON" | jq -r '[.items[]?.status.containerStatuses[]?.state.waiting.reason] | map(select(. != null)) | unique | join(",")')"
-READY="$(echo "$POD_JSON" | jq -r '[.items[]?.status.conditions[]? | select(.type=="Ready") | .status] | join(",")')"
-SECRET_PRESENT="$(kubectl --context "$CONTEXT" -n "$NS" get secret app-db-secret >/dev/null 2>&1 && echo yes || echo no)"
-echo
-echo "pod waiting reason      : ${WAIT_REASONS:-<none>}"
-echo "pod Ready condition     : ${READY:-<none>}"
-echo "required Secret present : $SECRET_PRESENT  (app-db-secret — the unmet prerequisite)"
 
 # ---------------------------------------------------------------------------
-rule "3. receipt vs reality — where object-set-matches falls short"
-FALSE_GREEN="no"
-if [[ "$VERDICT" == "PASS" && ( "$WAIT_REASONS" == *CreateContainerConfigError* || "$READY" != *True* ) ]]; then
-    FALSE_GREEN="yes"
-fi
-
-# Probe the receipt envelope for the fields helm-expt expects but cub-scout
-# does not emit yet.
-HAS_FRESHNESS="$(grep -iEc 'ttl|fresh|expire' "$RECEIPT" 2>/dev/null || true)"
-HAS_READINESS="$(grep -iEc 'prerequisite|createcontainer|"ready"|isReady|readyReplicas' "$RECEIPT" 2>/dev/null || true)"
-OMISSIONS="$(jq -r '[.. | objects | .omissions? // empty] | add // [] | map(.id // .reason // tostring) | join(", ")' "$RECEIPT" 2>/dev/null || echo '')"
-
-printf '%-42s | %s\n' "claim / capability" "observed"
-printf -- '-------------------------------------------+----------------------------------\n'
-printf '%-42s | %s\n' "object-set-matches verdict"            "$VERDICT"
-printf '%-42s | %s\n' "workload actually usable?"             "$([[ "$READY" == *True* ]] && echo yes || echo NO)"
-printf '%-42s | %s\n' "=> false green (PASS but unusable)?"   "$FALSE_GREEN"
-printf '%-42s | %s\n' "readiness / Job / PVC status in claim" "$([[ "$HAS_READINESS" -gt 0 ]] && echo present || echo ABSENT)"
-printf '%-42s | %s\n' "prerequisite (required Secret) checked" "ABSENT"
-printf '%-42s | %s\n' "freshness / TTL field on receipt"      "$([[ "$HAS_FRESHNESS" -gt 0 ]] && echo present || echo ABSENT)"
-printf '%-42s | %s\n' "self-declared coverage omission(s)"    "${OMISSIONS:-<none>}"
-
-# ---------------------------------------------------------------------------
-rule "4. the rest of the runtime menu (informational)"
-for desc_cmd in \
-    "doctor|doctor --namespace $NS --format json" \
-    "map status|map status --namespace $NS --json" \
-    "compare drift|compare drift --file $MANIFESTS -n $NS --format json"; do
-    desc="${desc_cmd%%|*}"; args="${desc_cmd#*|}"
-    echo "--- cub-scout $desc ---"
-    # shellcheck disable=SC2086
-    "$CUB_SCOUT" $args >"$RUN_DIR/${desc// /-}.json" 2>/dev/null \
-        && echo "  saved out/${desc// /-}.json" \
-        || echo "  (command returned non-zero or unsupported in this build; see out/)"
-done
+rule "the install-receipt scorecard"
+HAS_FRESHNESS="$(grep -iEc 'ttl|fresh|expire' "$RUN_DIR/object-set.receipt.json" 2>/dev/null || true)"
+printf '%-38s | %s\n' "predicate / capability" "verdict"
+printf -- '---------------------------------------+--------------------------------------\n'
+printf '%-38s | %s\n' "object-set-matches (present+match)"  "$OS_VERDICT  <- green alone = false green"
+printf '%-38s | %s\n' "prerequisites-met (#477, pre-flight)" "$PQ_VERDICT  <- target fact: Secret absent"
+printf '%-38s | %s\n' "workloads-converged (#476, runtime)"  "$WL_VERDICT  <- pod CreateContainerConfigError"
+printf '%-38s | %s\n' "receipt freshness/TTL (#478, open)"   "$([[ "$HAS_FRESHNESS" -gt 0 ]] && echo present || echo ABSENT)"
 
 # ---------------------------------------------------------------------------
 rule "verdict for this example"
-if [[ "$FALSE_GREEN" == "yes" ]]; then
+if [[ "$OS_VERDICT" == "PASS" && "$WL_VERDICT" == "BLOCK" && "$PQ_VERDICT" == "BLOCK" ]]; then
 cat <<EOF
-object-set-matches returned ${VERDICT} and exit ${RECEIPT_RC}, yet the workload is
-not usable (${WAIT_REASONS:-not ready}) because the prerequisite Secret is absent.
+object-set-matches is PASS (exit $OS_RC) — desired objects are present and match.
+On its own that is the helm-expt F3 "silent false green": the workload cannot start.
 
-This is the helm-expt F3 "silent false green", reproduced against a real cluster.
-It is not a bug in object-set-matches — that predicate proves presence + authored
-field match by design — it is the SCOPE gap this example exists to document:
+The two install-receipt predicates now catch it from both ends, on the SAME install:
+  * prerequisites-met  (#477) BLOCKs pre-flight  — the required Secret is absent.
+  * workloads-converged (#476) BLOCKs at runtime — the pod is in CreateContainerConfigError.
 
-  * no readiness/Job/PVC predicate     -> see issue: workloads-converged
-  * no prerequisite predicate          -> see issue: prerequisites-met
-  * no freshness/TTL on the receipt    -> see issue: receipt observation freshness
-  * extra live objects not covered     -> see issue: closed-world object-set
+Still open: receipt observation freshness (#478) — observedAt + expiresAt so a
+workerless consumer can tell a fresh green from a stale one.
 
-See docs/proposals/helm-expt-driven-gaps.md for the write-ups.
+Receipts saved under: ${RUN_DIR/#$REPO_ROOT\//}
 EOF
 else
 cat <<EOF
-Expected a false-green reproduction but did not detect one. Inspect:
-  receipt verdict = $VERDICT, pod waiting = ${WAIT_REASONS:-none}, ready = ${READY:-none}
-Did ./setup.sh run, and was the Secret accidentally created?
+Unexpected verdicts: object-set=$OS_VERDICT prerequisites=$PQ_VERDICT workloads=$WL_VERDICT.
+Did ./setup.sh run, and was app-db-secret accidentally created?
 EOF
 fi
-echo
-echo "Receipt and command output saved under: ${RUN_DIR/#$REPO_ROOT\//}"


### PR DESCRIPTION
## What

`examples/helm-expt/verify.sh` now runs all three install-receipt predicates against the **same** F3 install and prints a scorecard:

| predicate | verdict |
|---|---|
| `object-set-matches` | PASS (present + match — a false green on its own) |
| `prerequisites-met` (#477) | BLOCK (required Secret absent, pre-flight) |
| `workloads-converged` (#476) | BLOCK (pod `CreateContainerConfigError`, runtime) |
| receipt freshness (#478) | ABSENT (still open) |

The example now **self-demonstrates the fix**: the two predicates that shipped in #484 / #485 catch the same install from both ends, where `object-set-matches` alone is a silent false green.

- Adds `fixtures/prerequisites.yaml` (the declared target facts).
- `verify.sh` builds a fresh binary when the available one predates the predicates.
- Updates README / AI_START_HERE / contracts to the scorecard.

Docs + example only; no code change. `examples/helm-expt/out/` stays gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
