### PR TITLE
feat(#481 Phase 1): templated-source provenance honesty marker

### DIFF
--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -1034,6 +1034,13 @@ func renderGitSourceASCII(gs *agent.GitSourceAnchor) string {
 		}
 		parts = append(parts, fileRef)
 	}
+	if gs.SourceType != "" {
+		marker := "source=" + gs.SourceType
+		if gs.Resolution != "" {
+			marker += " (" + gs.Resolution + ")"
+		}
+		parts = append(parts, marker)
+	}
 	return strings.Join(parts, " ")
 }
 
@@ -1054,6 +1061,13 @@ func renderGitSourceMarkdown(gs *agent.GitSourceAnchor) string {
 			fileRef = fmt.Sprintf("file=`%s:%d`", gs.File, gs.Line)
 		}
 		parts = append(parts, fileRef)
+	}
+	if gs.SourceType != "" {
+		marker := "source=`" + gs.SourceType + "`"
+		if gs.Resolution != "" {
+			marker += " (" + gs.Resolution + ")"
+		}
+		parts = append(parts, marker)
 	}
 	return strings.Join(parts, " ")
 }

--- a/pkg/agent/git_source_anchor.go
+++ b/pkg/agent/git_source_anchor.go
@@ -46,6 +46,20 @@ type GitSourceAnchor struct {
 	// when the field path could not be resolved to a single line (e.g.,
 	// rendered Helm/Kustomize output).
 	Line int `json:"line,omitempty"`
+
+	// SourceType classifies the manifest source as "helm" or "kustomize" for
+	// TEMPLATED sources. Empty (treated as raw YAML) otherwise. Templated
+	// sources cannot be back-resolved to a single source file:line without a
+	// render-time source map (#481). Set only for templated sources, so raw
+	// anchors are byte-identical to before.
+	SourceType string `json:"sourceType,omitempty"`
+
+	// Resolution records how File/Line provenance was resolved. For templated
+	// sources it is "templated-source-not-resolved" — an explicit honesty
+	// marker that file:line is not recoverable from rendered output (rather
+	// than silently emitting a bare anchor). Empty for raw sources (where
+	// File/Line carry the answer when back-resolution succeeds). (#481)
+	Resolution string `json:"resolution,omitempty"`
 }
 
 // IsEmpty reports whether the anchor carries no useful information.
@@ -128,7 +142,7 @@ func collectArgoGitSource(ctx context.Context, obj *unstructured.Unstructured, o
 	if err != nil || res == nil || len(res.Chain) == 0 {
 		return nil
 	}
-	return anchorFromChainRoot(res.Chain[0])
+	return anchorWithTemplatedSource(res.Chain)
 }
 
 // traceArgoForOwner dispatches to the right Argo tracer entry point
@@ -166,7 +180,7 @@ func collectFluxGitSource(ctx context.Context, obj *unstructured.Unstructured, o
 	if err != nil || res == nil || len(res.Chain) == 0 {
 		return nil
 	}
-	return anchorFromChainRoot(res.Chain[0])
+	return anchorWithTemplatedSource(res.Chain)
 }
 
 // traceFluxForOwner dispatches Flux tracing similarly. Flux's Trace
@@ -195,6 +209,46 @@ func anchorFromChainRoot(root ChainLink) *GitSourceAnchor {
 	}
 	if anchor.IsEmpty() {
 		return nil
+	}
+	return anchor
+}
+
+// GitSourceAnchor.SourceType / Resolution values (#481).
+const (
+	GitSourceTypeHelm      = "helm"
+	GitSourceTypeKustomize = "kustomize"
+
+	// GitSourceTemplatedNotResolved is the honesty marker for Helm/Kustomize
+	// sources: their rendered output cannot be back-resolved to a single
+	// source file:line without a render-time source map.
+	GitSourceTemplatedNotResolved = "templated-source-not-resolved"
+)
+
+// classifyTemplatedSource scans an ownership chain for a Helm or Kustomize
+// link and returns the (sourceType, resolution) honesty marker. The whole
+// chain is scanned, not just the root, because the templated link (HelmChart /
+// HelmRelease / Kustomization) is often a non-root link while the root is the
+// underlying GitRepository/OCIRepository. Returns ("","") for plain raw YAML.
+func classifyTemplatedSource(chain []ChainLink) (string, string) {
+	for _, link := range chain {
+		if strings.Contains(link.Kind, "Helm") {
+			return GitSourceTypeHelm, GitSourceTemplatedNotResolved
+		}
+	}
+	for _, link := range chain {
+		if link.Kind == "Kustomization" {
+			return GitSourceTypeKustomize, GitSourceTemplatedNotResolved
+		}
+	}
+	return "", ""
+}
+
+// anchorWithTemplatedSource builds the root anchor and stamps the templated
+// honesty marker (#481) by scanning the chain.
+func anchorWithTemplatedSource(chain []ChainLink) *GitSourceAnchor {
+	anchor := anchorFromChainRoot(chain[0])
+	if anchor != nil {
+		anchor.SourceType, anchor.Resolution = classifyTemplatedSource(chain)
 	}
 	return anchor
 }

