### PR TITLE
docs: polish v2.7 release readiness

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -89,7 +89,21 @@ Do not claim that `cub scout` can do SDK/renderer work locally unless the curren
 
 ## Current High-Signal Shipped Capabilities
 
-Current release: **v2.2.1** (next: **v2.3.0** — release-notes draft at `docs/releases/v2.3.0.md`; everything below was shipped after `v2.2.1`'s tag). As of 2026-05-25, these areas are fully or materially shipped:
+Current release tag: **v2.6.0** (next: **v2.7.0** — release-candidate notes at `docs/releases/v2.7.0.md`; PR #500 merged on 2026-07-09). As of 2026-07-09, these areas are fully or materially shipped:
+
+- **Live delivery observability release slice — merged for v2.7.0** (`#500`)
+  - README now starts with a user-question table covering ownership, delegated delivery health, intended-vs-live agreement, rollout progress, proceed/wait/retry framing, drift, delivery-vs-runtime separation, attribution, low-load repeated review paths, and receipts
+  - Shared generation-aware rollout decision model now surfaces beyond receipts on `doctor`, `explain`, and `compare three-way` as optional `currentChange` / `rollouts` JSON plus ASCII/Markdown renderings
+  - First-class `fluxcd.controlplane.io/v1` aggregate resources: `FluxInstance`, `FluxReport`, `ResourceSet`, `ResourceSetInputProvider`, `ExternalArtifact`, `ArtifactGenerator`
+  - Aggregate resources participate in controller-resource discovery, ownership detection, map deployers/status views, `gitops status`, trace lookup, and activity timelines where the CRDs are installed
+  - Audited action event parsing for Kubernetes Events with reason `WebAction`; `trace`, `explain`, and `map activity` preserve actor, subject, groups, action, and raw annotation evidence without guessing missing fields
+  - New example fixture at `examples/live-delivery-observability/` and operator flow at `docs/howto/delivery-readiness-decision.md`
+  - Safe follow-ups remain tracked in `docs/roadmap.md`: aggregate failures as top-level `doctor` findings, audited actions as history/receipt evidence, broader freshness metadata for snapshot/watch/summary/receipt paths, and deeper controller-family parity omissions
+
+- **Post-v2.3 receipt / comparison / controller evidence — tagged through v2.6.0**
+  - Install/object-set receipts, `workloads-converged`, `prerequisites-met`, `--ttl`, `--no-extras`, external reference evidence, normalization profiles, `receipt digest`, and `receipt chain`
+  - Standalone rendered-state comparison via `compare three-way --dry-from` and set-level `compare object-set --dry-from`
+  - First-class Sveltos and Modelplane support alongside Flux, Argo CD, Helm, Crossplane, kro, ConfigHub-managed, Terraform, and native resources
 
 - **Receipts v1 + v2 — feature complete** (`#446` closed; v1 in `#454`+`#455`+`#456`+`#461`; v2 surface in `#463`+`#469`+`#470` covering `#451`+`#448`+`#449`)
   - Typed, fingerprinted, immutable evidence artifacts wrapping the existing attribution + source-truth + gitSource evidence
@@ -153,33 +167,42 @@ Current release: **v2.2.1** (next: **v2.3.0** — release-notes draft at `docs/r
 
 ## Current Open Queue
 
-Verify live state before acting. As of 2026-05-25 the receipts arc and Pilot consumer arc both closed end-to-end. Remaining open follow-ons:
+Verify live state before acting. As of 2026-07-09, the receipts arc, Pilot consumer arc, controller-evidence arc, and live delivery observability release slice have all merged. Remaining open follow-ons:
 
 ### Recently closed (this session's arc)
 
-- ~~**`#446`**~~ (parent), ~~**`#444`**~~, ~~**`#448`**~~, ~~**`#449`**~~, ~~**`#451`**~~ — all closed; see HANDOVER.md § "May 2026 completions — session 2026-05-25" for the PR-by-PR breakdown
-- Next step: **tag `v2.3.0`** (release notes draft at `docs/releases/v2.3.0.md`)
+- ~~**`#500`**~~ — live delivery observability release slice, merged 2026-07-09; see `docs/releases/v2.7.0.md`
+- Earlier closed arcs: ~~**`#446`**~~ (parent), ~~**`#444`**~~, ~~**`#448`**~~, ~~**`#449`**~~, ~~**`#451`**~~ — see HANDOVER.md § "May 2026 completions — session 2026-05-25" for the PR-by-PR breakdown
+- Next step: **tag `v2.7.0`** after final release-note review
+
+### Live delivery observability follow-ups
+
+- Aggregate delivery failures as `doctor` top-level findings where controller status refs expose source/generated-artifact lineage
+- Audited action events as history and receipt supporting evidence
+- Broader source freshness metadata for snapshot, watch, summary, and receipt-backed reads
+- Controller-family parity rules and fallback omissions for controllers without status, source, event, or generation evidence
 
 ### Untracked v2 follow-ups (no separate issue)
 
 - **MCP `compare_source_truth` strategy-enum drift** — schema enum lists 4 strategies (Phase 1); CLI supports 9 (Phase 2). One-file fix in `cmd/cub-scout/mcp.go`.
-- **Codex round-5 P3** — source-truth receipt precedence tests (`StatusBLOCK + VerdictBLOCKED`, `StatusWATCH + VerdictINCOMPLETE`). Not blocking; nice-to-have.
+- **Source-truth receipt precedence edge coverage** — especially `StatusBLOCK + VerdictBLOCKED`. Not blocking; nice-to-have.
 
 ### Open tracked issues
 
+- **`#481`** — Helm/Kustomize provenance back-resolution for templated-source attribution.
+- **`#475`** — Blog/documentation publication series for introducing cub-scout.
 - **`#432`** — Grafana collector / data-source path using existing cub-scout outputs.
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design).
 - **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up). Scopes #1 (`#414`) and #3 (`#420`) already shipped.
 - **`#421`** — Views project: CEL + JSONPath column evaluators.
-- **`#409` Phase 3** — source-truth multi-source Argo (`spec.sources[]` len > 1). Phases 1 + 2 shipped (9 strategies).
 - **`#392`** — Initiatives compliance overlay; **deferred** until ConfigHub exposes Initiative as a backend primitive. Design doc at `docs/howto/initiatives-integration-when-ready.md`.
 - **`#386`** — `preferInvocationForm` lint extension to non-hint legacy string leaks.
 
-### Attribution-layer next-up (no separate issues yet; tracked in README § What's coming next)
+### Attribution-layer next-up
 
-- Helm / Kustomize back-resolution to populate `gitSource.file:line` for templated sources
+- **`#481`** — Helm / Kustomize back-resolution to populate `gitSource.file:line` for templated sources
 - List-key selectors (e.g., `[name="api"]` for container images) in `compareFieldToPath`
-- Standalone `--source-path` as DRY source for `compare three-way`
+- More standalone `--dry-from` / `--source-path` polish for source anchoring and proposal review flows
 - `import --git-path --output-dir` polish (reviewable proposal output)
 - Hierarchy-aware adoption/import (preserve ApplicationSet / app-of-apps / Flux composition)
 - Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,6 +1,6 @@
 # cub-scout Handover for the Next AI Coder
 
-Last updated: 2026-05-25 — captures the post-#465 arc that finished the `#446` receipts capability end-to-end and closed the `#444` Pilot consumer-side skill catalog. **The receipts arc is now feature-complete** (v1 + v2 chained + v2 aggregate-with-discovery + v2 CI-gate `--fail-on` + v2 real-time emission with full 4-event-type set + per-poll backpressure). **9 Pilot–cub-scout integration scenarios shipped** across two batches. **Three Codex review rounds (5/6/7)** of correctness fixes landed. Six PRs after `#465`: `7d424d1` (#466) → `82ceddc` (#467) → `485d8fb` (#468) → `fef5f3d` (#469) → `7e65a90` (#471) → `7796f85` (#470). `v2.3.0` is the natural next release tag.
+Last updated: 2026-07-09 — captures the post-#500 live delivery observability release slice merged at `ee84f01`. Current release tag is `v2.6.0`; `v2.7.0` is the next release candidate and release notes live at [`docs/releases/v2.7.0.md`](docs/releases/v2.7.0.md). The May 2026 receipts and skill-catalog sections below remain historical context.
 
 ## Current repo state
 
@@ -14,6 +14,21 @@ Last updated: 2026-05-25 — captures the post-#465 arc that finished the `#446`
   - `docs/reference/cli-reference.md` = A-Z command catalog
   - `docs/reference/commands.md` = detailed usage and examples
   - `docs/reference/cli-contract.md` = stable flags, exit codes, and schemas
+
+## July 2026 update — live delivery observability (`#500`)
+
+`#500` is merged and is the release slice after `v2.6.0`. It adds the README user-question table, generation-aware current-change evidence on diagnostic surfaces, aggregate delivery-resource support, audited action events, and the live-delivery how-to/example fixture.
+
+| PR | Subject |
+|----|---------|
+| [#500](https://github.com/confighub/cub-scout/pull/500) | Live delivery observability docs and implementation slice: user-question framing, `currentChange`/`rollouts` evidence on `doctor`/`explain`/`compare three-way`, first-class `fluxcd.controlplane.io/v1` aggregate resources, audited action event parsing, live-delivery fixture, operator how-to, v2.7.0 release notes, and CI hardening follow-ups. |
+
+Design decisions from this slice:
+
+- Diagnostic surfaces share the rollout progress/verdict shape, but receipt-specific desired-set and grace-window gates remain receipt-specific.
+- Aggregate resources are first-class for discovery, ownership, deployer/status views, `gitops status`, direct trace lookup, and activity timelines. Deeper source-to-generated lineage and top-level `doctor` findings remain follow-ups.
+- Action event parsing preserves raw evidence and omits missing fields. It does not infer actor, subject, groups, or action when the Event does not carry the recognized annotations.
+- The low-load repeated-question path points to existing captured, watched, summarized, or receipt evidence. Broader API-load-aware freshness metadata is still future work.
 
 ## May 2026 completions — session 2026-05-25 (receipts v2 closure + Pilot consumer skills)
 
@@ -30,7 +45,7 @@ Six PRs landed on top of the morning `#465` handover refresh, **closing `#444`, 
 
 ### Key design decisions locked in this session
 
-- **Aggregate-receipt subject is order-independent.** `BuildSyntheticAggregateSubject` sorts input digests by sha256 hex before concatenation, so re-running the verify with inputs in a different order produces the same `synthetic-aggregate://sha256/<id>` subject (the subject is set-shaped). Note: `predicate.inputAttestations[]` is emitted in caller order, so the aggregate's full **receipt-level fingerprint** is order-dependent — only the subject digest is set-shaped today. Sorting the wire array before stamping for receipt-level order-independence is a v2.3.1+ correctness improvement; the v2.3.0 surface is the subject-only invariant.
+- **Aggregate-receipt subject is order-independent.** `BuildSyntheticAggregateSubject` sorts input digests by sha256 hex before concatenation, so re-running the verify with inputs in a different order produces the same `synthetic-aggregate://sha256/<id>` subject (the subject is set-shaped). Note: `predicate.inputAttestations[]` is emitted in caller order, so the aggregate's full **receipt-level fingerprint** is order-dependent — only the subject digest is set-shaped today. A future correctness pass may sort the wire array before stamping so the receipt-level fingerprint also becomes set-shaped; the current contract only guarantees order-independence for the subject.
 - **`PredicateAggregateVerdict = "aggregate-verdict"`** is a new predicate distinct from the per-resource predicates. Aggregates don't evaluate evidence; they synthesize verdicts over input receipts. The per-resource `evidence` body is empty on the aggregate; the consumer drills into `inputAttestations[]` for per-resource detail.
 - **Max-severity is the only synthesis policy in v1.** The `AggregateVerdictPolicy` interface + `--aggregate-policy` flag are wired for future policies (majority, weighted); shipping one policy intentionally keeps the review surface narrow.
 - **API-boundary verify enforced on aggregates too.** `BuildAggregateReceipt` rejects zero-value `VerifiedAttestationRef` entries — same Codex round-6 P1 guard as `BuildReceipt`. Programmatic callers cannot forge inputs into the aggregate.
@@ -249,35 +264,41 @@ Key deliverables now in place:
 
 ## Open issues
 
-Current tracked follow-ons (verified 2026-05-25; reflects post-#470/#471 state):
+Current tracked follow-ons (verified 2026-07-09; reflects post-#500 state):
 
-**Receipts arc closed end-to-end:**
+**Recently closed arcs:**
+- ~~**`#500`**~~ — live delivery observability release slice. **Closed via `#500`** on 2026-07-09.
 - ~~**`#446`**~~ — Receipt capability parent. **Closed** (v1 in `#454`/`#455`/`#456`; v2 surface in `#463`/`#469`/`#470`).
 - ~~**`#444`**~~ — Pilot–cub-scout integration skills, 9 scenarios. **Closed via `#468`** (batch B; batch A in `#466`, Codex round-7 fixes in `#467`).
-- ~~**`#448`**~~ — Receipts v2 aggregate / chained receipts. **Closed via `#469`** (aggregate half; chained half shipped in `#463`). Only "GUAC graph-ingestibility verification" remains as an external test (deferred non-goal per the issue).
+- ~~**`#448`**~~ — Receipts v2 aggregate / chained receipts. **Closed via `#469`** (aggregate half; chained half shipped in `#463`).
 - ~~**`#449`**~~ — `watch --emit-receipt-on` event types + backpressure. **Closed via `#470`** (full 4-event-type set + per-poll cap; v1 had shipped in `#463`).
 - ~~**`#451`**~~ — `--fail-on RECEIPT_VERDICT` exit semantics. **Closed via `#463`** (Codex round-6 P2 tightened upfront parsing).
 
+**Live delivery observability follow-ups from `#500`:**
+- Aggregate delivery failures as top-level `doctor` findings where controller status refs expose source/generated-artifact lineage.
+- Audited action events as history and receipt supporting evidence.
+- Broader source-freshness metadata for snapshot, watch, summary, and receipt-backed reads.
+- Controller-family parity rules and structured fallback omissions where controllers lack status, source, event, or generation evidence.
+
 **Untracked v2 follow-ups (no separate issue):**
 - MCP `compare_source_truth` strategy-enum drift — MCP schema lists 4 strategies; CLI supports 9 (Phase 2 from `#418`). One-file fix in `cmd/cub-scout/mcp.go`.
-- Codex round-5 P3 — source-truth receipt precedence tests (`StatusBLOCK + VerdictBLOCKED`, `StatusWATCH + VerdictINCOMPLETE`). Nice-to-have, not blocking.
+- Source-truth receipt precedence edge coverage, especially `StatusBLOCK + VerdictBLOCKED`. Nice-to-have, not blocking.
 
 **Open tracked issues:**
+- **`#481`** — Helm/Kustomize provenance back-resolution for templated-source attribution (`gitSource.file:line` / `sourceMapRef` honesty markers).
+- **`#475`** — Blog/documentation publication series for introducing cub-scout.
 - **`#432`** — Grafana collector / data-source path using existing cub-scout JSON outputs. Design rather than code.
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design needed).
 - **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up).
 - **`#421`** — Views project: CEL + JSONPath column evaluators.
-- **`#391`** — Views integration parent. Scopes #1 (`#414`) and #3 (`#420`) shipped; scope #2 open under `#422`.
-- **`#409`** Phase 3 — source-truth multi-source Argo (`spec.sources[]` len > 1). Phases 1 + 2 shipped (9 strategies via `#393` + `#418`).
-- **`#410 / #428`** — Triad-compliance audit. Major item resolved (cub-scout categorically read-only). Lower-severity follow-ons on `import apply` wording remain; hint-command lint continues in `#386`.
 - **`#392`** — Initiatives compliance overlay. **Deferred** until ConfigHub exposes Initiative as a backend primitive. Design doc at [`docs/howto/initiatives-integration-when-ready.md`](docs/howto/initiatives-integration-when-ready.md).
 - **`#386`** — `preferInvocationForm` lint extension to non-hint legacy invocation-form leaks in strings.
 
-### Attribution-layer next-up (tracked in `README.md` § What's coming next, no separate issues yet)
+### Attribution-layer next-up
 
-- Helm / Kustomize back-resolution to extend stage B's `gitSource.file:line` from raw YAML to templated sources
+- **`#481`** — Helm / Kustomize back-resolution to extend stage B's `gitSource.file:line` from raw YAML to templated sources
 - List-key selectors in `compareFieldToPath` (e.g., `.spec.template.spec.containers[name="api"].image`)
-- Standalone `--source-path` as a DRY source for `compare three-way`
+- More standalone `--dry-from` / `--source-path` polish for source anchoring and proposal review flows
 - `import --git-path --output-dir` polish (disk-PR proposal flow)
 - Hierarchy-aware ingest (ApplicationSet / app-of-apps / Flux Kustomization composition)
 - Additional manager-string writers (Tekton, Argo Workflows, Cluster API, OIDC-based CD)
@@ -289,14 +310,18 @@ Current tracked follow-ons (verified 2026-05-25; reflects post-#470/#471 state):
 
 ## Current checkpoint
 
-Current release tag: **`v2.2.1`** (the next natural release is **`v2.3.0`** — substantial new flags + surfaces between `v2.2.1` and current `main`, all backwards-compatible). The v2.0.0 plugin switchover (`cub scout` as the preferred invocation, MCP gateway as the AI front door) shipped in `v2.0.0` and is now historical — `docs/releases/v2.0.0-plugin-plan.md` is preserved as a historical artifact.
+Current release tag: **`v2.6.0`**. The next release candidate is **`v2.7.0`**; release notes are in [`docs/releases/v2.7.0.md`](docs/releases/v2.7.0.md). The v2.0.0 plugin switchover (`cub scout` as the preferred invocation, MCP gateway as the AI front door) shipped in `v2.0.0` and is now historical — `docs/releases/v2.0.0-plugin-plan.md` is preserved as a historical artifact.
 
-`main` HEAD at handover time: `7796f85` (`feat(#446 v2 / #449): expand --emit-receipt-on + per-poll backpressure cap`, #470). Ten PRs landed in the 2026-05-22 → 2026-05-25 arc: `#462` → `#463` → `#464` → `#465` → `#466` → `#467` → `#468` → `#469` → `#470` → `#471`. Zero open PRs.
+`main` HEAD at handover time: `ee84f01` (`Merge pull request #500 from confighub/codex/feature-docs-live-delivery-observability`). Zero open PRs.
 
-`go test ./...` is green across every package touched by the receipts + skills + docs work. The only failure on a clean local checkout is the pre-existing `test/unit/demo_worker_lifecycle_script_test.go` (TestDemoWorkerLifecycleScript_StartStop + TestDemoWorkerLifecycleScript_CleanupKeepDoesNotStop) — environmental flake reproducible on unmodified `main`; main CI passes after re-run.
+`#500` CI was green before merge. Re-run `go test ./...` on any new release-polish branch before publishing.
 
-Recent shipped capability surface (sessions 2026-05-21 + 2026-05-22 + 2026-05-25):
+Recent shipped capability surface:
 
+- Live delivery observability release slice (`#500`): README user-question table; generation-aware rollout decision evidence on `doctor`, `explain`, and `compare three-way`; aggregate delivery resources; audited action event parsing; live-delivery fixture and how-to.
+- Standalone rendered-object comparison: `compare three-way --dry-from`, `compare object-set --dry-from`, install/object-set receipts, object-set diff receipts, normalization profiles, `--ttl`, `--no-extras`, and external reference evidence.
+- Delivery-done predicates: `object-set-matches`, `workloads-converged`, `prerequisites-met`, `receipt digest`, and `receipt chain`.
+- Controller coverage hardening: Sveltos and Modelplane first-class support alongside Flux, Argo CD, Helm, Crossplane, kro, ConfigHub-managed, Terraform, and native resources.
 - Attribution layer end-to-end (`cause` / `managerHint` / `gitSource` / `bindingSource` per field; stage B file:line back-resolution)
 - Source-truth contract Phase 1 + 2 (9 strategies)
 - Architectural triad locked in code (read-only-triad invariant; enforced at three layers)
@@ -307,18 +332,20 @@ Recent shipped capability surface (sessions 2026-05-21 + 2026-05-22 + 2026-05-25
 
 ## Next milestone
 
-There is **no single "next milestone"** — the receipts + Pilot consumer arcs both closed end-to-end this session. The codebase is in steady-state. Open work, in roughly descending leverage:
+Open work, in roughly descending leverage:
 
-1. **`v2.3.0` release tag.** The natural next step; everything between `v2.2.1` and `main` HEAD is backwards-compatible feature work. Release notes draft at `docs/releases/v2.3.0.md`.
-2. **`#432` Grafana collector / data-source path.** Uses existing cub-scout JSON outputs; design rather than code work.
-3. **Views project tail.** `#422` TUI Hub View column projection (`#391` scope #2 follow-up); `#421` CEL + JSONPath column evaluators. Scopes #1 (`#414`) and #3 (`#420`) already shipped.
-4. **`#427` watch kstatus migration behavior change.** Stalled workloads may flip `Ready=true → false` in v2.1.0+; needs design.
-5. **`#386` `preferInvocationForm` lint extension** to non-hint legacy string leaks.
-6. **`#392` ConfigHub Initiatives.** Deferred until ConfigHub exposes Initiative as a backend primitive — out of cub-scout's control.
+1. **`v2.7.0` release tag.** Release notes draft at `docs/releases/v2.7.0.md`; `#500` is the only post-`v2.6.0` merge currently on `main`.
+2. **`#481` Helm/Kustomize provenance back-resolution.** Extends raw-YAML field attribution to templated sources while preserving honesty markers when exact file:line evidence is unavailable.
+3. **`#432` Grafana collector / data-source path.** Uses existing cub-scout JSON outputs; design rather than code work.
+4. **Views project tail.** `#422` TUI Hub View column projection (`#391` scope #2 follow-up); `#421` CEL + JSONPath column evaluators. Scopes #1 (`#414`) and #3 (`#420`) already shipped.
+5. **`#427` watch kstatus migration behavior change.** Stalled workloads may flip `Ready=true → false` in v2.1.0+; needs design.
+6. **`#386` `preferInvocationForm` lint extension** to non-hint legacy string leaks.
+7. **`#392` ConfigHub Initiatives.** Deferred until ConfigHub exposes Initiative as a backend primitive — out of cub-scout's control.
+8. **`#475` publication docs.** Use the README user-question table and v2.7.0 release notes as the source of truth.
 
 Small untracked follow-ups carried from the receipts arc:
 - **MCP `compare_source_truth` strategy-enum drift** — schema lists 4 strategies; CLI supports 9. One-file fix in `cmd/cub-scout/mcp.go`.
-- **Codex round-5 P3** — source-truth receipt precedence tests. Nice-to-have, not blocking.
+- **Source-truth receipt precedence edge coverage** — especially `StatusBLOCK + VerdictBLOCKED`. Nice-to-have, not blocking.
 
 ### CLI migration table (`#375`)
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,23 @@
 
 cub-scout is an open-source observer for live Kubernetes clusters and GitOps. Point it at your current kube context and it reads what Kubernetes, Argo CD, Flux, Sveltos, Modelplane, Helm, Crossplane, kro, and ConfigHub already know: what is running, who owns it, where it came from, what is unhealthy, and what to check next.
 
-It diagnoses, explains, traces, maps, scans, **compares** intended vs running state, and **attributes** every field back to its source — but it never modifies cluster state and never makes authority calls about what *should* be true. Safe to run against production.
+It diagnoses, explains, traces, maps, scans, **compares** intended vs running state, and adds provenance evidence to supported field mismatches where signals exist — but it never modifies cluster state and never makes authority calls about what *should* be true. Safe to run against production.
 
 Cub-scout helps users answer questions about k8s and GitOps clusters in one place.
 
 | User question | cub-scout surface | What cub-scout provides |
 |---|---|---|
 | What is running, and who owns it? | `doctor`, `map`, `trace`, `explain` | Live inventory, ownership, source chain, recent events, and next read-only checks across supported controllers and platforms. |
-| Is delegated delivery healthy? | `gitops status` | Controller-reported backend, transport, source/build/apply/sync stages, reason/message, and explicit evidence gaps when status is incomplete. |
+| Is delegated delivery healthy? | `gitops status`, `map deployers`, `map activity`, `trace` | Controller-reported backend, transport, source/build/apply/sync stages, first-class aggregate delivery resources, reason/message, and explicit evidence gaps when status is incomplete. |
 | Has intended configuration reached the cluster? | `compare three-way` | DRY/WET/LIVE agreement for a resource, namespace, cluster, or governed view, with states like `agreed`, `converging`, `diverged`, and `partial`. |
-| Is this rollout still progressing, complete, or stuck? | `receipt verify --predicate workloads-converged`, `doctor`, `explain` | Generation-aware workload evidence: desired vs observed generation, kstatus, progress clock, pod failure signals, and `PASS` / `WATCH` / `BLOCK` / `INCONCLUSIVE` verdicts. |
+| Did this rendered install set land as a set? | `compare object-set`, `receipt verify --file` | Set-level desired-vs-live evidence from rendered YAML: authored-field deltas, optional added/removed object closure, object-set receipts, normalization profiles, freshness TTL, and CI-gate verdicts. |
+| Is this rollout still progressing, complete, or stuck? | `receipt verify --predicate workloads-converged`, `doctor`, `explain`, `compare three-way` | Generation-aware workload evidence: `metadata.generation`, `status.observedGeneration`, kstatus, progress clock, pod failure signals, and `PASS` / `WATCH` / `BLOCK` / `INCONCLUSIVE` verdicts. |
 | Can I move to the next task, wait, or retry delivery? | `receipt verify`, `compare three-way`, `doctor` | A read-only decision frame that separates "not applied yet", "still converging", "runtime failure", and "missing evidence". |
 | Is live state drifting from desired state? | `compare drift`, `compare three-way`, `compare source-truth` | Field-level differences, strategy-relative source-truth evidence, conformance exit codes, and explicit proof gaps when evidence is missing. |
-| Is this a delivery problem or an application/runtime problem? | `doctor`, `explain`, `patterns`, `scan` | kstatus health, Kubernetes events, workload symptoms, known-pattern matches, and phase-aware hints so operators can separate sync/convergence issues from runtime failures. |
+| Is this a delivery problem or an application/runtime problem? | `doctor`, `explain`, `gitops status`, `map activity`, `trace`, `patterns`, `scan` | kstatus health, Kubernetes events, audited action metadata when present, workload symptoms, known-pattern matches, and phase-aware hints so operators can separate sync/convergence issues from runtime failures. |
+| What triggered this reconcile, check, or action? | `map activity`, `trace`, `explain` | Audited Kubernetes action event metadata when present: action, actor, subject, groups, timestamp, and preserved raw annotation evidence. |
 | Who changed this field, and where did the value come from? | `compare`, `explain`, attribution JSON | `cause`, `managerHint`, `gitSource`, `bindingSource`, audit/event evidence where available, and optional file:line back-resolution from live `managedFields`, controller metadata, local source files, and governed links. |
-| Can I answer broad or repeated questions without hammering live APIs? | `snapshot`, `watch`, `summary`, receipts | Captured state, low-cardinality watch events, connected summaries, freshness metadata, and immutable receipts for repeated review, fleet triage, and audit paths. |
+| Can I answer broad or repeated questions without hammering live APIs? | `snapshot`, `watch`, `summary`, receipts | Existing captured state, low-cardinality watch events, connected summaries, observed timestamps/fingerprints where present, and immutable receipts for repeated review, fleet triage, and audit paths. |
 | Can I keep auditable evidence of the check? | `receipt verify`, `receipt validate`, `watch --emit-receipt-on` | Typed, fingerprinted, immutable evidence receipts for gates, incident closeout, audits, chained checks, and real-time watch events. |
 
 The main path starts from a **live cluster**. It works **standalone** with your current kube context, or **connected** to [ConfigHub](https://confighub.com) for governed comparison, history, import, fleet queries, and AI-friendly read-only workflows. Local repo and manifest inputs are available later for adoption, import-preview, and source-file enrichment, but they are not the first mental model.
@@ -78,10 +80,11 @@ Each command's **Inputs** column tells you exactly what it needs — cluster onl
 |---|---|---|
 | `compare` (resource mode) | Single-resource DRY/WET/LIVE picture when connected; LIVE-only when standalone | cluster (+ConfigHub for DRY/WET) |
 | `compare drift` | Desired (file) vs live drift detection | cluster + file |
-| `compare three-way` | Scope-wide DRY/WET/LIVE with agreement summary and conformance verdict | cluster + ConfigHub |
-| `compare source-truth` | Strategy-relative `PASS` / `WATCH` / `ASK` / `BLOCK` evidence Pilot consumes (#393) | cluster + ConfigHub |
+| `compare three-way` | Scope-wide DRY/WET/LIVE with agreement summary and conformance verdict; `--dry-from` supports standalone rendered YAML as DRY | cluster + ConfigHub or rendered YAML |
+| `compare object-set` | Set-level desired-vs-live ObjectSetDiffReceipt from rendered YAML, with optional closed-world added/removed object diff | cluster + rendered YAML |
+| `compare source-truth` | Strategy-relative `PASS` / `WATCH` / `ASK` / `BLOCK` evidence for downstream acceptance tools (#393) | cluster + ConfigHub |
 
-Today, `compare three-way` and `compare source-truth` require ConfigHub. A standalone "git as DRY" mode is in the [next-up](#whats-coming-next) list.
+`compare source-truth` still requires connected source-truth evidence. `compare three-way --dry-from` and `compare object-set --dry-from` support standalone rendered YAML as desired-state input.
 
 ### Verify — typed, fingerprinted, immutable evidence artifacts
 
@@ -306,11 +309,10 @@ For Claude, Codex, and other AI agents:
 
 Honest gaps in the current capability map, with the leverage on filling them:
 
-- **Standalone `compare three-way --git-path` / `--source-path` as DRY source** — would let raw-YAML repos run the same three-way view without ConfigHub. Stage B back-resolution (#440) already lays the parsing groundwork.
-- **`compare source-truth` Phase 3 (multi-source Argo)** — [#409](https://github.com/confighub/cub-scout/issues/409) Phase 1 (4 strategies) and Phase 2 (5 more strategies: `helm-flux`, `helm-argo`, `kustomize-flux`, `oci-flux`, `oci-argo`) already shipped (9 strategies total). Phase 3 — multi-source Argo `spec.sources[]` len > 1 — is the remaining open scope.
+- **Helm / Kustomize provenance back-resolution** — [#481](https://github.com/confighub/cub-scout/issues/481) extends raw-YAML field attribution from stage B (#440) to templated sources while preserving honesty markers when exact file:line evidence is unavailable.
+- **Live delivery observability follow-ups** — aggregate delivery failures as top-level `doctor` findings, audited action events as history/receipt evidence, broader freshness metadata for snapshot/watch/summary/receipt paths, and parity omissions for controllers without status/source/event/generation evidence.
 - **`import --git-path --output-dir`** — emit proposed unit YAMLs to disk for PR review, then upload via Installer's `--merge-external-source` once connected. One bundle, two workflows.
 - **Hierarchy-aware adoption/import** — preserve ApplicationSet / app-of-apps / Flux Kustomization composition in import proposals so imported ConfigHub state is navigable, not flat.
-- **Helm / Kustomize back-resolution** — extends stage B (#440) from raw YAML to templated sources for per-field `file:line` provenance.
 - **Additional manager-string writers** — Tekton, Argo Workflows, Cluster API, OIDC-based CD systems — gated on whether the variant-management story demands them.
 
 ---
@@ -326,7 +328,7 @@ Honest gaps in the current capability map, with the leverage on filling them:
 | JSON fields and output model | [docs/reference/json-contracts.md](docs/reference/json-contracts.md) |
 | Getting started checklist | [docs/getting-started/checklist.md](docs/getting-started/checklist.md) |
 | Import and migration path | [docs/howto/import-to-confighub.md](docs/howto/import-to-confighub.md) |
-| Delivery readiness decision | [docs/howto/delivery-readiness-decision.md](docs/howto/delivery-readiness-decision.md) |
+| Delivery readiness decision and live-delivery fixture | [docs/howto/delivery-readiness-decision.md](docs/howto/delivery-readiness-decision.md) + [examples/live-delivery-observability/](examples/live-delivery-observability/) |
 | AI tool integration | [docs/howto/using-cub-scout-from-ai-tool.md](docs/howto/using-cub-scout-from-ai-tool.md) |
 | Examples and demos | [examples/README.md](examples/README.md) |
 | Receipts (typed evidence artifacts) | [examples/receipts/README.md](examples/receipts/README.md) + [docs/reference/json-contracts.md § Receipt Contract](docs/reference/json-contracts.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,10 +32,10 @@
 | What | Command | Guide |
 |------|---------|-------|
 | GitOps pipeline health | `cub-scout gitops status` | [reference/commands.md#gitops-v014](reference/commands.md#gitops-v014) |
-| Delivery readiness decision | `cub-scout doctor`, `cub-scout explain`, `cub-scout receipt verify` | [howto/delivery-readiness-decision.md](howto/delivery-readiness-decision.md) |
+| Delivery readiness decision | `cub-scout doctor`, `cub-scout explain`, `cub-scout compare object-set`, `cub-scout receipt verify` | [howto/delivery-readiness-decision.md](howto/delivery-readiness-decision.md) |
 | Scan for risks | `cub-scout scan --state` | [howto/scan-for-risks.md](howto/scan-for-risks.md) |
 | Scan a manifest file | `cub-scout scan --file FILE` | [howto/scan-for-risks.md](howto/scan-for-risks.md) |
-| Drift detection | `cub-scout drift deploy/NAME -n NS` | [howto/drift.md](howto/drift.md) |
+| Drift detection | `cub-scout compare drift deploy/NAME -n NS` | [howto/drift.md](howto/drift.md) |
 
 ### Analyze
 
@@ -43,7 +43,7 @@
 |------|---------|-------|
 | Tree hierarchies | `cub-scout tree ownership` | [howto/tree-hierarchies.md](howto/tree-hierarchies.md) |
 | Git repo patterns | `cub-scout patterns detect --git-root PATH` | [reference/commands.md#patterns-v07](reference/commands.md#patterns-v07) |
-| Git + cluster alignment | `cub-scout combined --git-path PATH` | [combined-git-live example](../examples/combined-git-live/) |
+| Git + cluster alignment | `cub-scout compare --git-path PATH` | [combined-git-live example](../examples/combined-git-live/) |
 | Export resource graph | `cub-scout graph export` | [reference/commands.md#graph-v06](reference/commands.md#graph-v06) |
 | Debug bundles | `cub-scout bundle inspect FILE` | [howto/debug-bundle.md](howto/debug-bundle.md) |
 

--- a/docs/howto/delivery-readiness-decision.md
+++ b/docs/howto/delivery-readiness-decision.md
@@ -52,7 +52,8 @@ For an auditable gate over a rendered object set:
 | `currentChange.verdict=WATCH` with `reason=stale_generation` | The API has not yet observed the desired generation. | Wait and re-check; do not call it done. |
 | `currentChange.verdict=WATCH` with `reason=rollout_progressing` | Current generation is observed and still progressing. | Wait, or extend the grace window if your rollout is expected to be slow. |
 | `currentChange.verdict=BLOCK` with `reason=runtime_failed` | Runtime evidence, such as pod/container failure, is present. | Investigate application/runtime symptoms before retrying delivery. |
-| `currentChange.verdict=BLOCK` with drift or source-truth mismatch | Live state or controller evidence disagrees with intent. | Investigate drift/source mismatch before proceeding. |
+| `currentChange.verdict=BLOCK` with `reason=runtime_failed`, `rollout_failed`, or `progress_stalled` | Runtime or rollout evidence is blocking the current-generation change. | Investigate workload/controller symptoms before retrying delivery. |
+| `compare three-way` divergence or `compare source-truth` mismatch | Live state, rendered state, or controller source evidence disagrees with intent. | Investigate drift/source mismatch before proceeding. |
 | `INCONCLUSIVE` or omitted `currentChange` | cub-scout could not collect enough evidence for this resource or kind. | Treat as a proof gap; inspect raw cluster/controller evidence. |
 
 ## What Cub-Scout Checks
@@ -113,4 +114,3 @@ for a review fixture that includes:
 - audited action event metadata
 - stale-generation rollout evidence
 - runtime pod failure evidence
-

--- a/docs/proposals/next-release-live-delivery-observability.md
+++ b/docs/proposals/next-release-live-delivery-observability.md
@@ -1,6 +1,7 @@
 # Next-Release Mini PRD: Live Delivery Observability
 
-Status: draft
+Status: partially shipped in v2.7.0; remaining follow-ups are tracked in
+`docs/roadmap.md`
 
 Audience: maintainers and reviewers
 
@@ -34,9 +35,14 @@ clear proof gaps when evidence is missing.
 - No hidden inference. If a controller does not expose status, lineage, source,
   artifact, event, or generation evidence, the result must say so.
 
-## A. Next-Release Updates
+## A. v2.7.0 Slice And Remaining Follow-Ups
 
 ### A1. First-Class Aggregate Delivery Resources
+
+v2.7.0 status: partial. First-class resource discovery, ownership,
+deployer/status, direct trace lookup, `gitops status`, and activity support
+shipped. Deeper source/generated-artifact lineage and aggregate delivery
+failures as top-level `doctor` findings remain follow-ups.
 
 Add first-class observation for aggregate-report, app-bundle, input-provider,
 external-artifact, and generated-artifact resource families.
@@ -75,6 +81,10 @@ Acceptance criteria:
 
 ### A2. Audited User-Action Event Ingestion
 
+v2.7.0 status: partial. `map activity`, `trace`, and `explain` event summaries
+ship action metadata when Kubernetes Events expose it. History and receipt
+supporting evidence remain follow-ups.
+
 Parse audited action events emitted by controller web consoles or automation
 frontends when they are available as standard cluster events.
 
@@ -104,6 +114,9 @@ Acceptance criteria:
 - Tests cover present, partial, malformed, and unrelated event shapes.
 
 ### A3. Promote Rollout Progress and Verdicts
+
+v2.7.0 status: shipped for `doctor`, `explain`, `compare three-way`, and
+`receipt verify --predicate workloads-converged`.
 
 Move generation-aware rollout evidence from receipt-only workflows into primary
 diagnostic UX.
@@ -139,6 +152,10 @@ Acceptance criteria:
 
 ### A4. API-Load-Aware Inventory And Search
 
+v2.7.0 status: follow-up. The README now points users at existing snapshot,
+watch, summary, and receipt surfaces for repeated review; broader source
+freshness metadata and low-load search plumbing remain open.
+
 Make repeated and fleet-shaped observation cheap by preferring captured,
 summarized, or watched evidence when a fresh wide cluster crawl is not required.
 
@@ -172,6 +189,9 @@ Acceptance criteria:
 - No mandatory persistent database is added to standalone mode.
 
 ## B. Controller-Family Parity
+
+v2.7.0 status: follow-up for parity audit and structured fallback omissions
+beyond the controller/resource support already shipped.
 
 Parity means the observer can answer the same user questions for a controller
 family using deterministic evidence. It does not mean every controller exposes
@@ -209,7 +229,8 @@ Next-release parity rule:
 
 ### C1. Improve The Observer
 
-The next release should treat "done" as two separate outputs:
+Remaining work should preserve the release decision model that treats "done" as
+two separate outputs:
 
 - Progress: where the current change appears to be in the delivery/runtime
   path.
@@ -245,7 +266,7 @@ Implementation recommendations:
 ### C2. Improve The User-Questions Table
 
 The README table should stay near the top and remain framed around user
-questions, not controller internals. The next-release table should cover:
+questions, not controller internals. The README table should cover:
 
 - What is running, and who owns it?
 - Is delegated delivery healthy?
@@ -261,8 +282,8 @@ Acceptance criteria:
 
 - The table avoids claims that the observer owns deployment or application
   success.
-- Each row maps to an existing command, a next-release command enhancement, or
-  an explicit evidence gap.
+- Each row maps to an existing command, a shipped v2.7.0 enhancement, a
+  follow-up enhancement, or an explicit evidence gap.
 - The table uses "user question" language, not private stakeholder language.
 
 ## Definition Of Done

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -68,7 +68,8 @@ Alphabetical command index: [cli-reference.md](cli-reference.md)
 | `cub-scout connect` | Configure kube context from server URL or kubeconfig import | v1.0 |
 | `cub-scout status` | Show connection status and cluster info | v1.0 |
 | `cub-scout history` | Connected change timeline from ConfigHub ChangeSets | v1.4 |
-| `cub-scout compare three-way` | Connected DRY/WET/LIVE comparison with conformance and agreement summary | v1.6 |
+| `cub-scout compare three-way` | Connected DRY/WET/LIVE comparison with conformance and agreement summary; standalone DRY via `--dry-from` | v1.6 |
+| `cub-scout compare object-set` | Rendered object-set diff receipt against live state | v2.6 |
 | `cub-scout mcp serve` | Serve read-only MCP observation tools over stdio | v1.4 |
 
 ---
@@ -133,10 +134,14 @@ cub-scout explain <kind> <name> [flags]
 
 ## cub-scout compare three-way
 
-Connected DRY/WET/LIVE comparison for a resource, namespace, or cluster scope.
+Connected DRY/WET/LIVE comparison for a resource, namespace, cluster, or View
+scope.
+With `--dry-from`, compares rendered YAML directly against LIVE without
+connected mode.
 
 ```bash
 cub-scout compare three-way --scope <scope> [flags]
+cub-scout compare three-way --scope <scope> --dry-from <rendered.yaml|dir> [flags]
 ```
 
 ### Flags
@@ -144,7 +149,10 @@ cub-scout compare three-way --scope <scope> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--scope` | string | required | `<kind/name>`, `resource:<kind/name>`, `namespace/<ns>`, or `cluster` |
+| `--view` | string | - | View UUID or View Explorer URL; mutually exclusive with `--scope` and requires connected mode |
 | `-n, --namespace` | string | - | Namespace override for resource scope |
+| `--dry-from` | string | - | Standalone rendered YAML file or directory to use as DRY instead of ConfigHub |
+| `--source-path` | string | - | Optional local checkout for raw-YAML file:line enrichment |
 | `--format` | string | ascii | Output format: `ascii`, `json`, `md` |
 | `--json` | bool | false | Shorthand for `--format json` |
 | `--fail-on` | string | - | Exit non-zero when max severity meets `info` or `warning` |
@@ -159,7 +167,46 @@ cub-scout compare three-way --scope <scope> [flags]
 - `confighubRevisionsUrl` may be present when the exact unit revisions tab is known for the scope.
 - `nextSteps[]` may be present with deterministic read-only follow-up guidance for trust review or convergence re-checks.
 - `resources[].currentChange` may be present for workload resources when live rollout evidence can be read. It uses the same progress/verdict shape as `explain.currentChange`.
+- In `--dry-from` mode, connected ConfigHub evidence may be absent; the rendered path is the DRY source.
 - Exit behavior depends only on JSON facts plus `--fail-on`, not ASCII/Markdown formatting.
+
+---
+
+## cub-scout compare object-set
+
+Standalone rendered object-set comparison. Emits one ObjectSetDiffReceipt
+(`predicate: object-set-diff`) over a rendered desired set and live cluster
+state.
+
+```bash
+cub-scout compare object-set --dry-from <rendered.yaml|dir> [flags]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dry-from` | string | required | Rendered desired object set: YAML file or directory |
+| `-n, --namespace` | string | - | Default namespace for namespaced objects without `metadata.namespace` |
+| `--scope` | string | - | `namespace/<ns>` or `cluster` |
+| `--diff` | bool | false | Also compute added/removed object closure |
+| `--normalization-profile` | string | - | Apply a named server-normalization profile symmetrically before comparison and digesting |
+| `--ttl` | string | - | Record freshness boundary as `freshness{observedAt,expiresAt,ttl}` |
+| `--fail-on` | string | - | Exit 2 when receipt verdict matches `WATCH`, `BLOCK`, `INCONCLUSIVE`, or `any-non-pass` |
+| `--out` | string | - | Write the receipt to a file path |
+| `--save` | bool | false | Save the receipt to the local receipt store |
+| `--format` | string | json | Output format: `json`, `ascii` |
+
+### Stable Output Rules
+
+- JSON is the canonical contract.
+- The receipt predicate is `object-set-diff`.
+- Verdicts are `PASS`, `WATCH`, and `BLOCK`.
+- `PASS` means no authored-field, added-object, or removed-object deltas were found.
+- `WATCH` means only closure deltas were found when `--diff` is enabled.
+- `BLOCK` means at least one shared object has authored-field deltas.
+- Without `--diff`, added/removed object closure is not computed and the receipt records an omission.
+- The command reads the cluster and the rendered YAML source only; it never mutates and never asks a reconciler to apply or sync.
 
 ---
 
@@ -1074,7 +1121,7 @@ cub-scout history <resource> [flags]
 
 ---
 
-## cub-scout receipt (v2.2)
+## cub-scout receipt
 
 Typed, fingerprinted, immutable evidence artifacts (#446). Wire format is the in-toto Statement v1 envelope wrapping `https://cub-scout.dev/receipt/v1`. SHA-256 fingerprint over RFC 8785 canonical JSON of the full Statement minus only `predicate.fingerprint`.
 
@@ -1090,6 +1137,8 @@ cub-scout receipt <verb> [args] [flags]
 | `show` | Render a saved receipt (ASCII / JSON); does NOT verify the fingerprint |
 | `validate` | Recompute and compare the receipt's fingerprint |
 | `list` | Walk the local store |
+| `digest` | Compute the canonical rendered-object-set digest for a manifest set |
+| `chain` | Walk and verify a receipt's attestation chain |
 
 ### cub-scout receipt verify
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -43,12 +43,13 @@ For the **exhaustive stable surface** (all contracted commands, flags, exit code
 | `import parse-repo` | Parse GitOps repository structure for import preview | v1.0 |
 | `compare` (alias: `combined`) | Compare Git and cluster/bundle structures, or show LIVE snapshot for one resource | v1.0 |
 | `compare three-way` | Connected intent/render/observed comparison for resource/namespace/cluster/view scopes | v1.6 |
+| `compare object-set` | Rendered object-set diff receipt against live state | v2.6 |
 | `context-pack` | Export deterministic AI context JSON bundle | v1.8 |
 | `debug` | Guided GitOps debugging wizard | v0.14.2 |
 | `discover` | Scout-style workload discovery | v0.5 |
 | `health` | Scout-style health check | v0.5 |
 | `app` | Manage ConfigHub Apps | v1.0 |
-| `remedy` | Execute remediation for auto-fixable risk findings | v0.20 |
+| `suggest-remedy` | Describe read-only remediation guidance for auto-fixable risk findings | v0.20 |
 | `snapshot` | Export cluster state as GSF JSON | v0.20 |
 | `status` | Show connection status and cluster info | v1.0 |
 | `history` | Show connected change history from ConfigHub ChangeSets | v1.4 |
@@ -1222,13 +1223,17 @@ Resource compare mode behavior:
 
 ### compare three-way
 
-Connected three-way comparison command for selected scopes. For workload
+Connected or standalone three-way comparison command for selected scopes. In
+connected mode, cub-scout compares ConfigHub DRY/WET state against LIVE. With
+`--dry-from`, cub-scout uses a rendered YAML file or directory as DRY and
+compares it directly against LIVE without requiring connected mode. For workload
 resources, output may include generation-scoped current-change rollout evidence
 when live status can be read.
 
 ```bash
 cub-scout compare three-way --scope <scope> [flags]
 cub-scout compare three-way --view <uuid-or-url> [flags]
+cub-scout compare three-way --scope <scope> --dry-from <rendered.yaml|dir> [flags]
 ```
 
 Scoping options (mutually exclusive):
@@ -1243,9 +1248,15 @@ ConfigHub units match a saved View's filter. Accepts a bare UUID or a View
 Explorer URL (paste from the browser address bar). Requires connected mode.
 `report.scope` is set to `view/<uuid>` in JSON output.
 
+**`--dry-from <path>`** — standalone DRY source. The path must contain rendered
+Kubernetes YAML; cub-scout does not run Helm, Kustomize, or a ConfigHub renderer
+for this flag.
+
 Flags:
 - `--scope` / `--view` (one required; mutually exclusive)
 - `-n, --namespace` (resource scope namespace override)
+- `--dry-from <file|dir>` (standalone rendered YAML as DRY)
+- `--source-path <local-checkout>` (optional raw-YAML file:line enrichment)
 - `--format ascii|json|md`
 - `--json` (shorthand for `--format json`)
 - `--fail-on info|warning`
@@ -1258,6 +1269,9 @@ cub-scout compare three-way --scope deploy/payment-api -n prod
 
 # Namespace scope
 cub-scout compare three-way --scope namespace/prod --format json
+
+# Standalone rendered YAML as DRY
+cub-scout compare three-way --scope namespace/prod --dry-from out/manifests --format json
 
 # Cluster scope
 cub-scout compare three-way --scope cluster --format md
@@ -1275,7 +1289,63 @@ Output notes:
 - JSON includes `summary.agreement.{state,summary,reasons,sources}`
 - agreement states are `agreed`, `converging`, `diverged`, and `partial`
 - conformance exit codes still depend only on JSON facts + `--fail-on`
+- `--dry-from` mode omits connected ConfigHub evidence and reports the rendered YAML path as the DRY source
 - `--view` resolution chain: `cub view get` → extract `Filter.Where` → `cub unit list --where` → label-match cluster workloads
+
+---
+
+### compare object-set
+
+Standalone set-level comparison between a rendered desired object set and live
+cluster state. It emits one ObjectSetDiffReceipt (`predicate:
+object-set-diff`) for the set instead of one report per resource.
+
+```bash
+cub-scout compare object-set --dry-from <rendered.yaml|dir> [flags]
+```
+
+Flags:
+- `--dry-from <file|dir>` (required rendered desired object set)
+- `-n, --namespace` (default namespace for namespaced objects without `metadata.namespace`)
+- `--scope namespace/<ns>|cluster`
+- `--diff` (closed-world added/removed object diff)
+- `--normalization-profile <name>`
+- `--ttl <duration>` (records receipt freshness boundary)
+- `--fail-on WATCH|BLOCK|INCONCLUSIVE|any-non-pass`
+- `--out <path>`
+- `--save`
+- `--format json|ascii`
+
+Examples:
+
+```bash
+# Authored-field deltas for a rendered set
+cub-scout compare object-set --dry-from out/manifests -n prod --format json
+
+# Include added/removed object closure
+cub-scout compare object-set --dry-from out/manifests --scope namespace/prod --diff
+
+# CI gate on any non-PASS set verdict
+cub-scout compare object-set \
+  --dry-from out/manifests \
+  --scope namespace/prod \
+  --fail-on any-non-pass \
+  --out object-set-diff.receipt.json
+```
+
+Verdicts:
+- `PASS` — no authored-field, added-object, or removed-object deltas.
+- `WATCH` — only closure deltas when `--diff` is enabled.
+- `BLOCK` — one or more shared objects have authored-field deltas.
+
+Output notes:
+- The command reads the cluster and rendered YAML only; it never calls a
+  reconciler and never mutates.
+- `--diff` is required to compute added/removed object closure. Without it,
+  the receipt records an omission explaining that closure deltas were not
+  computed.
+- `--normalization-profile` applies supported Kubernetes server-default
+  normalization symmetrically before comparison and digesting.
 
 ---
 
@@ -2663,6 +2733,8 @@ See also:
 
 - Contract: [`json-contracts.md`](json-contracts.md) § Receipt Contract
 - Example: [`examples/receipts/`](../../examples/receipts/)
+- Delivery readiness: [`docs/howto/delivery-readiness-decision.md`](../howto/delivery-readiness-decision.md)
+- Live-delivery fixture: [`examples/live-delivery-observability/`](../../examples/live-delivery-observability/)
 - Locked design: [`docs/proposals/receipts-way-forward.md`](../proposals/receipts-way-forward.md)
 
 ---

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -44,6 +44,9 @@ When fields cross surface boundaries, mapping is explicit (e.g., metadata `creat
 | General CLI JSON behavior | [cli-contract.md](cli-contract.md) + [commands.md](commands.md) | Command-specific |
 | GitOps checkpoint proposal schemas | [gitops-checkpoint-schemas.md](gitops-checkpoint-schemas.md) | `change-intent.v1`, `execution-report.v1`, `change-interaction-card.v1`, `decision-receipt.v1`, `execution-receipt.v1`, `outcome-receipt.v1` |
 | Trace secret evidence | This doc (below) | Embedded in `trace` JSON |
+| Current-change rollout evidence | This doc (below) | Embedded in `doctor`, `explain`, and `compare three-way` JSON |
+| Install receipt predicates | This doc (below) | Embedded in `receipt verify` JSON |
+| Audited action event metadata | This doc (below) | Embedded in `trace`, `explain`, and `map activity` JSON |
 | Trace/explain recent events | This doc (below) | Embedded in `trace` and `explain` JSON (v1.10+) |
 | Compare three-way agreement summary | This doc (below) | Embedded in `compare three-way` JSON |
 | MCP standalone tools | CLI JSON contract of the wrapped command | Embedded in MCP `content[0].text` |
@@ -758,7 +761,7 @@ The wire format is the **in-toto Statement v1 envelope** (`_type =
     "version": "v1",
     "claim": "applied matches spec at apps/prod/api",
     "scope": { "kind": "Deployment", "name": "api", "namespace": "prod" },
-    "verifier": { "tool": "cub-scout", "version": "v2.3.0" },
+    "verifier": { "tool": "cub-scout", "version": "vX.Y.Z" },
     "verifiedAt": "2026-05-21T10:30:00Z",
     "predicateName": "applied-matches-spec",
     "spec": {
@@ -792,8 +795,8 @@ The wire format is the **in-toto Statement v1 envelope** (`_type =
 |--------|--------------|-------------|
 | `k8s-live://<apiVersion>/<kind>/<namespace>/<name>` | Always | SHA-256 over canonical JSON of the live object with dynamic fields pruned (`status`, `metadata.managedFields`, `metadata.resourceVersion`, `metadata.generation`, `metadata.uid`, `metadata.creationTimestamp`) |
 | `confighub-unit://<slug>@rev=<n>` | Connected mode + ConfigHub-linked resource | SHA-256 over the unit canonical body returned by ConfigHub |
-| `rendered-object-set://sha256/<id>` | `object-set-matches` receipts | SHA-256 over the canonical desired rendered object set after dynamic fields are pruned |
-| `k8s-live-object-set://namespace/<ns>` or `k8s-live-object-set://cluster` | `object-set-matches` receipts | SHA-256 over the canonical live projection for the desired object identities |
+| `rendered-object-set://sha256/<id>` | `object-set-matches` and `object-set-diff` receipts | SHA-256 over the canonical desired rendered object set after dynamic fields are pruned |
+| `k8s-live-object-set://namespace/<ns>` or `k8s-live-object-set://cluster` | `object-set-matches` and `object-set-diff` receipts | SHA-256 over the canonical live projection for the desired object identities |
 
 Standalone-mode single-resource receipts emit only the `k8s-live://`
 subject and record an `OmissionConfigHubUnitSubject` entry in
@@ -818,6 +821,7 @@ the rendered/live object-set subject pair instead.
 | `source-truth-pass` | `--strategy` (one of nine) + connected-mode ConfigHub auth | `--strategy` empty → INCONCLUSIVE + `OmissionStrategyMissing`. No source-truth evidence body → INCONCLUSIVE + `OmissionSourceTruthEvidence`. Strategy mismatch between caller and evidence → BLOCK + `OmissionStrategyMismatch`. Otherwise: Status PASS → PASS, WATCH → WATCH, BLOCK → BLOCK, **ASK → WATCH** (per the locked synthesis; receipt-level INCONCLUSIVE is reserved for receipts that themselves can't be built — not for cases where the underlying source-truth derivation just couldn't classify). Source-truth `proof_gaps[]` are mirrored into `omissions[]` under `source-truth-complete` regardless of verdict. |
 | `no-manual-edits-since` | `--since <RFC3339>` cutoff | `--since` zero → INCONCLUSIVE + `OmissionSinceMissing`. Live nil or no managedFields → INCONCLUSIVE + `OmissionManagedFields`. Any interactive (`kubectl-*`) manager with `Time > since` → BLOCK. Any interactive manager with nil `Time` → INCONCLUSIVE + `OmissionManagedFieldsTime`. Otherwise → PASS. |
 | `object-set-matches` | `--file <manifest.yaml\|dir>` + live cluster access | PASS when every desired object identity is present live and every authored field still matches. BLOCK when any desired object is missing or any authored field differs. INCONCLUSIVE when an API mapping or live read could not be checked. Kubernetes server-added map fields and `status` are outside the claim. |
+| `object-set-diff` | `compare object-set --dry-from <manifest.yaml\|dir>` + live cluster access | PASS when no authored-field, added-object, or removed-object deltas are present. WATCH when only closure deltas are present. BLOCK when any shared object has authored-field deltas. INCONCLUSIVE is reserved for load/build errors before receipt construction. |
 | `workloads-converged` | `--file <manifest.yaml\|dir>` + live cluster access | PASS when every desired workload is present and kstatus reports it current. WATCH when any workload is still progressing, including stale generation status (`status.observedGeneration < metadata.generation`). BLOCK when a workload is missing, has terminal pod/container failure evidence, or has made no current-generation progress beyond `--grace-window`. INCONCLUSIVE when an API mapping or live read could not be checked. |
 | `prerequisites-met` | `--prerequisites <yaml\|json>` + live cluster access | PASS when every declared fact is present. BLOCK when any declared fact is missing. INCONCLUSIVE when any fact could not be checked. |
 
@@ -868,6 +872,58 @@ length changes are considered material. This catches missing objects,
 changed images, changed replicas, changed RBAC rules, changed Service
 ports, injected list items, and similar install drift without failing on
 normal Kubernetes defaulting.
+
+#### `object-set-diff` evidence
+
+`object-set-diff` records its details under
+`predicate.evidence.objectSetDiff`:
+
+```json
+{
+  "desiredSource": {
+    "type": "directory",
+    "ref": "out/manifests",
+    "digest": "sha256-of-input-files",
+    "objectCount": 14
+  },
+  "scope": {"kind": "namespace", "namespace": "redis"},
+  "desiredDigest": "sha256-of-normalized-rendered-set",
+  "liveDigest": "sha256-of-live-projection",
+  "changedObjects": [
+    {
+      "id": {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "namespace": "redis",
+        "name": "redis-master"
+      },
+      "desiredDigest": "sha256...",
+      "liveDigest": "sha256...",
+      "differences": [
+        {
+          "field": ".spec.template.spec.containers[0].image",
+          "desired": "redis:7.2.4",
+          "live": "redis:7.2.3",
+          "cause": "controller-drift",
+          "managerHint": "helm-controller"
+        }
+      ]
+    }
+  ],
+  "addedObjects": [],
+  "removedObjects": [],
+  "summary": {"total": 14, "changed": 1, "added": 0, "removed": 0},
+  "normalizationProfile": "k8s-zero-defaults/v1"
+}
+```
+
+`changedObjects[]`, `addedObjects[]`, and `removedObjects[]` are sorted
+deterministically before fingerprinting. `addedObjects[]` / `removedObjects[]`
+are populated only when closed-world diffing is requested. Otherwise the receipt
+records an `object-set-diff-closure` omission and makes no claim about objects
+outside the desired identity set. Field-level `cause` and `managerHint` are
+optional; omitted values mean cub-scout could not attribute that field delta
+from live managedFields.
 
 #### `workloads-converged` evidence
 
@@ -1024,6 +1080,7 @@ Each entry explicitly converts a silent PASS into an honest PASS:
 | `object-set-coverage` | One or more desired objects in an `object-set-matches` receipt could not be checked because API mapping or live lookup was inconclusive |
 | `extra-live-object-coverage` | `object-set-matches` verified desired object identities and authored fields, but did not prove that no extra live resources exist outside the desired set |
 | `extra-live-objects` | `object-set-matches --no-extras` found extra live objects of rendered kinds in scope that are not in the desired set |
+| `object-set-diff-closure` | `object-set-diff` compared authored fields of the desired set but did not compute added/removed object closure because closed-world diffing was not requested |
 | `workload-convergence-snapshot` | `workloads-converged` reflects readiness observed at `verifiedAt`; it does not prove workloads stay converged afterward |
 | `workload-convergence-coverage` | One or more desired workloads in a `workloads-converged` receipt could not be checked because API mapping or live lookup was inconclusive |
 | `prerequisites-snapshot` | `prerequisites-met` reflects required facts observed at `verifiedAt`; it does not prove they remain present afterward |
@@ -1251,7 +1308,7 @@ Aggregate receipt wire shape:
       {"uri": "cub-scout-receipt://9e7d12fa11b2", "digest": {"sha256": "9e7d12fa11b2..."}}
     ],
     "nextSteps": [],
-    "verifier": {"tool": "cub-scout", "version": "v2.2.1"},
+    "verifier": {"tool": "cub-scout", "version": "vX.Y.Z"},
     "verifiedAt": "2026-05-22T22:00:00Z",
     "fingerprint": "sha256:..."
   }
@@ -1265,7 +1322,7 @@ Key shape rules (verified against `pkg/agent/receipt_aggregate.go`):
 - **Verdict synthesis:** the default policy is **max-severity** (`BLOCK > INCONCLUSIVE > WATCH > PASS`). `--aggregate-policy max-severity` is explicit; future policies (`majority`, weighted) are wired through the same flag.
 - **`omissions[]`:** any input attestation with verdict `INCONCLUSIVE` triggers an `aggregate-partial-coverage` omission entry so the consumer knows the aggregate verdict may not reflect full coverage. Per-resource verify failures (load errors, marshal errors) also surface here when discovery couldn't reach a resource.
 - **`inputAttestations[]`:** one entry per per-resource receipt successfully verified, **emitted in caller order**. Each entry's fingerprint is **verified at chain-construction time** via the same `VerifiedAttestationRef` typed wrapper the single-resource chained path uses (per `#463` Codex round-6 P1 fix; `pkg/agent/receipt_aggregate.go:BuildAggregateReceipt` rejects zero-value wrappers).
-- **Fingerprint coverage:** the aggregate's `fingerprint` covers every field including `inputAttestations[]`. Tampering with the input set (adding, removing, or reordering the entries) invalidates the recomputed fingerprint. Note that the **subject digest** is set-shaped (sorted-input concatenation; reordering is a no-op on the subject) but the **receipt-level fingerprint** is list-shaped (covers the wire-order array). A v2.3.1+ correctness pass may sort `inputAttestations[]` before stamping so the receipt-level fingerprint also becomes set-shaped; in v2.3.0 only the subject is order-independent.
+- **Fingerprint coverage:** the aggregate's `fingerprint` covers every field including `inputAttestations[]`. Tampering with the input set (adding, removing, or reordering the entries) invalidates the recomputed fingerprint. Note that the **subject digest** is set-shaped (sorted-input concatenation; reordering is a no-op on the subject) but the **receipt-level fingerprint** is list-shaped (covers the wire-order array). A future correctness pass may sort `inputAttestations[]` before stamping so the receipt-level fingerprint also becomes set-shaped; the current contract only guarantees order-independence for the subject.
 
 Per-resource receipt failures during discovery are **non-fatal**: the aggregate is composed from the successful subset, with an `aggregate-partial-coverage` omission entry recording the failure count.
 

--- a/docs/releases/v2.7.0.md
+++ b/docs/releases/v2.7.0.md
@@ -1,6 +1,6 @@
 # v2.7.0 Release Notes — Live Delivery Observability
 
-> **Status:** Draft release candidate.
+> **Status:** Merged release candidate; tag pending.
 > **Previous release:** [`v2.6.0`](v2.6.0.md) — first-class controller evidence.
 
 **Theme:** answer delivery, rollout, drift, and action-audit questions from one
@@ -21,14 +21,16 @@ questions to cub-scout surfaces:
 - has intended configuration reached the cluster?
 - is this rollout progressing, complete, or stuck?
 - can I move to the next task, wait, or retry?
-- can broad or repeated questions use captured, watched, summarized, or receipt
-  evidence instead of repeatedly crawling live APIs?
+- when existing captured, watched, summarized, or receipt evidence is available,
+  can broad or repeated questions avoid unnecessary fresh crawls?
 
 ### Current-change rollout verdicts
 
-`doctor`, `explain`, and `compare three-way` now share the same
-generation-aware rollout decision model used by `receipt verify --predicate
-workloads-converged`.
+`doctor`, `explain`, and `compare three-way` now expose the same
+generation-aware rollout progress/verdict shape used by
+`receipt verify --predicate workloads-converged`. The diagnostic surfaces are
+live-observation enrichments; receipt-only desired-set and grace-window gates
+remain receipt-specific.
 
 The new optional JSON shape includes:
 
@@ -56,20 +58,24 @@ now first-class controller resources:
 - `ArtifactGenerator`
 
 They participate in controller-resource discovery, ownership detection,
-deployer/status views, trace lookup, and activity timelines.
+deployer/status views, `gitops status`, direct trace lookup, and activity
+timelines. Deeper source-to-generated-artifact lineage remains a follow-up.
 
 ### Audited action events
 
 `trace`, `explain`, and `map activity` now parse audited action metadata from
-Kubernetes Events with reason `WebAction` and action annotations.
+Kubernetes Events when the event has reason `WebAction` or recognized
+`event.toolkit.fluxcd.io/*` action annotations. `map activity` also includes
+ordinary Kubernetes Event rows as `source=k8s.event`; rows with parsed action
+metadata use `source=k8s.action`.
 
 Optional JSON fields include:
 
-- `events[].action.action`
-- `events[].action.actor`
-- `events[].action.groups[]`
-- `events[].action.subject`
-- `events[].action.raw`
+- `events.events[].action.action`
+- `events.events[].action.actor`
+- `events.events[].action.groups[]`
+- `events.events[].action.subject`
+- `events.events[].action.raw`
 - `map activity` row fields `actor`, `subject`, and `actionEvidence`
 
 Unknown action annotations under the same annotation namespace are preserved as
@@ -104,6 +110,13 @@ go test ./...
 go build ./cmd/cub-scout
 ```
 
+PR #500 CI passed on the merged release slice:
+
+- Unit Tests
+- Integration Tests
+- GitOps E2E
+- Proof Artifact
+
 Focused tests added or extended:
 
 - rollout decision synthesis
@@ -113,7 +126,10 @@ Focused tests added or extended:
 - aggregate controller resource discovery
 - aggregate API-group ownership detection
 - audited action event parsing
+- general Kubernetes Event rows in `map activity`
 - `map activity` audited action rows
+- nil-context guard for rollout enrichment in command tests
+- isolated kubectl-plugin map parity fixture to avoid live-cluster volatility
 
 ## Follow-Ups
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,9 +25,10 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 
 ### Live Delivery Observability (`proposals/next-release-live-delivery-observability.md`)
 
-- [x] First-class aggregate delivery/app-bundle/input-provider/external-artifact/generated-artifact resources in controller-resource discovery, ownership, deployer/status, trace, and activity surfaces
+- [x] First-class aggregate delivery resources (`FluxInstance`, `FluxReport`, `ResourceSet`, `ResourceSetInputProvider`, `ExternalArtifact`, `ArtifactGenerator`) in controller-resource discovery, ownership, deployer/status, trace, and activity surfaces
 - [x] Audited user-action event ingestion for activity, explain, and trace event summaries
 - [x] Generation-aware rollout progress/verdict UX promoted from receipts into doctor, explain, and compare surfaces
+- [x] README user-question table for live delivery decisions
 - [ ] Aggregate delivery failures as doctor top-level findings with deeper source/generated-artifact lineage where status refs expose it
 - [ ] Audited user-action event ingestion for history and receipt supporting evidence
 - [ ] API-load-aware inventory and search paths with source freshness for snapshot, watch, summary, and receipt-backed reads
@@ -130,15 +131,15 @@ Read-only-triad invariant: every cub-scout skill's `allowed-tools` line stays in
 
 Consumer-side complement to the AI Agent Skills above: these are scenario skills covering how **Pilot** (the architectural-triad acceptance judge) reads cub-scout's read-only evidence and produces verdicts that gate CD, fleet conformance, drift response, promotion, rollback, compliance, release verification, and event-driven flows. The 9th skill (`pilot-watch-alert-response`) makes `cub-scout watch` the real-time channel into Pilot; implementing it may surface follow-on feature requests against `cub-scout watch` itself (attribution-cause-flip events, source-truth verdict change events, Pilot-shaped event format).
 
-- [ ] `pilot-cd-gate` — pre-deploy gate consuming `compare source-truth` per-strategy verdict — tracked in #444 batch A
-- [ ] `pilot-fleet-conformance` — multi-cluster audit via `compare three-way --scope cluster` + `fleet outliers` — tracked in #444 batch A
-- [ ] `pilot-patch-and-drift` — manual edit + drift attribution → revert / quarantine / accept-as-canonical — tracked in #444 batch A
-- [ ] `pilot-watch-alert-response` — real-time event-driven response over `cub-scout watch` + on-demand call-back into `explain` / `compare three-way` for context — tracked in #444 batch A
-- [ ] `pilot-incident-evidence` — postmortem evidence package from `trace` + `explain` + attribution + events + `bundle` — tracked in #444 batch A
-- [ ] `pilot-rollback-decision` — when and which revision to roll back to — tracked in #444 batch B
-- [ ] `pilot-promotion-gate` — variant A → variant B promotion safety via per-variant three-way + `bindingSource` — tracked in #444 batch B
-- [ ] `pilot-compliance-audit` — periodic policy conformance via scope-wide source-truth + `scan` findings — tracked in #444 batch B
-- [ ] `pilot-release-verification` — post-deploy validation via three-way + `bindingSource` + `history` since deploy — tracked in #444 batch B
+- [x] `pilot-cd-gate` — pre-deploy gate consuming `compare source-truth` per-strategy verdict — shipped in #444 batch A
+- [x] `pilot-fleet-conformance` — multi-cluster audit via `compare three-way --scope cluster` + `fleet outliers` — shipped in #444 batch A
+- [x] `pilot-patch-and-drift` — manual edit + drift attribution → revert / quarantine / accept-as-canonical — shipped in #444 batch A
+- [x] `pilot-watch-alert-response` — real-time event-driven response over `cub-scout watch` + on-demand call-back into `explain` / `compare three-way` for context — shipped in #444 batch A
+- [x] `pilot-incident-evidence` — postmortem evidence package from `trace` + `explain` + attribution + events + `bundle` — shipped in #444 batch A
+- [x] `pilot-rollback-decision` — when and which revision to roll back to — shipped in #444 batch B
+- [x] `pilot-promotion-gate` — variant A → variant B promotion safety via per-variant three-way + `bindingSource` — shipped in #444 batch B
+- [x] `pilot-compliance-audit` — periodic policy conformance via scope-wide source-truth + `scan` findings — shipped in #444 batch B
+- [x] `pilot-release-verification` — post-deploy validation via three-way + `bindingSource` + `history` since deploy — shipped in #444 batch B
 
 Same read-only-triad invariant applies: every `pilot-*` skill's `allowed-tools` stays in the read set. Pilot itself may mutate (via `cub` / Argo / Flux / whatever), but the cub-scout skill surface stays witness-shaped.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -117,6 +117,9 @@ understands the core ownership model.
   controller.
 - "Can an AI tool use cub-scout safely?" Start with `ai-agent-quest`,
   `ai-integration`, or `mcp-gateway`.
+- "Can I move to the next delivery task, wait, or investigate?" Start with
+  `live-delivery-observability` and
+  `docs/howto/delivery-readiness-decision.md`.
 - "Can I show a deterministic demo without a live cluster?" Start with
   `connect-and-compare` or `demos`.
 

--- a/examples/live-delivery-observability/README.md
+++ b/examples/live-delivery-observability/README.md
@@ -1,6 +1,6 @@
 # Live Delivery Observability Fixture
 
-This fixture demonstrates the next-release diagnostic questions in one small
+This fixture demonstrates the v2.7.0 diagnostic questions in one small
 recorded object set:
 
 - aggregate delivery status from first-class controller resources


### PR DESCRIPTION
## Summary

- refresh the README user-question table and docs index so live delivery, API-load-aware review, and rendered object-set questions point at the right cub-scout surfaces
- align the v2.7.0 release notes, mini PRD, roadmap, AI cold-start guide, and handover with the post-#500 merged state and current open issue queue
- document standalone rendered comparison surfaces, including `compare three-way --dry-from`, `compare object-set --dry-from`, and the `object-set-diff` JSON receipt contract

## Validation

- `git diff --check`
- `go build ./cmd/cub-scout`
- `go test ./...`

## Notes

- Local untracked `AGENTS.md` was left unstaged and untouched.
