### PR TITLE
docs(releases): v2.4.0 release notes

### DIFF
--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -1,0 +1,172 @@
+# v2.4.0 Release Notes — Standalone Install Verification
+
+> **Status:** Draft release notes. This file describes what the `v2.4.0`
+> tag will ship when cut from `main`.
+>
+> **Previous release:** [`v2.3.1`](v2.3.1.md) — install/object-set receipts.
+
+**Theme:** *verify an install actually worked — standalone, no ConfigHub required.*
+v2.3.1 added `object-set-matches` (the desired objects are present and their
+authored fields match). v2.4.0 completes the install-verification story:
+readiness, prerequisites, freshness, closed-world, standalone drift, external-
+evidence chaining, and templated-source provenance honesty. Together these close
+the gap set surfaced by the `confighub/helm-expt` experiment — where a receipt
+could report PASS while the workload could not start (finding F3).
+
+There are **no breaking changes.** Every addition is a new predicate, flag, or
+optional field; existing predicates, JSON contracts, command names, exit codes,
+and read-only invariants are unchanged.
+
+---
+
+## What's In This Release
+
+### Two new install-receipt predicates
+
+**`workloads-converged`** — readiness, not just presence. Where `object-set-matches`
+strips `status`, this predicate reads it: Deployments / StatefulSets / DaemonSets
+rolled out, Jobs Succeeded, PVCs Bound, and pods not wedged in
+`CreateContainerConfigError` / `CrashLoopBackOff` / `ImagePullBackOff`.
+
+```bash
+cub-scout receipt verify --file out/manifests --scope namespace/redis \
+  --predicate workloads-converged [--grace-window 5m] --fail-on any-non-pass
+```
+
+Verdict: PASS (all ready) / WATCH (rolling out within `--grace-window`) /
+BLOCK (failed, missing, stuck past grace, or a wedged pod) / INCONCLUSIVE.
+
+**`prerequisites-met`** — pre-flight target facts. Verifies declared cluster-state
+dependencies exist before an install is applied: CRDs established, Secrets present
+with named keys, namespaces / StorageClasses / IngressClasses existing.
+
+```bash
+cub-scout receipt verify --prerequisites prereqs.yaml --scope namespace/redis \
+  --fail-on any-non-pass
+```
+
+`prereqs.yaml` declares `requiredCRDs`, `requiredSecrets` (name/namespace/keys),
+`requiredNamespaces`, `requiredStorageClasses`, `requiredIngressClasses`. BLOCK on
+any missing fact.
+
+Together these catch the helm-expt F3 "silent false green" from both ends —
+`prerequisites-met` before apply (the missing Secret), `workloads-converged` after
+(the wedged pod) — where `object-set-matches` alone returns PASS.
+
+### Receipt observation freshness
+
+`receipt verify --ttl <duration>` stamps an immutable
+`freshness{observedAt, expiresAt, ttl}` on a receipt so a consumer can tell a
+fresh receipt from a stale one. `observedAt` = the verify moment; `expiresAt` =
+observedAt + ttl; staleness is the consumer's read-time computation — the receipt
+itself stays immutable.
+
+### Closed-world object-set check
+
+`receipt verify --file ... --no-extras` resolves the standing
+`extra-live-object-coverage` omission: it enumerates live objects of the rendered
+kinds in scope and flags any not in the desired set (skipping owner-referenced
+children and a small system denylist). Extras downgrade a clean PASS to WATCH.
+
+### Standalone git/file-as-DRY for `compare three-way`
+
+`compare three-way --dry-from <file|dir>` sources the intended (DRY) state from a
+rendered YAML file or git checkout instead of ConfigHub, so the DRY-vs-LIVE
+agreement view works with **no connected mode**:
+
+```bash
+cub-scout compare three-way --scope namespace/prod \
+  --dry-from rendered/release-objects.yaml --fail-on warning
+```
+
+### External-evidence chaining
+
+`receipt verify --reference-evidence <path>` references an external
+(non-cub-scout) artifact in a receipt's `inputAttestations[]` by content digest,
+under a distinct `external-evidence://` scheme — digest-asserted, not
+fingerprint-verified — so an upstream producer's artifact can enter a cub-scout
+receipt's chain without cub-scout understanding its format.
+
+### Templated-source provenance honesty (Helm / Kustomize)
+
+`GitSourceAnchor` now carries `sourceType` (`helm` / `kustomize`) and
+`resolution: templated-source-not-resolved` for templated sources, so field
+provenance no longer silently degrades to a bare anchor where Helm/Kustomize
+lives. (Phase 1 of #481; values-key and render-source-map resolution are planned
+follow-ons.)
+
+### Helm-experiment example + gap analysis
+
+[`examples/helm-expt/`](../../examples/helm-expt/) now runs all three
+install-receipt predicates against the same install and prints a scorecard,
+reproducing finding F3 on an ephemeral kind cluster. The driving gap analysis is
+[`docs/proposals/helm-expt-driven-gaps.md`](../proposals/helm-expt-driven-gaps.md).
+
+---
+
+## Behavior
+
+### What changes (all additive)
+
+- New predicates: `workloads-converged`, `prerequisites-met`
+- New `receipt verify` flags: `--grace-window`, `--prerequisites`, `--ttl`,
+  `--no-extras`, `--reference-evidence`
+- New `compare three-way` flag: `--dry-from`
+- New receipt fields (omitempty): `predicate.freshness`,
+  `objectSet.extraChecked` / `objectSet.extraObjects`
+- New evidence shapes: `workloads`, `prerequisites`
+- New subject schemes: `k8s-live-workloads://`, `declared-prerequisites://`,
+  `k8s-live-prerequisites://`
+- New attestation scheme: `external-evidence://`
+- New `gitSource` fields (omitempty): `sourceType`, `resolution`
+
+### What does not change
+
+- Existing predicates: `applied-matches-spec`, `source-truth-pass`,
+  `no-manual-edits-since`, `object-set-matches`, `aggregate-verdict`
+- Existing single-resource / aggregate / object-set receipt behavior
+- Existing `compare three-way` connected-mode behavior
+- Existing CLI exit codes, read-only invariants, and JSON contracts — raw git
+  anchors are byte-identical (the new fields are omitempty)
+
+---
+
+## Validation
+
+`go test ./...` green on `main`. Each capability was verified end-to-end on an
+ephemeral kind cluster (see PRs #484–#491). Focused coverage added:
+
+- `pkg/agent/receipt_{workloads,prerequisites,freshness}*_test.go`,
+  `receipt_external_ref_test.go`, `receipt_object_set_extras_test.go`,
+  `git_source_anchor_templated_test.go`
+- `cmd/cub-scout/receipt_{workloads,prerequisites,reference_evidence,freshness}*_test.go`,
+  `receipt_object_set_extras_test.go`, `compare_three_way_dryfrom_test.go`
+
+---
+
+## Upgrade / Install
+
+### Plugin form
+
+```bash
+cub plugin install confighub/cub-scout
+cub scout version    # should print v2.4.0
+```
+
+### Standalone
+
+```bash
+brew upgrade confighub/tap/cub-scout
+kubectl krew upgrade cub-scout
+curl -L https://github.com/confighub/cub-scout/releases/download/v2.4.0/cub-scout_v2.4.0_darwin_arm64.tar.gz | tar xz
+./cub-scout version
+```
+
+---
+
+## Linked
+
+- [`v2.3.1`](v2.3.1.md) — previous release
+- [`docs/proposals/helm-expt-driven-gaps.md`](../proposals/helm-expt-driven-gaps.md) — the gap analysis driving this release
+- [`examples/helm-expt`](../../examples/helm-expt/) — runnable install-verification example
+- `confighub/helm-expt#261` — the live-lane wiring on the producer side


### PR DESCRIPTION
Release notes for v2.4.0 (standalone install verification — the 9 PRs since v2.3.1). Docs-only; lands ahead of the v2.4.0 tag.