### PR TITLE
Add live delivery observability release slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,20 @@ cub-scout is an open-source observer for live Kubernetes clusters and GitOps. Po
 
 It diagnoses, explains, traces, maps, scans, **compares** intended vs running state, and **attributes** every field back to its source — but it never modifies cluster state and never makes authority calls about what *should* be true. Safe to run against production.
 
-It helps you answer:
-- what owns this resource, really?
-- where did each field's value come from — controller, git file, ConfigHub binding, or someone editing manually?
-- what's broken right now, and what should I do next?
-- how does **intended** (governed) state compare to **live** (cluster) state?
+Cub-scout helps users answer questions about k8s and GitOps clusters in one place.
+
+| User question | cub-scout surface | What cub-scout provides |
+|---|---|---|
+| What is running, and who owns it? | `doctor`, `map`, `trace`, `explain` | Live inventory, ownership, source chain, recent events, and next read-only checks across supported controllers and platforms. |
+| Is delegated delivery healthy? | `gitops status` | Controller-reported backend, transport, source/build/apply/sync stages, reason/message, and explicit evidence gaps when status is incomplete. |
+| Has intended configuration reached the cluster? | `compare three-way` | DRY/WET/LIVE agreement for a resource, namespace, cluster, or governed view, with states like `agreed`, `converging`, `diverged`, and `partial`. |
+| Is this rollout still progressing, complete, or stuck? | `receipt verify --predicate workloads-converged`, `doctor`, `explain` | Generation-aware workload evidence: desired vs observed generation, kstatus, progress clock, pod failure signals, and `PASS` / `WATCH` / `BLOCK` / `INCONCLUSIVE` verdicts. |
+| Can I move to the next task, wait, or retry delivery? | `receipt verify`, `compare three-way`, `doctor` | A read-only decision frame that separates "not applied yet", "still converging", "runtime failure", and "missing evidence". |
+| Is live state drifting from desired state? | `compare drift`, `compare three-way`, `compare source-truth` | Field-level differences, strategy-relative source-truth evidence, conformance exit codes, and explicit proof gaps when evidence is missing. |
+| Is this a delivery problem or an application/runtime problem? | `doctor`, `explain`, `patterns`, `scan` | kstatus health, Kubernetes events, workload symptoms, known-pattern matches, and phase-aware hints so operators can separate sync/convergence issues from runtime failures. |
+| Who changed this field, and where did the value come from? | `compare`, `explain`, attribution JSON | `cause`, `managerHint`, `gitSource`, `bindingSource`, audit/event evidence where available, and optional file:line back-resolution from live `managedFields`, controller metadata, local source files, and governed links. |
+| Can I answer broad or repeated questions without hammering live APIs? | `snapshot`, `watch`, `summary`, receipts | Captured state, low-cardinality watch events, connected summaries, freshness metadata, and immutable receipts for repeated review, fleet triage, and audit paths. |
+| Can I keep auditable evidence of the check? | `receipt verify`, `receipt validate`, `watch --emit-receipt-on` | Typed, fingerprinted, immutable evidence receipts for gates, incident closeout, audits, chained checks, and real-time watch events. |
 
 The main path starts from a **live cluster**. It works **standalone** with your current kube context, or **connected** to [ConfigHub](https://confighub.com) for governed comparison, history, import, fleet queries, and AI-friendly read-only workflows. Local repo and manifest inputs are available later for adoption, import-preview, and source-file enrichment, but they are not the first mental model.
 
@@ -317,6 +326,7 @@ Honest gaps in the current capability map, with the leverage on filling them:
 | JSON fields and output model | [docs/reference/json-contracts.md](docs/reference/json-contracts.md) |
 | Getting started checklist | [docs/getting-started/checklist.md](docs/getting-started/checklist.md) |
 | Import and migration path | [docs/howto/import-to-confighub.md](docs/howto/import-to-confighub.md) |
+| Delivery readiness decision | [docs/howto/delivery-readiness-decision.md](docs/howto/delivery-readiness-decision.md) |
 | AI tool integration | [docs/howto/using-cub-scout-from-ai-tool.md](docs/howto/using-cub-scout-from-ai-tool.md) |
 | Examples and demos | [examples/README.md](examples/README.md) |
 | Receipts (typed evidence artifacts) | [examples/receipts/README.md](examples/receipts/README.md) + [docs/reference/json-contracts.md § Receipt Contract](docs/reference/json-contracts.md) |

--- a/cmd/cub-scout/compare_three_way.go
+++ b/cmd/cub-scout/compare_three_way.go
@@ -37,10 +37,11 @@ type threeWayTarget struct {
 }
 
 type threeWayResourceEntry struct {
-	Result   compareResourceResult `json:"result"`
-	Severity string                `json:"severity"`
-	Causes   []string              `json:"causes,omitempty"`
-	Pattern  ThreeWayPattern       `json:"pattern"`
+	Result        compareResourceResult  `json:"result"`
+	Severity      string                 `json:"severity"`
+	Causes        []string               `json:"causes,omitempty"`
+	Pattern       ThreeWayPattern        `json:"pattern"`
+	CurrentChange *agent.RolloutDecision `json:"currentChange,omitempty"`
 }
 
 // ConformanceResult contains the pass/fail conformance summary.
@@ -318,6 +319,9 @@ func buildThreeWayReport(ctx context.Context, scope threeWayScope, failOnThresho
 			Causes:   causes,
 			Pattern:  pattern,
 		}
+		if decision, ok := fetchThreeWayRolloutDecision(ctx, target); ok {
+			entry.CurrentChange = decision
+		}
 		entries = append(entries, entry)
 
 		summary.TotalResources++
@@ -372,6 +376,21 @@ func buildThreeWayReport(ctx context.Context, scope threeWayScope, failOnThresho
 	}
 	report.ConfigHubURL, report.ConfigHubRevisionsURL, report.NextSteps = buildThreeWayNavigation(report)
 	return report, nil
+}
+
+func fetchThreeWayRolloutDecision(ctx context.Context, target threeWayTarget) (*agent.RolloutDecision, bool) {
+	kind, name, err := parseResourceArg(target.ResourceArg)
+	if err != nil {
+		return nil, false
+	}
+	namespace := strings.TrimSpace(target.Namespace)
+	if namespace == "" {
+		namespace = combinedNamespace
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	return fetchRolloutDecision(ctx, namespace, kind, name)
 }
 
 func buildThreeWayNavigation(report threeWayReport) (string, string, []StructuredHint) {
@@ -943,6 +962,9 @@ func renderThreeWayASCII(report threeWayReport) string {
 		if len(entry.Causes) > 0 {
 			b.WriteString("  causes: " + strings.Join(entry.Causes, ", ") + "\n")
 		}
+		if entry.CurrentChange != nil {
+			b.WriteString("  current-change: " + formatRolloutDecisionLine(entry.CurrentChange) + "\n")
+		}
 		for _, note := range entry.Result.Notes {
 			b.WriteString("  note: " + note + "\n")
 		}
@@ -995,19 +1017,24 @@ func renderThreeWayMarkdown(report threeWayReport) string {
 		return b.String()
 	}
 
-	b.WriteString("| Resource | Namespace | Mode | Severity | Mismatches | Causes |\n")
-	b.WriteString("|---|---|---|---|---:|---|\n")
+	b.WriteString("| Resource | Namespace | Mode | Severity | Mismatches | Current Change | Causes |\n")
+	b.WriteString("|---|---|---|---|---:|---|---|\n")
 	for _, entry := range report.Resources {
 		causes := strings.Join(entry.Causes, ",")
 		if causes == "" {
 			causes = "-"
 		}
-		b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %d | %s |\n",
+		currentChange := "-"
+		if entry.CurrentChange != nil {
+			currentChange = formatRolloutDecisionLine(entry.CurrentChange)
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %d | %s | %s |\n",
 			historyEscapeMarkdown(entry.Result.Resource),
 			historyEscapeMarkdown(entry.Result.Namespace),
 			historyEscapeMarkdown(entry.Result.Mode),
 			historyEscapeMarkdown(entry.Severity),
 			len(entry.Result.Mismatches),
+			historyEscapeMarkdown(currentChange),
 			historyEscapeMarkdown(causes),
 		))
 	}

--- a/cmd/cub-scout/compare_three_way.go
+++ b/cmd/cub-scout/compare_three_way.go
@@ -271,6 +271,10 @@ func parseThreeWayScope(raw string) (threeWayScope, error) {
 }
 
 func buildThreeWayReport(ctx context.Context, scope threeWayScope, failOnThreshold string) (threeWayReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	targets, err := collectThreeWayTargets(ctx, scope)
 	if err != nil {
 		return threeWayReport{}, err

--- a/cmd/cub-scout/compare_three_way_test.go
+++ b/cmd/cub-scout/compare_three_way_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/spf13/cobra"
 )
 
@@ -616,6 +617,51 @@ func TestRenderThreeWayASCII_ConvergingState(t *testing.T) {
 	}
 }
 
+func TestRenderThreeWayASCII_IncludesCurrentChange(t *testing.T) {
+	report := threeWayReport{
+		Scope: "namespace/prod",
+		Summary: threeWaySummary{
+			TotalResources: 1,
+			SeverityCounts: map[string]int{"warning": 1},
+			Agreement: AgreementSummary{
+				State:   StateConverging,
+				Summary: "1/1 resources converging",
+			},
+		},
+		Resources: []threeWayResourceEntry{{
+			Result: compareResourceResult{
+				Resource:  "Deployment/api",
+				Namespace: "prod",
+				Mode:      "dry-wet-live",
+			},
+			Severity: "warning",
+			Pattern:  PatternRolloutPending,
+			CurrentChange: &agent.RolloutDecision{
+				Verdict: agent.VerdictWATCH,
+				Reason:  agent.RolloutReasonStaleGeneration,
+				Progress: agent.RolloutProgress{
+					Phase: agent.RolloutProgressApplied,
+				},
+				Evidence: agent.RolloutDecisionEvidence{
+					Generation:         2,
+					ObservedGeneration: 1,
+				},
+			},
+		}},
+	}
+
+	output := renderThreeWayASCII(report)
+	for _, want := range []string{
+		"current-change: WATCH phase=applied",
+		"reason=stale_generation",
+		"generation=2 observed=1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in ASCII output:\n%s", want, output)
+		}
+	}
+}
+
 func TestRenderThreeWayMarkdown_IncludesAgreementSummary(t *testing.T) {
 	report := threeWayReport{
 		Scope: "namespace/prod",
@@ -642,5 +688,52 @@ func TestRenderThreeWayMarkdown_IncludesAgreementSummary(t *testing.T) {
 	}
 	if !strings.Contains(output, "1/2 resources diverged") {
 		t.Error("expected divergence summary in markdown output")
+	}
+}
+
+func TestRenderThreeWayMarkdown_IncludesCurrentChange(t *testing.T) {
+	report := threeWayReport{
+		Scope: "namespace/prod",
+		Summary: threeWaySummary{
+			TotalResources: 1,
+			SeverityCounts: map[string]int{"warning": 1},
+			Agreement: AgreementSummary{
+				State:   StateDiverged,
+				Summary: "1/1 resources diverged",
+			},
+		},
+		Resources: []threeWayResourceEntry{{
+			Result: compareResourceResult{
+				Resource:  "Deployment/api",
+				Namespace: "prod",
+				Mode:      "dry-wet-live",
+			},
+			Severity: "warning",
+			Pattern:  PatternRolloutPending,
+			CurrentChange: &agent.RolloutDecision{
+				Verdict: agent.VerdictBLOCK,
+				Reason:  agent.RolloutReasonRuntimeFailed,
+				Progress: agent.RolloutProgress{
+					Phase: agent.RolloutProgressStalled,
+				},
+				Evidence: agent.RolloutDecisionEvidence{
+					PodReasons: []agent.WorkloadPodReason{
+						{Pod: "api-abc", Reason: "CrashLoopBackOff"},
+					},
+				},
+			},
+		}},
+	}
+
+	output := renderThreeWayMarkdown(report)
+	for _, want := range []string{
+		"Current Change",
+		"BLOCK phase=stalled",
+		"reason=runtime_failed",
+		"pod=api-abc:CrashLoopBackOff",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in markdown output:\n%s", want, output)
+		}
 	}
 }

