### PR TITLE
feat(compare): object-set-diff — set-level diff receipt (proposal Issue A)

### DIFF
--- a/cmd/cub-scout/compare_object_set.go
+++ b/cmd/cub-scout/compare_object_set.go
@@ -1,0 +1,382 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// compare object-set flags (#496, Issue A). Named distinctly from the receipt
+// flags so the two surfaces never share state.
+var (
+	compareObjectSetDryFrom   string
+	compareObjectSetNamespace string
+	compareObjectSetScopeRaw  string
+	compareObjectSetDiff      bool
+	compareObjectSetFormat    string
+	compareObjectSetOut       string
+	compareObjectSetSave      bool
+	compareObjectSetTTL       string
+	compareObjectSetFailOn    string
+	compareObjectSetNormProf  string
+)
+
+var compareObjectSetCmd = &cobra.Command{
+	Use:   "object-set",
+	Short: "Emit a set-level diff receipt between a rendered object set and live",
+	Long: `object-set compares a rendered (desired) object set against live cluster
+state and emits a single signed, chain-walkable ObjectSetDiffReceipt
+(predicate object-set-diff). Unlike compare three-way (per resource) and
+receipt verify --predicate object-set-matches (a boolean "does the set
+match?"), this aggregates the per-object authored-field deltas into ONE
+set-level receipt: changedObjects (with field deltas), and — with --diff —
+addedObjects / removedObjects.
+
+One receipt shape serves both day-1 and day-2 (#496):
+  - dry-run (pre-apply): --dry-from <changed render>  -> what a proposed
+    change would touch across the set.
+  - drift (post-apply):  --dry-from <current render>  -> what differs now.
+
+It is tool-agnostic by construction: it reads the cluster and the --dry-from
+source, never the reconciler, so Argo-, Flux-, and cub-direct-delivered
+objects diff identically. Read-only against the cluster.
+
+Verdict:
+  PASS   no authored-field, added, or removed deltas.
+  WATCH  only closure deltas (added/removed objects), no shared-object field
+         changes (requires --diff to compute closure).
+  BLOCK  one or more objects have authored-field deltas.
+
+Examples:
+  cub-scout compare object-set --dry-from out/manifests -n redis --format json
+  cub-scout compare object-set --dry-from out/changed.yaml -n redis --diff
+  cub-scout compare object-set --dry-from out/manifests --scope namespace/redis --fail-on any-non-pass`,
+	Args: cobra.NoArgs,
+	RunE: runCompareObjectSet,
+}
+
+func init() {
+	combinedCmd.AddCommand(compareObjectSetCmd)
+
+	compareObjectSetCmd.Flags().StringVar(&compareObjectSetDryFrom, "dry-from", "", "Rendered desired object set: a YAML file or directory (e.g. a git checkout / helm template output) used as the DESIRED state to diff against live (required).")
+	compareObjectSetCmd.Flags().StringVarP(&compareObjectSetNamespace, "namespace", "n", "", "Default namespace for namespaced objects without an explicit metadata.namespace")
+	compareObjectSetCmd.Flags().StringVar(&compareObjectSetScopeRaw, "scope", "", "Scope selector: 'namespace/<ns>' or 'cluster'. Defaults to namespace/<-n> or mixed.")
+	compareObjectSetCmd.Flags().BoolVar(&compareObjectSetDiff, "diff", false, "Closed-world diff: also report addedObjects (live objects of the rendered kinds in scope not in the desired set) and removedObjects (desired objects absent live). Closure deltas alone downgrade a clean PASS to WATCH.")
+	compareObjectSetCmd.Flags().StringVar(&compareObjectSetFormat, "format", "json", "Output format: json | ascii")
+	compareObjectSetCmd.Flags().StringVar(&compareObjectSetOut, "out", "", "Write the receipt to this file path (also printed to stdout in the chosen format)")
+	compareObjectSetCmd.Flags().BoolVar(&compareObjectSetSave, "save", false, "Save the receipt to the local store ($CUB_SCOUT_RECEIPTS_DIR or $XDG_DATA_HOME/cub-scout/receipts) for later cub-scout receipt list / show / validate")
+	compareObjectSetCmd.Flags().StringVar(&compareObjectSetTTL, "ttl", "", "Observation-freshness boundary, e.g. 1h. When set, the receipt records an immutable freshness{observedAt,expiresAt,ttl}. Empty means the receipt makes no freshness claim.")
+	compareObjectSetCmd.Flags().StringVar(&compareObjectSetFailOn, "fail-on", "", "Exit non-zero (code 2) when the receipt verdict matches. Accepts a comma-separated list of verdicts (WATCH, BLOCK, INCONCLUSIVE) or the sugar 'any-non-pass'. The receipt is still printed / saved / written to --out regardless of exit code.")
+	compareObjectSetCmd.Flags().StringVar(&compareObjectSetNormProf, "normalization-profile", "", "Named server-normalization profile applied symmetrically to desired and live objects before comparison and digesting (e.g. k8s-zero-defaults/v1). Recorded on the receipt. Empty means raw comparison.")
+}
+
+func runCompareObjectSet(cmd *cobra.Command, _ []string) error {
+	format := strings.ToLower(strings.TrimSpace(compareObjectSetFormat))
+	if format != "ascii" && format != "json" {
+		return fmt.Errorf("invalid --format %q (valid: ascii, json)", compareObjectSetFormat)
+	}
+
+	if strings.TrimSpace(compareObjectSetDryFrom) == "" {
+		return fmt.Errorf("--dry-from is required for compare object-set (a rendered YAML file or directory)")
+	}
+
+	ttlDur, ttlErr := parseCompareObjectSetTTL()
+	if ttlErr != nil {
+		return ttlErr
+	}
+
+	var failOnSet map[agent.ReceiptVerdict]bool
+	failOnRaw := strings.TrimSpace(compareObjectSetFailOn)
+	if failOnRaw != "" {
+		parsed, parseErr := parseReceiptFailOn(failOnRaw)
+		if parseErr != nil {
+			return parseErr
+		}
+		failOnSet = parsed
+	}
+
+	scope, defaultNamespace, err := resolveObjectSetScope(compareObjectSetScopeRaw, compareObjectSetNamespace)
+	if err != nil {
+		return err
+	}
+
+	desired, source, err := loadObjectSetDesiredManifests(compareObjectSetDryFrom)
+	if err != nil {
+		return err
+	}
+	if len(desired) == 0 {
+		return fmt.Errorf("--dry-from %q contained no Kubernetes objects", compareObjectSetDryFrom)
+	}
+
+	observed, err := loadObjectSetLiveObjectsFn(cmd.Context(), desired, defaultNamespace)
+	if err != nil {
+		return err
+	}
+	profile := strings.TrimSpace(compareObjectSetNormProf)
+	observed, err = agent.NormalizeObservedObjects(profile, observed)
+	if err != nil {
+		return err
+	}
+
+	evidence, err := buildObjectSetDiffEvidence(source, scope, observed)
+	if err != nil {
+		return err
+	}
+	evidence.NormalizationProfile = profile
+
+	// Removed objects (desired-but-absent-live) are a membership delta we get
+	// for free from the observed desired/live pairs, so they are always
+	// reported. The closed-world ADDED side (live objects of the rendered
+	// kinds not in the desired set) requires a cluster-wide list, so it is
+	// gated behind --diff.
+	evidence.RemovedObjects = collectObjectSetRemoved(observed)
+	if compareObjectSetDiff {
+		extras, exErr := loadObjectSetExtrasFn(cmd.Context(), desired, scope, defaultNamespace)
+		if exErr != nil {
+			return fmt.Errorf("closed-world diff: %w", exErr)
+		}
+		evidence.AddedObjects = extras
+	}
+
+	stmt, err := agent.BuildObjectSetDiffReceipt(agent.BuildObjectSetDiffReceiptInput{
+		Evidence: evidence,
+		Verifier: agent.Verifier{
+			Tool:    "cub-scout",
+			Version: BuildTag,
+		},
+		VerifiedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		return fmt.Errorf("build object-set-diff receipt: %w", err)
+	}
+	if err := agent.ApplyFreshness(&stmt, ttlDur); err != nil {
+		return fmt.Errorf("apply freshness: %w", err)
+	}
+
+	var out []byte
+	switch format {
+	case "json":
+		buf, mErr := json.MarshalIndent(stmt, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal receipt: %w", mErr)
+		}
+		out = buf
+	case "ascii":
+		out = []byte(renderReceiptASCII(stmt))
+	}
+	fmt.Println(string(out))
+
+	if outPath := strings.TrimSpace(compareObjectSetOut); outPath != "" {
+		jsonBytes, mErr := json.MarshalIndent(stmt, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("marshal receipt for --out: %w", mErr)
+		}
+		if err := writeReceiptOutFile(outPath, jsonBytes); err != nil {
+			return err
+		}
+	}
+
+	if compareObjectSetSave {
+		if err := saveOneReceipt(cmd, stmt); err != nil {
+			return fmt.Errorf("save receipt: %w", err)
+		}
+	}
+
+	if failOnSet != nil && failOnSet[stmt.Predicate.Verdict] {
+		return newExitCodeError(
+			fmt.Errorf("receipt verdict %q matches --fail-on %q", stmt.Predicate.Verdict, failOnRaw),
+			2,
+		)
+	}
+	return nil
+}
+
+// buildObjectSetDiffEvidence assembles the set-level diff evidence from the
+// observed desired/live pairs. It reuses BuildObjectSetEvidence to do the
+// authored-field projection + digesting (so the desired/live digests and the
+// per-object field differences are computed identically to object-set-matches),
+// then maps each mismatched object into the diff shape. Per-field
+// cause/managerHint attribution is sourced from the live managedFields via the
+// shared compare path (detectCompareFieldMismatches) when a live object exists.
+//
+// changedObjects are objects present on BOTH sides whose authored fields
+// differ. A desired object that is absent live is a membership delta, recorded
+// by the caller as a removedObject (not a changed object), so the verdict rule
+// can separate field drift (BLOCK) from closure deltas (WATCH). Inconclusive
+// lookups return an error so the caller maps them to a build failure rather
+// than a false PASS.
+func buildObjectSetDiffEvidence(source agent.ObjectSetSource, scope agent.ObjectSetScope, observed []agent.ObjectSetObservedObject) (agent.ObjectSetDiffEvidence, error) {
+	for _, obs := range observed {
+		if obs.Inconclusive {
+			id := agent.NewObjectSetObjectID(obs.Desired)
+			return agent.ObjectSetDiffEvidence{}, fmt.Errorf("object-set-diff: live lookup inconclusive for %s: %s", id.String(), obs.Error)
+		}
+	}
+
+	base, err := agent.BuildObjectSetEvidence(source, scope, observed)
+	if err != nil {
+		return agent.ObjectSetDiffEvidence{}, err
+	}
+
+	// Index the observed live objects by identity so per-field attribution can
+	// be pulled from the same compare path the three-way diff uses.
+	liveByKey := map[string]*unstructured.Unstructured{}
+	desiredByKey := map[string]*unstructured.Unstructured{}
+	for i := range observed {
+		if observed[i].Desired == nil {
+			continue
+		}
+		key := agent.NewObjectSetObjectID(observed[i].Desired).Key()
+		desiredByKey[key] = observed[i].Desired
+		if observed[i].Live != nil {
+			liveByKey[key] = observed[i].Live
+		}
+	}
+
+	var changed []agent.ObjectSetDiffObject
+	for _, summary := range base.Objects {
+		if summary.Status != agent.ObjectSetObjectMismatched {
+			// Matched objects carry no delta; missing objects are membership
+			// deltas the caller records as removedObjects.
+			continue
+		}
+		changed = append(changed, agent.ObjectSetDiffObject{
+			ID:            summary.ID,
+			DesiredDigest: summary.DesiredDigest,
+			LiveDigest:    summary.LiveDigest,
+			Differences:   mapObjectSetFieldDiffs(summary, desiredByKey[summary.ID.Key()], liveByKey[summary.ID.Key()]),
+		})
+	}
+
+	sort.Slice(changed, func(i, j int) bool { return changed[i].ID.Key() < changed[j].ID.Key() })
+
+	return agent.ObjectSetDiffEvidence{
+		DesiredSource:  base.DesiredSource,
+		Scope:          base.Scope,
+		DesiredDigest:  base.DesiredDigest,
+		LiveDigest:     base.LiveDigest,
+		ChangedObjects: changed,
+		Summary: agent.ObjectSetDiffSummary{
+			Total: base.Summary.Desired,
+		},
+	}, nil
+}
+
+// mapObjectSetFieldDiffs converts the authored-field projection differences for
+// one object into ObjectSetFieldDiff entries. It primarily uses the projection
+// diffs (which cover EVERY authored field, nested) from BuildObjectSetEvidence,
+// then overlays per-field cause/managerHint attribution for the small set of
+// well-known fields the compare path classifies (replicas, images, …) when a
+// live object is present.
+func mapObjectSetFieldDiffs(summary agent.ObjectSetObjectSummary, desired, live *unstructured.Unstructured) []agent.ObjectSetFieldDiff {
+	// Build an attribution lookup keyed by compare field name from the shared
+	// three-way compare path, so drift on classified fields carries the
+	// writing field-manager. Only meaningful when both sides exist.
+	attrByField := map[string]compareFieldMismatch{}
+	if desired != nil && live != nil {
+		drySummary := summarizeCompareManifestObject("dry", desired.Object)
+		liveSummary := summarizeCompareLiveObject(live)
+		for _, m := range detectCompareFieldMismatches(drySummary, nil, liveSummary) {
+			attrByField[m.Field] = m
+		}
+	}
+
+	out := make([]agent.ObjectSetFieldDiff, 0, len(summary.Differences))
+	for _, d := range summary.Differences {
+		fd := agent.ObjectSetFieldDiff{
+			Field:   d.Path,
+			Desired: formatObjectSetDiffValue(d.Desired),
+			Live:    formatObjectSetDiffValue(d.Live),
+		}
+		if attr, ok := attrByField[compareFieldForPath(d.Path)]; ok {
+			// Only carry a meaningful attribution. A bare "unknown" cause with
+			// no manager hint is the absence of a managedFields signal, not a
+			// finding — leave Cause/ManagerHint empty so the receipt stays
+			// honest (the field is documented as optional).
+			if (attr.Cause != "" && attr.Cause != agent.CauseUnknown) || attr.ManagerHint != "" {
+				fd.Cause = string(attr.Cause)
+				fd.ManagerHint = attr.ManagerHint
+			}
+		}
+		out = append(out, fd)
+	}
+	return out
+}
+
+// compareFieldForPath maps an authored-field projection path (e.g.
+// "spec.replicas" or "spec.template.spec.containers[0].image") to the compare
+// field name (e.g. "replicas", "images") used by detectCompareFieldMismatches,
+// so we can overlay that path's field-manager attribution. Unmapped paths
+// return "" (no attribution overlay).
+func compareFieldForPath(path string) string {
+	switch {
+	case path == "spec.replicas":
+		return "replicas"
+	case strings.Contains(path, ".containers[") && strings.HasSuffix(path, "].image"):
+		return "images"
+	case path == "metadata.namespace":
+		return "namespace"
+	case path == "apiVersion":
+		return "apiVersion"
+	case path == "kind":
+		return "kind"
+	default:
+		return ""
+	}
+}
+
+func formatObjectSetDiffValue(v interface{}) string {
+	if v == nil {
+		return "-"
+	}
+	switch typed := v.(type) {
+	case string:
+		if typed == "" {
+			return "-"
+		}
+		return typed
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+// collectObjectSetRemoved returns the desired objects that were absent live —
+// the removed side of the closed-world diff (--diff). It mirrors the
+// object-set-matches "missing" classification.
+func collectObjectSetRemoved(observed []agent.ObjectSetObservedObject) []agent.ObjectSetObjectID {
+	var removed []agent.ObjectSetObjectID
+	for _, obs := range observed {
+		if obs.Desired == nil || obs.Inconclusive {
+			continue
+		}
+		if obs.Live == nil {
+			removed = append(removed, agent.NewObjectSetObjectID(obs.Desired))
+		}
+	}
+	sort.Slice(removed, func(i, j int) bool { return removed[i].Key() < removed[j].Key() })
+	return removed
+}
+
+func parseCompareObjectSetTTL() (time.Duration, error) {
+	raw := strings.TrimSpace(compareObjectSetTTL)
+	if raw == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --ttl %q (expected a Go duration like 1h or 30m): %w", raw, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("invalid --ttl %q (must not be negative)", raw)
+	}
+	return d, nil
+}

--- a/cmd/cub-scout/compare_object_set_test.go
+++ b/cmd/cub-scout/compare_object_set_test.go
@@ -1,0 +1,373 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/confighub/cub-scout/pkg/agent"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func resetCompareObjectSetFlags(t *testing.T) {
+	t.Helper()
+	prev := struct {
+		dryFrom, ns, scope, format, out, ttl, failOn, norm string
+		diff, save                                         bool
+	}{
+		compareObjectSetDryFrom, compareObjectSetNamespace, compareObjectSetScopeRaw,
+		compareObjectSetFormat, compareObjectSetOut, compareObjectSetTTL,
+		compareObjectSetFailOn, compareObjectSetNormProf,
+		compareObjectSetDiff, compareObjectSetSave,
+	}
+	compareObjectSetDryFrom = ""
+	compareObjectSetNamespace = ""
+	compareObjectSetScopeRaw = ""
+	compareObjectSetFormat = "json"
+	compareObjectSetOut = ""
+	compareObjectSetTTL = ""
+	compareObjectSetFailOn = ""
+	compareObjectSetNormProf = ""
+	compareObjectSetDiff = false
+	compareObjectSetSave = false
+	t.Cleanup(func() {
+		compareObjectSetDryFrom = prev.dryFrom
+		compareObjectSetNamespace = prev.ns
+		compareObjectSetScopeRaw = prev.scope
+		compareObjectSetFormat = prev.format
+		compareObjectSetOut = prev.out
+		compareObjectSetTTL = prev.ttl
+		compareObjectSetFailOn = prev.failOn
+		compareObjectSetNormProf = prev.norm
+		compareObjectSetDiff = prev.diff
+		compareObjectSetSave = prev.save
+	})
+}
+
+// runCompareObjectSetJSON executes `compare object-set` with the given extra
+// args (--dry-from / --scope are supplied by the caller via args) and decodes
+// the emitted Statement.
+func runCompareObjectSetJSON(t *testing.T, args []string) agent.Statement {
+	t.Helper()
+	out := captureStdout(t, func() {
+		rootCmd.SetArgs(append([]string{"compare", "object-set", "--format", "json"}, args...))
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("compare object-set returned error: %v", err)
+		}
+	})
+	var stmt agent.Statement
+	if err := json.Unmarshal([]byte(out), &stmt); err != nil {
+		t.Fatalf("unmarshal statement: %v\n%s", err, out)
+	}
+	if stmt.Predicate.PredicateName != string(agent.PredicateObjectSetDiff) {
+		t.Fatalf("predicateName = %q, want %q", stmt.Predicate.PredicateName, agent.PredicateObjectSetDiff)
+	}
+	if strings.TrimSpace(stmt.Predicate.Fingerprint) == "" {
+		t.Fatal("fingerprint is empty")
+	}
+	if stmt.Predicate.Evidence.ObjectSetDiff == nil {
+		t.Fatal("objectSetDiff evidence missing")
+	}
+	return stmt
+}
+
+// (a) desired == live: no diff -> PASS, no changed/added/removed.
+func TestCompareObjectSet_NoDiff_Pass(t *testing.T) {
+	resetCompareObjectSetFlags(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: api
+        image: example/api:v1
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, defaultNS string) ([]agent.ObjectSetObservedObject, error) {
+		if defaultNS != "redis" {
+			t.Fatalf("default namespace = %q, want redis", defaultNS)
+		}
+		live := desired[0].DeepCopy()
+		live.SetNamespace(defaultNS)
+		desired[0].SetNamespace(defaultNS)
+		// Server-added noise must be ignored by authored-field projection.
+		_ = unstructured.SetNestedField(live.Object, "123", "metadata", "resourceVersion")
+		_ = unstructured.SetNestedField(live.Object, "server-added", "metadata", "annotations", "example.com/defaulted")
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	stmt := runCompareObjectSetJSON(t, []string{"--dry-from", path, "--scope", "namespace/redis"})
+	if stmt.Predicate.Verdict != agent.VerdictPASS {
+		t.Fatalf("verdict = %s, want PASS", stmt.Predicate.Verdict)
+	}
+	ev := stmt.Predicate.Evidence.ObjectSetDiff
+	if len(ev.ChangedObjects) != 0 || len(ev.AddedObjects) != 0 || len(ev.RemovedObjects) != 0 {
+		t.Fatalf("expected no deltas; got changed=%d added=%d removed=%d", len(ev.ChangedObjects), len(ev.AddedObjects), len(ev.RemovedObjects))
+	}
+	if ev.Summary.Total != 1 || ev.Summary.Changed != 0 {
+		t.Fatalf("summary = %+v, want total=1 changed=0", ev.Summary)
+	}
+}
+
+// (b) one object with changed image + replicas -> BLOCK, 1 changedObject with
+// the right field deltas (reproduces helm-expt#992 image.digest dry-run).
+func TestCompareObjectSet_ChangedObject_Block(t *testing.T) {
+	resetCompareObjectSetFlags(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: redis
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: redis
+        image: redis@sha256:newdigest
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		// Live differs from the desired (changed) render: old digest + old replicas.
+		_ = unstructured.SetNestedField(live.Object, int64(2), "spec", "replicas")
+		containers := []interface{}{map[string]interface{}{"name": "redis", "image": "redis@sha256:olddigest"}}
+		_ = unstructured.SetNestedSlice(live.Object, containers, "spec", "template", "spec", "containers")
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	stmt := runCompareObjectSetJSON(t, []string{"--dry-from", path})
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+	ev := stmt.Predicate.Evidence.ObjectSetDiff
+	if len(ev.ChangedObjects) != 1 {
+		t.Fatalf("changedObjects = %d, want 1", len(ev.ChangedObjects))
+	}
+	if ev.Summary.Changed != 1 || ev.Summary.Total != 1 {
+		t.Fatalf("summary = %+v, want changed=1 total=1", ev.Summary)
+	}
+	co := ev.ChangedObjects[0]
+	if co.ID.Kind != "Deployment" || co.ID.Name != "redis" {
+		t.Fatalf("changed object id = %+v, want Deployment/redis", co.ID)
+	}
+	gotFields := map[string]agent.ObjectSetFieldDiff{}
+	for _, d := range co.Differences {
+		gotFields[d.Field] = d
+	}
+	repl, ok := gotFields["spec.replicas"]
+	if !ok {
+		t.Fatalf("expected a spec.replicas delta; got fields %v", fieldNames(co.Differences))
+	}
+	if repl.Desired != "3" || repl.Live != "2" {
+		t.Fatalf("replicas delta = desired %q live %q, want desired 3 live 2", repl.Desired, repl.Live)
+	}
+	img, ok := gotFields["spec.template.spec.containers[0].image"]
+	if !ok {
+		t.Fatalf("expected an image delta; got fields %v", fieldNames(co.Differences))
+	}
+	if img.Desired != "redis@sha256:newdigest" || img.Live != "redis@sha256:olddigest" {
+		t.Fatalf("image delta = desired %q live %q", img.Desired, img.Live)
+	}
+}
+
+// (c) --diff with a live-only object -> addedObjects populated, WATCH.
+func TestCompareObjectSet_DiffAddedObject_Watch(t *testing.T) {
+	resetCompareObjectSetFlags(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: redis
+spec:
+  replicas: 3
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+	withFakeObjectSetExtrasLoader(t, func(_ context.Context, _ []*unstructured.Unstructured, _ agent.ObjectSetScope, _ string) ([]agent.ObjectSetObjectID, error) {
+		return []agent.ObjectSetObjectID{{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Namespace:  "redis",
+			Name:       "rogue-config",
+		}}, nil
+	})
+
+	stmt := runCompareObjectSetJSON(t, []string{"--dry-from", path, "--diff"})
+	if stmt.Predicate.Verdict != agent.VerdictWATCH {
+		t.Fatalf("verdict = %s, want WATCH", stmt.Predicate.Verdict)
+	}
+	ev := stmt.Predicate.Evidence.ObjectSetDiff
+	if len(ev.ChangedObjects) != 0 {
+		t.Fatalf("changedObjects = %d, want 0", len(ev.ChangedObjects))
+	}
+	if len(ev.AddedObjects) != 1 || ev.AddedObjects[0].Name != "rogue-config" {
+		t.Fatalf("addedObjects = %+v, want [rogue-config]", ev.AddedObjects)
+	}
+	if ev.Summary.Added != 1 {
+		t.Fatalf("summary.added = %d, want 1", ev.Summary.Added)
+	}
+}
+
+// A desired object absent live is a removed (membership) delta -> WATCH even
+// without --diff, since removed is computed from the observed pairs.
+func TestCompareObjectSet_RemovedObject_Watch(t *testing.T) {
+	resetCompareObjectSetFlags(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: redis
+spec:
+  replicas: 3
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		// Desired object not found live (Live nil, no inconclusive flag).
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Error: "live object not found"}}, nil
+	})
+
+	stmt := runCompareObjectSetJSON(t, []string{"--dry-from", path})
+	if stmt.Predicate.Verdict != agent.VerdictWATCH {
+		t.Fatalf("verdict = %s, want WATCH", stmt.Predicate.Verdict)
+	}
+	ev := stmt.Predicate.Evidence.ObjectSetDiff
+	if len(ev.RemovedObjects) != 1 || ev.RemovedObjects[0].Name != "api" {
+		t.Fatalf("removedObjects = %+v, want [api]", ev.RemovedObjects)
+	}
+	if len(ev.ChangedObjects) != 0 {
+		t.Fatalf("changedObjects = %d, want 0 (missing is a membership delta)", len(ev.ChangedObjects))
+	}
+}
+
+// --fail-on BLOCK on a changed object exits non-zero (code 2) while still
+// emitting the receipt.
+func TestCompareObjectSet_FailOnBlock(t *testing.T) {
+	resetCompareObjectSetFlags(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: redis
+spec:
+  replicas: 3
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		_ = unstructured.SetNestedField(live.Object, int64(5), "spec", "replicas")
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	rootCmd.SetArgs([]string{"compare", "object-set", "--dry-from", path, "--format", "json", "--fail-on", "BLOCK"})
+	captureStdout(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("BLOCK object-set-diff with --fail-on BLOCK must error")
+		}
+		var ec interface{ ExitCode() int }
+		if !errors.As(err, &ec) || ec.ExitCode() != 2 {
+			t.Fatalf("expected exit code 2 wrapper; got %v", err)
+		}
+		if !strings.Contains(err.Error(), "fail-on") {
+			t.Fatalf("expected fail-on error, got %v", err)
+		}
+	})
+}
+
+// An inconclusive live lookup must not produce a false PASS — it errors out.
+func TestCompareObjectSet_InconclusiveErrors(t *testing.T) {
+	resetCompareObjectSetFlags(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+  namespace: redis
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Error: "no matches for kind", Inconclusive: true}}, nil
+	})
+
+	rootCmd.SetArgs([]string{"compare", "object-set", "--dry-from", path, "--format", "json"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("inconclusive live lookup must error, not emit a PASS receipt")
+	}
+	if !strings.Contains(err.Error(), "inconclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A live object whose replicas were last written by kubectl-edit carries that
+// field-manager attribution through to the corresponding field delta
+// (cause=manual-edit + managerHint). This is the "which tool changed this
+// field" provenance reused from the three-way compare path.
+func TestCompareObjectSet_FieldAttribution(t *testing.T) {
+	resetCompareObjectSetFlags(t)
+	path := writeObjectSetManifest(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: redis
+spec:
+  replicas: 3
+`)
+	withFakeObjectSetLoader(t, func(_ context.Context, desired []*unstructured.Unstructured, _ string) ([]agent.ObjectSetObservedObject, error) {
+		live := desired[0].DeepCopy()
+		_ = unstructured.SetNestedField(live.Object, int64(5), "spec", "replicas")
+		live.SetManagedFields([]metav1.ManagedFieldsEntry{{
+			Manager:    agent.ManagerKubectlEdit,
+			Operation:  metav1.ManagedFieldsOperationUpdate,
+			FieldsType: "FieldsV1",
+			FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:spec":{"f:replicas":{}}}`)},
+		}})
+		return []agent.ObjectSetObservedObject{{Desired: desired[0], Live: live}}, nil
+	})
+
+	stmt := runCompareObjectSetJSON(t, []string{"--dry-from", path})
+	if stmt.Predicate.Verdict != agent.VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", stmt.Predicate.Verdict)
+	}
+	ev := stmt.Predicate.Evidence.ObjectSetDiff
+	if len(ev.ChangedObjects) != 1 {
+		t.Fatalf("changedObjects = %d, want 1", len(ev.ChangedObjects))
+	}
+	var repl *agent.ObjectSetFieldDiff
+	for i := range ev.ChangedObjects[0].Differences {
+		if ev.ChangedObjects[0].Differences[i].Field == "spec.replicas" {
+			repl = &ev.ChangedObjects[0].Differences[i]
+		}
+	}
+	if repl == nil {
+		t.Fatalf("no spec.replicas delta; fields = %v", fieldNames(ev.ChangedObjects[0].Differences))
+	}
+	if repl.Cause != string(agent.CauseManualEdit) {
+		t.Fatalf("replicas cause = %q, want %q", repl.Cause, agent.CauseManualEdit)
+	}
+	if repl.ManagerHint != agent.ManagerKubectlEdit {
+		t.Fatalf("replicas managerHint = %q, want %q", repl.ManagerHint, agent.ManagerKubectlEdit)
+	}
+}
+
+func fieldNames(diffs []agent.ObjectSetFieldDiff) []string {
+	out := make([]string, 0, len(diffs))
+	for _, d := range diffs {
+		out = append(out, d.Field)
+	}
+	return out
+}

