### PR TITLE
feat: normalization profiles, canonical receipt digest, and chain walking (v2.5.0)

### DIFF
--- a/cmd/cub-scout/receipt.go
+++ b/cmd/cub-scout/receipt.go
@@ -39,6 +39,7 @@ var (
 	receiptTTLDur            time.Duration
 	receiptReferenceEvidence []string
 	receiptNoExtras          bool
+	receiptNormalizationProf string
 )
 
 // runReceiptVerifyDispatch is the shared entry point for the receipt
@@ -173,6 +174,7 @@ func init() {
 	receiptVerifyCmd.Flags().StringVar(&receiptPrerequisitesFile, "prerequisites", "", "YAML/JSON file declaring required cluster facts (requiredCRDs, requiredSecrets, requiredNamespaces, requiredStorageClasses, requiredIngressClasses) for a prerequisites-met receipt.")
 	receiptVerifyCmd.Flags().StringVar(&receiptTTL, "ttl", "", "Observation-freshness boundary, e.g. 1h. When set, the receipt records an immutable freshness{observedAt,expiresAt,ttl} so a consumer can tell a fresh receipt from a stale one. Empty means the receipt makes no freshness claim.")
 	receiptVerifyCmd.Flags().BoolVar(&receiptNoExtras, "no-extras", false, "For --predicate object-set-matches: also run the closed-world check — flag live objects of the rendered kinds in scope that are not in the desired set (resolves the extra-live-object-coverage omission). Extras downgrade a clean PASS to WATCH. Skips owner-referenced children and system objects.")
+	receiptVerifyCmd.Flags().StringVar(&receiptNormalizationProf, "normalization-profile", "", "Named server-normalization profile applied symmetrically to desired and live objects before object-set comparison and digesting (e.g. k8s-zero-defaults/v1). Recorded on the receipt. Empty means raw comparison.")
 	receiptVerifyCmd.Flags().StringVar(&receiptAtCommit, "at-commit", "", "Override the spec anchor revision (Git SHA). When empty, the controller-resolved anchor is used as both the spec and the evidence.")
 	receiptVerifyCmd.Flags().StringVar(&receiptStrategy, "strategy", "", "Source-truth strategy for source-truth-pass (e.g. git-argo). cub-scout does not infer the strategy.")
 	receiptVerifyCmd.Flags().StringVar(&receiptSince, "since", "", "RFC 3339 cutoff for no-manual-edits-since (e.g. 2026-05-22T00:00:00Z).")

--- a/cmd/cub-scout/receipt_chain_test.go
+++ b/cmd/cub-scout/receipt_chain_test.go
@@ -1,0 +1,153 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func resetChainFlags(t *testing.T) {
+	t.Helper()
+	prevD, prevP, prevF, prevE := digestFile, digestProfile, chainFile, chainEvidenceDir
+	prevIA, prevRE := receiptInputAttestations, receiptReferenceEvidence
+	digestFile, digestProfile, chainFile, chainEvidenceDir = "", "", "", ""
+	receiptInputAttestations, receiptReferenceEvidence = nil, nil
+	t.Cleanup(func() {
+		digestFile, digestProfile, chainFile, chainEvidenceDir = prevD, prevP, prevF, prevE
+		receiptInputAttestations, receiptReferenceEvidence = prevIA, prevRE
+	})
+}
+
+func buildChainFixture(t *testing.T, dir string) (leafPath string) {
+	t.Helper()
+	manifest := writeObjectSetManifest(t, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+  namespace: prod
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		live.SetNamespace("prod")
+		desired[0].SetNamespace("prod")
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	upstream := filepath.Join(dir, "upstream.receipt.json")
+	receiptInputAttestations, receiptReferenceEvidence = nil, nil
+	captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "--file", manifest, "--scope", "namespace/prod", "--predicate", "object-set-matches", "--format", "json", "--out", upstream})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("build upstream receipt: %v", err)
+		}
+	})
+
+	external := filepath.Join(dir, "render.evidence.json")
+	if err := os.WriteFile(external, []byte(`{"kind":"InstallerPackageReceipt","renderedObjectSetSHA256":"abc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	leafPath = filepath.Join(dir, "leaf.receipt.json")
+	receiptInputAttestations, receiptReferenceEvidence = nil, nil
+	captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "verify", "--file", manifest, "--scope", "namespace/prod", "--predicate", "object-set-matches", "--format", "json",
+			"--input-attestation", upstream, "--reference-evidence", external, "--out", leafPath})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("build leaf receipt: %v", err)
+		}
+	})
+	return leafPath
+}
+
+func TestReceiptChain_VerifiesAndDetectsTamper(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	resetChainFlags(t)
+	dir := t.TempDir()
+	leaf := buildChainFixture(t, dir)
+
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "chain", "--file", leaf, "--evidence-dir", dir})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("chain verify should pass: %v", err)
+		}
+	})
+	if !strings.Contains(out, "chain verified") {
+		t.Fatalf("expected chain verified, got:\n%s", out)
+	}
+	if !strings.Contains(out, "digest-asserted, not fingerprint-verified") {
+		t.Fatalf("external link must print its weaker trust label, got:\n%s", out)
+	}
+
+	// Tamper with the upstream receipt: the chain must fail with exit 2.
+	upstream := filepath.Join(dir, "upstream.receipt.json")
+	data, _ := os.ReadFile(upstream)
+	if err := os.WriteFile(upstream, []byte(strings.Replace(string(data), "PASS", "FAIL", 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resetChainFlags(t)
+	captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "chain", "--file", leaf, "--evidence-dir", dir})
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("tampered upstream must fail the chain")
+		}
+		var ec interface{ ExitCode() int }
+		if !errors.As(err, &ec) || ec.ExitCode() != 2 {
+			t.Fatalf("expected exit 2, got %v", err)
+		}
+	})
+}
+
+func TestReceiptDigest_MatchesReceiptSubject(t *testing.T) {
+	resetReceiptFlags(t)
+	resetReceiptBatch3Flags(t)
+	resetReceiptFailOnFlag(t)
+	resetChainFlags(t)
+	dir := t.TempDir()
+	leaf := buildChainFixture(t, dir)
+
+	// receipt digest over the same manifests must equal the leaf's
+	// rendered-object-set subject digest (the cross-tool convention).
+	stmt, err := agent.LoadStatement(leaf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var subjectDigest string
+	for _, s := range stmt.Subject {
+		if strings.HasPrefix(s.Name, agent.SubjectSchemeRenderedObjectSet) {
+			subjectDigest = s.Digest["sha256"]
+		}
+	}
+	if subjectDigest == "" {
+		t.Fatal("leaf has no rendered-object-set subject")
+	}
+
+	manifest := writeObjectSetManifest(t, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+  namespace: prod
+`)
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs([]string{"receipt", "digest", "--file", manifest})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("receipt digest: %v", err)
+		}
+	})
+	if !strings.Contains(out, subjectDigest) {
+		t.Fatalf("digest command output does not contain the receipt subject digest %s:\n%s", subjectDigest, out)
+	}
+}

