### PR TITLE
docs: plan event-consumer argobot integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,12 @@ jobs:
 
       - name: Test map commands
         run: |
-          ./cub-scout map status
+          map_status_exit=0
+          ./cub-scout map status || map_status_exit=$?
+          if [ "$map_status_exit" -gt 1 ]; then
+            echo "map status failed with unexpected exit code $map_status_exit"
+            exit "$map_status_exit"
+          fi
           ./cub-scout map list
           ./cub-scout map list --json | head -20
           ./cub-scout scan

--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -180,6 +180,7 @@ Verify live state before acting. As of 2026-07-09, the receipts arc, Pilot consu
 - Aggregate delivery failures as `doctor` top-level findings where controller status refs expose source/generated-artifact lineage
 - Audited action events as history and receipt supporting evidence
 - Broader source freshness metadata for snapshot, watch, summary, and receipt-backed reads
+- ConfigHub event-consumer / Argobot evidence integration with observer-safe cursors, OCI release correlation, and no production cursor sharing; see `docs/proposals/event-consumer-argobot-integration.md` and `#502`
 - Controller-family parity rules and fallback omissions for controllers without status, source, event, or generation evidence
 
 ### Untracked v2 follow-ups (no separate issue)
@@ -190,6 +191,7 @@ Verify live state before acting. As of 2026-07-09, the receipts arc, Pilot consu
 ### Open tracked issues
 
 - **`#481`** — Helm/Kustomize provenance back-resolution for templated-source attribution.