--- a/examples/helm-expt/README.md
+++ b/examples/helm-expt/README.md
@@ -225,6 +225,43 @@ INSTALL_WORKDIR=/tmp/chart-run
   --fail-on any-non-pass
 ```
 
+## Set-level diff receipt (`object-set-diff`, #496)
+
+`object-set-matches` answers a boolean ("does the whole set match?") and
+`compare three-way` answers per resource. Neither emits a single **set-level
+delta receipt**. `compare object-set --dry-from` does: it diffs a rendered
+(desired) object set against live and emits an `object-set-diff` receipt
+aggregating per-object **authored-field deltas** (`changedObjects`), plus
+`removedObjects` and — with `--diff` — `addedObjects`.
+
+One receipt shape serves both day-1 and day-2, tool-agnostically (it reads the
+cluster + the `--dry-from` render, never the reconciler):
+
+```bash
+# drift (post-apply): does the current render still match live across the set?
+./cub-scout compare object-set \
+  --dry-from "$MANIFESTS" \
+  --scope namespace/"$NS" \
+  --format json \
+  --out "$RUN_DIR/object-set-diff.drift.receipt.json"
+
+# dry-run (pre-apply): what would a PROPOSED change (e.g. an image.digest bump)
+# touch across the set? A changed image -> BLOCK with one changedObject.
+./cub-scout compare object-set \
+  --dry-from "$RUN_DIR/release-objects.changed-image.yaml" \
+  --scope namespace/"$NS" \
+  --format json \
+  --fail-on any-non-pass
+```
+
+Verdict: **BLOCK** if any object has authored-field deltas; **WATCH** if only
+closure deltas (added/removed objects); **PASS** if none. The receipt is signed
+(fingerprint) and chain-walkable, like the other receipts. `verify.sh` runs both
+the drift and dry-run cases against this example's live fixture, reproducing the
+helm-expt#992 `image.digest` worked example offline. (Value-provenance per
+changed object is Issue B; a cross-fleet roll-up is Issue C — see
+[`docs/proposals/object-set-diff.md`](../../docs/proposals/object-set-diff.md).)
+
 ## Full Proof Chain
 
 The strongest story is a sequence of independent receipts:

--- a/examples/helm-expt/contracts.md
+++ b/examples/helm-expt/contracts.md
@@ -6,6 +6,7 @@ This example is precise about claim strength, in the spirit of helm-expt's
 | Artifact | Proves | Does NOT prove |
 |---|---|---|
 | `object-set-matches` receipt | Every desired object identity in `fixtures/release-objects.yaml` is present live, and every **authored field** matches. | That the workload is **running** (status is stripped); that **prerequisites** (the Secret) exist; that **no extra** live objects exist; freshness. |
+| `object-set-diff` receipt (`compare object-set --dry-from`) | The **set-level delta** between a rendered (desired) object set and live: `changedObjects` with per-object **authored-field deltas**, plus `removedObjects` (desired absent live) and — with `--diff` — `addedObjects` (live extras). One shape for dry-run (changed render vs live) and drift (current render vs live). | That the workload is **running** (status is stripped); value-provenance (which input value caused a delta — Issue B); a cross-fleet roll-up (Issue C); that no live extras exist unless `--diff` was passed. |
 | `cub-scout doctor` | A human-readable health summary; surfaces the broken pod as a **warning**. | A gating verdict — `error: 0` here despite a dead pod. |
 | `cub-scout compare drift --file` | Whether supported workload fields (e.g. replicas, images) drifted. | Full authored-field equivalence; readiness; prerequisites. |
 | The fixture's missing Secret | (by design) reproduces F3 — the unmet prerequisite. | n/a |
@@ -30,6 +31,27 @@ Both receipt subjects (`rendered-object-set://…` and `k8s-live-object-set://�
 carry the same SHA-256 because `matchMode: authored-fields` hashes the projected
 authored fields, not an independent snapshot of live state. Read the "live"
 subject as "the authored-field projection of live", not "everything that is live".