--- a/cmd/cub-scout/receipt_digest_chain.go
+++ b/cmd/cub-scout/receipt_digest_chain.go
@@ -1,0 +1,216 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+)
+
+// receipt digest — the producer half of the cross-tool digest convention.
+// Computes the canonical rendered-object-set digest for a manifest set,
+// byte-identical to the desiredDigest an object-set-matches receipt records
+// for the same inputs and normalization profile. External producers (e.g.
+// helm-expt render receipts) call this instead of reimplementing the
+// canonicalization, which is what makes digest-equality chaining possible.
+var receiptDigestCmd = &cobra.Command{
+	Use:   "digest",
+	Short: "Compute the canonical rendered-object-set digest for a manifest set",
+	Long: `digest computes the canonical digest of a rendered object set: SHA-256 over
+RFC 8785 canonical JSON of the sorted (id, comparable-object) entries, after
+optional --normalization-profile normalization.
+
+The value is byte-identical to the desiredDigest (and rendered-object-set://
+subject digest) that 'receipt verify --file' records for the same inputs and
+profile. Producers stamp it on their own artifacts; verifiers chain by digest
+equality.`,
+	Args: cobra.NoArgs,
+	RunE: runReceiptDigest,
+}
+
+var receiptChainCmd = &cobra.Command{
+	Use:   "chain",
+	Short: "Walk and verify a receipt's attestation chain",
+	Long: `chain loads a leaf receipt, verifies its fingerprint, then resolves every
+inputAttestations[] entry against --evidence-dir:
+
+  cub-scout-receipt://  resolved by recomputing fingerprints of candidate
+                        receipts in the directory; resolved receipts are
+                        verified and walked recursively
+  external-evidence://  resolved by content SHA-256 over the files in the
+                        directory; digest-asserted (the trust label is
+                        printed, not upgraded)
+
+Exit 0 only when the leaf and every reachable link verify. Any unresolved or
+tampered link exits 2. Subject digests are printed so producers can check
+rendered-object-set digest equality across tools.`,
+	Args: cobra.NoArgs,
+	RunE: runReceiptChain,
+}
+
+var (
+	digestFile        string
+	digestProfile     string
+	chainFile         string
+	chainEvidenceDir  string
+	chainPrintMaxDeep = 16
+)
+
+func init() {
+	receiptCmd.AddCommand(receiptDigestCmd)
+	receiptDigestCmd.Flags().StringVar(&digestFile, "file", "", "YAML file or directory containing the rendered object set (required)")
+	receiptDigestCmd.Flags().StringVar(&digestProfile, "normalization-profile", "", "Named server-normalization profile (e.g. k8s-zero-defaults/v1); must match the verifier's profile for digests to chain")
+
+	receiptCmd.AddCommand(receiptChainCmd)
+	receiptChainCmd.Flags().StringVar(&chainFile, "file", "", "Leaf receipt JSON to start from (required)")
+	receiptChainCmd.Flags().StringVar(&chainEvidenceDir, "evidence-dir", "", "Directory holding the referenced receipts and external artifacts (required)")
+}
+
+func runReceiptDigest(cmd *cobra.Command, args []string) error {
+	if strings.TrimSpace(digestFile) == "" {
+		return fmt.Errorf("--file is required")
+	}
+	objs, source, err := loadObjectSetDesiredManifests(digestFile)
+	if err != nil {
+		return err
+	}
+	profile := strings.TrimSpace(digestProfile)
+	digest, count, err := agent.ComputeRenderedObjectSetDigest(profile, objs)
+	if err != nil {
+		return err
+	}
+	out := map[string]interface{}{
+		"convention":              "rendered-object-set/v1",
+		"renderedObjectSetDigest": digest,
+		"objectCount":             count,
+		"normalizationProfile":    profile,
+		"sourceDigest":            source.Digest,
+		"sourceRef":               source.Ref,
+	}
+	buf, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(buf))
+	return nil
+}
+
+type chainResolver struct {
+	statements map[string]agent.Statement // full fingerprint hex -> verified statement
+	files      map[string][]string        // content sha256 -> file paths
+	problems   []string
+}
+
+func newChainResolver(dir string) (*chainResolver, error) {
+	resolver := &chainResolver{statements: map[string]agent.Statement{}, files: map[string][]string{}}
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		sum := sha256.Sum256(data)
+		key := hex.EncodeToString(sum[:])
+		resolver.files[key] = append(resolver.files[key], path)
+		if strings.HasSuffix(path, ".json") {
+			var stmt agent.Statement
+			if json.Unmarshal(data, &stmt) == nil && stmt.Type == agent.StatementType {
+				fp := strings.TrimPrefix(strings.TrimSpace(stmt.Predicate.Fingerprint), "sha256:")
+				if fp != "" && agent.VerifyStatementFingerprint(stmt) == nil {
+					resolver.statements[fp] = stmt
+				}
+			}
+		}
+		return nil
+	})
+	return resolver, err
+}
+
+func (r *chainResolver) walk(stmt agent.Statement, depth int, out *strings.Builder) {
+	indent := strings.Repeat("  ", depth)
+	name := string(stmt.Predicate.PredicateName)
+	if name == "" {
+		name = "(no predicate)"
+	}
+	fmt.Fprintf(out, "%s- %s verdict=%s fingerprint=%s [verified]\n", indent, name, stmt.Predicate.Verdict, shortHex(stmt.Predicate.Fingerprint))
+	for _, subject := range stmt.Subject {
+		fmt.Fprintf(out, "%s    subject %s sha256=%s\n", indent, subject.Name, shortHex(subject.Digest["sha256"]))
+	}
+	if depth >= chainPrintMaxDeep {
+		r.problems = append(r.problems, "chain deeper than the walk limit")
+		return
+	}
+	for _, ref := range stmt.Predicate.InputAttestations {
+		digest := ref.Digest["sha256"]
+		switch {
+		case strings.HasPrefix(ref.URI, agent.AttestationURIScheme):
+			child, ok := r.statements[digest]
+			if !ok {
+				r.problems = append(r.problems, fmt.Sprintf("unresolved or tampered cub-scout receipt %s (digest %s)", ref.URI, shortHex(digest)))
+				fmt.Fprintf(out, "%s  - %s [UNRESOLVED]\n", indent, ref.URI)
+				continue
+			}
+			r.walk(child, depth+1, out)
+		case strings.HasPrefix(ref.URI, agent.ExternalEvidenceURIScheme):
+			paths, ok := r.files[digest]
+			if !ok {
+				r.problems = append(r.problems, fmt.Sprintf("unresolved external evidence %s (digest %s)", ref.URI, shortHex(digest)))
+				fmt.Fprintf(out, "%s  - %s [UNRESOLVED]\n", indent, ref.URI)
+				continue
+			}
+			sort.Strings(paths)
+			fmt.Fprintf(out, "%s  - %s -> %s [digest-asserted, not fingerprint-verified]\n", indent, ref.URI, paths[0])
+		default:
+			r.problems = append(r.problems, fmt.Sprintf("unknown attestation scheme %s", ref.URI))
+			fmt.Fprintf(out, "%s  - %s [UNKNOWN SCHEME]\n", indent, ref.URI)
+		}
+	}
+}
+
+func shortHex(value string) string {
+	value = strings.TrimPrefix(strings.TrimSpace(value), "sha256:")
+	if len(value) > 12 {
+		return value[:12]
+	}
+	return value
+}
+
+func runReceiptChain(cmd *cobra.Command, args []string) error {
+	if strings.TrimSpace(chainFile) == "" || strings.TrimSpace(chainEvidenceDir) == "" {
+		return fmt.Errorf("--file and --evidence-dir are required")
+	}
+	leaf, err := agent.LoadStatement(chainFile)
+	if err != nil {
+		return fmt.Errorf("load leaf receipt: %w", err)
+	}
+	if err := agent.VerifyStatementFingerprint(leaf); err != nil {
+		return newExitCodeError(fmt.Errorf("leaf receipt fingerprint does not verify: %w", err), 2)
+	}
+	resolver, err := newChainResolver(chainEvidenceDir)
+	if err != nil {
+		return fmt.Errorf("scan evidence dir: %w", err)
+	}
+	var out strings.Builder
+	resolver.walk(leaf, 0, &out)
+	fmt.Print(out.String())
+	if len(resolver.problems) > 0 {
+		for _, problem := range resolver.problems {
+			fmt.Fprintf(os.Stderr, "chain: %s\n", problem)
+		}
+		return newExitCodeError(fmt.Errorf("chain verification failed: %d problem(s)", len(resolver.problems)), 2)
+	}
+	fmt.Println("chain verified")
+	return nil
+}

