### PR TITLE
docs: mark v2.5.0 release notes published

### DIFF
--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -1,6 +1,6 @@
 # v2.5.0 Release Notes — The Cross-Tool Evidence Chain
 
-> **Status:** Draft release notes; describes what the `v2.5.0` tag ships.
+> **Status:** Published. Tag `v2.5.0` is live: GitHub release (6 platforms + checksums), Homebrew tap cask 2.5.0, `ghcr.io/confighub/cub-scout:v2.5.0`.
 > **Previous release:** [`v2.4.0`](v2.4.0.md) — standalone install verification.
 
 **Theme:** *make rendered-set digests mean the same thing in every tool, then


### PR DESCRIPTION
Tag v2.5.0 is live: GitHub release assets (6 platforms + checksums.txt), Homebrew tap cask at 2.5.0, ghcr.io/confighub/cub-scout:v2.5.0 + :latest at digest 9e3bf7a2. Mirrors #493 for v2.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)