+
+## object-set-diff verdict rule
+
+`compare object-set --dry-from` emits an `object-set-diff` receipt whose verdict
+is, by construction:
+
+- **BLOCK** — one or more objects present on both sides have **authored-field
+  deltas** (`changedObjects` non-empty). This is real drift / "this change would
+  touch these fields".
+- **WATCH** — only **closure deltas** (`addedObjects` / `removedObjects`) and no
+  changed objects. The set's membership differs but every shared object's
+  authored fields match.
+- **PASS** — no changed, added, or removed objects.
+
+It is **tool-agnostic** by construction (reads the cluster + the `--dry-from`
+source, never the reconciler) and **deterministic-desired** (the desired side is
+the supplied render, not a re-render). The receipt is signed (fingerprint) and
+chain-walkable (`inputAttestations[]`), like the other receipts. Per-field
+`cause` / `managerHint` attribution is carried for classified fields when live
+`managedFields` resolve a writer; absent that signal the field is left
+unattributed (it is **not** stamped a bare `unknown`).
 
 ## What would make the claim complete
 

--- a/examples/helm-expt/verify.sh
+++ b/examples/helm-expt/verify.sh
@@ -94,7 +94,43 @@ echo "verdict: $WL_VERDICT  (exit $WL_RC)"
 jq -r '.predicate.evidence.workloads.workloads[] | select(.status!="converged") | "  "+.id.kind+"/"+.id.name+" -> "+.status+" (kstatus "+.kstatusStatus+(if (.podReasons|length)>0 then ", pod "+.podReasons[0].reason else "" end)+")"' "$RUN_DIR/workloads.receipt.json" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
