### PR TITLE
docs: mark v2.4.0 release notes published

### DIFF
--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -1,7 +1,9 @@
 # v2.4.0 Release Notes — Standalone Install Verification
 
-> **Status:** Draft release notes. This file describes what the `v2.4.0`
-> tag will ship when cut from `main`.
+> **Status:** Published on 2026-06-09.
+> [`v2.4.0`](https://github.com/confighub/cub-scout/releases/tag/v2.4.0)
+> is the latest public release, with six platform binaries and `checksums.txt`
+> attached to the GitHub release.
 >
 > **Previous release:** [`v2.3.1`](v2.3.1.md) — install/object-set receipts.
 


### PR DESCRIPTION
## Summary
- update v2.4.0 release notes from draft wording to published status
- link the public GitHub release and note the verified binary/checksum assets

## Checks
- git diff --check