### PR TITLE
feat(receipts #482): reference external evidence by content digest

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -37,6 +37,7 @@ var (
 	receiptPrerequisitesFile string
 	receiptTTL               string
 	receiptTTLDur            time.Duration
+	receiptReferenceEvidence []string
 )
 
 // runReceiptVerifyDispatch is the shared entry point for the receipt
@@ -154,6 +155,7 @@ Examples:
   cub-scout receipt verify --file out/manifests --scope namespace/redis --format json --out install.receipt.json
   cub-scout receipt verify --file out/manifests --scope namespace/redis --predicate workloads-converged --fail-on any-non-pass
   cub-scout receipt verify --prerequisites prereqs.yaml --scope namespace/redis --fail-on any-non-pass
+  cub-scout receipt verify --file out/manifests --scope namespace/redis --reference-evidence upstream-package.receipt.json
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runReceiptVerifyDispatch,
@@ -178,6 +180,7 @@ func init() {
 	receiptVerifyCmd.Flags().StringVar(&receiptSaveDir, "save-dir", "", "Override the store directory used when --save is set")
 	receiptVerifyCmd.Flags().StringVar(&receiptFailOn, "fail-on", "", "Exit non-zero (code 2) when the receipt verdict matches. Accepts a comma-separated list of verdicts (WATCH, BLOCK, INCONCLUSIVE) or the sugar 'any-non-pass' (= WATCH,BLOCK,INCONCLUSIVE). The receipt is still printed / saved / written to --out regardless of exit code.")
 	receiptVerifyCmd.Flags().StringArrayVar(&receiptInputAttestations, "input-attestation", nil, "Path to a prior receipt to reference via inputAttestations[] (repeatable). Each referenced receipt's fingerprint is verified at chain-construction time; tampered receipts are refused. The new receipt's fingerprint covers the inputAttestations[] field by construction.")
+	receiptVerifyCmd.Flags().StringArrayVar(&receiptReferenceEvidence, "reference-evidence", nil, "Path to an EXTERNAL (non-cub-scout) evidence artifact to reference via inputAttestations[] by content digest (repeatable). Recorded under the external-evidence:// scheme with digest-asserted (not fingerprint-verified) trust — lets an upstream producer's artifact (e.g. a render/package receipt) enter the chain without cub-scout understanding its format (#482).")
 	receiptVerifyCmd.Flags().StringVar(&receiptScope, "scope", "", "Scope selector. Without --file: aggregate-receipt scope (#448), accepting 'namespace/<ns>' or a comma-list positional. With --file: object-set scope, accepting 'namespace/<ns>' or 'cluster'.")
 	receiptVerifyCmd.Flags().StringVar(&receiptAggregatePolicy, "aggregate-policy", "", "Verdict-synthesis policy for the aggregate receipt (#448). v1 supports only 'max-severity' (the default; BLOCK > INCONCLUSIVE > WATCH > PASS).")
 
@@ -321,13 +324,9 @@ func runReceiptVerify(cmd *cobra.Command, args []string) error {
 	// evidence. The returned wrappers are the API-boundary-checked type
 	// (`VerifiedAttestationRef`); BuildReceipt unwraps them when it
 	// populates the wire shape. See pkg/agent/receipt_inputattestations.go.
-	var inputAttestations []agent.VerifiedAttestationRef
-	if len(receiptInputAttestations) > 0 {
-		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
-		if refErr != nil {
-			return fmt.Errorf("build input-attestations: %w", refErr)
-		}
-		inputAttestations = refs
+	inputAttestations, iaErr := collectReceiptInputAttestations()
+	if iaErr != nil {
+		return iaErr
 	}
 
 	// 5. Build the receipt.
@@ -500,6 +499,29 @@ func parseReceiptTTL() (time.Duration, error) {
 		return 0, fmt.Errorf("invalid --ttl %q (must not be negative)", raw)
 	}
 	return d, nil
+}
+
+// collectReceiptInputAttestations builds the combined inputAttestations[] from
+// both --input-attestation (cub-scout receipts, fingerprint-verified) and
+// --reference-evidence (external artifacts, digest-asserted, #482). The two
+// reference kinds share the field but are distinguished by URI scheme.
+func collectReceiptInputAttestations() ([]agent.VerifiedAttestationRef, error) {
+	var refs []agent.VerifiedAttestationRef
+	if len(receiptInputAttestations) > 0 {
+		r, err := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build input-attestations: %w", err)
+		}
+		refs = append(refs, r...)
+	}
+	if len(receiptReferenceEvidence) > 0 {
+		r, err := agent.BuildExternalAttestationRefsFromPaths(receiptReferenceEvidence, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build reference-evidence: %w", err)
+		}
+		refs = append(refs, r...)
+	}
+	return refs, nil
 }
 
 // loadReceiptLive fetches the live K8s object via the dynamic client. The

--- a/cmd/cub-scout/receipt_object_set.go
+++ b/cmd/cub-scout/receipt_object_set.go
@@ -82,13 +82,9 @@ func runReceiptVerifyObjectSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var inputAttestations []agent.VerifiedAttestationRef
-	if len(receiptInputAttestations) > 0 {
-		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
-		if refErr != nil {
-			return fmt.Errorf("build input-attestations: %w", refErr)
-		}
-		inputAttestations = refs
+	inputAttestations, iaErr := collectReceiptInputAttestations()
+	if iaErr != nil {
+		return iaErr
 	}
 
 	stmt, err := agent.BuildObjectSetReceipt(agent.BuildObjectSetReceiptInput{

--- a/cmd/cub-scout/receipt_prerequisites.go
+++ b/cmd/cub-scout/receipt_prerequisites.go
@@ -104,13 +104,9 @@ func runReceiptVerifyPrerequisites(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var inputAttestations []agent.VerifiedAttestationRef
-	if len(receiptInputAttestations) > 0 {
-		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
-		if refErr != nil {
-			return fmt.Errorf("build input-attestations: %w", refErr)
-		}
-		inputAttestations = refs
+	inputAttestations, iaErr := collectReceiptInputAttestations()
+	if iaErr != nil {
+		return iaErr
 	}
 
 	stmt, err := agent.BuildPrerequisitesReceipt(agent.BuildPrerequisitesReceiptInput{

--- a/cmd/cub-scout/receipt_reference_evidence_test.go
+++ b/cmd/cub-scout/receipt_reference_evidence_test.go
@@ -1,0 +1,72 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// --reference-evidence chains an external (non-cub-scout) artifact into a
+// cub-scout receipt's inputAttestations[] by content digest, under the
+// external-evidence:// scheme, and the receipt fingerprint covers it.
+func TestReceiptVerify_ReferenceEvidence_ChainsExternalByDigest(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	prevRef := receiptReferenceEvidence
+	receiptReferenceEvidence = nil
+	t.Cleanup(func() { receiptReferenceEvidence = prevRef })
+
+	dir := t.TempDir()
+	ext := filepath.Join(dir, "upstream-package.receipt.json")
+	if err := os.WriteFile(ext, []byte(`{"kind":"InstallerPackageReceipt","renderedObjectSetSHA256":"deadbeef"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := writeObjectSetManifest(t, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+  namespace: prod
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		live.SetNamespace("prod")
+		desired[0].SetNamespace("prod")
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "--file", manifest, "--scope", "namespace/prod", "--predicate", "object-set-matches", "--reference-evidence", ext, "--format", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if len(stmt.Predicate.InputAttestations) != 1 {
+		t.Fatalf("expected 1 inputAttestation, got %d", len(stmt.Predicate.InputAttestations))
+	}
+	ref := stmt.Predicate.InputAttestations[0]
+	if !strings.HasPrefix(ref.URI, agent.ExternalEvidenceURIScheme) {
+		t.Fatalf("URI %q is not external-evidence://", ref.URI)
+	}
+	if ref.Digest["sha256"] == "" {
+		t.Fatal("external ref missing sha256 digest")
+	}
+	if err := agent.VerifyStatementFingerprint(stmt); err != nil {
+		t.Fatalf("fingerprint must cover the external reference: %v", err)
+	}
+}

--- a/cmd/cub-scout/receipt_workloads.go
+++ b/cmd/cub-scout/receipt_workloads.go
@@ -82,13 +82,9 @@ func runReceiptVerifyWorkloadsConverged(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	var inputAttestations []agent.VerifiedAttestationRef
-	if len(receiptInputAttestations) > 0 {
-		refs, refErr := agent.BuildAttestationRefsFromPaths(receiptInputAttestations, nil)
-		if refErr != nil {
-			return fmt.Errorf("build input-attestations: %w", refErr)
-		}
-		inputAttestations = refs
+	inputAttestations, iaErr := collectReceiptInputAttestations()
+	if iaErr != nil {
+		return iaErr
 	}
 
 	stmt, err := agent.BuildWorkloadsConvergedReceipt(agent.BuildWorkloadsConvergedReceiptInput{

--- a/pkg/agent/receipt_external_ref_test.go
+++ b/pkg/agent/receipt_external_ref_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestBuildExternalAttestationRef_DigestAndScheme(t *testing.T) {
+	content := []byte(`{"kind":"InstallerPackageReceipt","renderedObjectSetSHA256":"abc"}`)
+	ref, err := BuildExternalAttestationRef(content)
+	if err != nil {
+		t.Fatalf("BuildExternalAttestationRef: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	want := hex.EncodeToString(sum[:])
+	if got := ref.Ref().Digest["sha256"]; got != want {
+		t.Fatalf("digest = %s, want %s", got, want)
+	}
+	if !strings.HasPrefix(ref.Ref().URI, ExternalEvidenceURIScheme) {
+		t.Fatalf("URI %q lacks the external-evidence:// scheme", ref.Ref().URI)
+	}
+	// Must be distinguishable from a fingerprint-verified cub-scout receipt ref.
+	if strings.HasPrefix(ref.Ref().URI, AttestationURIScheme) {
+		t.Fatalf("external ref must NOT use the cub-scout-receipt:// scheme")
+	}
+	if ref.IsZero() {
+		t.Fatal("external ref must be non-zero (usable by BuildReceipt)")
+	}
+}
+
+func TestBuildExternalAttestationRef_EmptyErrors(t *testing.T) {
+	if _, err := BuildExternalAttestationRef(nil); err == nil {
+		t.Fatal("empty content must error")
+	}
+}
+
+func TestBuildExternalAttestationRefsFromPaths_FakeReader(t *testing.T) {
+	refs, err := BuildExternalAttestationRefsFromPaths([]string{"a", "b"}, func(p string) ([]byte, error) {
+		return []byte("content-of-" + p), nil
+	})
+	if err != nil {
+		t.Fatalf("BuildExternalAttestationRefsFromPaths: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("got %d refs, want 2", len(refs))
+	}
+	// Distinct content -> distinct digests.
+	if refs[0].Ref().Digest["sha256"] == refs[1].Ref().Digest["sha256"] {
+		t.Fatal("distinct content must yield distinct digests")
+	}
+}

--- a/pkg/agent/receipt_inputattestations.go
+++ b/pkg/agent/receipt_inputattestations.go
@@ -4,7 +4,10 @@
 package agent
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -179,6 +182,63 @@ func BuildAttestationRefsFromPaths(paths []string, loadFn func(path string) (Sta
 		ref, err := BuildAttestationRef(stmt)
 		if err != nil {
 			return nil, fmt.Errorf("build input-attestation from %s: %w", p, err)
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}
+
+// ExternalEvidenceURIScheme is the URI prefix for references to EXTERNAL
+// (non-cub-scout) evidence artifacts chained by content digest (#482). Format:
+//
+//	external-evidence://sha256/<short-digest>
+//
+// The distinct scheme is the whole point: a consumer reading
+// inputAttestations[] can tell a fingerprint-verified cub-scout receipt
+// (cub-scout-receipt://) apart from a digest-asserted external artifact
+// (external-evidence://). External refs carry a WEAKER trust basis — cub-scout
+// vouches only that the referenced bytes hashed to this SHA-256, not that the
+// artifact is a valid cub-scout receipt. This is what lets an upstream
+// producer's artifact (e.g. helm-expt's installer-package receipt) enter a
+// cub-scout receipt's chain without cub-scout having to understand its format.
+const ExternalEvidenceURIScheme = "external-evidence://"
+
+// BuildExternalAttestationRef references an external evidence artifact by the
+// SHA-256 of its raw bytes. Unlike BuildAttestationRef there is no cub-scout
+// fingerprint to verify — the trust basis is the content digest, recorded
+// under the external-evidence:// scheme (see ExternalEvidenceURIScheme).
+func BuildExternalAttestationRef(content []byte) (VerifiedAttestationRef, error) {
+	if len(content) == 0 {
+		return VerifiedAttestationRef{}, fmt.Errorf("build-external-attestation-ref: empty content; cannot reference an empty artifact")
+	}
+	sum := sha256.Sum256(content)
+	hexDigest := hex.EncodeToString(sum[:])
+	return VerifiedAttestationRef{
+		ref: AttestationRef{
+			URI: ExternalEvidenceURIScheme + "sha256/" + hexDigest[:12],
+			Digest: map[string]string{
+				"sha256": hexDigest,
+			},
+		},
+	}, nil
+}
+
+// BuildExternalAttestationRefsFromPaths reads each path and builds an external
+// (digest-asserted) attestation ref. The reader is injectable for tests.
+// Errors short-circuit — there is no partial-chain semantics.
+func BuildExternalAttestationRefsFromPaths(paths []string, readFn func(path string) ([]byte, error)) ([]VerifiedAttestationRef, error) {
+	if readFn == nil {
+		readFn = os.ReadFile
+	}
+	out := make([]VerifiedAttestationRef, 0, len(paths))
+	for _, p := range paths {
+		content, err := readFn(p)
+		if err != nil {
+			return nil, fmt.Errorf("read reference-evidence %s: %w", p, err)
+		}
+		ref, err := BuildExternalAttestationRef(content)
+		if err != nil {
+			return nil, fmt.Errorf("build reference-evidence from %s: %w", p, err)
 		}
 		out = append(out, ref)
 	}


### PR DESCRIPTION
## What

Implements #482 (v1) — the cub-scout side of the foreign-receipt bridge. A new `--reference-evidence <path>` flag references an **external (non-cub-scout) evidence artifact** in a receipt's `inputAttestations[]` by its content digest, under a distinct `external-evidence://` scheme — so an upstream producer's artifact (e.g. helm-expt's installer-package receipt) can enter a cub-scout receipt's chain without cub-scout having to understand its format. This turns the render → package → live story into one referenceable thread.

## How

- `agent.BuildExternalAttestationRef(content)` hashes the bytes (SHA-256) and records `AttestationRef{ URI: external-evidence://sha256/<short>, Digest: {sha256} }`. **Honest trust model:** the distinct `external-evidence://` scheme (vs the fingerprint-verified `cub-scout-receipt://`) tells a consumer this reference is **digest-asserted**, not fingerprint-verified — cub-scout vouches only that the referenced bytes hashed to this digest.
- `--reference-evidence` (repeatable) on `receipt verify`, alongside the existing `--input-attestation` (cub-scout receipts). Both feed the same `inputAttestations[]`; the receipt fingerprint covers them.
- Factored the four inline input-attestation blocks (single / object-set / workloads-converged / prerequisites) into one `collectReceiptInputAttestations()` helper — a net cleanup that also adds the flag uniformly.

## Tests

- `pkg/agent`: external ref digest + scheme, distinct from `cub-scout-receipt://`, empty-content error, distinct-content → distinct-digest.
- `cmd/cub-scout`: `--reference-evidence` chains an external artifact into a receipt's `inputAttestations[]` (external-evidence:// scheme, sha256 digest, fingerprint covers it).
- Full `pkg/agent` + `cmd/cub-scout` suites green.

## Scope (v1 vs follow-up)

v1 = reference any external artifact by **its content digest**, with honest digest-asserted trust. The **shared rendered-object-set digest convention** — so a cub-scout object-set receipt's rendered-set digest *equals* helm-expt's `renderedObjectSetSHA256` and the chain is verifiable by digest equality — is the harder, coordination-needing half and is deferred (it needs the helm-expt producer side, the #261 Codex work). This PR ships the cub-scout-side primitive that work would target.

Closes #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