-rule "4. what is ACTUALLY happening in the cluster"
+# object-set-diff (#496, Issue A): the SET-LEVEL delta receipt. One receipt
+# shape serves both day-1 (dry-run: "what would a proposed change touch?") and
+# day-2 (drift: "what differs now?"). Tool-agnostic: reads the cluster + the
+# --dry-from source, never the reconciler. This reproduces the helm-expt#992
+# image.digest worked example offline against THIS example's live fixture.
+rule "4. object-set-diff (#496) — set-level delta receipt (dry-run + drift)"
+
+# Drift reading: diff the EXACT applied render against live. Authored fields
+# match, so the set-level diff is PASS (no changed/added/removed). This is the
+# day-2 "what differs across the set now?" question.
+set +e
+"$CUB_SCOUT" compare object-set --dry-from "$MANIFESTS" --scope "namespace/$NS" \
+    --format json --ttl 1h --out "$RUN_DIR/object-set-diff.drift.receipt.json" \
+    >"$RUN_DIR/object-set-diff.drift.stdout.json" 2>"$RUN_DIR/object-set-diff.drift.stderr.txt"
+set -e
+DIFF_DRIFT_VERDICT="$(jq -r '.predicate.verdict // "UNKNOWN"' "$RUN_DIR/object-set-diff.drift.receipt.json" 2>/dev/null || echo UNKNOWN)"
+echo "drift  (--dry-from = current render):  verdict $DIFF_DRIFT_VERDICT"
+
+# Dry-run reading: build a CHANGED render (bump the container image, the
+# image.digest case from helm-expt#992) and diff THAT against live. The image
+# field delta makes the set-level diff BLOCK with one changedObject — "this
+# proposed change would touch the web Deployment's image". The changed render is
+# derived from the committed fixture at runtime so it never drifts from it.
+CHANGED_MANIFEST="$RUN_DIR/release-objects.changed-image.yaml"
+sed 's#image: busybox:1.36#image: busybox:1.37#' "$MANIFESTS" > "$CHANGED_MANIFEST"
+set +e
+"$CUB_SCOUT" compare object-set --dry-from "$CHANGED_MANIFEST" --scope "namespace/$NS" \
+    --format json --ttl 1h --out "$RUN_DIR/object-set-diff.dryrun.receipt.json" \
+    >"$RUN_DIR/object-set-diff.dryrun.stdout.json" 2>"$RUN_DIR/object-set-diff.dryrun.stderr.txt"
+set -e
+DIFF_DRYRUN_VERDICT="$(jq -r '.predicate.verdict // "UNKNOWN"' "$RUN_DIR/object-set-diff.dryrun.receipt.json" 2>/dev/null || echo UNKNOWN)"
+echo "dry-run (--dry-from = changed image):  verdict $DIFF_DRYRUN_VERDICT"
+jq -r '.predicate.evidence.objectSetDiff.changedObjects[]? | "  changed "+.id.kind+"/"+.id.name' "$RUN_DIR/object-set-diff.dryrun.receipt.json" 2>/dev/null || true
+jq -r '.predicate.evidence.objectSetDiff.changedObjects[]?.differences[]? | "    "+.field+": "+.desired+" -> "+.live' "$RUN_DIR/object-set-diff.dryrun.receipt.json" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+rule "5. what is ACTUALLY happening in the cluster"
 kubectl --context "$CONTEXT" -n "$NS" get deploy,pods -o wide || true
 
 # ---------------------------------------------------------------------------