--- a/pkg/agent/git_source_anchor_templated_test.go
+++ b/pkg/agent/git_source_anchor_templated_test.go
@@ -1,0 +1,68 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClassifyTemplatedSource(t *testing.T) {
+	cases := []struct {
+		name  string
+		chain []ChainLink
+		want  string
+	}{
+		{"helm chart root", []ChainLink{{Kind: "HelmChart", URL: "https://repo"}}, GitSourceTypeHelm},
+		{"helm release non-root", []ChainLink{{Kind: "GitRepository", URL: "g"}, {Kind: "HelmRelease"}}, GitSourceTypeHelm},
+		{"kustomization non-root", []ChainLink{{Kind: "GitRepository", URL: "g"}, {Kind: "Kustomization", Path: "overlays/prod"}}, GitSourceTypeKustomize},
+		{"raw git", []ChainLink{{Kind: "GitRepository", URL: "g"}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st, res := classifyTemplatedSource(tc.chain)
+			if st != tc.want {
+				t.Fatalf("sourceType = %q, want %q", st, tc.want)
+			}
+			if tc.want == "" {
+				if res != "" {
+					t.Fatalf("raw must have empty resolution, got %q", res)
+				}
+			} else if res != GitSourceTemplatedNotResolved {
+				t.Fatalf("templated must carry the honesty marker, got %q", res)
+			}
+		})
+	}
+}
+
+func TestAnchorWithTemplatedSource_HelmMarker(t *testing.T) {
+	anchor := anchorWithTemplatedSource([]ChainLink{{Kind: "HelmChart", URL: "https://charts.example.com", Revision: "1.2.3"}})
+	if anchor == nil {
+		t.Fatal("anchor is nil")
+	}
+	if anchor.SourceType != GitSourceTypeHelm || anchor.Resolution != GitSourceTemplatedNotResolved {
+		t.Fatalf("sourceType=%q resolution=%q", anchor.SourceType, anchor.Resolution)
+	}
+	b, _ := json.Marshal(anchor)
+	if !strings.Contains(string(b), `"sourceType":"helm"`) || !strings.Contains(string(b), `"resolution":"templated-source-not-resolved"`) {
+		t.Fatalf("JSON missing the honesty marker: %s", b)
+	}
+}
+
+// Raw sources must stay byte-identical (omitempty) so existing provenance
+// output / golden tests are unaffected.
+func TestAnchorWithTemplatedSource_RawUnmarked(t *testing.T) {
+	anchor := anchorWithTemplatedSource([]ChainLink{{Kind: "GitRepository", URL: "https://github.com/x/y", Revision: "abc", Path: "manifests"}})
+	if anchor == nil {
+		t.Fatal("anchor is nil")
+	}
+	if anchor.SourceType != "" || anchor.Resolution != "" {
+		t.Fatalf("raw must be unmarked, got sourceType=%q resolution=%q", anchor.SourceType, anchor.Resolution)
+	}
+	b, _ := json.Marshal(anchor)
+	if strings.Contains(string(b), "sourceType") || strings.Contains(string(b), "resolution") {
+		t.Fatalf("raw anchor must not serialize the new fields: %s", b)
+	}
+}


### PR DESCRIPTION
## What

**Phase 1 of #481** (Helm/Kustomize provenance — an epic). This ships the honesty marker, not the full back-resolution. cub-scout's field provenance (`gitSource.file:line`) is recoverable for raw YAML but **silently degrades to a bare anchor for Helm/Kustomize** — exactly where most real config lives. Phase 1 makes that explicit instead of silent: a `GitSourceAnchor` for a templated source now carries `sourceType` (`helm`/`kustomize`) and `resolution: templated-source-not-resolved`.

## How

- `GitSourceAnchor` gains `SourceType` + `Resolution` (both `omitempty` — raw anchors are byte-identical, so existing output/goldens are unaffected).
- `classifyTemplatedSource` scans the **whole** ownership chain (not just the root — the templated link, HelmChart / HelmRelease / Kustomization, is often a non-root link over a GitRepository root) and stamps the marker. Wired into both the Argo and Flux collectors.
- ASCII/Markdown provenance renderers show the marker for templated sources (guarded, so raw output is unchanged).

## Why this is the right Phase 1

The full epic (true field → template-line + values-key for Helm and Kustomize) needs a render-time source map that neither tool emits natively — a multi-week effort (re-render engine / external source-map contract). Phase 1 is low-risk, additive, and directly fixes the proposal's stated concern that provenance must not "degrade silently exactly where Helm/Kustomize lives." It also unblocks consumers: a tool reading the receipt/compare JSON can now branch on `sourceType` instead of guessing.

## Phased plan (full scope)

- **Phase 1 (this PR):** templated-source identity + honesty marker. ✅
- **Phase 2:** values-key resolution — map a field to the Helm/HelmRelease values key, using data cub-scout already decodes (`helm_trace.go` Config, `gitops_extract.go` `spec.values`). Local-only, no rendering.
- **Phase 3:** ingest an external render-time source-map (pairs with helm-expt, which holds the chart→render mapping; reuses the #482 digest bridge).
- **Phase 4 (epic core):** local re-render (`helm template` / `kustomize build`) + line-tracked diff trace. Large, fragile; opt-in fallback.

## Tests

- `pkg/agent`: classification (helm root / helm non-root / kustomize non-root / raw), the JSON marker for helm, and raw-anchor-stays-unmarked (no golden breakage).
- Full `pkg/agent` + `cmd/cub-scout` suites green.

Part of #481 (does **not** close it — Phases 2–4 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
