### PR TITLE
feat(#479): standalone git/file-as-DRY for compare three-way (--dry-from)

### DIFF
--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -149,7 +149,14 @@ var (
 	compareConnectedFn            = isCompareConnected
 	compareDefaultSpaceFn         = detectCompareSpace
 	runCompareCubCommand          = runCompareCubCommandImpl
+	loadCompareDryFromPathFn      = loadCompareDryFromPath
 )
+
+// compareThreeWayDrySummaries holds the DRY-side summaries loaded from a local
+// --dry-from file/dir (standalone git/file-as-DRY mode, #479). Non-nil only
+// while a `compare three-way --dry-from` run is in flight; buildCompareResourceResult
+// sources DRY from here instead of ConfigHub when set.
+var compareThreeWayDrySummaries []*compareSideSummary
 
 // compareSourcePath holds the value of --source-path (stage B back-resolution).
 // Read by detectCompareFieldMismatches when populating per-mismatch
@@ -226,6 +233,30 @@ func buildCompareResourceResult(ctx context.Context, resourceArg, namespace stri
 	}
 	if strings.TrimSpace(live.Source) == "" {
 		live.Source = "cluster"
+	}
+
+	// Standalone git/file-as-DRY (#479): when a --dry-from source is loaded,
+	// source the DRY side from it instead of ConfigHub and compare DRY vs LIVE.
+	// WET is unavailable without a deployer/ConfigHub, so it stays nil — the
+	// mismatch detector skips empty sides, so this is a clean DRY-vs-LIVE diff.
+	if compareThreeWayDrySummaries != nil {
+		dry := matchCompareDryFromSummaries(compareThreeWayDrySummaries, kind, name, ns)
+		notes := make([]string, 0, 1)
+		mode := "live-only"
+		if dry != nil {
+			mode = "dry-live"
+		} else {
+			notes = append(notes, fmt.Sprintf("No DRY manifest for %s/%s in %s found in the --dry-from source.", kind, name, ns))
+		}
+		return finalizeCompareResourceResultWithBindings(ctx, compareResourceResult{
+			Resource:  kind + "/" + name,
+			Namespace: ns,
+			Mode:      mode,
+			Connected: false,
+			Dry:       dry,
+			Live:      live,
+			Notes:     notes,
+		}), nil
 	}
 
 	connected := compareConnectedFn()
@@ -591,6 +622,36 @@ func matchesCompareSummaryTarget(summary *compareSideSummary, target compareReso
 	docNamespace := strings.TrimSpace(summary.Namespace)
 	targetNamespace := strings.TrimSpace(target.Namespace)
 	return docNamespace == "" || strings.EqualFold(docNamespace, targetNamespace)
+}
+
+// loadCompareDryFromPath loads DRY-side summaries from a local rendered YAML
+// file or directory (#479, standalone git/file-as-DRY). It reuses the
+// object-set loader so a directory (e.g. a git checkout), multi-doc YAML, and
+// kind:List are all handled, then summarizes each object into the same
+// compareSideSummary shape the ConfigHub DRY path produces — so the downstream
+// three-way comparison is identical regardless of where DRY came from.
+func loadCompareDryFromPath(path string) ([]*compareSideSummary, error) {
+	objs, _, err := loadObjectSetDesiredManifests(path)
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]*compareSideSummary, 0, len(objs))
+	for _, obj := range objs {
+		summaries = append(summaries, summarizeCompareManifestObject("dry", obj.Object))
+	}
+	return summaries, nil
+}
+
+// matchCompareDryFromSummaries finds the DRY summary for a target resource,
+// using the same Kind+Name(+Namespace) matching as the ConfigHub DRY path.
+func matchCompareDryFromSummaries(summaries []*compareSideSummary, kind, name, ns string) *compareSideSummary {
+	target := compareResourceRef{Kind: kind, Name: name, Namespace: ns}
+	for _, s := range summaries {
+		if matchesCompareSummaryTarget(s, target) {
+			return s
+		}
+	}
+	return nil
 }
 
 func loadCompareLiveSnapshot(ctx context.Context, kind, name, namespace string) (compareSideSummary, error) {

--- a/cmd/cub-scout/compare_three_way.go
+++ b/cmd/cub-scout/compare_three_way.go
@@ -91,6 +91,7 @@ var (
 	compareThreeWayFormat   string
 	compareThreeWayJSON     bool
 	compareThreeWayFailOn   string
+	compareThreeWayDryFrom  string
 
 	buildThreeWayResourceResultFn = buildCompareResourceResult
 	discoverThreeWayNamespacesFn  = discoverNamespacesWithWorkloads
@@ -147,11 +148,27 @@ func init() {
 	compareThreeWayCmd.Flags().BoolVar(&compareThreeWayJSON, "json", false, "Output as JSON (shorthand for --format json)")
 	compareThreeWayCmd.Flags().StringVar(&compareThreeWayFailOn, "fail-on", "", "Exit non-zero if max severity >= level (info, warning)")
 	compareThreeWayCmd.Flags().StringVar(&compareSourcePath, "source-path", "", "Local git checkout to back-resolve gitSource.file:line for each field mismatch (stage B; raw YAML only)")
+	compareThreeWayCmd.Flags().StringVar(&compareThreeWayDryFrom, "dry-from", "", "Standalone DRY source: a rendered YAML file or directory (e.g. a git checkout) used as the intended (DRY) state instead of ConfigHub. Compares DRY vs LIVE with no connected mode (#479).")
 }
 
 func runCompareThreeWay(cmd *cobra.Command, args []string) error {
 	if compareThreeWayScopeRaw != "" && compareThreeWayView != "" {
 		return fmt.Errorf("--scope and --view are mutually exclusive")
+	}
+
+	// Standalone git/file-as-DRY (#479): load the DRY side from a local
+	// rendered file/dir, so the three-way runs without ConfigHub. Loaded once
+	// here (not per resource) and consumed by buildCompareResourceResult.
+	if dryFrom := strings.TrimSpace(compareThreeWayDryFrom); dryFrom != "" {
+		if compareThreeWayView != "" {
+			return fmt.Errorf("--dry-from and --view are mutually exclusive (--view requires connected mode)")
+		}
+		summaries, err := loadCompareDryFromPathFn(dryFrom)
+		if err != nil {
+			return fmt.Errorf("load --dry-from %s: %w", dryFrom, err)
+		}
+		compareThreeWayDrySummaries = summaries
+		defer func() { compareThreeWayDrySummaries = nil }()
 	}
 
 	var scope threeWayScope
@@ -637,8 +654,10 @@ func compareResourceUnitIdentity(result compareResourceResult) (unitSlug, unitID
 // classifyResourcePattern determines the three-way pattern for a resource.
 // This reuses the logic from classifyThreeWayPattern but without sync/health status.
 func classifyResourcePattern(result compareResourceResult) ThreeWayPattern {
-	// Not connected = disconnected
-	if !result.Connected {
+	// Not connected AND no local DRY source = disconnected. A standalone
+	// --dry-from run (#479) is not connected but carries DRY evidence, so it
+	// must not be labeled disconnected.
+	if !result.Connected && result.Dry == nil {
 		return PatternDisconnected
 	}
 

--- a/cmd/cub-scout/compare_three_way_dryfrom_test.go
+++ b/cmd/cub-scout/compare_three_way_dryfrom_test.go
@@ -1,0 +1,119 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func threeWayDeploymentDryMap(name, ns string, replicas int64) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": name, "namespace": ns},
+		"spec":       map[string]interface{}{"replicas": replicas},
+	}
+}
+
+func withFakeDryFromLoader(t *testing.T, summaries []*compareSideSummary) {
+	t.Helper()
+	prev := loadCompareDryFromPathFn
+	loadCompareDryFromPathFn = func(string) ([]*compareSideSummary, error) { return summaries, nil }
+	t.Cleanup(func() { loadCompareDryFromPathFn = prev })
+}
+
+// withStandaloneThreeWayLive fakes LIVE (replicas) and forces standalone mode.
+func withStandaloneThreeWayLive(t *testing.T, replicas int64) {
+	t.Helper()
+	prevLive := loadCompareLiveSnapshotFn
+	prevConn := compareConnectedFn
+	loadCompareLiveSnapshotFn = func(_ context.Context, _, name, ns string) (compareSideSummary, error) {
+		r := replicas
+		return compareSideSummary{Source: "cluster", APIVersion: "apps/v1", Kind: "Deployment", Name: name, Namespace: ns, Replicas: &r}, nil
+	}
+	compareConnectedFn = func() bool { return false }
+	t.Cleanup(func() {
+		loadCompareLiveSnapshotFn = prevLive
+		compareConnectedFn = prevConn
+	})
+}
+
+func resetThreeWayFlags(t *testing.T) {
+	t.Helper()
+	prev := struct{ scope, view, format, failOn, dryFrom, ns string }{
+		compareThreeWayScopeRaw, compareThreeWayView, compareThreeWayFormat, compareThreeWayFailOn, compareThreeWayDryFrom, combinedNamespace,
+	}
+	compareThreeWayScopeRaw, compareThreeWayView, compareThreeWayFormat, compareThreeWayFailOn, compareThreeWayDryFrom, combinedNamespace = "", "", "ascii", "", "", ""
+	compareThreeWayJSON = false
+	t.Cleanup(func() {
+		compareThreeWayScopeRaw, compareThreeWayView, compareThreeWayFormat, compareThreeWayFailOn, compareThreeWayDryFrom, combinedNamespace = prev.scope, prev.view, prev.format, prev.failOn, prev.dryFrom, prev.ns
+		compareThreeWayJSON = false
+	})
+}
+
+func runStandaloneThreeWay(t *testing.T) threeWayReport {
+	t.Helper()
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"compare", "three-way", "--scope", "deploy/web", "-n", "prod", "--dry-from", "/tmp/ignored-by-fake", "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+	var report threeWayReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("unmarshal report: %v\n%s", err, out)
+	}
+	if len(report.Resources) != 1 {
+		t.Fatalf("resources=%d want 1\n%s", len(report.Resources), out)
+	}
+	return report
+}
+
+// Standalone DRY (from a rendered file) vs LIVE: replicas differ -> drift.
+func TestThreeWay_DryFromFile_DriftDetected(t *testing.T) {
+	resetThreeWayFlags(t)
+	withFakeDryFromLoader(t, []*compareSideSummary{summarizeCompareManifestObject("dry", threeWayDeploymentDryMap("web", "prod", 3))})
+	withStandaloneThreeWayLive(t, 5)
+
+	report := runStandaloneThreeWay(t)
+	r := report.Resources[0]
+	if r.Result.Connected {
+		t.Fatal("standalone --dry-from must be Connected=false")
+	}
+	if r.Result.Dry == nil {
+		t.Fatal("DRY must be sourced from --dry-from")
+	}
+	if r.Pattern == PatternDisconnected {
+		t.Fatal("standalone-with-DRY must NOT be classified disconnected")
+	}
+	if report.Summary.MismatchedResources != 1 {
+		t.Fatalf("mismatchedResources=%d want 1", report.Summary.MismatchedResources)
+	}
+	found := false
+	for _, m := range r.Result.Mismatches {
+		if m.Field == "replicas" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a replicas mismatch (DRY 3 vs LIVE 5); got %+v", r.Result.Mismatches)
+	}
+}
+
+// Standalone DRY matches LIVE -> agreed, no mismatches.
+func TestThreeWay_DryFromFile_Agreed(t *testing.T) {
+	resetThreeWayFlags(t)
+	withFakeDryFromLoader(t, []*compareSideSummary{summarizeCompareManifestObject("dry", threeWayDeploymentDryMap("web", "prod", 3))})
+	withStandaloneThreeWayLive(t, 3)
+
+	report := runStandaloneThreeWay(t)
+	if report.Summary.MismatchedResources != 0 {
+		t.Fatalf("mismatchedResources=%d want 0", report.Summary.MismatchedResources)
+	}
+	if report.Resources[0].Pattern != PatternAgreed {
+		t.Fatalf("pattern=%v want Agreed", report.Resources[0].Pattern)
+	}
+}


### PR DESCRIPTION
## What

Implements #479 — standalone **git/file-as-DRY** for `compare three-way`. A new `--dry-from <file|dir>` flag sources the DRY (intended) state from a rendered YAML file or directory (e.g. a git checkout) instead of ConfigHub, so the DRY/WET/LIVE comparison runs **without connected mode** — DRY-vs-LIVE drift detection for anyone who has rendered manifests but no ConfigHub (e.g. helm-expt).

## How

The seam was already clean: target collection for resource/namespace/cluster scope is cluster-only, DRY sourcing sits behind a function variable, and the YAML→summary canonicalizer + mismatch detector are source-agnostic (the detector skips empty sides, so WET=nil is a clean DRY-vs-LIVE diff).

- `--dry-from` loads the rendered set **once** (reusing the object-set loader — handles directories, multi-doc YAML, `kind:List`) into DRY `compareSideSummary`s, matched per resource by the same Kind+Name(+Namespace) logic as the ConfigHub DRY path.
- `buildCompareResourceResult` gains a guarded branch: when a `--dry-from` source is active it builds a `dry-live` result (Connected=false, Wet=nil) and skips the ConfigHub path entirely.
- Fixed `classifyResourcePattern` so a standalone result that *has* local DRY is not mislabeled "disconnected" (the one behavioral subtlety — behavior-identical for all existing cases, since connected mode always had DRY).

## Verified end-to-end (kind, no ConfigHub)

```
# DRY = rendered fixture, LIVE = cluster
compare three-way --scope namespace/helm-expt-demo --dry-from release-objects.yaml
  -> connectedResources:0   web: connected=false mode=dry-live pattern=agreed   (DRY 1 == LIVE 1)

# kubectl scale deploy/web --replicas=3  -> drift
  -> exit 2 (--fail-on warning)  mismatched:1  web: pattern=change-in-progress  mismatches=[replicas]   (DRY 1 vs LIVE 3)
```

## Tests

- `cmd/cub-scout`: standalone drift-detected (DRY≠LIVE → replicas mismatch, Connected=false, **not** "disconnected") and agreed (DRY==LIVE → PatternAgreed), via the `loadCompareDryFromPathFn` + `loadCompareLiveSnapshotFn` seams.
- Full `cmd/cub-scout` suite green — golden three-way tests unaffected (the new branch is guarded; the classifier change is behavior-equivalent for connected mode).

## Scope

v1 = local file/dir DRY for resource/namespace/cluster scope, DRY-vs-LIVE (WET is unavailable standalone). Follow-ups: `--git-url` remote clone (prior art: `loadCombinedRepoSource`) and a dedicated "drift" pattern label.

Closes #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