@@ -105,6 +141,8 @@ printf -- '---------------------------------------+-----------------------------
 printf '%-38s | %s\n' "object-set-matches (present+match)"  "$OS_VERDICT  <- green alone = false green"
 printf '%-38s | %s\n' "prerequisites-met (#477, pre-flight)" "$PQ_VERDICT  <- target fact: Secret absent"
 printf '%-38s | %s\n' "workloads-converged (#476, runtime)"  "$WL_VERDICT  <- pod CreateContainerConfigError"
+printf '%-38s | %s\n' "object-set-diff drift (#496, day-2)"  "$DIFF_DRIFT_VERDICT  <- current render == live, set-level"
+printf '%-38s | %s\n' "object-set-diff dry-run (#496, day-1)" "$DIFF_DRYRUN_VERDICT  <- changed image would touch web Deployment"
 printf '%-38s | %s\n' "receipt freshness/TTL (#478)"         "$([[ "$HAS_FRESHNESS" -gt 0 ]] && echo "present (ttl 1h)" || echo ABSENT)"
 
 # ---------------------------------------------------------------------------
@@ -121,6 +159,11 @@ The two install-receipt predicates now catch it from both ends, on the SAME inst
 The three install-receipt predicates plus receipt freshness (#478, via --ttl:
 observedAt + expiresAt) now ship — so a workerless consumer can tell a fresh
 green from a stale one.
