### PR TITLE
feat(receipts #478): observation freshness (--ttl)

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -35,6 +35,8 @@ var (
 	receiptInputAttestations []string
 	receiptGraceWindow       string
 	receiptPrerequisitesFile string
+	receiptTTL               string
+	receiptTTLDur            time.Duration
 )
 
 // runReceiptVerifyDispatch is the shared entry point for the receipt
@@ -43,6 +45,14 @@ var (
 // (#448, runReceiptVerifyScoped in receipt_aggregate.go) based on
 // whether --scope is set or the positional argument is comma-shaped.
 func runReceiptVerifyDispatch(cmd *cobra.Command, args []string) error {
+	// Parse --ttl UPFRONT (before any routing or side effect) so a bad value
+	// rejects cleanly; every receipt path reads receiptTTLDur.
+	ttl, ttlErr := parseReceiptTTL()
+	if ttlErr != nil {
+		return ttlErr
+	}
+	receiptTTLDur = ttl
+
 	// Detect aggregate mode by inspecting --scope OR the positional.
 	scopeFlag := strings.TrimSpace(receiptScope)
 	positional := ""
@@ -158,6 +168,7 @@ func init() {
 	receiptVerifyCmd.Flags().StringVar(&receiptObjectSetFile, "file", "", "YAML file or directory containing rendered desired objects for object-set-matches / workloads-converged install receipts.")
 	receiptVerifyCmd.Flags().StringVar(&receiptGraceWindow, "grace-window", "", "For --predicate workloads-converged: how long a workload may stay InProgress before it counts as failed (BLOCK) rather than progressing (WATCH), e.g. 5m. Empty means no deadline (InProgress is WATCH).")
 	receiptVerifyCmd.Flags().StringVar(&receiptPrerequisitesFile, "prerequisites", "", "YAML/JSON file declaring required cluster facts (requiredCRDs, requiredSecrets, requiredNamespaces, requiredStorageClasses, requiredIngressClasses) for a prerequisites-met receipt.")
+	receiptVerifyCmd.Flags().StringVar(&receiptTTL, "ttl", "", "Observation-freshness boundary, e.g. 1h. When set, the receipt records an immutable freshness{observedAt,expiresAt,ttl} so a consumer can tell a fresh receipt from a stale one. Empty means the receipt makes no freshness claim.")
 	receiptVerifyCmd.Flags().StringVar(&receiptAtCommit, "at-commit", "", "Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence.")
 	receiptVerifyCmd.Flags().StringVar(&receiptStrategy, "strategy", "", "Source-truth strategy for source-truth-pass (e.g. git-argo). cub-scout does not infer the strategy.")
 	receiptVerifyCmd.Flags().StringVar(&receiptSince, "since", "", "RFC 3339 cutoff for no-manual-edits-since (e.g. 2026-05-22T00:00:00Z).")
@@ -345,6 +356,11 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("build receipt: %w", err)
 	}
 
+	// 5b. Stamp observation freshness (#478) when --ttl was passed.
+	if err := agent.ApplyFreshness(&stmt, receiptTTLDur); err != nil {
+		return fmt.Errorf("apply freshness: %w", err)
+	}
+
 	// 6. Serialize to bytes.
 	var out []byte
 	switch format {
@@ -467,6 +483,23 @@ func parseReceiptFailOn(raw string) (map[agent.ReceiptVerdict]bool, error) {
 		return nil, fmt.Errorf("--fail-on %q resolved to empty verdict set", raw)
 	}
 	return out, nil
+}
+
+// parseReceiptTTL parses the --ttl flag into a duration. Empty means "no
+// freshness boundary" (0). Negative or unparseable values are rejected.
+func parseReceiptTTL() (time.Duration, error) {
+	raw := strings.TrimSpace(receiptTTL)
+	if raw == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --ttl %q (expected a Go duration like 1h or 30m): %w", raw, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("invalid --ttl %q (must not be negative)", raw)
+	}
+	return d, nil
 }
 
 // loadReceiptLive fetches the live K8s object via the dynamic client. The

--- a/cmd/cub-scout/receipt_aggregate.go
+++ b/cmd/cub-scout/receipt_aggregate.go
@@ -243,21 +243,21 @@ var gvrCronJobV1 = schema.GroupVersionResource{Group: "batch", Version: "v1", Re
 // `--scope namespace/<ns>` OR a comma-list positional triggers it.
 //
 // Steps:
-//   1. Parse the scope spec (already done by the caller, here for
-//      explicitness via re-parse).
-//   2. Resolve the resource list (discovery for namespace mode; the
-//      comma-list is already a resolved set).
-//   3. For each resource, run the same verify logic the single-resource
-//      flow uses (build live, build evidence, build per-resource
-//      receipt). The receipts go through the existing BuildReceipt
-//      machinery — same predicate auto-detection, same flag semantics.
-//      Each per-resource receipt is optionally persisted to the store
-//      if --save is set.
-//   4. Build the aggregate receipt over the per-resource receipts via
-//      pkg/agent.BuildAggregateReceipt with the configured policy
-//      (default: max-severity).
-//   5. Emit the per-resource receipts (JSONL stream) followed by the
-//      aggregate receipt; --fail-on applies to the aggregate verdict.
+//  1. Parse the scope spec (already done by the caller, here for
+//     explicitness via re-parse).
+//  2. Resolve the resource list (discovery for namespace mode; the
+//     comma-list is already a resolved set).
+//  3. For each resource, run the same verify logic the single-resource
+//     flow uses (build live, build evidence, build per-resource
+//     receipt). The receipts go through the existing BuildReceipt
+//     machinery — same predicate auto-detection, same flag semantics.
+//     Each per-resource receipt is optionally persisted to the store
+//     if --save is set.
+//  4. Build the aggregate receipt over the per-resource receipts via
+//     pkg/agent.BuildAggregateReceipt with the configured policy
+//     (default: max-severity).
+//  5. Emit the per-resource receipts (JSONL stream) followed by the
+//     aggregate receipt; --fail-on applies to the aggregate verdict.
 //
 // The function is intentionally separate from runReceiptVerify (the
 // single-resource flow) — both paths share helpers but the aggregate
@@ -344,6 +344,13 @@ func runReceiptVerifyScoped(
 			continue
 		}
 
+		// Stamp freshness (#478) before emit/save/chain so the persisted
+		// and chained per-resource receipts carry the same boundary.
+		if frErr := agent.ApplyFreshness(&stmt, receiptTTLDur); frErr != nil {
+			perResourceFailures = append(perResourceFailures, fmt.Sprintf("%s/%s in %s: apply freshness: %v", r.Kind, r.Name, r.Namespace, frErr))
+			continue
+		}
+
 		// Emit the per-resource receipt to stdout (JSONL line for
 		// machine consumption; aggregate flow always emits JSON
 		// regardless of --format for the per-resource set).
@@ -403,6 +410,9 @@ func runReceiptVerifyScoped(
 	})
 	if aggErr != nil {
 		return fmt.Errorf("build aggregate receipt: %w", aggErr)
+	}
+	if frErr := agent.ApplyFreshness(&aggregateStmt, receiptTTLDur); frErr != nil {
+		return fmt.Errorf("apply freshness to aggregate: %w", frErr)
 	}
 
 	// Emit the aggregate receipt (always JSON; ASCII rendering for

--- a/cmd/cub-scout/receipt_freshness_test.go
+++ b/cmd/cub-scout/receipt_freshness_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestReceiptVerify_TTLStampsFreshness(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, ns string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		live.SetNamespace(ns)
+		desired[0].SetNamespace(ns)
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "--file", path, "--scope", "namespace/prod", "--predicate", "object-set-matches", "--ttl", "2h", "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if stmt.Predicate.Freshness == nil {
+		t.Fatal("freshness missing with --ttl")
+	}
+	if stmt.Predicate.Freshness.TTL != "2h0m0s" {
+		t.Fatalf("ttl = %s, want 2h0m0s", stmt.Predicate.Freshness.TTL)
+	}
+	if stmt.Predicate.Freshness.ObservedAt == "" || stmt.Predicate.Freshness.ExpiresAt == "" {
+		t.Fatalf("observedAt/expiresAt empty: %+v", stmt.Predicate.Freshness)
+	}
+	if err := agent.VerifyStatementFingerprint(stmt); err != nil {
+		t.Fatalf("fingerprint with freshness: %v", err)
+	}
+}
+
+func TestReceiptVerify_NoTTLNoFreshness(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, ns string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		live.SetNamespace(ns)
+		desired[0].SetNamespace(ns)
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "--file", path, "--scope", "namespace/prod", "--predicate", "object-set-matches", "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if stmt.Predicate.Freshness != nil {
+		t.Fatalf("no --ttl must not stamp freshness, got %+v", stmt.Predicate.Freshness)
+	}
+}
+
+func TestReceiptVerify_RejectsBadTTL(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	rootCmd.SetArgs([]string{"receipt", "verify", "deploy/api", "-n", "prod", "--ttl", "nope"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("invalid --ttl must error")
+	}
+}

--- a/cmd/cub-scout/receipt_object_set.go
+++ b/cmd/cub-scout/receipt_object_set.go
@@ -103,6 +103,9 @@ func runReceiptVerifyObjectSet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("build object-set receipt: %w", err)
 	}