--- a/cmd/cub-scout/receipt_input_attestation_test.go
+++ b/cmd/cub-scout/receipt_input_attestation_test.go
@@ -59,7 +59,10 @@ func TestReceiptVerify_InputAttestation_AttachesRefs(t *testing.T) {
 	resetReceiptBatch2Flags(t)
 	resetReceiptInputAttestationFlag(t)
 	withFakeReceiptLoader(t, makeReceiptArgoLive())
-	receiptInputAttestations = []string{pathA, pathB}
+	// The paths are passed via --input-attestation below. Do not also pre-set
+	// receiptInputAttestations here: pflag's StringArray keeps a sticky
+	// `changed` bit, so once any earlier test has passed the flag, cobra
+	// APPENDS to the pre-set instead of replacing it.
 
 	out := captureStdout(t, func() {
 		rootCmd.SetArgs([]string{

--- a/cmd/cub-scout/receipt_object_set.go
+++ b/cmd/cub-scout/receipt_object_set.go
@@ -79,10 +79,16 @@ func runReceiptVerifyObjectSet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	profile := strings.TrimSpace(receiptNormalizationProf)
+	observed, err = agent.NormalizeObservedObjects(profile, observed)
+	if err != nil {
+		return err
+	}
 	evidence, err := agent.BuildObjectSetEvidence(source, scope, observed)
 	if err != nil {
 		return err
 	}
+	evidence.NormalizationProfile = profile
 
 	if receiptNoExtras {
 		extras, exErr := loadObjectSetExtrasFn(cmd.Context(), desired, scope, defaultNamespace)

--- a/cmd/cub-scout/receipt_test.go
+++ b/cmd/cub-scout/receipt_test.go
@@ -64,6 +64,8 @@ func resetReceiptFlags(t *testing.T) {
 		ns, pred, at, fmt, out, file, scope, grace, prereq, ttl string
 		noExtras                                                bool
 	}{receiptNamespace, receiptPredicate, receiptAtCommit, receiptFormat, receiptOut, receiptObjectSetFile, receiptScope, receiptGraceWindow, receiptPrerequisitesFile, receiptTTL, receiptNoExtras}
+	prevIA, prevRE, prevNorm := receiptInputAttestations, receiptReferenceEvidence, receiptNormalizationProf
+	receiptInputAttestations, receiptReferenceEvidence, receiptNormalizationProf = nil, nil, ""
 	receiptNamespace = ""
 	receiptPredicate = ""
 	receiptAtCommit = ""
@@ -87,6 +89,7 @@ func resetReceiptFlags(t *testing.T) {
 		receiptPrerequisitesFile = prev.prereq
 		receiptTTL = prev.ttl
 		receiptNoExtras = prev.noExtras
+		receiptInputAttestations, receiptReferenceEvidence, receiptNormalizationProf = prevIA, prevRE, prevNorm
 	})
 }
 

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -1,0 +1,64 @@
+# v2.5.0 Release Notes — The Cross-Tool Evidence Chain
+
+> **Status:** Draft release notes; describes what the `v2.5.0` tag ships.
+> **Previous release:** [`v2.4.0`](v2.4.0.md) — standalone install verification.
+
+**Theme:** *make rendered-set digests mean the same thing in every tool, then
+walk the chain.* Three additions, no breaking changes; all fields and flags
+are additive and opt-in.
+
+## Server-normalization profiles
+
+`receipt verify --file ... --normalization-profile k8s-zero-defaults/v1`
+applies a named, versioned set of server-normalization rules symmetrically to
+the desired and live objects before projection and digesting, and records the
+profile on the receipt (`evidence.objectSet.normalizationProfile`).
+
+The profile absorbs the consumer-side prune list helm-expt maintained
+(probe `initialDelaySeconds: 0`, empty `caBundle`, host* `false`, empty
+`metadata.annotations/labels`, empty `subPath`, `supplementalGroups`/`sysctls`,
+`publishNotReadyAddresses: false`) plus the RBAC empty-`rules` case its strict
+witness surfaced on grafana: under the profile, authored `rules: []` matches a
+live object the API server stored without `rules`, while meaningful empty
+lists (NetworkPolicy `ingress: []`) are preserved. Without the flag, raw
+comparison is unchanged.
+
+## The canonical digest, as a command
+
+`receipt digest --file <manifests> [--normalization-profile p]` prints the
+canonical rendered-object-set digest: SHA-256 over RFC 8785 canonical JSON of
+the sorted (id, comparable-object) entries. **Contract, locked by test:** the
+value is byte-identical to the `desiredDigest` / `rendered-object-set://`
+subject digest a `receipt verify --file` run records for the same inputs and
+profile. External producers call this command instead of reimplementing the
+canonicalization — which is what makes cross-tool chaining by digest equality
+possible.
+
+## Chain walking
+
+`receipt chain --file <leaf.receipt.json> --evidence-dir <dir>` verifies the
+leaf fingerprint, then resolves every `inputAttestations[]` entry:
+`cub-scout-receipt://` links by recomputed fingerprint (verified, walked
+recursively), `external-evidence://` links by content SHA-256 (printed with
+the explicit *digest-asserted, not fingerprint-verified* trust label). Any
+unresolved or tampered link exits 2. Subject digests print so producers can
+check rendered-set digest equality across tools.
+
+## Also in this release
+
+- Test-suite fix: pflag StringArray keeps a sticky `changed` bit, so the
+  first `--input-attestation` in a process permanently switches the flag from
+  replace to append mode; the shared test reset now clears the arrays and a
+  redundant pre-set was removed.
+
+## Validation
+
+`go test ./pkg/agent ./cmd/cub-scout` green, including: per-rule
+normalization tests, the grafana acceptance shape (raw comparison mismatches,
+profile comparison matches), the digest contract test, and chain
+happy-path/tamper tests.
+
+## Linked
+
+- [`v2.4.0`](v2.4.0.md) — previous release
+- `confighub/helm-expt` — the producer side wiring the profile and digest

--- a/pkg/agent/receipt_object_set.go
+++ b/pkg/agent/receipt_object_set.go
@@ -50,6 +50,13 @@ type ObjectSetEvidence struct {
 	Summary       ObjectSetSummary         `json:"summary"`
 	Objects       []ObjectSetObjectSummary `json:"objects"`
 
+	// NormalizationProfile names the server-normalization profile applied
+	// symmetrically to the desired and live objects before projection and
+	// digesting (e.g. k8s-zero-defaults/v1). Empty means raw comparison.
+	// Recording it on the receipt makes the normalization assumption part
+	// of the claim instead of a hidden transform. (#492-chain)
+	NormalizationProfile string `json:"normalizationProfile,omitempty"`
+
 	// ExtraChecked is true when the closed-world check ran (--no-extras).
 	// When true, the extra-live-object-coverage omission is dropped and
 	// ExtraObjects lists any live objects of the rendered kinds in scope

--- a/pkg/agent/receipt_object_set_normalize.go
+++ b/pkg/agent/receipt_object_set_normalize.go
@@ -1,0 +1,231 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Server-normalization profiles for object-set comparison.
+//
+// Kubernetes API servers drop or normalize certain authored zero-value
+// fields on admission (probe initialDelaySeconds: 0, empty caBundle, empty
+// RBAC rules, ...). Without normalization, object-set-matches honestly
+// reports those as "missing field in live object" — true at the byte level,
+// noise at the intent level. A profile is a NAMED, VERSIONED set of such
+// rules applied symmetrically to the desired and live sides before
+// projection and digesting, and recorded on the receipt so the claim says
+// exactly which normalization it assumed.
+//
+// This profile absorbs the consumer-side prune list that helm-expt
+// maintained (scripts/lib/cub-scout-live.mjs pruneApiDroppedNoops) plus the
+// RBAC empty-rules case its strict witness surfaced on grafana. Producers
+// and verifiers that share a profile name compute identical canonical
+// digests for the same rendered set — the basis of the cross-tool digest
+// convention (see ComputeRenderedObjectSetDigest).
+const NormalizationProfileK8sZeroDefaultsV1 = "k8s-zero-defaults/v1"
+
+// KnownNormalizationProfiles lists the accepted --normalization-profile
+// values. Adding a profile is additive; renaming or changing rules in an
+// existing profile is a breaking change and requires a new version suffix.
+func KnownNormalizationProfiles() []string {
+	return []string{NormalizationProfileK8sZeroDefaultsV1}
+}
+
+// NormalizeObjectForProfile returns a deep-pruned copy of obj.Object under
+// the named profile. Unknown profiles error. The empty profile returns the
+// object unchanged.
+func NormalizeObjectForProfile(profile string, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if profile == "" || obj == nil {
+		return obj, nil
+	}
+	if profile != NormalizationProfileK8sZeroDefaultsV1 {
+		return nil, fmt.Errorf("unknown normalization profile %q (known: %v)", profile, KnownNormalizationProfiles())
+	}
+	cloned := obj.DeepCopy()
+	pruned, _ := pruneZeroDefaults(cloned.Object, nil, cloned.GetKind())
+	if m, ok := pruned.(map[string]interface{}); ok {
+		cloned.Object = m
+	}
+	return cloned, nil
+}
+
+func stringAt(path []string, fromEnd int) string {
+	idx := len(path) - fromEnd
+	if idx < 0 || idx >= len(path) {
+		return ""
+	}
+	return path[idx]
+}
+
+func isIndexSegment(segment string) bool {
+	for _, r := range segment {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return segment != ""
+}
+
+// pruneZeroDefaults walks value with a path of segments (list indices appear
+// as decimal strings) and removes the profile's server-dropped zero-value
+// noops. Returns the pruned value and whether it should be dropped entirely.
+func pruneZeroDefaults(value interface{}, path []string, kind string) (interface{}, bool) {
+	last := stringAt(path, 1)
+	parent := stringAt(path, 2)
+	grandparent := stringAt(path, 3)
+	if isIndexSegment(parent) {
+		// For list members, the structural parent is one level further out
+		// (volumeMounts.3.subPath -> parent volumeMounts).
+		parent = grandparent
+		grandparent = stringAt(path, 4)
+	}
+
+	switch typed := value.(type) {
+	case int64:
+		if typed == 0 && last == "initialDelaySeconds" &&
+			(parent == "livenessProbe" || parent == "readinessProbe" || parent == "startupProbe") {
+			return nil, true
+		}
+		if typed == 0 && last == "minReadySeconds" && parent == "spec" && len(path) == 2 {
+			return nil, true
+		}
+		return value, false
+	case string:
+		if typed == "" && last == "caBundle" && (parent == "clientConfig" || parent == "spec") {
+			return nil, true
+		}
+		if typed == "" && last == "subPath" && parent == "volumeMounts" {
+			return nil, true
+		}
+		return value, false
+	case bool:
+		if !typed {
+			if (last == "hostIPC" || last == "hostNetwork" || last == "hostPID") &&
+				parent == "spec" && grandparent == "template" {
+				return nil, true
+			}
+			if last == "publishNotReadyAddresses" && parent == "spec" && len(path) == 2 {
+				return nil, true
+			}
+		}
+		return value, false
+	case []interface{}:
+		if len(typed) == 0 {
+			if (last == "supplementalGroups" || last == "sysctls") && parent == "securityContext" {
+				return nil, true
+			}
+			if last == "rules" && len(path) == 1 && (kind == "Role" || kind == "ClusterRole") {
+				// The API server normalizes authored `rules: []` on RBAC
+				// objects to an absent field (the grafana watch case).
+				return nil, true
+			}
+		}
+		out := make([]interface{}, 0, len(typed))
+		for i, item := range typed {
+			pruned, drop := pruneZeroDefaults(item, append(path, fmt.Sprintf("%d", i)), kind)
+			if !drop {
+				out = append(out, pruned)
+			}
+		}
+		return out, false
+	case map[string]interface{}:
+		out := map[string]interface{}{}
+		for key, item := range typed {
+			pruned, drop := pruneZeroDefaults(item, append(path, key), kind)
+			if !drop {
+				out[key] = pruned
+			}
+		}
+		if len(out) == 0 && last != "" && parent == "metadata" &&
+			(last == "annotations" || last == "labels") {
+			return nil, true
+		}
+		return out, false
+	default:
+		// YAML decoding may produce int (not int64) in some paths; treat the
+		// same as int64 for the zero rules.
+		if n, ok := value.(int); ok {
+			pruned, drop := pruneZeroDefaults(int64(n), path, kind)
+			return pruned, drop
+		}
+		if f, ok := value.(float64); ok && f == 0 {
+			pruned, drop := pruneZeroDefaults(int64(0), path, kind)
+			if drop {
+				return pruned, true
+			}
+		}
+		return value, false
+	}
+}
+
+// NormalizeObservedObjects applies the profile to every desired and live
+// object in observed, returning a new slice. A nil/empty profile returns
+// observed unchanged.
+func NormalizeObservedObjects(profile string, observed []ObjectSetObservedObject) ([]ObjectSetObservedObject, error) {
+	if profile == "" {
+		return observed, nil
+	}
+	out := make([]ObjectSetObservedObject, 0, len(observed))
+	for _, obs := range observed {
+		desired, err := NormalizeObjectForProfile(profile, obs.Desired)
+		if err != nil {
+			return nil, err
+		}
+		live, err := NormalizeObjectForProfile(profile, obs.Live)
+		if err != nil {
+			return nil, err
+		}
+		obs.Desired = desired
+		obs.Live = live
+		out = append(out, obs)
+	}
+	return out, nil
+}
+
+// ComputeRenderedObjectSetDigest computes the canonical digest of a rendered
+// object set: the SHA-256 over RFC 8785 canonical JSON of the sorted
+// (id, comparable-object) entries, after optional profile normalization.
+//
+// CONTRACT: this is byte-identical to the `desiredDigest` an
+// object-set-matches receipt records for the same inputs and profile
+// (locked by TestRenderedObjectSetDigest_MatchesEvidenceDesiredDigest).
+// Producers (e.g. helm-expt render receipts) call `cub-scout receipt digest`
+// to stamp this value; verifiers compare it to the receipt subject digest,
+// which is what makes cross-tool chaining by digest equality possible.
+func ComputeRenderedObjectSetDigest(profile string, objs []*unstructured.Unstructured) (string, int, error) {
+	entries := make([]interface{}, 0, len(objs))
+	seen := map[string]struct{}{}
+	for _, obj := range objs {
+		if obj == nil {
+			continue
+		}
+		normalized, err := NormalizeObjectForProfile(profile, obj)
+		if err != nil {
+			return "", 0, err
+		}
+		id := NewObjectSetObjectID(normalized)
+		if _, dup := seen[id.Key()]; dup {
+			return "", 0, fmt.Errorf("duplicate desired object identity %s", id.String())
+		}
+		seen[id.Key()] = struct{}{}
+		entries = append(entries, objectSetDigestEntry(id, ComparableObject(normalized)))
+	}
+	sortDigestEntries(entries)
+	digest, err := digestJSON(entries)
+	if err != nil {
+		return "", 0, err
+	}
+	return digest, len(entries), nil
+}
+
+func sortDigestEntries(entries []interface{}) {
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0 && digestEntryKey(entries[j]) < digestEntryKey(entries[j-1]); j-- {
+			entries[j], entries[j-1] = entries[j-1], entries[j]
+		}
+	}
+}

--- a/pkg/agent/receipt_object_set_normalize_test.go
+++ b/pkg/agent/receipt_object_set_normalize_test.go
@@ -1,0 +1,156 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func obj(kind string, m map[string]interface{}) *unstructured.Unstructured {
+	m["apiVersion"] = "v1"
+	m["kind"] = kind
+	if _, ok := m["metadata"]; !ok {
+		m["metadata"] = map[string]interface{}{"name": "x", "namespace": "ns"}
+	}
+	return &unstructured.Unstructured{Object: m}
+}
+
+func normalized(t *testing.T, u *unstructured.Unstructured) map[string]interface{} {
+	t.Helper()
+	out, err := NormalizeObjectForProfile(NormalizationProfileK8sZeroDefaultsV1, u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	return out.Object
+}
+
+func TestNormalize_ProbeInitialDelayZeroDropped(t *testing.T) {
+	u := obj("Pod", map[string]interface{}{
+		"spec": map[string]interface{}{
+			"containers": []interface{}{map[string]interface{}{
+				"name":          "c",
+				"livenessProbe": map[string]interface{}{"initialDelaySeconds": int64(0), "periodSeconds": int64(10)},
+			}},
+		},
+	})
+	spec := normalized(t, u)["spec"].(map[string]interface{})
+	probe := spec["containers"].([]interface{})[0].(map[string]interface{})["livenessProbe"].(map[string]interface{})
+	if _, present := probe["initialDelaySeconds"]; present {
+		t.Fatal("initialDelaySeconds: 0 must be dropped")
+	}
+	if probe["periodSeconds"] != int64(10) {
+		t.Fatal("non-zero sibling must survive")
+	}
+}
+
+func TestNormalize_RBACEmptyRulesDropped_GrafanaCase(t *testing.T) {
+	role := obj("ClusterRole", map[string]interface{}{"rules": []interface{}{}})
+	if _, present := normalized(t, role)["rules"]; present {
+		t.Fatal("ClusterRole rules: [] must normalize to absent (grafana watch case)")
+	}
+	// A non-RBAC kind keeps its empty list (NetworkPolicy ingress: [] is meaningful).
+	np := obj("NetworkPolicy", map[string]interface{}{"spec": map[string]interface{}{"ingress": []interface{}{}}})
+	spec := normalized(t, np)["spec"].(map[string]interface{})
+	if _, present := spec["ingress"]; !present {
+		t.Fatal("NetworkPolicy spec.ingress: [] must be preserved")
+	}
+}
+
+func TestNormalize_OtherRules(t *testing.T) {
+	u := obj("Service", map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "s", "annotations": map[string]interface{}{}},
+		"spec": map[string]interface{}{
+			"publishNotReadyAddresses": false,
+			"caBundle":                 "",
+			"ports":                    []interface{}{map[string]interface{}{"port": int64(80)}},
+		},
+	})
+	out := normalized(t, u)
+	meta := out["metadata"].(map[string]interface{})
+	if _, present := meta["annotations"]; present {
+		t.Fatal("empty metadata.annotations must be dropped")
+	}
+	spec := out["spec"].(map[string]interface{})
+	if _, present := spec["publishNotReadyAddresses"]; present {
+		t.Fatal("spec.publishNotReadyAddresses: false must be dropped")
+	}
+	if _, present := spec["caBundle"]; present {
+		t.Fatal("spec.caBundle: \"\" must be dropped")
+	}
+}
+
+func TestNormalize_UnknownProfileErrors(t *testing.T) {
+	if _, err := NormalizeObjectForProfile("nope/v9", obj("Pod", map[string]interface{}{})); err == nil {
+		t.Fatal("unknown profile must error")
+	}
+}
+
+// The cross-tool contract: the standalone digest equals the receipt's
+// desiredDigest for the same inputs and profile.
+func TestRenderedObjectSetDigest_MatchesEvidenceDesiredDigest(t *testing.T) {
+	desired := []*unstructured.Unstructured{
+		obj("ClusterRole", map[string]interface{}{"metadata": map[string]interface{}{"name": "r"}, "rules": []interface{}{}}),
+		objectSetDeployment(2, "example/api:v1"),
+	}
+	profile := NormalizationProfileK8sZeroDefaultsV1
+	standalone, count, err := ComputeRenderedObjectSetDigest(profile, desired)
+	if err != nil {
+		t.Fatalf("standalone digest: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count = %d", count)
+	}
+
+	observed := make([]ObjectSetObservedObject, 0, len(desired))
+	for _, d := range desired {
+		observed = append(observed, ObjectSetObservedObject{Desired: d, Live: d.DeepCopy()})
+	}
+	normalizedObs, err := NormalizeObservedObjects(profile, observed)
+	if err != nil {
+		t.Fatalf("normalize observed: %v", err)
+	}
+	evidence, err := BuildObjectSetEvidence(
+		ObjectSetSource{Type: "file", Ref: "rendered.yaml"},
+		ObjectSetScope{Kind: "namespace", Namespace: "ns"},
+		normalizedObs,
+	)
+	if err != nil {
+		t.Fatalf("BuildObjectSetEvidence: %v", err)
+	}
+	if evidence.DesiredDigest != standalone {
+		t.Fatalf("contract broken: standalone %s != evidence desiredDigest %s", standalone, evidence.DesiredDigest)
+	}
+}
+
+// The acceptance shape for the grafana watch row: desired authors rules: [],
+// the live API server stores the object without rules. Raw comparison
+// mismatches; the profile matches.
+func TestNormalize_GrafanaRulesAcceptance(t *testing.T) {
+	desired := obj("ClusterRole", map[string]interface{}{"metadata": map[string]interface{}{"name": "g"}, "rules": []interface{}{}})
+	live := obj("ClusterRole", map[string]interface{}{"metadata": map[string]interface{}{"name": "g"}})
+
+	raw, err := BuildObjectSetEvidence(ObjectSetSource{Type: "file", Ref: "r.yaml"}, ObjectSetScope{Kind: "cluster"},
+		[]ObjectSetObservedObject{{Desired: desired, Live: live}})
+	if err != nil {
+		t.Fatalf("raw evidence: %v", err)
+	}
+	if raw.Summary.Mismatched != 1 {
+		t.Fatalf("raw comparison should mismatch (got %+v)", raw.Summary)
+	}
+
+	normalizedObs, err := NormalizeObservedObjects(NormalizationProfileK8sZeroDefaultsV1,
+		[]ObjectSetObservedObject{{Desired: desired.DeepCopy(), Live: live.DeepCopy()}})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	prof, err := BuildObjectSetEvidence(ObjectSetSource{Type: "file", Ref: "r.yaml"}, ObjectSetScope{Kind: "cluster"}, normalizedObs)
+	if err != nil {
+		t.Fatalf("profile evidence: %v", err)
+	}
+	if prof.Summary.Matched != 1 {
+		t.Fatalf("profile comparison should match (got %+v)", prof.Summary)
+	}
+}


### PR DESCRIPTION
Phase 1 of the cross-repo evidence chain. Three additive features:

1. **`--normalization-profile k8s-zero-defaults/v1`** — named, versioned server-normalization rules applied symmetrically to desired and live before projection/digesting, recorded on the receipt. Absorbs helm-expt's consumer prune list + the grafana RBAC `rules: []` watch case (acceptance test: raw comparison mismatches, profile comparison matches; NetworkPolicy `ingress: []` stays meaningful).
2. **`receipt digest`** — the canonical rendered-object-set digest as a producer command, **contract-locked by test** to equal the receipt's `desiredDigest`/subject digest for the same inputs+profile. External producers (helm-expt) call this instead of reimplementing canonicalization → cross-tool chaining by digest equality.
3. **`receipt chain`** — walks `inputAttestations[]` from a leaf: cub-scout links fingerprint-verified and recursed, external links digest-asserted with the weaker trust label printed; tampered/unresolved ⇒ exit 2 (tamper test included).

Also fixes real test pollution: pflag StringArray's sticky `changed` bit (first `--input-attestation` in-process flips replace→append); shared reset now clears the arrays.

Full `pkg/agent` + `cmd/cub-scout` suites green. Release notes: docs/releases/v2.5.0.md; tag v2.5.0 follows merge.