+
+object-set-diff (#496) adds the SET-LEVEL delta receipt on top, with one shape
+for both day-1 and day-2:
+  * drift   (--dry-from = current render): $DIFF_DRIFT_VERDICT — the applied set still matches live.
+  * dry-run (--dry-from = changed image):  $DIFF_DRYRUN_VERDICT — the proposed image bump would touch the web Deployment (image.digest case, helm-expt#992).
 
 Receipts saved under: ${RUN_DIR/#$REPO_ROOT\//}
 EOF

--- a/pkg/agent/receipt.go
+++ b/pkg/agent/receipt.go
@@ -254,6 +254,7 @@ type Evidence struct {
 	SourceTruth     *SourceTruthEvidence        `json:"sourceTruth,omitempty"`
 	GitSource       *GitSourceAnchor            `json:"gitSource,omitempty"`
 	ObjectSet       *ObjectSetEvidence          `json:"objectSet,omitempty"`
+	ObjectSetDiff   *ObjectSetDiffEvidence      `json:"objectSetDiff,omitempty"`
 	Workloads       *WorkloadsConvergedEvidence `json:"workloads,omitempty"`
 	Prerequisites   *PrerequisitesEvidence      `json:"prerequisites,omitempty"`
 }
@@ -355,6 +356,13 @@ const (
 	// one or more desired objects could not be checked because the API
 	// mapping or live read was inconclusive.
 	OmissionObjectSetCoverage = "object-set-coverage"
+
+	// OmissionObjectSetDiffClosure is recorded by object-set-diff receipts
+	// (#496, Issue A) when the closed-world diff (--diff) was not requested:
+	// the receipt reports authored-field deltas on the desired set but makes
+	// no claim about objects that exist live outside that set (addedObjects)
+	// or desired objects absent live (removedObjects).
+	OmissionObjectSetDiffClosure = "object-set-diff-closure"
 
 	// OmissionWorkloadConvergence is recorded by workloads-converged
 	// receipts to mark that readiness was observed at verifiedAt; the

--- a/pkg/agent/receipt_object_set_diff.go
+++ b/pkg/agent/receipt_object_set_diff.go
@@ -1,0 +1,220 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// ObjectSetDiffEvidence is attached under predicate.evidence.objectSetDiff for
+// object-set-diff receipts (#496, Issue A). It is the set-level delta between a
+// rendered (desired) object set and live cluster state: per-object authored
+// field deltas plus closure deltas (objects added or removed relative to the
+// desired set). Both a dry-run ("what would this change touch across the set?")
+// and a drift check ("what differs across the set now?") emit this shape — the
+// only difference is which side is the "current render".
+type ObjectSetDiffEvidence struct {
+	DesiredSource  ObjectSetSource       `json:"desiredSource"`
+	Scope          ObjectSetScope        `json:"scope"`
+	DesiredDigest  string                `json:"desiredDigest"`
+	LiveDigest     string                `json:"liveDigest"`
+	ChangedObjects []ObjectSetDiffObject `json:"changedObjects,omitempty"`
+	AddedObjects   []ObjectSetObjectID   `json:"addedObjects,omitempty"`
+	RemovedObjects []ObjectSetObjectID   `json:"removedObjects,omitempty"`
+	Summary        ObjectSetDiffSummary  `json:"summary"`
+
+	// NormalizationProfile names the server-normalization profile applied
+	// symmetrically to the desired and live objects before projection and
+	// digesting (e.g. k8s-zero-defaults/v1). Empty means raw comparison.
+	// Recording it makes the normalization assumption part of the claim.
+	NormalizationProfile string `json:"normalizationProfile,omitempty"`
+}
+
+// ObjectSetDiffObject is one desired object whose authored fields differ from
+// live, with the field-level deltas that drove the difference.
+type ObjectSetDiffObject struct {
+	ID            ObjectSetObjectID    `json:"id"`
+	DesiredDigest string               `json:"desiredDigest,omitempty"`
+	LiveDigest    string               `json:"liveDigest,omitempty"`
+	Differences   []ObjectSetFieldDiff `json:"differences,omitempty"`
+}
+
+// ObjectSetFieldDiff is one authored-field delta on a changed object. Cause and
+// ManagerHint carry the writing field-manager attribution when it is available
+// (drift attributed to a controller/tool); they are optional.
+type ObjectSetFieldDiff struct {
+	Field   string `json:"field"`
+	Desired string `json:"desired"`
+	Live    string `json:"live"`
+	// Cause classifies the mutation source for this field delta (e.g.
+	// controller-drift, manual-edit). Optional; empty when no managedFields
+	// attribution mapped to this field.
+	Cause string `json:"cause,omitempty"`
+	// ManagerHint is a representative field-manager string for transparency.
+	// Optional; empty when unknown.
+	ManagerHint string `json:"managerHint,omitempty"`
+}
+
+// ObjectSetDiffSummary is the set-level roll-up: how many desired objects were
+// compared, how many changed (field deltas), and the closure deltas.
+type ObjectSetDiffSummary struct {
+	Total   int `json:"total"`
+	Changed int `json:"changed"`
+	Added   int `json:"added"`
+	Removed int `json:"removed"`
+}
+
+// BuildObjectSetDiffReceiptInput is the pure input to BuildObjectSetDiffReceipt.
+// Callers do file and cluster reads, then assemble the evidence, before
+// invoking this function.
+type BuildObjectSetDiffReceiptInput struct {
+	Evidence          ObjectSetDiffEvidence
+	Verifier          Verifier
+	VerifiedAt        time.Time
+	InputAttestations []VerifiedAttestationRef
+}
+
+// BuildObjectSetDiffReceipt builds a single set-level diff receipt for a
+// rendered manifest set compared against live cluster state. It mirrors
+// BuildObjectSetReceipt: same subject schemes (rendered-object-set:// desired +
+// k8s-live-object-set:// live), the object-set-diff predicate, and the shared
+// fingerprint stamper so the receipt is signed and chain-walkable. It is pure.
+//
+// Verdict rule (#496, Issue A):
+//   - BLOCK         any object has field-level Differences (real authored drift).
+//   - WATCH         only closure deltas (addedObjects / removedObjects) and no
+//     changed objects — the set's membership differs but every
+//     shared object's authored fields match.
+//   - PASS          no changed, added, or removed objects.
+//
+// INCONCLUSIVE is reserved for load/build errors surfaced by the caller before
+// this function (e.g. an inconclusive live lookup), which the caller maps to an
+// error return; this builder itself only enumerates PASS / WATCH / BLOCK over
+// well-formed evidence.
+func BuildObjectSetDiffReceipt(in BuildObjectSetDiffReceiptInput) (Statement, error) {
+	if in.Evidence.DesiredDigest == "" {
+		return Statement{}, fmt.Errorf("object-set-diff receipt: missing desired digest")
+	}
+	if in.Evidence.LiveDigest == "" {
+		return Statement{}, fmt.Errorf("object-set-diff receipt: missing live digest")
+	}
+
+	verifiedAt := in.VerifiedAt
+	if verifiedAt.IsZero() {
+		verifiedAt = time.Now().UTC()
+	}
+
+	// Sort the evidence collections deterministically so the canonical JSON
+	// (and therefore the fingerprint) is stable regardless of input order.
+	sort.Slice(in.Evidence.ChangedObjects, func(i, j int) bool {
+		return in.Evidence.ChangedObjects[i].ID.Key() < in.Evidence.ChangedObjects[j].ID.Key()
+	})
+	sort.Slice(in.Evidence.AddedObjects, func(i, j int) bool {
+		return in.Evidence.AddedObjects[i].Key() < in.Evidence.AddedObjects[j].Key()
+	})
+	sort.Slice(in.Evidence.RemovedObjects, func(i, j int) bool {
+		return in.Evidence.RemovedObjects[i].Key() < in.Evidence.RemovedObjects[j].Key()
+	})
+
+	changed := len(in.Evidence.ChangedObjects)
+	added := len(in.Evidence.AddedObjects)
+	removed := len(in.Evidence.RemovedObjects)
+	in.Evidence.Summary.Changed = changed
+	in.Evidence.Summary.Added = added
+	in.Evidence.Summary.Removed = removed
+
+	verdict := VerdictPASS
+	switch {
+	case changed > 0:
+		verdict = VerdictBLOCK
+	case added > 0 || removed > 0:
+		verdict = VerdictWATCH
+	}
+
+	omissions := []Omission{}
+	// The diff is over authored fields of the desired set; it never claims
+	// the live cluster contains nothing else unless closure deltas were
+	// computed (--diff). Record the boundary honestly.
+	if added == 0 && removed == 0 {
+		omissions = append(omissions, Omission{
+			Missing:  OmissionObjectSetDiffClosure,
+			Reason:   "object-set-diff compares authored fields of the desired set against live; addedObjects/removedObjects closure deltas are only computed when the closed-world diff (--diff) is requested",
+			Severity: "info",
+		})
+	}
+
+	nextSteps := []ReceiptNextStep{}
+	switch verdict {
+	case VerdictPASS:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      "no authored-field, added, or removed deltas between the desired object set and live — the change touches nothing across the set",
+			NextCommand: "cub-scout doctor",
+			NextSurface: "cub-scout",
+		})
+	case VerdictWATCH:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      fmt.Sprintf("no shared object's authored fields changed, but the set membership differs (%d added, %d removed) — review the closure deltas before accepting", added, removed),
+			NextCommand: "cub-scout map list",
+			NextSurface: "cub-scout",
+		})
+	case VerdictBLOCK:
+		nextSteps = append(nextSteps, ReceiptNextStep{
+			ActionType:  "read-only",
+			Reason:      fmt.Sprintf("%d object(s) have authored-field deltas between the desired set and live; inspect changedObjects before applying or accepting the drift", changed),
+			NextCommand: "cub-scout compare three-way",
+			NextSurface: "cub-scout",
+		})
+	}
+	filteredSteps, stepOmissions := FilterNextSteps(nextSteps)
+	omissions = append(omissions, stepOmissions...)
+
+	inputAttestations := make([]AttestationRef, 0, len(in.InputAttestations))
+	for i, v := range in.InputAttestations {
+		if v.IsZero() {
+			return Statement{}, fmt.Errorf("object-set-diff receipt: inputAttestations[%d] is a zero-value VerifiedAttestationRef; construct via BuildAttestationRef or BuildAttestationRefsFromPaths", i)
+		}
+		inputAttestations = append(inputAttestations, v.Ref())
+	}
+
+	scope := Scope{
+		Kind:      "ObjectSet",
+		Name:      "rendered-install",
+		Namespace: in.Evidence.Scope.Namespace,
+	}
+	claim := "object-set diff between rendered manifests and live"
+	if in.Evidence.DesiredSource.Ref != "" {
+		claim = fmt.Sprintf("object-set diff between rendered manifests from %s and live", in.Evidence.DesiredSource.Ref)
+	}
+
+	stmt := Statement{
+		Type: StatementType,
+		Subject: []Subject{
+			BuildRenderedObjectSetSubject(in.Evidence.DesiredDigest),
+			BuildLiveObjectSetSubject(in.Evidence.Scope, in.Evidence.LiveDigest),
+		},
+		PredicateType: PredicateTypeReceiptV1,
+		Predicate: Predicate{
+			Version:           PredicateVersion,
+			Claim:             claim,
+			Scope:             scope,
+			Verifier:          in.Verifier,
+			VerifiedAt:        verifiedAt.UTC().Format(time.RFC3339),
+			PredicateName:     string(PredicateObjectSetDiff),
+			Verdict:           verdict,
+			Evidence:          Evidence{ObjectSetDiff: &in.Evidence},
+			Omissions:         omissions,
+			InputAttestations: inputAttestations,
+			NextSteps:         filteredSteps,
+		},
+	}
+
+	if err := StampFingerprint(&stmt); err != nil {
+		return Statement{}, fmt.Errorf("object-set-diff receipt: stamp fingerprint: %w", err)
+	}
+	return stmt, nil
+}