+- **`#502`** — ConfigHub event-consumer / Argobot evidence integration; do not reuse production event-consumer cursors.
 - **`#475`** — Blog/documentation publication series for introducing cub-scout.
 - **`#432`** — Grafana collector / data-source path using existing cub-scout outputs.
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design).

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -278,6 +278,7 @@ Current tracked follow-ons (verified 2026-07-09; reflects post-#500 state):
 - Aggregate delivery failures as top-level `doctor` findings where controller status refs expose source/generated-artifact lineage.
 - Audited action events as history and receipt supporting evidence.
 - Broader source-freshness metadata for snapshot, watch, summary, and receipt-backed reads.
+- ConfigHub event-consumer / Argobot evidence integration with observer-safe cursors, OCI release correlation, and no production cursor sharing; see [`docs/proposals/event-consumer-argobot-integration.md`](docs/proposals/event-consumer-argobot-integration.md) and `#502`.
 - Controller-family parity rules and structured fallback omissions where controllers lack status, source, event, or generation evidence.
 
 **Untracked v2 follow-ups (no separate issue):**
@@ -286,6 +287,7 @@ Current tracked follow-ons (verified 2026-07-09; reflects post-#500 state):
 
 **Open tracked issues:**
 - **`#481`** — Helm/Kustomize provenance back-resolution for templated-source attribution (`gitSource.file:line` / `sourceMapRef` honesty markers).
+- **`#502`** — ConfigHub event-consumer / Argobot evidence integration; current Argobot force-syncs Argo from release events, but status feedback write-back is future work.
 - **`#475`** — Blog/documentation publication series for introducing cub-scout.
 - **`#432`** — Grafana collector / data-source path using existing cub-scout JSON outputs. Design rather than code.
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design needed).

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ For Claude, Codex, and other AI agents:
 Honest gaps in the current capability map, with the leverage on filling them:
 
 - **Helm / Kustomize provenance back-resolution** — [#481](https://github.com/confighub/cub-scout/issues/481) extends raw-YAML field attribution from stage B (#440) to templated sources while preserving honesty markers when exact file:line evidence is unavailable.
-- **Live delivery observability follow-ups** — aggregate delivery failures as top-level `doctor` findings, audited action events as history/receipt evidence, broader freshness metadata for snapshot/watch/summary/receipt paths, and parity omissions for controllers without status/source/event/generation evidence.
+- **Live delivery observability follow-ups** — aggregate delivery failures as top-level `doctor` findings, audited action events as history/receipt evidence, broader freshness metadata for snapshot/watch/summary/receipt paths, ConfigHub event-consumer / Argobot evidence with observer-safe cursors ([#502](https://github.com/confighub/cub-scout/issues/502)), and parity omissions for controllers without status/source/event/generation evidence.
 - **`import --git-path --output-dir`** — emit proposed unit YAMLs to disk for PR review, then upload via Installer's `--merge-external-source` once connected. One bundle, two workflows.
 - **Hierarchy-aware adoption/import** — preserve ApplicationSet / app-of-apps / Flux Kustomization composition in import proposals so imported ConfigHub state is navigable, not flat.
 - **Additional manager-string writers** — Tekton, Argo Workflows, Cluster API, OIDC-based CD systems — gated on whether the variant-management story demands them.

--- a/docs/proposals/event-consumer-argobot-integration.md
+++ b/docs/proposals/event-consumer-argobot-integration.md
@@ -1,0 +1,118 @@
+# Event-Consumer And Argobot Integration
+
+Status: next-release planning. Tracked in
+[#502](https://github.com/confighub/cub-scout/issues/502).
+
+This note captures the current integration facts for ConfigHub's event-consumer
+path and the open-source `argobot` consumer so cub-scout can integrate with the
+right boundary.
+
+## Verified Facts
+
+- ConfigHub's event system is deployed to production.
+- `argobot` is running in ConfigHubOps as an in-cluster event consumer.
+- The dogfood delivery path now uses OCI bundle releases instead of Unit apply
+  as the primary path.
+- `argobot` listens for release publishing and force-syncs the corresponding
+  Argo CD Application.
+- Current `argobot` is an immediacy layer, not a live status reporter. It does
+  not yet push Argo or Kubernetes health back to ConfigHub.
+- `cub` supports `CUB_CONTEXT`, which should be used in multi-terminal and
+  multi-agent work to avoid context bleed between ConfigHub sessions.
+
+Sources:
+
+- [confighub/argobot](https://github.com/confighub/argobot)
+- [ConfigHub event-consumer docs PR](https://github.com/confighubai/docs/pull/122)
+- [AI and software deployment blog post](https://confighub.com/blog/ai-and-software-deployment)
+
+## Integration Boundary
+
+The event log is trigger evidence, not delivery truth.
+
+For the current production shape, cub-scout can use these evidence layers:
+
+| Layer | Owner | What cub-scout may report |
+|---|---|---|
+| Release event | ConfigHub | A release-published fact, when connected evidence exposes it. |
+| Event consumer | argobot | That an in-cluster consumer exists and appears healthy as a normal Kubernetes workload. |
+| Delivery controller | Argo CD | Application sync, health, operation, and source evidence from Argo-owned status. |
+| Runtime | Kubernetes | Workload generation, kstatus, pod symptoms, and Kubernetes Events. |
+| Feedback write-back | Future ConfigHub API shape | External observed status with `observedAt`, freshness, and omissions once the REST shape exists. |
+
+cub-scout should not claim that `argobot` proves delivery success. A successful
+event reaction only means the immediacy layer attempted to nudge Argo; Argo and
+Kubernetes still own sync and runtime truth.
+
+## Cursor Safety
+
+ConfigHub event-consumer cursors are server-held and keyed by the worker plus
+subscription `Name`. Delivery is at-most-once: the server advances the cursor as
+events are delivered, without a later client acknowledgment.
+
+Therefore:
+
+- cub-scout must never reuse the production `argobot` worker and subscription
+  name.
+- If cub-scout reads the event stream directly, it must use its own dedicated
+  read-only worker/subscription name.
+- Prefer a non-consuming REST/history surface for observation if one exists.
+- Any event-log observation must state its coverage: first connect starts at the
+  log tail unless an explicit earlier cursor is requested.
+
+This is a correctness guard, not just an implementation detail. Sharing a cursor
+could steal events from the delivery consumer.
+
+## User Questions To Cover
+
+| User question | Evidence path |
+|---|---|
+| Was a release published for this desired state? | Connected release/event evidence, with release number, digest, target, and `observedAt` where available. |
+| Did the immediacy layer react? | Argobot structured evidence when available; otherwise only ordinary workload health/log-adjacent evidence, with omissions. |
+| Did Argo actually sync the app? | Existing Argo CD Application status, operation state, source revision/digest, and Kubernetes Events. |
+| Did the workload converge after sync? | Existing generation-aware rollout, kstatus, pod symptoms, and event evidence. |
+| Can an agent answer this without hammering clusters? | Snapshot/watch/summary/receipt evidence today; future event-log reads only through observer-safe cursors or non-consuming history. |
+| Is this delivery failure or runtime failure? | Keep release/event facts, Argo sync state, and Kubernetes runtime symptoms separate in output. |
+
+These rows should inform the README user-question table once a user-visible
+feature ships. Until then, the README must not imply that cub-scout already
+reads the ConfigHub event log or Argobot feedback.
+
+## Proposed Implementation Phases
+
+1. Document the production shape and safety rule.
+2. Add fixtures for OCI release, argobot Deployment, Argo Application sync, and
+   workload rollout evidence.
+3. Add a normalized evidence model for external event-consumer observations:
+   source type, subject, target, release number, digest, app ref, `observedAt`,
+   and omissions.
+4. Wire read-only surfaces only where deterministic identifiers exist:
+   `trace`, `explain`, `map activity`, `doctor`, and receipts.
+5. Add feedback write-back parsing after ConfigHub exposes a stable REST shape
+   for reported delivery/application observations.
+
+## Open Questions
+
+- Is there a non-consuming REST/history API for event-log observation, or must
+  cub-scout use a dedicated observer cursor?
+- What stable fields link `release.published` to an Argo CD Application in the
+  general case: space slug, target, release digest, app annotation, or an
+  explicit mapping?
+- Will `argobot` emit structured Kubernetes Events or ConfigHub feedback records
+  for attempted sync, sync failure, and sync accepted states?
+- What labels or annotations identify an `argobot` Deployment without relying on
+  image/name heuristics?
+- Which `cub` version first supports `CUB_CONTEXT`, and should cub-scout docs
+  mention a minimum version for multi-agent examples?
+
+## Acceptance Criteria
+
+- Missing event access, absent `argobot`, or absent feedback write-back produces
+  structured omissions, never false healthy/synced claims.
+- JSON output separates release/event, event-consumer, Argo delivery, and
+  Kubernetes runtime evidence.
+- ASCII and Markdown output labels Argobot evidence as external context, not as
+  cub-scout-owned truth.
+- Tests cover present, partial, malformed, stale, and absent event-consumer
+  evidence.
+- No implementation path mutates ConfigHub, Argo CD, `argobot`, or Kubernetes.

--- a/docs/proposals/next-release-live-delivery-observability.md
+++ b/docs/proposals/next-release-live-delivery-observability.md
@@ -188,6 +188,22 @@ Acceptance criteria:
 - The observer never hides stale evidence behind fresh-sounding language.
 - No mandatory persistent database is added to standalone mode.
 
+ConfigHub event-consumer / Argobot follow-up:
+
+- Current production shape: ConfigHub emits release events; `argobot` consumes
+  them in-cluster and force-syncs Argo CD Applications.
+- Treat this as trigger/immediacy evidence, not as delivery or application
+  success evidence.
+- Do not reuse the production `argobot` worker/subscription cursor. ConfigHub
+  event-consumer cursors are server-held and at-most-once; an observer must use
+  a dedicated read-only subscription or a non-consuming history surface.
+- Correlate OCI release evidence to Argo sync and Kubernetes rollout evidence
+  only where deterministic identifiers exist.
+- Status feedback from event consumers is future work until ConfigHub exposes a
+  stable REST shape for those observations.
+
+Detailed plan: [`event-consumer-argobot-integration.md`](event-consumer-argobot-integration.md).
+
 ## B. Controller-Family Parity
 
 v2.7.0 status: follow-up for parity audit and structured fallback omissions

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,6 +32,7 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 - [ ] Aggregate delivery failures as doctor top-level findings with deeper source/generated-artifact lineage where status refs expose it
 - [ ] Audited user-action event ingestion for history and receipt supporting evidence
 - [ ] API-load-aware inventory and search paths with source freshness for snapshot, watch, summary, and receipt-backed reads
+- [ ] ConfigHub event-consumer / Argobot evidence path with observer-safe cursors, OCI release correlation, and no production cursor sharing — tracked in [#502](https://github.com/confighub/cub-scout/issues/502)
 - [ ] Controller-family parity rules and fallback omissions for controllers without status, source, event, or generation evidence
 
 ### Rendered Manifest + Argo (`roadmap-rendered-manifest-and-argo.md`)


### PR DESCRIPTION
## Summary

- add a next-release proposal for ConfigHub event-consumer / Argobot integration
- correct the boundary: current Argobot is an event-triggered Argo force-sync consumer, not a live status reporter
- document the cursor safety rule: cub-scout must not reuse or advance the production Argobot event-consumer cursor
- wire the tracked #502 follow-up into README, roadmap, AI handover, and the live-delivery proposal
- fix the integration smoke harness to accept `map status` exit code 1 when it reports documented cluster findings

## Why

The production event system and Argobot deployment create a useful evidence path for OCI release delivery questions, but the integration has a sharp edge: event delivery is at-most-once with server-held cursors. cub-scout needs to observe this path without stealing events from the delivery consumer or overclaiming status feedback that is not built yet.

The CI smoke step also ran `map status` under `bash -e`; that command intentionally exits 1 when it finds unhealthy workloads, so the workflow should only fail on unexpected exit codes.

Refs #502.

## Validation

- `git diff --check`
- `go test ./...`