+	if err := agent.ApplyFreshness(&stmt, receiptTTLDur); err != nil {
+		return fmt.Errorf("apply freshness: %w", err)
+	}
 
 	var out []byte
 	switch format {

--- a/cmd/cub-scout/receipt_prerequisites.go
+++ b/cmd/cub-scout/receipt_prerequisites.go
@@ -122,6 +122,9 @@ func runReceiptVerifyPrerequisites(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("build prerequisites receipt: %w", err)
 	}
+	if err := agent.ApplyFreshness(&stmt, receiptTTLDur); err != nil {
+		return fmt.Errorf("apply freshness: %w", err)
+	}
 
 	var out []byte
 	switch format {

--- a/cmd/cub-scout/receipt_render.go
+++ b/cmd/cub-scout/receipt_render.go
@@ -35,6 +35,9 @@ func renderReceiptASCII(stmt agent.Statement) string {
 
 	// Verifier + timestamp.
 	fmt.Fprintf(&b, "  By:      %s %s at %s\n", pred.Verifier.Tool, pred.Verifier.Version, pred.VerifiedAt)
+	if pred.Freshness != nil {
+		fmt.Fprintf(&b, "  Fresh:   observed %s, expires %s (ttl %s)\n", pred.Freshness.ObservedAt, pred.Freshness.ExpiresAt, pred.Freshness.TTL)
+	}
 
 	// Spec anchor (when present).
 	if pred.Spec != nil {

--- a/cmd/cub-scout/receipt_test.go
+++ b/cmd/cub-scout/receipt_test.go
@@ -61,8 +61,8 @@ func withFakeReceiptLoader(t *testing.T, obj *unstructured.Unstructured) {
 func resetReceiptFlags(t *testing.T) {
 	t.Helper()
 	prev := struct {
-		ns, pred, at, fmt, out, file, scope, grace, prereq string
-	}{receiptNamespace, receiptPredicate, receiptAtCommit, receiptFormat, receiptOut, receiptObjectSetFile, receiptScope, receiptGraceWindow, receiptPrerequisitesFile}
+		ns, pred, at, fmt, out, file, scope, grace, prereq, ttl string
+	}{receiptNamespace, receiptPredicate, receiptAtCommit, receiptFormat, receiptOut, receiptObjectSetFile, receiptScope, receiptGraceWindow, receiptPrerequisitesFile, receiptTTL}
 	receiptNamespace = ""
 	receiptPredicate = ""
 	receiptAtCommit = ""
@@ -72,6 +72,7 @@ func resetReceiptFlags(t *testing.T) {
 	receiptScope = ""
 	receiptGraceWindow = ""
 	receiptPrerequisitesFile = ""
+	receiptTTL = ""
 	t.Cleanup(func() {
 		receiptNamespace = prev.ns
 		receiptPredicate = prev.pred
@@ -82,6 +83,7 @@ func resetReceiptFlags(t *testing.T) {
 		receiptScope = prev.scope
 		receiptGraceWindow = prev.grace
 		receiptPrerequisitesFile = prev.prereq
+		receiptTTL = prev.ttl
 	})
 }
 

--- a/cmd/cub-scout/receipt_workloads.go
+++ b/cmd/cub-scout/receipt_workloads.go
@@ -100,6 +100,9 @@ func runReceiptVerifyWorkloadsConverged(cmd *cobra.Command, args []string) error
 	if err != nil {
 		return fmt.Errorf("build workloads-converged receipt: %w", err)
 	}
+	if err := agent.ApplyFreshness(&stmt, receiptTTLDur); err != nil {
+		return fmt.Errorf("apply freshness: %w", err)
+	}
 
 	var out []byte
 	switch format {

--- a/examples/helm-expt/AI_START_HERE.md
+++ b/examples/helm-expt/AI_START_HERE.md
@@ -50,7 +50,7 @@ To run against your current context instead of a new kind cluster:
 - `object-set-matches` → **PASS** (present + match) — a false green on its own
 - `prerequisites-met` (#477) → **BLOCK** — the required Secret is absent (pre-flight)
 - `workloads-converged` (#476) → **BLOCK** — the pod is in `CreateContainerConfigError` (runtime)
-- receipt freshness/TTL (#478) → **ABSENT** — still open
+- receipt freshness/TTL (#478) → **present** — `verify.sh` passes `--ttl 1h`, so each receipt carries an immutable `observedAt`+`expiresAt`
 
 The two BLOCKs catching the same F3 install from both ends is the point. The full
 set maps to

--- a/examples/helm-expt/README.md
+++ b/examples/helm-expt/README.md
@@ -34,8 +34,8 @@ prints a scorecard. The fixture reproduces helm-expt finding **F3**, so
 `object-set-matches` is `PASS` (present + match) — a false green on its own — while
 `prerequisites-met` (#477) BLOCKs pre-flight (the required Secret is absent) and
 `workloads-converged` (#476) BLOCKs at runtime (the pod is in
-`CreateContainerConfigError`). The remaining gap, receipt freshness (#478), and the
-full set are in
+`CreateContainerConfigError`); `--ttl` stamps receipt freshness (#478). The
+remaining gaps and the full set are in
 [`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md).
 Start with [AI_START_HERE.md](./AI_START_HERE.md). The scripts never touch a
 helm-expt checkout.

--- a/examples/helm-expt/contracts.md
+++ b/examples/helm-expt/contracts.md
@@ -35,7 +35,8 @@ subject as "the authored-field projection of live", not "everything that is live
 
 `workloads-converged` (#476, readiness) and `prerequisites-met` (#477, target
 facts) now ship and `verify.sh` runs them — `object-set-matches` PASS plus those
-two BLOCKs is the honest picture of this install. Still open in
+two BLOCKs is the honest picture of this install. Observation freshness
+(`observedAt` + `expiresAt`, #478) now ships too — pass `--ttl` to stamp it, as
+`verify.sh` does. Still open in
 [`docs/proposals/helm-expt-driven-gaps.md`](../../docs/proposals/helm-expt-driven-gaps.md):
-observation freshness (`observedAt` + `expiresAt`, #478) and an optional
-closed-world check.
+the optional closed-world check.

--- a/examples/helm-expt/verify.sh
+++ b/examples/helm-expt/verify.sh
@@ -63,7 +63,7 @@ LAST_VERDICT=""; LAST_RC=0
 run_predicate() {
     local label="$1"; shift
     set +e
-    "$CUB_SCOUT" receipt verify "$@" --scope "namespace/$NS" --format json \
+    "$CUB_SCOUT" receipt verify "$@" --scope "namespace/$NS" --format json --ttl 1h \
         --out "$RUN_DIR/$label.receipt.json" --fail-on any-non-pass \
         >"$RUN_DIR/$label.stdout.json" 2>"$RUN_DIR/$label.stderr.txt"
     LAST_RC=$?
@@ -105,7 +105,7 @@ printf -- '---------------------------------------+-----------------------------
 printf '%-38s | %s\n' "object-set-matches (present+match)"  "$OS_VERDICT  <- green alone = false green"
 printf '%-38s | %s\n' "prerequisites-met (#477, pre-flight)" "$PQ_VERDICT  <- target fact: Secret absent"
 printf '%-38s | %s\n' "workloads-converged (#476, runtime)"  "$WL_VERDICT  <- pod CreateContainerConfigError"
-printf '%-38s | %s\n' "receipt freshness/TTL (#478, open)"   "$([[ "$HAS_FRESHNESS" -gt 0 ]] && echo present || echo ABSENT)"
+printf '%-38s | %s\n' "receipt freshness/TTL (#478)"         "$([[ "$HAS_FRESHNESS" -gt 0 ]] && echo "present (ttl 1h)" || echo ABSENT)"
 
 # ---------------------------------------------------------------------------
 rule "verdict for this example"
@@ -118,8 +118,9 @@ The two install-receipt predicates now catch it from both ends, on the SAME inst
   * prerequisites-met  (#477) BLOCKs pre-flight  — the required Secret is absent.
   * workloads-converged (#476) BLOCKs at runtime — the pod is in CreateContainerConfigError.
 
-Still open: receipt observation freshness (#478) — observedAt + expiresAt so a
-workerless consumer can tell a fresh green from a stale one.
+The three install-receipt predicates plus receipt freshness (#478, via --ttl:
+observedAt + expiresAt) now ship — so a workerless consumer can tell a fresh
+green from a stale one.
 
 Receipts saved under: ${RUN_DIR/#$REPO_ROOT\//}
 EOF

--- a/pkg/agent/receipt.go
+++ b/pkg/agent/receipt.go
@@ -129,6 +129,11 @@ type Predicate struct {
 	// VerifiedAt is the ISO 8601 timestamp of receipt creation.
 	VerifiedAt string `json:"verifiedAt"`
 
+	// Freshness is the optional, immutable observation-freshness boundary
+	// (#478). Present only when the caller passed a TTL (e.g. --ttl). When
+	// absent, the receipt makes no freshness claim. See receipt_freshness.go.
+	Freshness *Freshness `json:"freshness,omitempty"`
+
 	// PredicateName is the predicate evaluated (e.g.,
 	// "applied-matches-spec"). See AllPredicates() in
 	// receipt_predicates.go for the v1 list.

--- a/pkg/agent/receipt_freshness.go
+++ b/pkg/agent/receipt_freshness.go
@@ -1,0 +1,47 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"fmt"
+	"time"
+)
+
+// Freshness is an immutable, stamped observation-freshness boundary on a
+// receipt (#478). It is populated only when the caller passes a TTL (e.g.
+// `--ttl`). It does NOT make the receipt mutable: observedAt records when the
+// live read happened and expiresAt = observedAt + ttl, both fixed at creation.
+// A consumer computes staleness at read time as `now > expiresAt`; the receipt
+// itself never changes. This is what lets a workerless ConfigHub tell a fresh
+// green from a stale one.
+type Freshness struct {
+	ObservedAt string `json:"observedAt"`
+	ExpiresAt  string `json:"expiresAt"`
+	TTL        string `json:"ttl"`
+}
+
+// ApplyFreshness stamps freshness onto an already-built receipt and re-stamps
+// the fingerprint so it covers the freshness fields. ttl <= 0 is a no-op (the
+// receipt keeps no freshness boundary and its existing fingerprint). observedAt
+// is taken from the receipt's verifiedAt — the moment cub-scout read the
+// cluster — so no separate clock read is needed and the two timestamps cannot
+// disagree.
+func ApplyFreshness(stmt *Statement, ttl time.Duration) error {
+	if stmt == nil || ttl <= 0 {
+		return nil
+	}
+	observedAt, err := time.Parse(time.RFC3339, stmt.Predicate.VerifiedAt)
+	if err != nil {
+		return fmt.Errorf("apply freshness: parse verifiedAt %q: %w", stmt.Predicate.VerifiedAt, err)
+	}
+	stmt.Predicate.Freshness = &Freshness{
+		ObservedAt: stmt.Predicate.VerifiedAt,
+		ExpiresAt:  observedAt.Add(ttl).UTC().Format(time.RFC3339),
+		TTL:        ttl.String(),
+	}
+	if err := StampFingerprint(stmt); err != nil {
+		return fmt.Errorf("apply freshness: re-stamp fingerprint: %w", err)
+	}
+	return nil
+}

--- a/pkg/agent/receipt_freshness_test.go
+++ b/pkg/agent/receipt_freshness_test.go
@@ -1,0 +1,73 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func freshnessTestReceipt(t *testing.T) Statement {
+	t.Helper()
+	desired := objectSetDeployment(1, "example/api:v1")
+	live := objectSetDeployment(1, "example/api:v1")
+	ev, err := BuildObjectSetEvidence(
+		ObjectSetSource{Type: "file", Ref: "rendered.yaml"},
+		ObjectSetScope{Kind: "namespace", Namespace: "prod"},
+		[]ObjectSetObservedObject{{Desired: desired, Live: live}},
+	)
+	if err != nil {
+		t.Fatalf("BuildObjectSetEvidence: %v", err)
+	}
+	stmt, err := BuildObjectSetReceipt(BuildObjectSetReceiptInput{
+		Evidence:   ev,
+		Verifier:   Verifier{Tool: "cub-scout", Version: "test"},
+		VerifiedAt: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("BuildObjectSetReceipt: %v", err)
+	}
+	return stmt
+}
+
+func TestApplyFreshness_StampsAndReFingerprints(t *testing.T) {
+	stmt := freshnessTestReceipt(t)
+	if stmt.Predicate.Freshness != nil {
+		t.Fatal("freshness should be nil before apply")
+	}
+	if err := ApplyFreshness(&stmt, time.Hour); err != nil {
+		t.Fatalf("ApplyFreshness: %v", err)
+	}
+	f := stmt.Predicate.Freshness
+	if f == nil {
+		t.Fatal("freshness nil after apply")
+	}
+	if f.ObservedAt != "2026-05-28T12:00:00Z" {
+		t.Fatalf("observedAt = %s", f.ObservedAt)
+	}
+	if f.ExpiresAt != "2026-05-28T13:00:00Z" {
+		t.Fatalf("expiresAt = %s, want observedAt + 1h", f.ExpiresAt)
+	}
+	if f.TTL != "1h0m0s" {
+		t.Fatalf("ttl = %s", f.TTL)
+	}
+	// The fingerprint must now cover the freshness fields.
+	if err := VerifyStatementFingerprint(stmt); err != nil {
+		t.Fatalf("fingerprint after freshness: %v", err)
+	}
+}
+
+func TestApplyFreshness_ZeroTTLIsNoOp(t *testing.T) {
+	stmt := freshnessTestReceipt(t)
+	before := stmt.Predicate.Fingerprint
+	if err := ApplyFreshness(&stmt, 0); err != nil {
+		t.Fatalf("ApplyFreshness(0): %v", err)
+	}
+	if stmt.Predicate.Freshness != nil {
+		t.Fatal("zero ttl must not stamp freshness")
+	}
+	if stmt.Predicate.Fingerprint != before {
+		t.Fatal("zero ttl must not change the fingerprint")
+	}
+}


### PR DESCRIPTION
## What

Implements #478 — receipt observation freshness. Adds an optional `--ttl` flag that stamps an immutable `freshness{observedAt, expiresAt, ttl}` onto a receipt so a workerless consumer can tell a fresh receipt from a stale one — the last structural piece the "submit observation receipts to a workerless ConfigHub" model needs (and the final ABSENT row on the `examples/helm-expt` scorecard).

## How

- New `Freshness` type + `Predicate.Freshness *Freshness` (`omitempty` — receipts without `--ttl` are byte-identical to before, so existing fingerprints are unchanged).
- `agent.ApplyFreshness(stmt, ttl)`: `observedAt` = the receipt's `verifiedAt` (the moment cub-scout read the cluster), `expiresAt` = observedAt + ttl, then re-stamps the fingerprint so it covers freshness. `ttl <= 0` is a no-op.
- Respects the receipts-immutability stance: freshness is fixed at creation; staleness is the consumer's read-time computation (`now > expiresAt`). The receipt never mutates.
- `--ttl <duration>` parsed once upfront in the dispatch; applied across every receipt path — single, object-set-matches, workloads-converged, prerequisites-met, and the aggregate (+ its per-resource receipts, stamped before they're chained).
- ASCII render gains a `Fresh:` line.

## Verified end-to-end (kind, `examples/helm-expt`)

`verify.sh` now passes `--ttl 1h`; the scorecard's freshness row flips ABSENT → present:

| predicate / capability | verdict |
|---|---|
| object-set-matches | PASS |
| prerequisites-met (#477) | BLOCK |
| workloads-converged (#476) | BLOCK |
| receipt freshness (#478) | **present (ttl 1h)** |

Sample: `freshness = {observedAt: …T12:28:21Z, expiresAt: …T13:28:21Z, ttl: 1h0m0s}`, fingerprint valid.

## Tests

- `pkg/agent`: `ApplyFreshness` stamps + re-fingerprints; `ttl=0` is a no-op (fingerprint unchanged).
- `cmd/cub-scout`: `--ttl` → freshness in JSON (fingerprint verifies); no `--ttl` → no freshness field; bad `--ttl` rejected.
- Full `pkg/agent` + `cmd/cub-scout` suites green; backward-compatible.
- Updates the `examples/helm-expt` example + docs to use and reflect `--ttl`.

Closes #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