--- a/pkg/agent/receipt_predicates.go
+++ b/pkg/agent/receipt_predicates.go
@@ -36,6 +36,17 @@ const (
 	// controller-populated status are deliberately outside this claim.
 	PredicateObjectSetMatches PredicateName = "object-set-matches"
 
+	// PredicateObjectSetDiff emits a set-level delta between a rendered
+	// (desired) object set and live cluster state: changedObjects (with
+	// per-object authored-field deltas), addedObjects, and removedObjects.
+	// Unlike object-set-matches (a boolean "does the set match?"), this
+	// predicate aggregates the per-resource field deltas into one signed,
+	// chain-walkable receipt that serves both dry-run ("what would this
+	// change touch?") and drift ("what differs now?"). It is --dry-from
+	// routed and evaluated by BuildObjectSetDiffReceipt, not the
+	// BuildReceipt switch.
+	PredicateObjectSetDiff PredicateName = "object-set-diff"
+
 	// PredicateWorkloadsConverged verifies that every desired workload in
 	// the rendered manifest set reached a ready/converged runtime state
 	// (Deployments/StatefulSets/DaemonSets rolled out, Jobs Succeeded,


### PR DESCRIPTION
## What

Implements **Issue A** of the merged object-set-diff proposal (#496): a set-level diff that aggregates cub-scout's existing per-resource field deltas into a signed, chain-walkable **`ObjectSetDiffReceipt`** (predicate `object-set-diff`), via a new `compare object-set --dry-from` command.

## Command

```
cub-scout compare object-set --dry-from <set> [--diff] [-n <ns>] \
  [--format json|ascii] [--out <file>] [--save] [--fail-on <verdict>] [--ttl <dur>]
```

Compares a rendered/desired object set (DRY) against live cluster state and emits the receipt. Verdict rule:
- **PASS** — no field deltas, no membership deltas
- **WATCH** — membership-only (a desired object missing → `removedObjects`; with `--diff`, live-only extras → `addedObjects`)
- **BLOCK** — at least one object has field drift (`changedObjects`)
- **INCONCLUSIVE** — load/observe error

## How (clean extension — no new infra)

- `pkg/agent/receipt_object_set_diff.go` — `ObjectSetDiffEvidence` / `ObjectSetDiffObject` / `ObjectSetFieldDiff` + `BuildObjectSetDiffReceipt`. Reuses the existing object-set loader, authored-field projection (`BuildObjectSetEvidence`), per-field mutation attribution (`cause`/`managerHint`), the `rendered-object-set://` + `k8s-live-object-set://` subject schemes, and `StampFingerprint` — so the receipt is signed + chain-walkable like the others.
- `cmd/cub-scout/compare_object_set.go` — the cobra subcommand under `compare`.
- `pkg/agent/receipt.go` / `receipt_predicates.go` — `Evidence.ObjectSetDiff` + the `object-set-diff` predicate constant.

## Tests + example

- 7 table tests: verdict rules, `--diff` added-objects, removed→WATCH, `--fail-on` exit code, and field-manager attribution flowing into the deltas. `go build ./...` + `go test ./cmd/cub-scout/... ./pkg/agent/...` green; `gofmt` clean on touched files.
- `examples/helm-expt/verify.sh` runs a dry-run (image bump → BLOCK, the helm-expt#992 `image.digest` case) + a drift case; `README.md`/`contracts.md` document the receipt.

## Scope
Issue A only — Issue B (value-provenance `provenance.valuePath`) and Issue C (fleet roll-up) are out of scope. Source-only; for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)