--- a/cmd/cub-scout/controller_resources.go
+++ b/cmd/cub-scout/controller_resources.go
@@ -22,7 +22,8 @@ type controllerResourceSpec struct {
 }
 
 func firstClassControllerResources() []controllerResourceSpec {
-	out := make([]controllerResourceSpec, 0, len(sveltosControllerResources())+len(modelplaneControllerResources()))
+	out := make([]controllerResourceSpec, 0, len(fluxOperatorControllerResources())+len(sveltosControllerResources())+len(modelplaneControllerResources()))
+	out = append(out, fluxOperatorControllerResources()...)
 	out = append(out, sveltosControllerResources()...)
 	out = append(out, modelplaneControllerResources()...)
 	return out
@@ -35,6 +36,17 @@ func firstClassControllerGVRs() []schema.GroupVersionResource {
 		out = append(out, spec.GVR)
 	}
 	return out
+}
+
+func fluxOperatorControllerResources() []controllerResourceSpec {
+	return []controllerResourceSpec{
+		{GVR: schema.GroupVersionResource{Group: "fluxcd.controlplane.io", Version: "v1", Resource: "fluxinstances"}, Kind: "FluxInstance", Namespaced: true, Owner: "Flux"},
+		{GVR: schema.GroupVersionResource{Group: "fluxcd.controlplane.io", Version: "v1", Resource: "fluxreports"}, Kind: "FluxReport", Namespaced: true, Owner: "Flux"},
+		{GVR: schema.GroupVersionResource{Group: "fluxcd.controlplane.io", Version: "v1", Resource: "resourcesets"}, Kind: "ResourceSet", Namespaced: true, Owner: "Flux"},
+		{GVR: schema.GroupVersionResource{Group: "fluxcd.controlplane.io", Version: "v1", Resource: "resourcesetinputproviders"}, Kind: "ResourceSetInputProvider", Namespaced: true, Owner: "Flux"},
+		{GVR: schema.GroupVersionResource{Group: "fluxcd.controlplane.io", Version: "v1", Resource: "externalartifacts"}, Kind: "ExternalArtifact", Namespaced: true, Owner: "Flux"},
+		{GVR: schema.GroupVersionResource{Group: "fluxcd.controlplane.io", Version: "v1", Resource: "artifactgenerators"}, Kind: "ArtifactGenerator", Namespaced: true, Owner: "Flux"},
+	}
 }
 
 func sveltosControllerResources() []controllerResourceSpec {

--- a/cmd/cub-scout/controller_resources_test.go
+++ b/cmd/cub-scout/controller_resources_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestFluxOperatorControllerResourcesAreFirstClass(t *testing.T) {
+	want := map[string]schema.GroupVersionResource{
+		"FluxInstance":             {Group: "fluxcd.controlplane.io", Version: "v1", Resource: "fluxinstances"},
+		"FluxReport":               {Group: "fluxcd.controlplane.io", Version: "v1", Resource: "fluxreports"},
+		"ResourceSet":              {Group: "fluxcd.controlplane.io", Version: "v1", Resource: "resourcesets"},
+		"ResourceSetInputProvider": {Group: "fluxcd.controlplane.io", Version: "v1", Resource: "resourcesetinputproviders"},
+		"ExternalArtifact":         {Group: "fluxcd.controlplane.io", Version: "v1", Resource: "externalartifacts"},
+		"ArtifactGenerator":        {Group: "fluxcd.controlplane.io", Version: "v1", Resource: "artifactgenerators"},
+	}
+	got := map[string]controllerResourceSpec{}
+	for _, spec := range firstClassControllerResources() {
+		got[spec.Kind] = spec
+	}
+
+	for kind, gvr := range want {
+		spec, ok := got[kind]
+		if !ok {
+			t.Fatalf("firstClassControllerResources missing %s", kind)
+		}
+		if spec.GVR != gvr {
+			t.Fatalf("%s GVR = %#v, want %#v", kind, spec.GVR, gvr)
+		}
+		if !spec.Namespaced {
+			t.Fatalf("%s Namespaced = false, want true", kind)
+		}
+		if spec.Owner != "Flux" {
+			t.Fatalf("%s Owner = %q, want Flux", kind, spec.Owner)
+		}
+	}
+}

--- a/cmd/cub-scout/doctor.go
+++ b/cmd/cub-scout/doctor.go
@@ -13,9 +13,11 @@ import (
 	"time"
 
 	"github.com/confighub/cub-scout/internal/scan"
+	"github.com/confighub/cub-scout/pkg/agent"
 	"github.com/confighub/cub-scout/pkg/hub"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
@@ -61,6 +63,7 @@ type DoctorSummary struct {
 	Health    DoctorHealthSummary    `json:"health"`
 	Risks     DoctorRiskSummary      `json:"risks"`
 	Drift     DoctorDriftSummary     `json:"drift"`
+	Rollouts  *DoctorRolloutSummary  `json:"rollouts,omitempty"`
 	ThreeWay  *DoctorThreeWaySummary `json:"threeWay,omitempty"`
 	TopIssues []DoctorIssue          `json:"topIssues,omitempty"`
 	NextSteps []StructuredHint       `json:"nextSteps,omitempty"` // Structured action-typed hints for AI/MCP
@@ -112,6 +115,17 @@ type DoctorRiskSummary struct {
 // DoctorDriftSummary contains drift signal counts.
 type DoctorDriftSummary struct {
 	Resources int `json:"resources"`
+}
+
+// DoctorRolloutSummary contains generation-scoped current-change evidence for
+// workload resources in the doctor scope.
+type DoctorRolloutSummary struct {
+	Total          int                     `json:"total"`
+	Pass           int                     `json:"pass"`
+	Watch          int                     `json:"watch"`
+	Block          int                     `json:"block"`
+	Inconclusive   int                     `json:"inconclusive"`
+	CurrentChanges []agent.RolloutDecision `json:"currentChanges,omitempty"`
 }
 
 // DoctorIssue is a concise issue entry for doctor output.
@@ -275,6 +289,132 @@ func collectDoctorFindings(ctx context.Context, namespace string) ([]scan.Normal
 		return nil, nil
 	}
 	return normalized.Findings, nil
+}
+
+func collectDoctorRollouts(ctx context.Context, namespace string, topN int) (*DoctorRolloutSummary, error) {
+	cfg, err := buildConfig()
+	if err != nil {
+		return nil, fmt.Errorf("build kubernetes config: %w", err)
+	}
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create dynamic client: %w", err)
+	}
+
+	observedAt := time.Now().UTC()
+	decisions := []agent.RolloutDecision{}
+	for _, gvr := range []schema.GroupVersionResource{
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "apps", Version: "v1", Resource: "statefulsets"},
+		{Group: "apps", Version: "v1", Resource: "daemonsets"},
+		{Group: "batch", Version: "v1", Resource: "jobs"},
+	} {
+		var items []unstructured.Unstructured
+		var listErr error
+		if namespace != "" {
+			list, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, v1.ListOptions{})
+			listErr = err
+			if list != nil {
+				items = list.Items
+			}
+		} else {
+			list, err := dynClient.Resource(gvr).List(ctx, v1.ListOptions{})
+			listErr = err
+			if list != nil {
+				items = list.Items
+			}
+		}
+		if listErr != nil {
+			continue
+		}
+
+		for i := range items {
+			item := items[i]
+			decision, ok := agent.BuildRolloutDecisionForWorkload(&item, nil, 0, observedAt)
+			if !ok {
+				continue
+			}
+			if decision.Verdict != agent.VerdictPASS {
+				pods := relatedPodsForRolloutDecision(ctx, dynClient, item.GetNamespace(), &item)
+				if len(pods) > 0 {
+					if withPods, ok := agent.BuildRolloutDecisionForWorkload(&item, pods, 0, observedAt); ok {
+						decision = withPods
+					}
+				}
+			}
+			decisions = append(decisions, decision)
+		}
+	}
+
+	if len(decisions) == 0 {
+		return nil, nil
+	}
+	return buildDoctorRolloutSummary(decisions, topN), nil
+}
+
+func buildDoctorRolloutSummary(decisions []agent.RolloutDecision, topN int) *DoctorRolloutSummary {
+	summary := &DoctorRolloutSummary{Total: len(decisions)}
+	current := make([]agent.RolloutDecision, 0)
+	for _, decision := range decisions {
+		switch decision.Verdict {
+		case agent.VerdictPASS:
+			summary.Pass++
+		case agent.VerdictWATCH:
+			summary.Watch++
+			current = append(current, decision)
+		case agent.VerdictBLOCK:
+			summary.Block++
+			current = append(current, decision)
+		case agent.VerdictINCONCLUSIVE:
+			summary.Inconclusive++
+			current = append(current, decision)
+		default:
+			summary.Inconclusive++
+			current = append(current, decision)
+		}
+	}
+
+	sort.Slice(current, func(i, j int) bool {
+		ri := rolloutVerdictRank(current[i].Verdict)
+		rj := rolloutVerdictRank(current[j].Verdict)
+		if ri != rj {
+			return ri < rj
+		}
+		ii := current[i].Resource
+		ij := current[j].Resource
+		if ii.Namespace != ij.Namespace {
+			return ii.Namespace < ij.Namespace
+		}
+		if ii.Kind != ij.Kind {
+			return ii.Kind < ij.Kind
+		}
+		return ii.Name < ij.Name
+	})
+
+	if topN < 0 {
+		topN = 0
+	}
+	if topN > len(current) {
+		topN = len(current)
+	}
+	summary.CurrentChanges = current[:topN]
+	return summary
+}
+
+func rolloutVerdictRank(verdict agent.ReceiptVerdict) int {
+	switch verdict {
+	case agent.VerdictBLOCK:
+		return 0
+	case agent.VerdictINCONCLUSIVE:
+		return 1
+	case agent.VerdictWATCH:
+		return 2
+	case agent.VerdictPASS:
+		return 3
+	default:
+		return 4
+	}
 }
 
 func buildDoctorSummary(entries []MapEntry, findings []scan.NormalizedFinding, cluster, namespace string, topN int) DoctorSummary {
@@ -470,6 +610,27 @@ func renderDoctorASCII(summary DoctorSummary, mode PresentationMode, explicitMod
 	fmt.Fprintf(&b, "  %s: %d\n", Green("Healthy"), summary.Health.Healthy)
 	fmt.Fprintf(&b, "  %s: %d\n", Yellow("Warning"), summary.Health.Warning)
 	fmt.Fprintf(&b, "  %s: %d\n\n", Red("Error"), summary.Health.Error)
+
+	if summary.Rollouts != nil && summary.Rollouts.Total > 0 {
+		fmt.Fprintf(&b, "%s %d workloads (%s, %s, %s, %s)\n",
+			sectionLabel("Rollouts"),
+			summary.Rollouts.Total,
+			Green(fmt.Sprintf("%d PASS", summary.Rollouts.Pass)),
+			Yellow(fmt.Sprintf("%d WATCH", summary.Rollouts.Watch)),
+			Red(fmt.Sprintf("%d BLOCK", summary.Rollouts.Block)),
+			Yellow(fmt.Sprintf("%d INCONCLUSIVE", summary.Rollouts.Inconclusive)),
+		)
+		for i, decision := range summary.Rollouts.CurrentChanges {
+			id := decision.Resource
+			ns := id.Namespace
+			if ns == "" {
+				ns = "-"
+			}
+			resource := fmt.Sprintf("%s/%s", id.Kind, id.Name)
+			fmt.Fprintf(&b, "  %d. %s (ns: %s) - %s\n", i+1, resource, ns, colorExplainRolloutDecision(&decision))
+		}
+		fmt.Fprintf(&b, "\n")
+	}
 
 	// Color severity counts in the risks line
 	criticalText := fmt.Sprintf("%d CRITICAL", summary.Risks.Critical)

--- a/cmd/cub-scout/doctor_test.go
+++ b/cmd/cub-scout/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/confighub/cub-scout/internal/scan"
+	"github.com/confighub/cub-scout/pkg/agent"
 )
 
 func TestBuildDoctorSummary_ComputesCoreSections(t *testing.T) {
@@ -75,6 +76,45 @@ func TestBuildDoctorSummary_TopIssuesRespectsLimitAndOrdering(t *testing.T) {
 	}
 }
 
+func TestBuildDoctorRolloutSummary_CountsAndOrdersCurrentChanges(t *testing.T) {
+	decisions := []agent.RolloutDecision{
+		doctorRolloutDecision("Deployment", "prod", "watch", agent.VerdictWATCH, agent.RolloutProgressRollingOut, agent.RolloutReasonProgressing),
+		doctorRolloutDecision("Deployment", "prod", "pass", agent.VerdictPASS, agent.RolloutProgressComplete, agent.RolloutReasonConverged),
+		doctorRolloutDecision("StatefulSet", "prod", "blocked", agent.VerdictBLOCK, agent.RolloutProgressStalled, agent.RolloutReasonRuntimeFailed),
+		doctorRolloutDecision("Deployment", "prod", "unknown", agent.VerdictINCONCLUSIVE, agent.RolloutProgressUnknown, agent.RolloutReasonEvidenceMissing),
+	}
+
+	summary := buildDoctorRolloutSummary(decisions, 2)
+	if summary.Total != 4 || summary.Pass != 1 || summary.Watch != 1 || summary.Block != 1 || summary.Inconclusive != 1 {
+		t.Fatalf("unexpected rollout summary: %+v", summary)
+	}
+	if len(summary.CurrentChanges) != 2 {
+		t.Fatalf("current changes = %d, want 2", len(summary.CurrentChanges))
+	}
+	if summary.CurrentChanges[0].Verdict != agent.VerdictBLOCK {
+		t.Fatalf("first current change verdict = %s, want BLOCK", summary.CurrentChanges[0].Verdict)
+	}
+	if summary.CurrentChanges[1].Verdict != agent.VerdictINCONCLUSIVE {
+		t.Fatalf("second current change verdict = %s, want INCONCLUSIVE", summary.CurrentChanges[1].Verdict)
+	}
+}
+
+func doctorRolloutDecision(kind, namespace, name string, verdict agent.ReceiptVerdict, phase, reason string) agent.RolloutDecision {
+	return agent.RolloutDecision{
+		Resource: agent.ObjectSetObjectID{
+			APIVersion: "apps/v1",
+			Kind:       kind,
+			Namespace:  namespace,
+			Name:       name,
+		},
+		Verdict: verdict,
+		Reason:  reason,
+		Progress: agent.RolloutProgress{
+			Phase: phase,
+		},
+	}
+}
+
 func TestRenderDoctorASCII_ContainsSummarySections(t *testing.T) {
 	// Set NO_COLOR to get plain text output for string matching
 	t.Setenv("NO_COLOR", "1")
@@ -85,6 +125,15 @@ func TestRenderDoctorASCII_ContainsSummarySections(t *testing.T) {
 		Resources: DoctorResourceSummary{Total: 10},
 		Ownership: DoctorOwnershipSummary{Flux: 3, ArgoCD: 2, Sveltos: 1, Modelplane: 1, Helm: 1, Native: 2, Unmanaged: 2},
 		Health:    DoctorHealthSummary{Healthy: 7, Warning: 2, Error: 1},
+		Rollouts: &DoctorRolloutSummary{
+			Total: 4,
+			Pass:  2,
+			Watch: 1,
+			Block: 1,
+			CurrentChanges: []agent.RolloutDecision{
+				doctorRolloutDecision("Deployment", "prod", "api", agent.VerdictBLOCK, agent.RolloutProgressStalled, agent.RolloutReasonRuntimeFailed),
+			},
+		},
 		Risks:     DoctorRiskSummary{Total: 5, Critical: 1, Warning: 3, Info: 1},
 		Drift:     DoctorDriftSummary{Resources: 2},
 		TopIssues: []DoctorIssue{{Severity: "CRITICAL", Resource: "Deployment/api", Namespace: "prod", Message: "missing limits"}},
@@ -99,6 +148,11 @@ func TestRenderDoctorASCII_ContainsSummarySections(t *testing.T) {
 		"Sveltos: 1",
 		"Modelplane: 1",
 		"Health:",
+		"Rollouts: 4 workloads",
+		"2 PASS",
+		"1 WATCH",
+		"1 BLOCK",
+		"Deployment/api (ns: prod) - BLOCK phase=stalled",
 		"Risks: 5 findings (1 CRITICAL, 3 WARNING, 1 INFO)",
 		"Drift: 2 resources drifted from declared state",
 		"Top Issues:",

--- a/cmd/cub-scout/explain.go
+++ b/cmd/cub-scout/explain.go
@@ -60,6 +60,11 @@ type ExplainSummary struct {
 	ConfigHubRevisionNum     string   `json:"configHubRevisionNum,omitempty"`     // Deployed ConfigHub revision when known
 	ConfigHubLiveRevisionNum string   `json:"configHubLiveRevisionNum,omitempty"` // Latest/live ConfigHub revision when known
 
+	// CurrentChange contains generation-scoped rollout progress and verdict
+	// evidence for workload resources. It is omitted when the resource kind is
+	// not a rollout workload or live evidence cannot be fetched.
+	CurrentChange *agent.RolloutDecision `json:"currentChange,omitempty"`
+
 	// Events contains recent Kubernetes events for the resource.
 	// Prioritizes Warning/error events, bounded to top 5.
 	Events *agent.ResourceEventSummary `json:"events,omitempty"`
@@ -679,6 +684,9 @@ func renderExplainText(summary ExplainSummary, mode PresentationMode, explicitMo
 	fmt.Fprintf(&b, "  %s %s\n", label("Source"), summary.Source)
 	fmt.Fprintf(&b, "  %s %s\n", label("Deployed via"), summary.DeployedVia)
 	fmt.Fprintf(&b, "  %s %s\n", label("Health"), StatusColor(summary.Health))
+	if summary.CurrentChange != nil {
+		fmt.Fprintf(&b, "  %s %s\n", label("Current change"), colorExplainRolloutDecision(summary.CurrentChange))
+	}
 	fmt.Fprintf(&b, "  %s %s\n", label("Risks"), summary.Risks)
 	fmt.Fprintf(&b, "  %s %s\n", label("Drift"), colorExplainDrift(summary.Drift))
 	if summary.MutationCause != "" {
@@ -782,6 +790,56 @@ func colorExplainMutationCause(cause agent.FieldMutationCause, text string) stri
 	}
 }
 
+func colorExplainRolloutDecision(decision *agent.RolloutDecision) string {
+	line := formatRolloutDecisionLine(decision)
+	if decision == nil {
+		return line
+	}
+	switch decision.Verdict {
+	case agent.VerdictPASS:
+		return Green(line)
+	case agent.VerdictWATCH:
+		return Yellow(line)
+	case agent.VerdictBLOCK:
+		return Red(line)
+	default:
+		return Yellow(line)
+	}
+}
+
+func formatRolloutDecisionLine(decision *agent.RolloutDecision) string {
+	if decision == nil {
+		return ""
+	}
+	phase := strings.TrimSpace(decision.Progress.Phase)
+	if phase == "" {
+		phase = agent.RolloutProgressUnknown
+	}
+	base := fmt.Sprintf("%s phase=%s", decision.Verdict, phase)
+	details := []string{}
+	if decision.Reason != "" {
+		details = append(details, "reason="+decision.Reason)
+	}
+	if decision.Evidence.Generation > 0 || decision.Evidence.ObservedGeneration > 0 {
+		details = append(details, fmt.Sprintf("generation=%d observed=%d", decision.Evidence.Generation, decision.Evidence.ObservedGeneration))
+	}
+	if len(decision.Evidence.PodReasons) > 0 {
+		first := decision.Evidence.PodReasons[0]
+		podDetail := first.Reason
+		if first.Pod != "" {
+			podDetail = first.Pod + ":" + podDetail
+		}
+		details = append(details, "pod="+podDetail)
+	}
+	if decision.Message != "" {
+		details = append(details, "message="+decision.Message)
+	}
+	if len(details) == 0 {
+		return base
+	}
+	return base + " (" + strings.Join(details, "; ") + ")"
+}
+
 func renderExplainMarkdown(summary ExplainSummary, mode PresentationMode, explicitMode bool, hintCtx HintContext) string {
 	var b strings.Builder
 
@@ -800,6 +858,9 @@ func renderExplainMarkdown(summary ExplainSummary, mode PresentationMode, explic
 	fmt.Fprintf(&b, "- **Source:** %s\n", summary.Source)
 	fmt.Fprintf(&b, "- **Deployed via:** %s\n", summary.DeployedVia)
 	fmt.Fprintf(&b, "- **Health:** %s\n", summary.Health)
+	if summary.CurrentChange != nil {
+		fmt.Fprintf(&b, "- **Current change:** `%s`\n", formatRolloutDecisionLine(summary.CurrentChange))
+	}
 	fmt.Fprintf(&b, "- **Risks:** %s\n", summary.Risks)
 	fmt.Fprintf(&b, "- **Drift:** %s\n", summary.Drift)
 	if summary.MutationCause != "" {
@@ -885,11 +946,16 @@ func renderEventsSection(events *agent.ResourceEventSummary, mode PresentationMo
 		if ev.Count > 1 {
 			countStr = fmt.Sprintf(" (x%d)", ev.Count)
 		}
+		detail := formatEventActionDetail(ev.Action)
+		if detail != "" {
+			detail = " [" + detail + "]"
+		}
 
-		fmt.Fprintf(&b, "  %s%s%s %s %s: %s%s%s\n",
+		fmt.Fprintf(&b, "  %s%s%s %s %s%s: %s%s%s\n",
 			color, icon, reset,
 			ev.Age,
 			ev.Reason,
+			detail,
 			ev.Message,
 			countStr,
 			reset,
@@ -928,9 +994,33 @@ func renderEventsMarkdown(events *agent.ResourceEventSummary, mode PresentationM
 		if ev.Count > 1 {
 			countStr = fmt.Sprintf(" (x%d)", ev.Count)
 		}
+		reason := ev.Reason
+		if detail := formatEventActionDetail(ev.Action); detail != "" {
+			reason = reason + " (" + detail + ")"
+		}
 		fmt.Fprintf(&b, "| %s | %s | %s | %s%s |\n",
-			ev.Age, ev.Type, ev.Reason, msg, countStr)
+			ev.Age, ev.Type, reason, msg, countStr)
 	}
 
 	return b.String()
+}
+
+func formatEventActionDetail(action *agent.ActionEvent) string {
+	if action == nil {
+		return ""
+	}
+	parts := make([]string, 0, 3)
+	if action.Action != "" {
+		parts = append(parts, "action="+action.Action)
+	}
+	if action.Actor != "" {
+		parts = append(parts, "actor="+action.Actor)
+	}
+	if action.Subject != "" {
+		parts = append(parts, "subject="+action.Subject)
+	}
+	if len(parts) == 0 && len(action.Raw) > 0 {
+		parts = append(parts, "action-metadata")
+	}
+	return strings.Join(parts, " ")
 }

--- a/cmd/cub-scout/explain_test.go
+++ b/cmd/cub-scout/explain_test.go
@@ -133,6 +133,44 @@ func TestRenderExplainText_ContainsPlainEnglishSections(t *testing.T) {
 	}
 }
 
+func TestRenderExplainText_ContainsCurrentChange(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	summary := ExplainSummary{
+		Resource:    "Deployment/payments-api",
+		Namespace:   "prod",
+		Owner:       "Flux",
+		Source:      "unknown",
+		DeployedVia: "Deployment/payments-api",
+		Health:      "Progressing",
+		Risks:       "0 findings",
+		Drift:       "Unknown",
+		CurrentChange: &agent.RolloutDecision{
+			Verdict: agent.VerdictWATCH,
+			Reason:  agent.RolloutReasonStaleGeneration,
+			Progress: agent.RolloutProgress{
+				Phase: agent.RolloutProgressApplied,
+			},
+			Evidence: agent.RolloutDecisionEvidence{
+				Generation:         2,
+				ObservedGeneration: 1,
+			},
+		},
+	}
+
+	out := renderExplainText(summary, DefaultPresentationMode, false, DefaultHintContext())
+	required := []string{
+		"Current change: WATCH phase=applied",
+		"reason=stale_generation",
+		"generation=2 observed=1",
+	}
+	for _, s := range required {
+		if !strings.Contains(out, s) {
+			t.Fatalf("expected %q in explain text:\n%s", s, out)
+		}
+	}
+}
+
 func TestRenderExplainMarkdown_ContainsHeadingsAndFields(t *testing.T) {
 	summary := ExplainSummary{
 		Resource:    "Deployment/payments-api",
@@ -153,6 +191,43 @@ func TestRenderExplainMarkdown_ContainsHeadingsAndFields(t *testing.T) {
 		"- **Namespace:** `prod`",
 		"- **Owner:** Flux",
 		"- **Source:** https://github.com/acme/platform-config.git",
+	}
+	for _, s := range required {
+		if !strings.Contains(out, s) {
+			t.Fatalf("expected %q in explain markdown:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderExplainMarkdown_ContainsCurrentChange(t *testing.T) {
+	summary := ExplainSummary{
+		Resource:    "Deployment/payments-api",
+		Namespace:   "prod",
+		Owner:       "Flux",
+		Source:      "unknown",
+		DeployedVia: "Deployment/payments-api",
+		Health:      "Progressing",
+		Risks:       "0 findings",
+		Drift:       "Unknown",
+		CurrentChange: &agent.RolloutDecision{
+			Verdict: agent.VerdictBLOCK,
+			Reason:  agent.RolloutReasonRuntimeFailed,
+			Progress: agent.RolloutProgress{
+				Phase: agent.RolloutProgressStalled,
+			},
+			Evidence: agent.RolloutDecisionEvidence{
+				PodReasons: []agent.WorkloadPodReason{
+					{Pod: "payments-api-abc", Reason: "CrashLoopBackOff"},
+				},
+			},
+		},
+	}
+
+	out := renderExplainMarkdown(summary, DefaultPresentationMode, false, DefaultHintContext())
+	required := []string{
+		"- **Current change:** `BLOCK phase=stalled",
+		"reason=runtime_failed",
+		"pod=payments-api-abc:CrashLoopBackOff",
 	}
 	for _, s := range required {
 		if !strings.Contains(out, s) {

--- a/cmd/cub-scout/map.go
+++ b/cmd/cub-scout/map.go
@@ -3545,14 +3545,17 @@ type mapActionPreview struct {
 }
 
 type mapActivityRow struct {
-	Time              string `json:"time"`
-	Source            string `json:"source"`
-	Resource          string `json:"resource"`
-	Action            string `json:"action"`
-	Result            string `json:"result"`
-	Message           string `json:"message,omitempty"`
-	SuggestedNextStep string `json:"suggestedNextStep,omitempty"`
-	Owner             string `json:"owner,omitempty"`
+	Time              string            `json:"time"`
+	Source            string            `json:"source"`
+	Resource          string            `json:"resource"`
+	Action            string            `json:"action"`
+	Result            string            `json:"result"`
+	Message           string            `json:"message,omitempty"`
+	SuggestedNextStep string            `json:"suggestedNextStep,omitempty"`
+	Owner             string            `json:"owner,omitempty"`
+	Actor             string            `json:"actor,omitempty"`
+	Subject           string            `json:"subject,omitempty"`
+	ActionEvidence    map[string]string `json:"actionEvidence,omitempty"`
 }
 
 type mapPreviewRow struct {
@@ -4143,6 +4146,7 @@ func collectFluxActivity(ctx context.Context, dynClient dynamic.Interface) []map
 			}
 		}
 	}
+	rows = append(rows, collectFirstClassControllerActivity(ctx, dynClient, fluxOperatorControllerResources(), "Flux")...)
 	return rows
 }
 
@@ -4331,6 +4335,17 @@ func formatControllerActivityResource(obj *unstructured.Unstructured) string {
 
 func controllerActivityNextStep(owner, kind string) string {
 	switch owner {
+	case "Flux":
+		switch kind {
+		case "ResourceSet", "ResourceSetInputProvider":
+			return "Inspect inputs, generated resources, and Ready conditions for this aggregate configuration."
+		case "ExternalArtifact", "ArtifactGenerator":
+			return "Inspect artifact conditions and the resources consuming this generated input."
+		case "FluxInstance", "FluxReport":
+			return "Inspect controller readiness, distribution status, and reported inventory for this cluster."
+		default:
+			return "Inspect Flux conditions, inventory, and source references for this resource."
+		}
 	case "Sveltos":
 		switch kind {
 		case "ClusterProfile", "Profile":
@@ -4386,15 +4401,39 @@ func collectEventActivity(ctx context.Context, dynClient dynamic.Interface) []ma
 			result = "warning"
 		}
 		resource := fmt.Sprintf("%s/%s/%s", firstNonEmpty(kind, "Resource"), firstNonEmpty(objNS, ns), firstNonEmpty(objName, ev.GetName()))
+		actionName := firstNonEmpty(strings.ToLower(reason), "event")
+		source := "k8s.event"
+		owner := "Native"
+		suggestion := agent.GetEventSuggestion(reason)
+		actor := ""
+		subject := ""
+		var actionEvidence map[string]string
+		if action, ok := agent.ParseActionEvent(reason, ev.GetAnnotations()); ok {
+			actionName = firstNonEmpty(action.Action, actionName)
+			source = "k8s.action"
+			if action.Action != "" || action.Actor != "" || action.Subject != "" || len(action.Groups) > 0 || len(action.Raw) > 0 {
+				owner = "Flux"
+			}
+			actor = action.Actor
+			subject = action.Subject
+			actionEvidence = action.Raw
+			if detail := formatEventActionDetail(action); detail != "" {
+				msg = strings.TrimSpace(strings.TrimSpace(msg) + " [" + detail + "]")
+			}
+			suggestion = "Review the audited action with the resource status and follow-up events."
+		}
 		rows = append(rows, mapActivityRow{
 			Time:              when.UTC().Format(time.RFC3339),
-			Source:            "k8s.event",
+			Source:            source,
 			Resource:          resource,
-			Action:            firstNonEmpty(strings.ToLower(reason), "event"),
+			Action:            actionName,
 			Result:            result,
 			Message:           msg,
-			SuggestedNextStep: agent.GetEventSuggestion(reason),
-			Owner:             "Native",
+			SuggestedNextStep: suggestion,
+			Owner:             owner,
+			Actor:             actor,
+			Subject:           subject,
+			ActionEvidence:    actionEvidence,
 		})
 	}
 	return rows

--- a/cmd/cub-scout/map_activity_test.go
+++ b/cmd/cub-scout/map_activity_test.go
@@ -1,0 +1,76 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestCollectEventActivityIncludesAuditedAction(t *testing.T) {
+	oldNamespace, oldOwner := mapNamespace, mapOwner
+	t.Cleanup(func() {
+		mapNamespace, mapOwner = oldNamespace, oldOwner
+	})
+	mapNamespace, mapOwner = "", ""
+
+	eventGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{eventGVR: "EventList"},
+		&unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Event",
+			"metadata": map[string]interface{}{
+				"name":      "api-action",
+				"namespace": "prod",
+				"annotations": map[string]interface{}{
+					"event.toolkit.fluxcd.io/action":       "restart",
+					"event.toolkit.fluxcd.io/username":     "operator@example.com",
+					"event.toolkit.fluxcd.io/subject":      "Deployment/prod/api",
+					"event.toolkit.fluxcd.io/change-token": "chg-123",
+				},
+			},
+			"involvedObject": map[string]interface{}{
+				"kind":      "Deployment",
+				"namespace": "prod",
+				"name":      "api",
+			},
+			"type":      "Normal",
+			"reason":    "WebAction",
+			"message":   "operator@example.com requested restart for Deployment/prod/api",
+			"eventTime": "2026-07-09T10:00:00Z",
+		}},
+	)
+
+	rows := collectEventActivity(context.Background(), client)
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Source != "k8s.action" {
+		t.Fatalf("Source = %q, want k8s.action", row.Source)
+	}
+	if row.Action != "restart" {
+		t.Fatalf("Action = %q, want restart", row.Action)
+	}
+	if row.Owner != "Flux" {
+		t.Fatalf("Owner = %q, want Flux", row.Owner)
+	}
+	if row.Actor != "operator@example.com" || row.Subject != "Deployment/prod/api" {
+		t.Fatalf("Actor/Subject = %q/%q, want operator@example.com/Deployment/prod/api", row.Actor, row.Subject)
+	}
+	if row.ActionEvidence["event.toolkit.fluxcd.io/change-token"] != "chg-123" {
+		t.Fatalf("ActionEvidence = %#v, want change-token evidence", row.ActionEvidence)
+	}
+	if !strings.Contains(row.Message, "action=restart") || !strings.Contains(row.Message, "actor=operator@example.com") {
+		t.Fatalf("Message = %q, want action detail", row.Message)
+	}
+}

--- a/cmd/cub-scout/observe.go
+++ b/cmd/cub-scout/observe.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/confighub/cub-scout/pkg/agent"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
@@ -97,6 +99,12 @@ func observeScopeSummaryFromCluster(ctx context.Context, namespace, namespaceLab
 	}
 
 	result.Summary = buildDoctorSummary(entries, findings, cluster, namespaceLabel, topN)
+	rollouts, rolloutsErr := collectDoctorRollouts(ctx, namespace, topN)
+	if rolloutsErr != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("rollout evidence unavailable: %v", rolloutsErr))
+	} else if rollouts != nil && rollouts.Total > 0 {
+		result.Summary.Rollouts = rollouts
+	}
 	return result, nil
 }
 
@@ -162,7 +170,66 @@ func ObserveResourceContext(ctx context.Context, req ObserveResourceContextReque
 		summary.MutationManager = attr.ManagerHint
 	}
 
+	if decision, ok := fetchRolloutDecision(ctx, ns, kind, name); ok {
+		summary.CurrentChange = decision
+	}
+
 	return summary, nil
+}
+
+func fetchRolloutDecision(ctx context.Context, namespace, kind, name string) (*agent.RolloutDecision, bool) {
+	if !agent.IsRolloutWorkloadKind(kind) {
+		return nil, false
+	}
+	cfg, err := buildConfig()
+	if err != nil {
+		return nil, false
+	}
+	gvr := kindToGVR(kind)
+	if gvr.Resource == "" {
+		return nil, false
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, false
+	}
+
+	obj, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		return nil, false
+	}
+
+	pods := relatedPodsForRolloutDecision(ctx, dynClient, namespace, obj)
+	decision, ok := agent.BuildRolloutDecisionForWorkload(obj, pods, 0, time.Now().UTC())
+	if !ok {
+		return nil, false
+	}
+	return &decision, true
+}
+
+func relatedPodsForRolloutDecision(ctx context.Context, dynClient dynamic.Interface, namespace string, obj *unstructured.Unstructured) []*unstructured.Unstructured {
+	selector := workloadSelectorMatchLabels(obj)
+	if len(selector) == 0 || namespace == "" {
+		return nil
+	}
+	podsGVR := kindToGVR("Pod")
+	if podsGVR.Resource == "" {
+		return nil
+	}
+	labelSelector, err := v1.LabelSelectorAsSelector(&v1.LabelSelector{MatchLabels: selector})
+	if err != nil {
+		return nil
+	}
+	list, err := dynClient.Resource(podsGVR).Namespace(namespace).List(ctx, v1.ListOptions{LabelSelector: labelSelector.String()})
+	if err != nil {
+		return nil
+	}
+	pods := make([]*unstructured.Unstructured, 0, len(list.Items))
+	for i := range list.Items {
+		item := list.Items[i]
+		pods = append(pods, &item)
+	}
+	return matchPodsBySelector(pods, selector)
 }
 
 // fetchResourceAttribution loads the live resource and computes mutation-source

--- a/cmd/cub-scout/observe.go
+++ b/cmd/cub-scout/observe.go
@@ -181,6 +181,9 @@ func fetchRolloutDecision(ctx context.Context, namespace, kind, name string) (*a
 	if !agent.IsRolloutWorkloadKind(kind) {
 		return nil, false
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	cfg, err := buildConfig()
 	if err != nil {
 		return nil, false

--- a/cmd/cub-scout/trace.go
+++ b/cmd/cub-scout/trace.go
@@ -1195,6 +1195,15 @@ func convertResourceEvents(events *agent.ResourceEventSummary) *mapsvc.TraceEven
 			Severity: ev.Severity,
 			Source:   ev.Source,
 		}
+		if ev.Action != nil {
+			te.Action = &mapsvc.TraceActionEvent{
+				Action:  ev.Action.Action,
+				Actor:   ev.Action.Actor,
+				Groups:  ev.Action.Groups,
+				Subject: ev.Action.Subject,
+				Raw:     ev.Action.Raw,
+			}
+		}
 		if ev.FirstSeen != nil {
 			te.FirstSeen = ev.FirstSeen.Format(time.RFC3339)
 		}
@@ -1672,11 +1681,16 @@ func outputTraceHuman(result *agent.TraceResult, artifacts map[string]mapsvc.Tra
 			if ev.Count > 1 {
 				countStr = fmt.Sprintf(" (x%d)", ev.Count)
 			}
+			detail := formatEventActionDetail(ev.Action)
+			if detail != "" {
+				detail = " [" + detail + "]"
+			}
 
-			fmt.Printf("  %s%s%s %s%s%s %s: %s%s\n",
+			fmt.Printf("  %s%s%s %s%s%s %s%s: %s%s\n",
 				iconColor, icon, colorReset,
 				colorDim, ev.Age, colorReset,
 				ev.Reason,
+				detail,
 				ev.Message,
 				countStr,
 			)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 | What | Command | Guide |
 |------|---------|-------|
 | GitOps pipeline health | `cub-scout gitops status` | [reference/commands.md#gitops-v014](reference/commands.md#gitops-v014) |
+| Delivery readiness decision | `cub-scout doctor`, `cub-scout explain`, `cub-scout receipt verify` | [howto/delivery-readiness-decision.md](howto/delivery-readiness-decision.md) |
 | Scan for risks | `cub-scout scan --state` | [howto/scan-for-risks.md](howto/scan-for-risks.md) |
 | Scan a manifest file | `cub-scout scan --file FILE` | [howto/scan-for-risks.md](howto/scan-for-risks.md) |
 | Drift detection | `cub-scout drift deploy/NAME -n NS` | [howto/drift.md](howto/drift.md) |

--- a/docs/howto/delivery-readiness-decision.md
+++ b/docs/howto/delivery-readiness-decision.md
@@ -1,0 +1,116 @@
+# How To: Decide Whether Delivery Is Done
+
+Use this guide when the operational question is:
+
+> Can I move to the next delivery task, wait, or retry/investigate?
+
+cub-scout does not deploy, sync, restart, or roll back anything. It reads the
+cluster and connected intent evidence, then gives you a decision frame:
+
+- `PASS`: evidence supports proceeding.
+- `WATCH`: delivery or rollout is still converging; wait or re-check.
+- `BLOCK`: evidence shows a failure or mismatch; investigate before proceeding.
+- `INCONCLUSIVE`: required evidence is missing or unreadable; do not treat this
+  as success.
+
+## Fast Path
+
+Start broad, then narrow.
+
+```bash
+# 1. Cluster or namespace overview.
+./cub-scout doctor -n prod --format json
+
+# 2. One resource, with current-generation rollout evidence when available.
+./cub-scout explain deployment/api -n prod --format json
+
+# 3. Delivery/controller status.
+./cub-scout gitops status -n prod --format json
+
+# 4. Desired/rendered/live agreement when connected intent is available.
+./cub-scout compare three-way --scope namespace/prod --format json
+```
+
+For an auditable gate over a rendered object set:
+
+```bash
+./cub-scout receipt verify \
+  --file out/manifests \
+  --scope namespace/prod \
+  --predicate workloads-converged \
+  --grace-window 5m \
+  --fail-on any-non-pass \
+  --format json \
+  --out delivery-readiness.receipt.json
+```
+
+## How To Read The Result
+
+| Evidence | Meaning | Decision |
+|---|---|---|
+| `currentChange.verdict=PASS` and no blocking drift | Workload is current-generation converged at observation time. | Proceed, while remembering this is a point-in-time observation. |
+| `currentChange.verdict=WATCH` with `reason=stale_generation` | The API has not yet observed the desired generation. | Wait and re-check; do not call it done. |
+| `currentChange.verdict=WATCH` with `reason=rollout_progressing` | Current generation is observed and still progressing. | Wait, or extend the grace window if your rollout is expected to be slow. |
+| `currentChange.verdict=BLOCK` with `reason=runtime_failed` | Runtime evidence, such as pod/container failure, is present. | Investigate application/runtime symptoms before retrying delivery. |
+| `currentChange.verdict=BLOCK` with drift or source-truth mismatch | Live state or controller evidence disagrees with intent. | Investigate drift/source mismatch before proceeding. |
+| `INCONCLUSIVE` or omitted `currentChange` | cub-scout could not collect enough evidence for this resource or kind. | Treat as a proof gap; inspect raw cluster/controller evidence. |
+
+## What Cub-Scout Checks
+
+For workload rollout evidence, cub-scout uses:
+
+- Kubernetes status and kstatus classification.
+- `metadata.generation` vs `status.observedGeneration`.
+- progress clock fields where available.
+- related pod waiting reasons such as `CrashLoopBackOff` or `ImagePullBackOff`.
+- optional desired object sets for `receipt verify --predicate
+  workloads-converged`.
+
+Stale generation matters: if `status.observedGeneration` is behind
+`metadata.generation`, cub-scout reports the current change as not complete
+instead of treating an old ready condition as proof.
+
+## Separate Delivery From Runtime Health
+
+The same release can fail in different places:
+
+| Symptom | Likely area | Start with |
+|---|---|---|
+| Controller not ready, missing source, failed apply | delegated delivery | `gitops status`, `trace`, `map activity` |
+| Desired/rendered/live disagreement | drift or source mismatch | `compare three-way`, `compare source-truth` |
+| Generation observed but pods fail | runtime/application | `explain`, `doctor`, `scan` |
+| Action event exists before failure | operator or automation action context | `map activity --owner Flux --format json`, `trace`, `explain` |
+
+cub-scout surfaces this evidence; it does not own the final application-success
+policy.
+
+## Keep A Receipt For The Decision
+
+When a pipeline, incident, or review needs durable evidence, use a receipt.
+
+```bash
+./cub-scout receipt verify \
+  --file out/manifests \
+  --scope namespace/prod \
+  --predicate workloads-converged \
+  --save \
+  --out delivery-readiness.receipt.json
+
+./cub-scout receipt validate delivery-readiness.receipt.json
+```
+
+The receipt is an immutable record of what cub-scout observed at `verifiedAt`.
+It does not prove the workload stays healthy forever; re-run the check for a new
+decision.
+
+## Example Fixture
+
+See [`examples/live-delivery-observability`](../../examples/live-delivery-observability/)
+for a review fixture that includes:
+
+- desired vs observed Deployment shape
+- aggregate delivery status
+- audited action event metadata
+- stale-generation rollout evidence
+- runtime pod failure evidence
+

--- a/docs/proposals/next-release-live-delivery-observability.md
+++ b/docs/proposals/next-release-live-delivery-observability.md
@@ -1,0 +1,276 @@
+# Next-Release Mini PRD: Live Delivery Observability
+
+Status: draft
+
+Audience: maintainers and reviewers
+
+Anonymization note: this document intentionally uses controller families,
+evidence types, and user questions instead of personal names, company names, or
+external product names.
+
+## Problem
+
+Users need one read-only place to answer:
+
+- What config should be where?
+- Has delegated delivery accepted and applied that config?
+- Is the current rollout still progressing, done, or blocked?
+- If blocked, is the problem delivery, live drift, or application/runtime health?
+- Can I move to the next task, wait, or retry?
+
+The observer should not own deployment, rollout strategy, application success
+definitions, or workflow orchestration. It should collect and explain the best
+available evidence from the cluster and connected intent sources, then report
+clear proof gaps when evidence is missing.
+
+## Non-Goals
+
+- No last-mile deploy, apply, sync, reconcile, restart, suspend, resume, or
+  delete actions.
+- No ownership of application-success policy. The observer may surface health
+  and verdict evidence, but it must not become the authority for custom success
+  definitions.
+- No complex workflow orchestration.
+- No hidden inference. If a controller does not expose status, lineage, source,
+  artifact, event, or generation evidence, the result must say so.
+
+## A. Next-Release Updates
+
+### A1. First-Class Aggregate Delivery Resources
+
+Add first-class observation for aggregate-report, app-bundle, input-provider,
+external-artifact, and generated-artifact resource families.
+
+User value:
+
+- Operators can see delivery readiness, inventory, source freshness, rendered
+  artifact freshness, and aggregate failure reasons from the same read-only
+  surface they use for workloads.
+- Reviewers can check whether the observer is reading controller status instead
+  of guessing.
+
+Surfaces:
+
+- `gitops status`: include aggregate report and app-bundle health alongside
+  existing delivery health.
+- `map activity`: show recently changed aggregate delivery resources and their
+  associated events.
+- `trace`: include source, input-provider, generated-artifact, delivery
+  resource, and workload edges when labels, owner references, status refs, or
+  annotations provide deterministic links.
+- `doctor`: include aggregate delivery failures as top-level findings when they
+  block source, render, apply, or reconciliation progress.
+
+Acceptance criteria:
+
+- Deterministic fixtures cover ready, progressing, failed, missing-status, and
+  stale-generation cases.
+- JSON output contains resource kind, namespace, name, observed generation,
+  ready condition, reason, message, last transition time where present, and
+  evidence omissions where absent.
+- ASCII/Markdown output avoids false "unmanaged" or false "healthy" claims
+  when aggregate resources are present but incomplete.
+- The feature remains read-only and works when only a subset of the CRDs are
+  installed.
+
+### A2. Audited User-Action Event Ingestion
+
+Parse audited action events emitted by controller web consoles or automation
+frontends when they are available as standard cluster events.
+
+User value:
+
+- Operators can answer "what triggered this reconcile/check/action?" without
+  opening a separate UI.
+- Incident and audit receipts can include human or automation action context
+  when the cluster already exposes it.
+
+Surfaces:
+
+- `map activity`: list audited action events near the managed resource they
+  affected.
+- `trace`: include recent action events in the resource history section.
+- `explain`: summarize action, actor, subject, and timestamp when those fields
+  are present.
+- `receipt verify`: optionally include audited action events as supporting
+  evidence, without changing the verdict.
+
+Acceptance criteria:
+
+- Event parsing is schema-tolerant: unknown action annotations are preserved as
+  raw evidence instead of dropped.
+- Missing actor, group, or subject fields produce omissions, not guesses.
+- Action events never imply a write by the observer.
+- Tests cover present, partial, malformed, and unrelated event shapes.
+
+### A3. Promote Rollout Progress and Verdicts
+
+Move generation-aware rollout evidence from receipt-only workflows into primary
+diagnostic UX.
+
+User value:
+
+- The operator can answer the operational question directly: proceed, wait,
+  retry delivery, or inspect runtime failure evidence.
+- The observer can distinguish "not applied", "applied but not observed",
+  "observed and progressing", "stalled", "runtime failed", and "insufficient
+  evidence".
+
+Surfaces:
+
+- `doctor`: show rollout progress and verdict for unhealthy or changing
+  workloads.
+- `explain`: add a "current change" section with generation, observed
+  generation, progress clock, workload status, pod symptoms, and verdict.
+- `compare three-way`: include rollout verdict when LIVE differs from intended
+  or rendered state.
+- `receipt verify --predicate workloads-converged`: remain the auditable source
+  of the same underlying evidence.
+
+Acceptance criteria:
+
+- JSON includes separate `progress` and `verdict` fields.
+- Verdicts keep the existing receipt vocabulary: `PASS`, `WATCH`, `BLOCK`,
+  `INCONCLUSIVE`.
+- Progress is generation-scoped; stale observed generations cannot be reported
+  as successful current-change completion.
+- Runtime evidence is attached as evidence, not reclassified as delivery
+  authority.
+
+### A4. API-Load-Aware Inventory And Search
+
+Make repeated and fleet-shaped observation cheap by preferring captured,
+summarized, or watched evidence when a fresh wide cluster crawl is not required.
+
+User value:
+
+- Operators can ask broad questions across many namespaces or clusters without
+  every UI, CLI, or agent interaction hammering live APIs.
+- Reviewers can see whether an answer came from a fresh read, a watch-fed
+  observation, a snapshot, a connected summary, or a receipt.
+
+Surfaces:
+
+- `snapshot`: remain the portable captured-state format for offline review and
+  repeat analysis.
+- `watch`: support low-cardinality event streams that external stores can index
+  without requiring the observer to own a database.
+- `summary` and fleet-oriented connected surfaces: prefer stored summaries for
+  repeated overview/search flows, with freshness metadata in the output.
+- `doctor`, `map`, `trace`, and `explain`: expose evidence freshness and source
+  type when reading from captured or summarized inputs.
+
+Acceptance criteria:
+
+- JSON includes evidence source type: `live`, `snapshot`, `watch`, `summary`, or
+  `receipt` where that distinction is known.
+- JSON includes `observedAt` and, when applicable, `staleness` or freshness
+  omissions.
+- Wide queries have a documented low-load path using snapshot, watch output, or
+  connected summaries.
+- The observer never hides stale evidence behind fresh-sounding language.
+- No mandatory persistent database is added to standalone mode.
+
+## B. Controller-Family Parity
+
+Parity means the observer can answer the same user questions for a controller
+family using deterministic evidence. It does not mean every controller exposes
+the same data or that the observer can make up missing data.
+
+Required parity dimensions:
+
+- Ownership and lineage.
+- Delivery or reconciliation status.
+- Desired/rendered/live comparison where a desired or rendered source exists.
+- Generation-aware rollout progress and verdict for workload objects.
+- Recent event and action history.
+- API-load-aware inventory and search paths for repeated or fleet-shaped reads.
+- Receipt-ready evidence with omissions for gaps.
+
+| Controller family | Can reach parity? | What blocks exact parity |
+|---|---:|---|
+| Declarative application controllers | Yes, for status, lineage, events, drift, and rollout evidence when source refs and status conditions are present. | Template-only or opaque render paths may prevent exact desired/rendered/live proof. |
+| Package release controllers | Mostly. Release status, chart/source refs, history, and workload ownership usually support the model. | Rendered values and hook-side effects may be unavailable unless the controller records them. |
+| Fleet placement controllers | Partial to strong. Placement status and per-cluster rollout state can fit the same UX. | Source diff parity depends on whether the controller exposes a desired object set per cluster. |
+| Composition controllers | Partial. Claim, composed resource, and managed resource lineage can be explained. | Full parity requires deterministic refs from claim to composed resources plus current-generation status on each layer. |
+| Resource-graph orchestration controllers | Partial. Ownership and graph lineage can be shown where refs are explicit. | Controllers that hide intermediate resources or do not expose conditions cannot support complete verdicts. |
+| Native workload controllers | Yes for rollout progress and runtime verdicts. | They do not answer delegated delivery status by themselves. |
+| Custom controllers | Config-dependent. | Without registered resources, status paths, ownership labels, or event conventions, the observer can only report LIVE facts and omissions. |
+
+Next-release parity rule:
+
+- If a controller exposes status, observed generation, conditions, owner refs,
+  source/artifact refs, or events, parse them.
+- If it does not, return structured omissions.
+- Do not downgrade missing evidence into "healthy", "synced", "orphaned", or
+  "unmanaged".
+
+## C. Delivery-Done Research Synthesis
+
+### C1. Improve The Observer
+
+The next release should treat "done" as two separate outputs:
+
+- Progress: where the current change appears to be in the delivery/runtime
+  path.
+- Verdict: whether the current evidence supports proceeding.
+
+Recommended model:
+
+| Field | Meaning |
+|---|---|
+| `changeRef` | Controller-provided change id when available, otherwise a deterministic fingerprint of source, resource, generation, and timestamp evidence. |
+| `progress.phase` | `pending`, `accepted`, `applied`, `observed`, `rolling_out`, `stalled`, `complete`, or `unknown`. |
+| `progress.clock` | The timestamp used to decide whether progress is fresh, stale, or absent. |
+| `verdict` | `PASS`, `WATCH`, `BLOCK`, or `INCONCLUSIVE`. |
+| `reason` | Stable machine-readable reason such as `source_unavailable`, `apply_failed`, `stale_generation`, `runtime_failed`, or `evidence_missing`. |
+| `evidence[]` | Conditions, events, generation values, managed fields, pod symptoms, source refs, rendered refs, and audit events. |
+| `omissions[]` | Missing evidence required for stronger claims. |
+
+Implementation recommendations:
+
+- Add a shared rollout-decision builder used by `doctor`, `explain`,
+  `compare three-way`, and receipts.
+- Treat current-generation success as a point-in-time statement, not a permanent
+  application-health guarantee.
+- Surface runtime failures in user language, but keep raw cluster evidence
+  beside the summary for reviewability.
+- Support optional external evidence stores through existing watch and receipt
+  outputs rather than adding a mandatory database to the observer.
+- Prefer low-cardinality summaries in interactive views and keep high-cardinality
+  evidence available in JSON/receipts.
+- Add fixtures for conflict, retry-needed, runtime-startup-failure,
+  stale-generation, and all-parts-succeeded cases.
+
+### C2. Improve The User-Questions Table
+
+The README table should stay near the top and remain framed around user
+questions, not controller internals. The next-release table should cover:
+
+- What is running, and who owns it?
+- Is delegated delivery healthy?
+- Has intended configuration reached the cluster?
+- Is this rollout still progressing, complete, or stuck?
+- Can I move to the next task, wait, or retry delivery?
+- Is live state drifting from desired state?
+- Is this a delivery problem or an application/runtime problem?
+- Who changed this field, and where did the value come from?
+- Can I keep auditable evidence of the check?
+
+Acceptance criteria:
+
+- The table avoids claims that the observer owns deployment or application
+  success.
+- Each row maps to an existing command, a next-release command enhancement, or
+  an explicit evidence gap.
+- The table uses "user question" language, not private stakeholder language.
+
+## Definition Of Done
+
+- Unit tests cover status extraction, event parsing, lineage construction,
+  rollout-decision synthesis, and omission behavior.
+- At least one example fixture demonstrates aggregate delivery status, audited
+  action events, drift, and current-generation rollout verdicts together.
+- `--format ascii|json|md` output exists for every changed user-visible surface.
+- TUI and CLI stay semantically aligned.
+- `go test ./...` passes.

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -40,7 +40,7 @@ Alphabetical command index: [cli-reference.md](cli-reference.md)
 | `cub-scout map` | Interactive TUI dashboard | v0.5 |
 | `cub-scout map list` | List resources (scriptable) | v0.5 |
 | `cub-scout map status` | One-line health check | v0.5 |
-| `cub-scout map deployers` | List controller deployers (Flux/ArgoCD/Sveltos/Modelplane + core Deployments) | v0.5 |
+| `cub-scout map deployers` | List controller deployers (Flux/ArgoCD/Sveltos/Modelplane/aggregate delivery resources + core Deployments) | v0.5 |
 | `cub-scout map hooks` | List lifecycle hooks (Helm/ArgoCD) | v0.19 |
 | `cub-scout map cronjobs` | List CronJobs with schedule/run state | v0.20 |
 | `cub-scout map jobs` | List Jobs with CronJob linkage and status | v0.20 |
@@ -94,6 +94,10 @@ cub-scout doctor [flags]
 ### Stable Output Rules
 
 - JSON is the canonical contract for `doctor`.
+- JSON may include `rollouts` when live workload rollout evidence is available:
+  total workloads, PASS/WATCH/BLOCK/INCONCLUSIVE counts, and top non-PASS
+  `currentChanges[]` bounded by `--top`.
+- ASCII includes a `Rollouts` section only when rollout evidence is available.
 - `--presentation` affects ASCII framing only.
 - `--hint-mode` affects recommendation ranking only.
 - Omitting `--presentation` preserves the legacy/default text render path.
@@ -154,6 +158,7 @@ cub-scout compare three-way --scope <scope> [flags]
 - `confighubUrl` may be present when a representative connected unit ID is known for the scope.
 - `confighubRevisionsUrl` may be present when the exact unit revisions tab is known for the scope.
 - `nextSteps[]` may be present with deterministic read-only follow-up guidance for trust review or convergence re-checks.
+- `resources[].currentChange` may be present for workload resources when live rollout evidence can be read. It uses the same progress/verdict shape as `explain.currentChange`.
 - Exit behavior depends only on JSON facts plus `--fail-on`, not ASCII/Markdown formatting.
 
 ---
@@ -357,6 +362,7 @@ List controller deployers in the cluster.
 Canonical deployer scope (v1.0):
 - Flux `Kustomization`
 - Flux `HelmRelease`
+- Flux aggregate resources: `FluxInstance`, `FluxReport`, `ResourceSet`, `ResourceSetInputProvider`, `ExternalArtifact`, `ArtifactGenerator`
 - Argo CD `Application`
 - Sveltos `ClusterProfile`, `Profile`, `EventTrigger`, `ClusterHealthCheck`, `ClusterPromotion`
 - Modelplane `InferenceGateway`, `InferenceCluster`, `ModelDeployment`, `ModelService`, `ModelCache`, `ServingStack`, `EKSCluster`, `GKECluster`
@@ -385,10 +391,10 @@ cub-scout map deployers [flags]
 **Stable JSON fields:**
 | Field | Type | Description |
 |-------|------|-------------|
-| `kind` | string | Deployer kind (`Kustomization`, `HelmRelease`, `Application`, Sveltos/Modelplane controller kinds, or `Deployment`) |
+| `kind` | string | Deployer kind (`Kustomization`, `HelmRelease`, `Application`, aggregate delivery resource kinds, Sveltos/Modelplane controller kinds, or `Deployment`) |
 | `name` | string | Deployer name |
 | `namespace` | string | Deployer namespace |
-| `owner` | string | Optional owner family for first-class controller CRDs (`Sveltos`, `Modelplane`) |
+| `owner` | string | Optional owner family for first-class controller CRDs (`Flux`, `Sveltos`, `Modelplane`) |
 | `status` | string | Status string (for example `Ready`, `Healthy`, `NotReady`, `Unhealthy`) |
 | `ready` | bool | Whether the deployer is healthy/ready |
 | `revision` | string | Revision string (or `-` if unavailable) |
@@ -462,7 +468,7 @@ Stable JSON fields per action:
 
 ## cub-scout map activity
 
-Show normalized activity from Flux/Argo/Sveltos/Modelplane/Helm/events, sorted descending by time.
+Show normalized activity from Flux/Argo/Sveltos/Modelplane/aggregate delivery resources/Helm/events, sorted descending by time.
 
 ```bash
 cub-scout map activity [--namespace <ns>] [--owner Flux|ArgoCD|Sveltos|Modelplane|Helm|Crossplane|kro|ConfigHub|Native] [--since 24h] [--format ascii|json|md]
@@ -477,6 +483,9 @@ Stable JSON fields per event:
 - `message` (optional)
 - `suggestedNextStep` (optional)
 - `owner` (optional)
+- `actor` (optional; audited action events only)
+- `subject` (optional; audited action events only)
+- `actionEvidence` (optional; raw action annotations not otherwise modeled)
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -17,12 +17,12 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `map issues` | Show resources with problems | v0.5 |
 | `map crashes` | Show crashing pods | v0.5 |
 | `map workloads` | List workloads by owner | v0.5 |
-| `map deployers` | List controller deployers (Flux, ArgoCD, Sveltos, Modelplane, core Deployments) | v0.5 |
+| `map deployers` | List controller deployers (Flux, ArgoCD, Sveltos, Modelplane, aggregate delivery resources, core Deployments) | v0.5 |
 | `map hooks` | List lifecycle hooks (Helm/ArgoCD) | v0.19 |
 | `map cronjobs` | List CronJobs with schedule/run state | v0.20 |
 | `map jobs` | List Jobs with CronJob linkage and run state | v0.20 |
 | `map actions` | Read-only operator action preview (runbook output) | v0.20 |
-| `map activity` | Unified activity timeline from Flux/Argo/Sveltos/Modelplane/Helm/events | v0.20 |
+| `map activity` | Unified activity timeline from Flux/Argo/Sveltos/Modelplane/aggregate delivery resources/Helm/events | v0.20 |
 | `map previews` | Detect PR preview environments | v0.20 |
 | `quickstart` | Guided first-run walkthrough | v1.4 |
 | `quickstart demo` | Fixture-backed demo runner | v1.0 |
@@ -280,7 +280,8 @@ cub-scout quickstart demo quick --cleanup
 
 ## doctor
 
-Single-command cluster health summary (ownership, health, risk, drift, top issues).
+Single-command cluster health summary (ownership, health, rollout progress,
+risk, drift, top issues).
 
 ```bash
 cub-scout doctor [flags]
@@ -521,6 +522,7 @@ cub-scout map deployers [flags]
 Canonical deployer scope (v1.0):
 - Flux `Kustomization`
 - Flux `HelmRelease`
+- Flux aggregate resources: `FluxInstance`, `FluxReport`, `ResourceSet`, `ResourceSetInputProvider`, `ExternalArtifact`, `ArtifactGenerator`
 - Argo CD `Application`
 - Sveltos `ClusterProfile`, `Profile`, `EventTrigger`, `ClusterHealthCheck`, `ClusterPromotion`
 - Modelplane `InferenceGateway`, `InferenceCluster`, `ModelDeployment`, `ModelService`, `ModelCache`, `ServingStack`, `EKSCluster`, `GKECluster`
@@ -634,7 +636,7 @@ cub-scout map actions cronjob/nightly-backup -n operations --format json
 
 ## map activity
 
-Show normalized activity from Flux, ArgoCD, Sveltos, Modelplane, Helm release history, and Kubernetes Events.
+Show normalized activity from Flux, ArgoCD, Sveltos, Modelplane, aggregate delivery resources, Helm release history, audited action events, and Kubernetes Events.
 
 ```bash
 cub-scout map activity [flags]
@@ -1220,7 +1222,9 @@ Resource compare mode behavior:
 
 ### compare three-way
 
-Connected three-way comparison command for selected scopes.
+Connected three-way comparison command for selected scopes. For workload
+resources, output may include generation-scoped current-change rollout evidence
+when live status can be read.
 
 ```bash
 cub-scout compare three-way --scope <scope> [flags]
@@ -2117,7 +2121,7 @@ cub-scout gitops status [flags]
 |---------|-----------|
 | `flux` | Kustomization or HelmRelease CRDs present |
 | `argocd` | Application CRD present |
-| `controllers` | Sveltos or Modelplane controller CRDs present without Flux/Argo CD |
+| `controllers` | First-class controller CRDs present without Flux/Argo CD application CRDs |
 | `worker` | ConfigHub worker labels |
 | `none` | No GitOps/controller backend detected |
 

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -302,6 +302,26 @@ The per-field-path map is also exposed under `live.attributionByPath`, keyed by 
   "namespace": "prod",
   "owner": "ArgoCD",
   "drift": "Detected by ConfigHub",
+  "currentChange": {
+    "resource": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "namespace": "prod",
+      "name": "api"
+    },
+    "progress": {
+      "phase": "applied",
+      "clockSource": "status.observedGeneration<metadata.generation"
+    },
+    "verdict": "WATCH",
+    "reason": "stale_generation",
+    "evidence": {
+      "kstatusStatus": "InProgress",
+      "generation": 2,
+      "observedGeneration": 1,
+      "observedAt": "2026-07-09T10:30:00Z"
+    }
+  },
   "mutationCause": "manual-edit",
   "mutationManager": "kubectl-edit"
 }
@@ -309,8 +329,83 @@ The per-field-path map is also exposed under `live.attributionByPath`, keyed by 
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `currentChange` | object | Optional generation-scoped rollout progress/verdict for workload resources. Omitted for non-workloads or when live rollout evidence cannot be fetched. |
+| `currentChange.progress.phase` | string enum | One of `pending`, `applied`, `rolling_out`, `stalled`, `complete`, or `unknown`. |
+| `currentChange.verdict` | string enum | `PASS`, `WATCH`, `BLOCK`, or `INCONCLUSIVE`. Uses the same vocabulary as receipts. |
+| `currentChange.reason` | string enum | Stable reason such as `workload_converged`, `rollout_progressing`, `stale_generation`, `progress_stalled`, `runtime_failed`, `rollout_failed`, `workload_missing`, or `evidence_missing`. |
+| `currentChange.evidence` | object | Reviewable kstatus, generation, observed generation, pod reason, and observation timestamp evidence used to build the verdict. |
 | `mutationCause` | string enum | Same enum as `cause` above. Best-effort; omitted on fetch failure or when no signal is present. |
 | `mutationManager` | string | Representative manager string for transparency. |
+
+### DoctorSummary rollout additions (doctor --format json)
+
+When live workload rollout evidence is available, `doctor --format json`
+includes a `rollouts` object. The field is omitted when no workload rollout
+evidence could be collected.
+
+```json
+{
+  "rollouts": {
+    "total": 4,
+    "pass": 2,
+    "watch": 1,
+    "block": 1,
+    "inconclusive": 0,
+    "currentChanges": [
+      {
+        "resource": {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "namespace": "prod",
+          "name": "api"
+        },
+        "progress": {"phase": "stalled"},
+        "verdict": "BLOCK",
+        "reason": "runtime_failed",
+        "evidence": {
+          "podReasons": [
+            {"pod": "api-abc", "reason": "CrashLoopBackOff"}
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+`currentChanges[]` contains non-`PASS` rollout decisions, sorted by severity
+(`BLOCK`, then `INCONCLUSIVE`, then `WATCH`) and bounded by `doctor --top`.
+
+### Three-way resource rollout additions (compare three-way --format json)
+
+Each `resources[]` entry may include `currentChange` for workload resources
+when live rollout evidence is available:
+
+```json
+{
+  "resources": [
+    {
+      "result": {"resource": "Deployment/api", "namespace": "prod"},
+      "severity": "warning",
+      "pattern": "rollout-pending",
+      "currentChange": {
+        "progress": {"phase": "rolling_out"},
+        "verdict": "WATCH",
+        "reason": "rollout_progressing",
+        "evidence": {
+          "kstatusStatus": "InProgress",
+          "generation": 2,
+          "observedGeneration": 2
+        }
+      }
+    }
+  ]
+}
+```
+
+`currentChange` is omitted for non-workload resources and when rollout
+evidence cannot be read. It does not change conformance exit-code semantics;
+`compare three-way --fail-on` remains based on resource severity.
 
 ### Verified manager strings
 
@@ -535,6 +630,25 @@ As of v1.10, `trace` and `explain` commands include recent Kubernetes events for
         "source": "kubelet",
         "firstSeen": "2026-04-09T10:00:00Z",
         "lastSeen": "2026-04-09T10:05:00Z"
+      },
+      {
+        "type": "Normal",
+        "reason": "WebAction",
+        "message": "operator@example.com requested restart for Deployment/prod/api",
+        "count": 1,
+        "age": "1m",
+        "severity": "info",
+        "source": "controller-web",
+        "lastSeen": "2026-07-09T10:05:00Z",
+        "action": {
+          "action": "restart",
+          "actor": "operator@example.com",
+          "groups": ["platform", "oncall"],
+          "subject": "Deployment/prod/api",
+          "raw": {
+            "event.toolkit.fluxcd.io/change-token": "chg-123"
+          }
+        }
       }
     ],
     "totalCount": 10,
@@ -579,6 +693,15 @@ As of v1.10, `trace` and `explain` commands include recent Kubernetes events for
 | `source` | string | Component that generated the event |
 | `firstSeen` | string | RFC3339 timestamp of first occurrence |
 | `lastSeen` | string | RFC3339 timestamp of last occurrence |
+| `action` | object | Optional audited action metadata when explicitly present on the Kubernetes Event |
+| `action.action` | string | Action name from event annotations |
+| `action.actor` | string | Actor/username from event annotations |
+| `action.groups[]` | string[] | Actor groups from event annotations |
+| `action.subject` | string | Target subject from event annotations |
+| `action.raw` | object | Unknown action annotations preserved as raw evidence |
+
+Action metadata is omitted for ordinary events. Missing actor, group, or subject
+fields are omitted rather than guessed.
 
 ### Severity Mapping
 

--- a/docs/reference/ownership-precedence.md
+++ b/docs/reference/ownership-precedence.md
@@ -16,7 +16,7 @@ cub-scout checks for ownership signals in the following order. The **first match
 
 | Priority | Owner | Detection Method |
 |----------|-------|------------------|
-| 1 | **Flux** | Labels: `kustomize.toolkit.fluxcd.io/*` or `helm.toolkit.fluxcd.io/*` |
+| 1 | **Flux** | Labels: `kustomize.toolkit.fluxcd.io/*` or `helm.toolkit.fluxcd.io/*`, or API group `fluxcd.controlplane.io` |
 | 2 | **Argo CD** | Label: `argocd.argoproj.io/instance` or annotation: `argocd.argoproj.io/tracking-id` |
 | 3 | **Sveltos** | Annotations: `projectsveltos.io/owner-kind` + `projectsveltos.io/owner-name`, `projectsveltos.io/deployed-by-sveltos`, Sveltos ownerRef, or Sveltos API group |
 | 4 | **Modelplane** | API group `modelplane.ai` / `infrastructure.modelplane.ai`, selected `modelplane.ai/*` identity labels, or Modelplane ownerRef |
@@ -44,10 +44,13 @@ cub-scout checks for ownership signals in the following order. The **first match
 | Label | `kustomize.toolkit.fluxcd.io/namespace` | `flux-system` | kustomization |
 | Label | `helm.toolkit.fluxcd.io/name` | `my-release` | helmrelease |
 | Label | `helm.toolkit.fluxcd.io/namespace` | `flux-system` | helmrelease |
+| API group | `fluxcd.controlplane.io` | `ResourceSet/prod-apps` | lower-case kind |
 
 **What cub-scout extracts:**
 - Owner name from the `/name` label
 - Owner namespace from the `/namespace` label
+- Aggregate delivery resource name and namespace from metadata when the API
+  group is `fluxcd.controlplane.io`
 
 ---
 

--- a/docs/releases/v2.7.0.md
+++ b/docs/releases/v2.7.0.md
@@ -1,0 +1,126 @@
+# v2.7.0 Release Notes — Live Delivery Observability
+
+> **Status:** Draft release candidate.
+> **Previous release:** [`v2.6.0`](v2.6.0.md) — first-class controller evidence.
+
+**Theme:** answer delivery, rollout, drift, and action-audit questions from one
+read-only observer surface.
+
+This release is additive. It does not change cub-scout's read-only boundary,
+CLI exit-code contract, or existing JSON fields.
+
+## Highlights
+
+### User questions first
+
+The README now opens with a reviewer-friendly table mapping common operator
+questions to cub-scout surfaces:
+
+- who owns this resource?
+- is delegated delivery healthy?
+- has intended configuration reached the cluster?
+- is this rollout progressing, complete, or stuck?
+- can I move to the next task, wait, or retry?
+- can broad or repeated questions use captured, watched, summarized, or receipt
+  evidence instead of repeatedly crawling live APIs?
+
+### Current-change rollout verdicts
+
+`doctor`, `explain`, and `compare three-way` now share the same
+generation-aware rollout decision model used by `receipt verify --predicate
+workloads-converged`.
+
+The new optional JSON shape includes:
+
+- `progress.phase`
+- `progress.clockSource`
+- `progress.progressAgeSeconds`
+- `verdict` (`PASS`, `WATCH`, `BLOCK`, `INCONCLUSIVE`)
+- stable `reason`
+- raw evidence: kstatus, generation, observed generation, pod symptoms, and
+  observation timestamp
+
+Stale observed generations are never reported as successful current-change
+completion.
+
+### First-class aggregate delivery resources
+
+Aggregate delivery resources in the `fluxcd.controlplane.io/v1` API group are
+now first-class controller resources:
+
+- `FluxInstance`
+- `FluxReport`
+- `ResourceSet`
+- `ResourceSetInputProvider`
+- `ExternalArtifact`
+- `ArtifactGenerator`
+
+They participate in controller-resource discovery, ownership detection,
+deployer/status views, trace lookup, and activity timelines.
+
+### Audited action events
+
+`trace`, `explain`, and `map activity` now parse audited action metadata from
+Kubernetes Events with reason `WebAction` and action annotations.
+
+Optional JSON fields include:
+
+- `events[].action.action`
+- `events[].action.actor`
+- `events[].action.groups[]`
+- `events[].action.subject`
+- `events[].action.raw`
+- `map activity` row fields `actor`, `subject`, and `actionEvidence`
+
+Unknown action annotations under the same annotation namespace are preserved as
+raw evidence. Missing actor, group, or subject fields are omitted rather than
+guessed.
+
+### Example fixture
+
+New fixture:
+
+- [`examples/live-delivery-observability`](../../examples/live-delivery-observability/)
+
+It demonstrates desired-vs-observed drift shape, aggregate delivery status,
+audited action events, stale-generation rollout evidence, and runtime pod
+symptoms in one reviewable object set.
+
+New how-to:
+
+- [`docs/howto/delivery-readiness-decision.md`](../howto/delivery-readiness-decision.md)
+
+It gives operators the short decision flow for "proceed, wait, or investigate"
+using `doctor`, `explain`, `gitops status`, `compare three-way`, and
+`receipt verify --predicate workloads-converged`.
+
+## Verification
+
+Release-candidate checks:
+
+```bash
+git diff --check
+go test ./...
+go build ./cmd/cub-scout
+```
+
+Focused tests added or extended:
+
+- rollout decision synthesis
+- `doctor` rollout summaries
+- `explain` current-change rendering
+- `compare three-way` current-change rendering
+- aggregate controller resource discovery
+- aggregate API-group ownership detection
+- audited action event parsing
+- `map activity` audited action rows
+
+## Follow-Ups
+
+The next backlog items are intentionally explicit:
+
+- aggregate delivery failures as `doctor` top-level findings where controller
+  status refs expose source/generated-artifact lineage
+- audited action events as history and receipt supporting evidence
+- broader source freshness metadata for snapshot, watch, summary, and
+  receipt-backed reads

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,6 +23,16 @@ remains future work. Items marked "resolved" had issues filed, implemented, and 
 
 Tracking: issue **#154** is closed. This checklist is now the live tracker.
 
+### Live Delivery Observability (`proposals/next-release-live-delivery-observability.md`)
+
+- [x] First-class aggregate delivery/app-bundle/input-provider/external-artifact/generated-artifact resources in controller-resource discovery, ownership, deployer/status, trace, and activity surfaces
+- [x] Audited user-action event ingestion for activity, explain, and trace event summaries
+- [x] Generation-aware rollout progress/verdict UX promoted from receipts into doctor, explain, and compare surfaces
+- [ ] Aggregate delivery failures as doctor top-level findings with deeper source/generated-artifact lineage where status refs expose it
+- [ ] Audited user-action event ingestion for history and receipt supporting evidence
+- [ ] API-load-aware inventory and search paths with source freshness for snapshot, watch, summary, and receipt-backed reads
+- [ ] Controller-family parity rules and fallback omissions for controllers without status, source, event, or generation evidence
+
 ### Rendered Manifest + Argo (`roadmap-rendered-manifest-and-argo.md`)
 
 - [x] Workstream A: Distinguish "ConfigHub via OCI" ownership in trace outputs (relates to [ConfigHub rendered manifests](https://docs.confighub.com/guide/rendered-manifests/)) — validated by `TestArgoTracerConfigHubOCIDetection` + trace ASCII/JSON proofs

--- a/examples/README.md
+++ b/examples/README.md
@@ -78,6 +78,7 @@ understands the core ownership model.
 - [`platform-example`](./platform-example/)
 - [`d2-control-plane`](./d2-control-plane/)
 - [`flux-boutique`](./flux-boutique/)
+- [`live-delivery-observability`](./live-delivery-observability/) — aggregate delivery status, audited action events, drift shape, and rollout evidence
 - [`kro-composition`](./kro-composition/)
 - [`custom-ownership-detectors`](./custom-ownership-detectors/)
 - [`orphans`](./orphans/)

--- a/examples/live-delivery-observability/README.md
+++ b/examples/live-delivery-observability/README.md
@@ -1,0 +1,57 @@
+# Live Delivery Observability Fixture
+
+This fixture demonstrates the next-release diagnostic questions in one small
+recorded object set:
+
+- aggregate delivery status from first-class controller resources
+- audited user-action events recorded as Kubernetes Events
+- desired-vs-observed drift shape
+- current-generation rollout evidence, including stale generation and runtime
+  pod symptoms
+
+The files are review fixtures, not a guaranteed `kubectl apply` recipe. Some
+objects include `status` fields that are normally written by controllers or the
+API server.
+
+For the operator workflow this fixture supports, see
+[`docs/howto/delivery-readiness-decision.md`](../../docs/howto/delivery-readiness-decision.md).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `desired.yaml` | Intended Deployment shape used as the comparison baseline. |
+| `observed.yaml` | Recorded live objects: aggregate resource, workload, pod symptom, and audited action event. |
+
+## Review Commands
+
+```bash
+# Inspect the objects and fields a reviewer should expect cub-scout to parse.
+grep -n "kind:\\|event.toolkit.fluxcd.io\\|observedGeneration\\|CrashLoopBackOff" \
+  examples/live-delivery-observability/observed.yaml
+
+# Against a cluster with equivalent objects:
+./cub-scout map activity --owner Flux --format json
+./cub-scout gitops status --format json
+./cub-scout explain deployment/api -n prod --format json
+./cub-scout doctor -n prod --format json
+
+# With desired.yaml as the intended object set and equivalent live objects:
+./cub-scout receipt verify \
+  --file examples/live-delivery-observability/desired.yaml \
+  --scope namespace/prod \
+  --predicate workloads-converged \
+  --format json
+```
+
+## Expected Evidence
+
+- `map activity` should surface the `WebAction` event as `source=k8s.action`
+  with `actor`, `subject`, and raw action metadata.
+- `gitops status`, `trace`, and map deployer surfaces should treat the
+  aggregate delivery resource as a first-class controller object.
+- `explain` and `doctor` should report the Deployment current change as
+  non-PASS because `status.observedGeneration` is behind
+  `metadata.generation` and the related Pod has `CrashLoopBackOff` evidence.
+- `receipt verify --predicate workloads-converged` should use the same rollout
+  decision model as the diagnostic surfaces.

--- a/examples/live-delivery-observability/desired.yaml
+++ b/examples/live-delivery-observability/desired.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+  labels:
+    app.kubernetes.io/name: api
+    kustomize.toolkit.fluxcd.io/name: prod-apps
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/example/api:v2
+          ports:
+            - containerPort: 8080
+

--- a/examples/live-delivery-observability/observed.yaml
+++ b/examples/live-delivery-observability/observed.yaml
@@ -1,0 +1,114 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: prod-apps
+  namespace: flux-system
+  generation: 4
+spec:
+  inputs:
+    - tenant: payments
+status:
+  observedGeneration: 4
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: ReconciliationFailed
+      message: Deployment/api is waiting for current-generation rollout evidence
+      lastTransitionTime: "2026-07-09T10:02:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+  generation: 3
+  labels:
+    app.kubernetes.io/name: api
+    kustomize.toolkit.fluxcd.io/name: prod-apps
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+    manual.example.com/hotfix: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/example/api:v2
+          ports:
+            - containerPort: 8080
+status:
+  observedGeneration: 2
+  replicas: 2
+  updatedReplicas: 1
+  readyReplicas: 1
+  unavailableReplicas: 1
+  conditions:
+    - type: Available
+      status: "False"
+      reason: MinimumReplicasUnavailable
+      message: Deployment does not have minimum availability.
+      lastTransitionTime: "2026-07-09T10:03:00Z"
+    - type: Progressing
+      status: "True"
+      reason: ReplicaSetUpdated
+      message: ReplicaSet api-abc is progressing.
+      lastTransitionTime: "2026-07-09T10:04:00Z"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: api-abc
+  namespace: prod
+  labels:
+    app.kubernetes.io/name: api
+spec:
+  containers:
+    - name: api
+      image: ghcr.io/example/api:v2
+status:
+  phase: Running
+  containerStatuses:
+    - name: api
+      ready: false
+      restartCount: 4
+      state:
+        waiting:
+          reason: CrashLoopBackOff
+          message: Back-off restarting failed container api in pod api-abc
+---
+apiVersion: v1
+kind: Event
+metadata:
+  name: api-action.1800000000000000
+  namespace: prod
+  annotations:
+    event.toolkit.fluxcd.io/action: restart
+    event.toolkit.fluxcd.io/username: operator@example.com
+    event.toolkit.fluxcd.io/groups: platform,oncall
+    event.toolkit.fluxcd.io/subject: Deployment/prod/api
+    event.toolkit.fluxcd.io/change-token: chg-123
+involvedObject:
+  apiVersion: apps/v1
+  kind: Deployment
+  namespace: prod
+  name: api
+type: Normal
+reason: WebAction
+message: operator@example.com requested restart for Deployment/prod/api
+firstTimestamp: "2026-07-09T10:05:00Z"
+lastTimestamp: "2026-07-09T10:05:00Z"
+count: 1
+source:
+  component: controller-web
+

--- a/internal/mapsvc/jsonout.go
+++ b/internal/mapsvc/jsonout.go
@@ -455,15 +455,24 @@ type TraceEvents struct {
 
 // TraceEvent represents a single Kubernetes event.
 type TraceEvent struct {
-	Type      string `json:"type"`                // Normal or Warning
-	Reason    string `json:"reason"`              // e.g., Pulled, BackOff, FailedScheduling
-	Message   string `json:"message"`             // Human-readable message
-	Count     int32  `json:"count,omitempty"`     // Number of occurrences
-	Age       string `json:"age"`                 // Human-readable age (e.g., "5m", "2h")
-	Severity  string `json:"severity"`            // info, warning, error
-	Source    string `json:"source,omitempty"`    // Component that generated the event
-	FirstSeen string `json:"firstSeen,omitempty"` // RFC3339 timestamp
-	LastSeen  string `json:"lastSeen,omitempty"`  // RFC3339 timestamp
+	Type      string            `json:"type"`                // Normal or Warning
+	Reason    string            `json:"reason"`              // e.g., Pulled, BackOff, FailedScheduling
+	Message   string            `json:"message"`             // Human-readable message
+	Count     int32             `json:"count,omitempty"`     // Number of occurrences
+	Age       string            `json:"age"`                 // Human-readable age (e.g., "5m", "2h")
+	Severity  string            `json:"severity"`            // info, warning, error
+	Source    string            `json:"source,omitempty"`    // Component that generated the event
+	FirstSeen string            `json:"firstSeen,omitempty"` // RFC3339 timestamp
+	LastSeen  string            `json:"lastSeen,omitempty"`  // RFC3339 timestamp
+	Action    *TraceActionEvent `json:"action,omitempty"`
+}
+
+type TraceActionEvent struct {
+	Action  string            `json:"action,omitempty"`
+	Actor   string            `json:"actor,omitempty"`
+	Groups  []string          `json:"groups,omitempty"`
+	Subject string            `json:"subject,omitempty"`
+	Raw     map[string]string `json:"raw,omitempty"`
 }
 
 // ChainRole constants for trace chain nodes.

--- a/pkg/agent/event_timeline.go
+++ b/pkg/agent/event_timeline.go
@@ -27,18 +27,18 @@ type TimelineEvent struct {
 	K8sEvent
 	ResourceKind string `json:"resourceKind"` // Pod, Deployment, ReplicaSet, etc.
 	ResourceName string `json:"resourceName"`
-	Explanation  string `json:"explanation,omitempty"`  // Human-readable explanation
-	Suggestion   string `json:"suggestion,omitempty"`   // Suggested action
-	Severity     string `json:"severity"`               // info, warning, error
+	Explanation  string `json:"explanation,omitempty"` // Human-readable explanation
+	Suggestion   string `json:"suggestion,omitempty"`  // Suggested action
+	Severity     string `json:"severity"`              // info, warning, error
 }
 
 // EventTimelineFetcher fetches and organizes events into a timeline
 type EventTimelineFetcher struct {
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 }
 
 // NewEventTimelineFetcher creates a new event timeline fetcher
-func NewEventTimelineFetcher(clientset *kubernetes.Clientset) *EventTimelineFetcher {
+func NewEventTimelineFetcher(clientset kubernetes.Interface) *EventTimelineFetcher {
 	return &EventTimelineFetcher{
 		clientset: clientset,
 	}
@@ -372,15 +372,27 @@ func GetEventSuggestion(reason string) string {
 // ResourceEvent is a compact event model for bounded display in explain/trace.
 // This is simpler than TimelineEvent and optimized for troubleshooting output.
 type ResourceEvent struct {
-	Type      string     `json:"type"`              // Normal or Warning
-	Reason    string     `json:"reason"`            // e.g., Pulled, BackOff, FailedScheduling
-	Message   string     `json:"message"`           // Human-readable message
-	Count     int32      `json:"count,omitempty"`   // Number of occurrences
-	Age       string     `json:"age"`               // Human-readable age (e.g., "5m", "2h")
-	LastSeen  *time.Time `json:"lastSeen"`          // Last occurrence timestamp
-	Severity  string     `json:"severity"`          // info, warning, error
-	Source    string     `json:"source,omitempty"`  // Component that generated the event
-	FirstSeen *time.Time `json:"firstSeen"`         // First occurrence timestamp
+	Type      string       `json:"type"`             // Normal or Warning
+	Reason    string       `json:"reason"`           // e.g., Pulled, BackOff, FailedScheduling
+	Message   string       `json:"message"`          // Human-readable message
+	Count     int32        `json:"count,omitempty"`  // Number of occurrences
+	Age       string       `json:"age"`              // Human-readable age (e.g., "5m", "2h")
+	LastSeen  *time.Time   `json:"lastSeen"`         // Last occurrence timestamp
+	Severity  string       `json:"severity"`         // info, warning, error
+	Source    string       `json:"source,omitempty"` // Component that generated the event
+	FirstSeen *time.Time   `json:"firstSeen"`        // First occurrence timestamp
+	Action    *ActionEvent `json:"action,omitempty"` // Audited user/action metadata when exposed by the event
+}
+
+// ActionEvent is safe, structured audit metadata extracted from Kubernetes
+// Events. It is optional and only populated when the event carries explicit
+// action annotations or a known action reason.
+type ActionEvent struct {
+	Action  string            `json:"action,omitempty"`
+	Actor   string            `json:"actor,omitempty"`
+	Groups  []string          `json:"groups,omitempty"`
+	Subject string            `json:"subject,omitempty"`
+	Raw     map[string]string `json:"raw,omitempty"`
 }
 
 // ResourceEventSummary summarizes events for a resource.
@@ -456,6 +468,9 @@ func (f *EventTimelineFetcher) FetchRecentEvents(ctx context.Context, namespace,
 			FirstSeen: firstTime,
 			LastSeen:  lastTime,
 		}
+		if action, ok := ParseActionEvent(event.Reason, event.Annotations); ok {
+			re.Action = action
+		}
 
 		// Calculate age string
 		if lastTime != nil {
@@ -485,6 +500,63 @@ func (f *EventTimelineFetcher) FetchRecentEvents(ctx context.Context, namespace,
 
 	summary.Events = resourceEvents
 	return summary, nil
+}
+
+// ParseActionEvent extracts audited action metadata from a Kubernetes Event.
+// It recognizes action annotations emitted by controller web consoles and keeps
+// unknown annotations from the same namespace as raw evidence.
+func ParseActionEvent(reason string, annotations map[string]string) (*ActionEvent, bool) {
+	const prefix = "event.toolkit.fluxcd.io/"
+	if len(annotations) == 0 && !strings.EqualFold(reason, "WebAction") {
+		return nil, false
+	}
+
+	action := &ActionEvent{}
+	raw := map[string]string{}
+	for key, value := range annotations {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		switch key {
+		case prefix + "action":
+			action.Action = value
+		case prefix + "username":
+			action.Actor = value
+		case prefix + "groups":
+			action.Groups = splitActionGroups(value)
+		case prefix + "subject":
+			action.Subject = value
+		default:
+			if strings.HasPrefix(key, prefix) {
+				raw[key] = value
+			}
+		}
+	}
+	if len(raw) > 0 {
+		action.Raw = raw
+	}
+	if action.Action == "" && action.Actor == "" && len(action.Groups) == 0 && action.Subject == "" && len(action.Raw) == 0 {
+		if strings.EqualFold(reason, "WebAction") {
+			return action, true
+		}
+		return nil, false
+	}
+	return action, true
+}
+
+func splitActionGroups(value string) []string {
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';'
+	})
+	groups := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			groups = append(groups, part)
+		}
+	}
+	return groups
 }
 
 // severityRank returns a numeric rank for sorting (higher = more severe)

--- a/pkg/agent/event_timeline_test.go
+++ b/pkg/agent/event_timeline_test.go
@@ -4,8 +4,13 @@
 package agent
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestSeverityRank(t *testing.T) {
@@ -136,5 +141,74 @@ func TestResourceEventSortOrder(t *testing.T) {
 	}
 	if events[2].Severity != "info" || events[2].Reason != "Created" {
 		t.Errorf("expected most recent info third, got %s/%s", events[2].Severity, events[2].Reason)
+	}
+}
+
+func TestParseActionEvent(t *testing.T) {
+	action, ok := ParseActionEvent("WebAction", map[string]string{
+		"event.toolkit.fluxcd.io/action":       "reconcile",
+		"event.toolkit.fluxcd.io/username":     "operator@example.com",
+		"event.toolkit.fluxcd.io/groups":       "platform, oncall",
+		"event.toolkit.fluxcd.io/subject":      "Deployment/prod/api",
+		"event.toolkit.fluxcd.io/change-token": "chg-123",
+	})
+	if !ok {
+		t.Fatal("ParseActionEvent returned ok=false")
+	}
+	if action.Action != "reconcile" {
+		t.Fatalf("Action = %q, want reconcile", action.Action)
+	}
+	if action.Actor != "operator@example.com" {
+		t.Fatalf("Actor = %q, want operator@example.com", action.Actor)
+	}
+	if len(action.Groups) != 2 || action.Groups[0] != "platform" || action.Groups[1] != "oncall" {
+		t.Fatalf("Groups = %#v, want platform/oncall", action.Groups)
+	}
+	if action.Subject != "Deployment/prod/api" {
+		t.Fatalf("Subject = %q, want Deployment/prod/api", action.Subject)
+	}
+	if action.Raw["event.toolkit.fluxcd.io/change-token"] != "chg-123" {
+		t.Fatalf("Raw = %#v, want change-token evidence", action.Raw)
+	}
+}
+
+func TestFetchRecentEventsIncludesActionMetadata(t *testing.T) {
+	now := metav1.Now()
+	client := fake.NewSimpleClientset(&corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-action",
+			Namespace: "prod",
+			Annotations: map[string]string{
+				"event.toolkit.fluxcd.io/action":   "restart",
+				"event.toolkit.fluxcd.io/username": "operator@example.com",
+				"event.toolkit.fluxcd.io/subject":  "Deployment/prod/api",
+			},
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Deployment",
+			Namespace: "prod",
+			Name:      "api",
+		},
+		Type:           "Normal",
+		Reason:         "WebAction",
+		Message:        "operator@example.com requested restart for Deployment/prod/api",
+		Count:          1,
+		FirstTimestamp: now,
+		LastTimestamp:  now,
+	})
+
+	summary, err := NewEventTimelineFetcher(client).FetchRecentEvents(context.Background(), "prod", "Deployment", "api", 5)
+	if err != nil {
+		t.Fatalf("FetchRecentEvents returned error: %v", err)
+	}
+	if len(summary.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(summary.Events))
+	}
+	action := summary.Events[0].Action
+	if action == nil {
+		t.Fatal("Action metadata is nil")
+	}
+	if action.Action != "restart" || action.Actor != "operator@example.com" || action.Subject != "Deployment/prod/api" {
+		t.Fatalf("Action = %+v, want restart/operator/subject", action)
 	}
 }

--- a/pkg/agent/ownership.go
+++ b/pkg/agent/ownership.go
@@ -31,7 +31,7 @@ func DetectOwnership(resource *unstructured.Unstructured) Ownership {
 	annotations := resource.GetAnnotations()
 
 	// Check for Flux ownership
-	if ownership := detectFluxOwnership(labels, annotations); ownership.Type != "" {
+	if ownership := detectFluxOwnership(labels, annotations, resource); ownership.Type != "" {
 		return ownership
 	}
 
@@ -94,7 +94,7 @@ func DetectOwnership(resource *unstructured.Unstructured) Ownership {
 	return Ownership{Type: OwnerUnknown}
 }
 
-func detectFluxOwnership(labels, annotations map[string]string) Ownership {
+func detectFluxOwnership(labels, annotations map[string]string, resource *unstructured.Unstructured) Ownership {
 	// Flux Kustomization
 	if name, ok := labels["kustomize.toolkit.fluxcd.io/name"]; ok {
 		ns := labels["kustomize.toolkit.fluxcd.io/namespace"]
@@ -121,7 +121,23 @@ func detectFluxOwnership(labels, annotations map[string]string) Ownership {
 		}
 	}
 
+	if resource != nil && fluxOperatorAPIGroup(resource.GetAPIVersion()) {
+		return Ownership{
+			Type:       OwnerFlux,
+			SubType:    strings.ToLower(resource.GetKind()),
+			Name:       resource.GetName(),
+			Namespace:  resource.GetNamespace(),
+			Source:     "apiGroup:fluxcd.controlplane.io",
+			Confidence: "high",
+		}
+	}
+
 	return Ownership{}
+}
+
+func fluxOperatorAPIGroup(apiVersion string) bool {
+	group, _, ok := strings.Cut(apiVersion, "/")
+	return ok && group == "fluxcd.controlplane.io"
 }
 
 func detectArgoOwnership(labels, annotations map[string]string) Ownership {

--- a/pkg/agent/ownership_test.go
+++ b/pkg/agent/ownership_test.go
@@ -45,10 +45,13 @@ func TestDetectOwnership_Flux(t *testing.T) {
 		name        string
 		labels      map[string]string
 		annotations map[string]string
+		apiVersion  string
+		kind        string
 		wantType    string
 		wantSubType string
 		wantName    string
 		wantNS      string
+		wantSource  string
 	}{
 		{
 			name: "Flux Kustomization ownership",
@@ -60,6 +63,7 @@ func TestDetectOwnership_Flux(t *testing.T) {
 			wantSubType: "kustomization",
 			wantName:    "my-app",
 			wantNS:      "flux-system",
+			wantSource:  "label:kustomize.toolkit.fluxcd.io/name",
 		},
 		{
 			name: "Flux HelmRelease ownership",
@@ -71,6 +75,7 @@ func TestDetectOwnership_Flux(t *testing.T) {
 			wantSubType: "helmrelease",
 			wantName:    "redis",
 			wantNS:      "default",
+			wantSource:  "label:helm.toolkit.fluxcd.io/name",
 		},
 		{
 			name: "Flux Kustomization without namespace",
@@ -81,12 +86,25 @@ func TestDetectOwnership_Flux(t *testing.T) {
 			wantSubType: "kustomization",
 			wantName:    "standalone-app",
 			wantNS:      "",
+			wantSource:  "label:kustomize.toolkit.fluxcd.io/name",
+		},
+		{
+			name:        "Flux Operator aggregate resource by API group",
+			apiVersion:  "fluxcd.controlplane.io/v1",
+			kind:        "ResourceSet",
+			wantType:    OwnerFlux,
+			wantSubType: "resourceset",
+			wantName:    "test-resource",
+			wantNS:      "test-ns",
+			wantSource:  "apiGroup:fluxcd.controlplane.io",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resource := newTestResource("test-ns", "test-resource", tt.labels, tt.annotations)
+			resource.SetAPIVersion(tt.apiVersion)
+			resource.SetKind(tt.kind)
 			ownership := DetectOwnership(resource)
 
 			if ownership.Type != tt.wantType {
@@ -100,6 +118,9 @@ func TestDetectOwnership_Flux(t *testing.T) {
 			}
 			if ownership.Namespace != tt.wantNS {
 				t.Errorf("Namespace = %q, want %q", ownership.Namespace, tt.wantNS)
+			}
+			if ownership.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", ownership.Source, tt.wantSource)
 			}
 		})
 	}

--- a/pkg/agent/receipt_workloads.go
+++ b/pkg/agent/receipt_workloads.go
@@ -276,15 +276,8 @@ func BuildWorkloadsConvergedReceipt(in BuildWorkloadsConvergedReceiptInput) (Sta
 	}
 
 	s := in.Evidence.Summary
-	verdict := VerdictPASS
-	switch {
-	case s.Failed > 0 || s.Missing > 0:
-		verdict = VerdictBLOCK
-	case s.Inconclusive > 0:
-		verdict = VerdictINCONCLUSIVE
-	case s.Progressing > 0:
-		verdict = VerdictWATCH
-	}
+	decisionSet := BuildRolloutDecisionSetFromWorkloadsConvergedEvidence(in.Evidence)
+	verdict := decisionSet.Verdict
 
 	omissions := []Omission{
 		{

--- a/pkg/agent/rollout_decision.go
+++ b/pkg/agent/rollout_decision.go
@@ -1,0 +1,234 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+const (
+	RolloutProgressPending    = "pending"
+	RolloutProgressApplied    = "applied"
+	RolloutProgressRollingOut = "rolling_out"
+	RolloutProgressStalled    = "stalled"
+	RolloutProgressComplete   = "complete"
+	RolloutProgressUnknown    = "unknown"
+)
+
+const (
+	RolloutReasonConverged       = "workload_converged"
+	RolloutReasonProgressing     = "rollout_progressing"
+	RolloutReasonStaleGeneration = "stale_generation"
+	RolloutReasonProgressStalled = "progress_stalled"
+	RolloutReasonRuntimeFailed   = "runtime_failed"
+	RolloutReasonRolloutFailed   = "rollout_failed"
+	RolloutReasonMissing         = "workload_missing"
+	RolloutReasonEvidenceMissing = "evidence_missing"
+)
+
+// RolloutDecision is the shared current-change decision model used by
+// diagnostic surfaces and receipt predicates. It is evidence-shaped: callers
+// can render the concise verdict while reviewers can inspect the raw status
+// and generation signals that led to it.
+type RolloutDecision struct {
+	Resource  ObjectSetObjectID       `json:"resource"`
+	Progress  RolloutProgress         `json:"progress"`
+	Verdict   ReceiptVerdict          `json:"verdict"`
+	Reason    string                  `json:"reason"`
+	Message   string                  `json:"message,omitempty"`
+	Evidence  RolloutDecisionEvidence `json:"evidence"`
+	Omissions []Omission              `json:"omissions,omitempty"`
+}
+
+type RolloutProgress struct {
+	Phase              string `json:"phase"`
+	ClockSource        string `json:"clockSource,omitempty"`
+	ProgressAgeSeconds int64  `json:"progressAgeSeconds,omitempty"`
+}
+
+type RolloutDecisionEvidence struct {
+	KstatusStatus      string              `json:"kstatusStatus,omitempty"`
+	KstatusMessage     string              `json:"kstatusMessage,omitempty"`
+	Generation         int64               `json:"generation,omitempty"`
+	ObservedGeneration int64               `json:"observedGeneration,omitempty"`
+	PodReasons         []WorkloadPodReason `json:"podReasons,omitempty"`
+	ObservedAt         string              `json:"observedAt,omitempty"`
+}
+
+type RolloutDecisionSet struct {
+	Verdict   ReceiptVerdict            `json:"verdict"`
+	Reason    string                    `json:"reason"`
+	Summary   WorkloadsConvergedSummary `json:"summary"`
+	Decisions []RolloutDecision         `json:"decisions"`
+}
+
+// BuildRolloutDecisionForWorkload builds a decision for one live workload.
+// It is pure and read-only: callers provide the live object and any related
+// pods they already fetched.
+func BuildRolloutDecisionForWorkload(live *unstructured.Unstructured, pods []*unstructured.Unstructured, graceWindow time.Duration, observedAt time.Time) (RolloutDecision, bool) {
+	if live == nil || !IsRolloutWorkloadKind(live.GetKind()) {
+		return RolloutDecision{}, false
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+
+	st, msg := WorkloadConvergence(live)
+	progressAge, progressAgeKnown, progressSource, generation, observedGeneration := workloadProgressClock(live, observedAt)
+	podReasons := make([]WorkloadPodReason, 0)
+	for _, pod := range pods {
+		if _, container, _, reason, message, ok := podWaitingFailure(pod); ok {
+			podReasons = append(podReasons, WorkloadPodReason{
+				Pod:       pod.GetName(),
+				Container: container,
+				Reason:    reason,
+				Message:   clampReason(message, 160),
+			})
+		}
+	}
+
+	summary := WorkloadConvergedObjectSummary{
+		ID:                  NewObjectSetObjectID(live),
+		Status:              classifyConvergence(st, podReasons, progressAge, progressAgeKnown, graceWindow),
+		KstatusStatus:       st.String(),
+		KstatusMessage:      msg,
+		Generation:          generation,
+		ObservedGeneration:  observedGeneration,
+		ProgressClockSource: progressSource,
+		PodReasons:          podReasons,
+	}
+	if progressAgeKnown {
+		summary.ProgressAgeSeconds = int64(progressAge.Seconds())
+	}
+	return RolloutDecisionFromWorkloadSummary(summary, observedAt), true
+}
+
+func IsRolloutWorkloadKind(kind string) bool {
+	switch kind {
+	case "Deployment", "StatefulSet", "DaemonSet", "Job", "Pod":
+		return true
+	default:
+		return false
+	}
+}
+
+func RolloutDecisionFromWorkloadSummary(summary WorkloadConvergedObjectSummary, observedAt time.Time) RolloutDecision {
+	decision := RolloutDecision{
+		Resource: summary.ID,
+		Progress: RolloutProgress{
+			Phase:              RolloutProgressUnknown,
+			ClockSource:        summary.ProgressClockSource,
+			ProgressAgeSeconds: summary.ProgressAgeSeconds,
+		},
+		Verdict: VerdictINCONCLUSIVE,
+		Reason:  RolloutReasonEvidenceMissing,
+		Message: summary.KstatusMessage,
+		Evidence: RolloutDecisionEvidence{
+			KstatusStatus:      summary.KstatusStatus,
+			KstatusMessage:     summary.KstatusMessage,
+			Generation:         summary.Generation,
+			ObservedGeneration: summary.ObservedGeneration,
+			PodReasons:         summary.PodReasons,
+		},
+	}
+	if !observedAt.IsZero() {
+		decision.Evidence.ObservedAt = observedAt.UTC().Format(time.RFC3339)
+	}
+
+	switch summary.Status {
+	case WorkloadConvergedConverged:
+		decision.Progress.Phase = RolloutProgressComplete
+		decision.Verdict = VerdictPASS
+		decision.Reason = RolloutReasonConverged
+	case WorkloadConvergedProgressing:
+		decision.Verdict = VerdictWATCH
+		if summary.ProgressClockSource == "status.observedGeneration<metadata.generation" {
+			decision.Progress.Phase = RolloutProgressApplied
+			decision.Reason = RolloutReasonStaleGeneration
+		} else {
+			decision.Progress.Phase = RolloutProgressRollingOut
+			decision.Reason = RolloutReasonProgressing
+		}
+	case WorkloadConvergedFailed:
+		decision.Progress.Phase = RolloutProgressStalled
+		decision.Verdict = VerdictBLOCK
+		decision.Reason = rolloutFailureReason(summary)
+	case WorkloadConvergedMissing:
+		decision.Progress.Phase = RolloutProgressPending
+		decision.Verdict = VerdictBLOCK
+		decision.Reason = RolloutReasonMissing
+		if summary.Error != "" {
+			decision.Message = summary.Error
+		}
+	case WorkloadConvergedInconclusive:
+		decision.Progress.Phase = RolloutProgressUnknown
+		decision.Verdict = VerdictINCONCLUSIVE
+		decision.Reason = RolloutReasonEvidenceMissing
+		if summary.Error != "" {
+			decision.Message = summary.Error
+		}
+		decision.Omissions = append(decision.Omissions, Omission{
+			Missing:  OmissionWorkloadConvergenceCoverage,
+			Reason:   "workload rollout evidence could not be classified",
+			Severity: "warning",
+		})
+	}
+
+	return decision
+}
+
+func rolloutFailureReason(summary WorkloadConvergedObjectSummary) string {
+	if len(summary.PodReasons) > 0 {
+		return RolloutReasonRuntimeFailed
+	}
+	switch status.Status(summary.KstatusStatus) {
+	case status.FailedStatus, status.TerminatingStatus:
+		return RolloutReasonRolloutFailed
+	default:
+		return RolloutReasonProgressStalled
+	}
+}
+
+func BuildRolloutDecisionSetFromWorkloadsConvergedEvidence(evidence WorkloadsConvergedEvidence) RolloutDecisionSet {
+	observedAt, _ := time.Parse(time.RFC3339, evidence.ObservedAt)
+	decisions := make([]RolloutDecision, 0, len(evidence.Workloads))
+	for _, workload := range evidence.Workloads {
+		decisions = append(decisions, RolloutDecisionFromWorkloadSummary(workload, observedAt))
+	}
+	verdict := WorkloadsConvergedVerdict(evidence.Summary)
+	return RolloutDecisionSet{
+		Verdict:   verdict,
+		Reason:    rolloutSetReason(verdict, decisions),
+		Summary:   evidence.Summary,
+		Decisions: decisions,
+	}
+}
+
+func WorkloadsConvergedVerdict(summary WorkloadsConvergedSummary) ReceiptVerdict {
+	switch {
+	case summary.Failed > 0 || summary.Missing > 0:
+		return VerdictBLOCK
+	case summary.Inconclusive > 0:
+		return VerdictINCONCLUSIVE
+	case summary.Progressing > 0:
+		return VerdictWATCH
+	default:
+		return VerdictPASS
+	}
+}
+
+func rolloutSetReason(verdict ReceiptVerdict, decisions []RolloutDecision) string {
+	if len(decisions) == 0 {
+		return RolloutReasonEvidenceMissing
+	}
+	for _, decision := range decisions {
+		if decision.Verdict == verdict {
+			return decision.Reason
+		}
+	}
+	return RolloutReasonEvidenceMissing
+}

--- a/pkg/agent/rollout_decision_test.go
+++ b/pkg/agent/rollout_decision_test.go
@@ -1,0 +1,116 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestBuildRolloutDecisionForWorkload_PASSWhenCurrent(t *testing.T) {
+	decision, ok := BuildRolloutDecisionForWorkload(liveDeployment("web", 1), nil, 0, workloadsObservedAt)
+	if !ok {
+		t.Fatal("decision not built")
+	}
+	if decision.Verdict != VerdictPASS {
+		t.Fatalf("verdict = %s, want PASS", decision.Verdict)
+	}
+	if decision.Progress.Phase != RolloutProgressComplete {
+		t.Fatalf("phase = %s, want complete", decision.Progress.Phase)
+	}
+	if decision.Reason != RolloutReasonConverged {
+		t.Fatalf("reason = %s, want workload_converged", decision.Reason)
+	}
+}
+
+func TestBuildRolloutDecisionForWorkload_WATCHWhenGenerationStale(t *testing.T) {
+	live := liveDeployment("web", 0)
+	live.SetGeneration(2)
+
+	decision, ok := BuildRolloutDecisionForWorkload(live, nil, time.Minute, workloadsObservedAt)
+	if !ok {
+		t.Fatal("decision not built")
+	}
+	if decision.Verdict != VerdictWATCH {
+		t.Fatalf("verdict = %s, want WATCH", decision.Verdict)
+	}
+	if decision.Progress.Phase != RolloutProgressApplied {
+		t.Fatalf("phase = %s, want applied", decision.Progress.Phase)
+	}
+	if decision.Reason != RolloutReasonStaleGeneration {
+		t.Fatalf("reason = %s, want stale_generation", decision.Reason)
+	}
+	if decision.Evidence.Generation != 2 || decision.Evidence.ObservedGeneration != 1 {
+		t.Fatalf("generation evidence = %d/%d, want 2/1", decision.Evidence.Generation, decision.Evidence.ObservedGeneration)
+	}
+}
+
+func TestBuildRolloutDecisionForWorkload_BLOCKWhenPodRuntimeFailed(t *testing.T) {
+	live := liveDeployment("web", 0)
+	decision, ok := BuildRolloutDecisionForWorkload(live, []*unstructured.Unstructured{
+		waitingPod("web-abc", "CreateContainerConfigError"),
+	}, 0, workloadsObservedAt)
+	if !ok {
+		t.Fatal("decision not built")
+	}
+	if decision.Verdict != VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", decision.Verdict)
+	}
+	if decision.Reason != RolloutReasonRuntimeFailed {
+		t.Fatalf("reason = %s, want runtime_failed", decision.Reason)
+	}
+	if len(decision.Evidence.PodReasons) != 1 {
+		t.Fatalf("pod reasons = %d, want 1", len(decision.Evidence.PodReasons))
+	}
+}
+
+func TestBuildRolloutDecisionForWorkload_BLOCKWhenPastGrace(t *testing.T) {
+	live := liveDeployment("web", 0)
+	setCreationTimestamp(live, workloadsObservedAt.Add(-10*time.Minute))
+
+	decision, ok := BuildRolloutDecisionForWorkload(live, nil, time.Minute, workloadsObservedAt)
+	if !ok {
+		t.Fatal("decision not built")
+	}
+	if decision.Verdict != VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", decision.Verdict)
+	}
+	if decision.Progress.Phase != RolloutProgressStalled {
+		t.Fatalf("phase = %s, want stalled", decision.Progress.Phase)
+	}
+	if decision.Reason != RolloutReasonProgressStalled {
+		t.Fatalf("reason = %s, want progress_stalled", decision.Reason)
+	}
+}
+
+func TestBuildRolloutDecisionSetFromWorkloadsConvergedEvidence_UsesMaxSeverityVerdict(t *testing.T) {
+	evidence, err := BuildWorkloadsConvergedEvidence(
+		ObjectSetSource{Type: "file", Ref: "rendered.yaml"},
+		ObjectSetScope{Kind: "namespace", Namespace: "prod"},
+		0,
+		[]WorkloadConvergedObservedObject{
+			{Desired: desiredDeployment("ready"), Live: liveDeployment("ready", 1)},
+			{Desired: desiredDeployment("failed"), Live: liveDeployment("failed", 0), Pods: []*unstructured.Unstructured{
+				waitingPod("failed-abc", "CrashLoopBackOff"),
+			}},
+		},
+		workloadsObservedAt,
+	)
+	if err != nil {
+		t.Fatalf("BuildWorkloadsConvergedEvidence: %v", err)
+	}
+
+	decisionSet := BuildRolloutDecisionSetFromWorkloadsConvergedEvidence(evidence)
+	if decisionSet.Verdict != VerdictBLOCK {
+		t.Fatalf("verdict = %s, want BLOCK", decisionSet.Verdict)
+	}
+	if decisionSet.Reason != RolloutReasonRuntimeFailed {
+		t.Fatalf("reason = %s, want runtime_failed", decisionSet.Reason)
+	}
+	if len(decisionSet.Decisions) != 2 {
+		t.Fatalf("decisions = %d, want 2", len(decisionSet.Decisions))
+	}
+}

--- a/test/integration/kubectl_plugin_test.go
+++ b/test/integration/kubectl_plugin_test.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -56,12 +57,14 @@ func TestKubectlPlugin_MapListJSONParity(t *testing.T) {
 		t.Fatalf("make build-kubectl-plugin failed: %v\n%s", err, makeOut)
 	}
 
-	directOut, err := runCmd(getCubAgentPath(), "map", "list", "--json")
+	namespace := createKubectlPluginParityFixture(t)
+
+	directOut, err := runCmd(getCubAgentPath(), "map", "list", "--namespace", namespace, "--json")
 	if err != nil {
 		t.Fatalf("cub-scout map list --json failed: %v\n%s", err, directOut)
 	}
 
-	pluginOut, err := runWithPath(repoRoot, "kubectl", "cub-scout", "map", "list", "--json")
+	pluginOut, err := runWithPath(repoRoot, "kubectl", "cub-scout", "map", "list", "--namespace", namespace, "--json")
 	if err != nil {
 		t.Fatalf("kubectl cub-scout map list --json failed: %v\n%s", err, pluginOut)
 	}
@@ -77,6 +80,9 @@ func TestKubectlPlugin_MapListJSONParity(t *testing.T) {
 
 	if len(directKeys) != len(pluginKeys) {
 		t.Fatalf("map list entry count mismatch: direct=%d plugin=%d", len(directKeys), len(pluginKeys))
+	}
+	if len(directKeys) == 0 {
+		t.Fatalf("map list returned no entries for fixture namespace %q", namespace)
 	}
 
 	for i := range directKeys {
@@ -134,6 +140,27 @@ func TestKubectlPlugin_KrewManifestContract(t *testing.T) {
 			t.Fatalf("platform[%d].uri is empty", i)
 		}
 	}
+}
+
+func createKubectlPluginParityFixture(t *testing.T) string {
+	t.Helper()
+
+	namespace := fmt.Sprintf("cub-scout-plugin-%d", time.Now().UnixNano())
+	if out, err := runCmd("kubectl", "create", "namespace", namespace); err != nil {
+		t.Fatalf("create fixture namespace %s: %v\n%s", namespace, err, out)
+	}
+	t.Cleanup(func() {
+		_, _ = runCmd("kubectl", "delete", "namespace", namespace, "--ignore-not-found=true", "--wait=false")
+	})
+
+	if out, err := runCmd("kubectl", "-n", namespace, "create", "deployment", "parity-api", "--image=nginx:1.25", "--replicas=0"); err != nil {
+		t.Fatalf("create fixture deployment in %s: %v\n%s", namespace, err, out)
+	}
+	if out, err := runCmd("kubectl", "-n", namespace, "create", "configmap", "parity-config", "--from-literal=mode=plugin-parity"); err != nil {
+		t.Fatalf("create fixture configmap in %s: %v\n%s", namespace, err, out)
+	}
+
+	return namespace
 }
 
 func extractMapListIdentityKeys(raw string) ([]string, error) {


### PR DESCRIPTION
## Summary

Adds the v2.7 live delivery observability release slice:

- adds a top-of-README user-questions table for delivery, drift, rollout, audit, and API-load-aware workflows
- adds a shared generation-aware rollout decision model and surfaces it in `doctor`, `explain`, `compare three-way`, and `workloads-converged` receipts
- adds first-class aggregate delivery resources for `fluxcd.controlplane.io/v1` resources across controller discovery, ownership, deployer/status, trace lookup, and activity
- parses audited `WebAction` Kubernetes Events into structured action metadata for `map activity`, `trace`, and `explain`
- adds release docs: anonymous mini PRD, delivery-readiness how-to, example fixture, JSON/CLI/ownership contract updates, and draft v2.7.0 release notes

## Validation

- `git diff --check`
- `go test ./...`
- `go build ./cmd/cub-scout`
- YAML fixture validation for `examples/live-delivery-observability/*.yaml`

## Notes

This remains read-only. The observer surfaces delivery, rollout, drift, runtime, and action evidence; it does not own last-mile delivery, application-success policy, or workflow orchestration.