### PR TITLE
Read a Unit's configuration with `cub unit data`

### DIFF
--- a/cmd/cub-scout/compare_resource.go
+++ b/cmd/cub-scout/compare_resource.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -335,17 +334,23 @@ func loadCompareDryWetSnapshots(ctx context.Context, unitSlug, space string, tar
 		return compareDryWetResult{}, fmt.Errorf("missing unit slug")
 	}
 
-	dryRaw, err := runCompareCubCommand(ctx, compareUnitGetArgs(unitSlug, space))
+	metaRaw, err := runCompareCubCommand(ctx, compareUnitGetArgs(unitSlug, space))
 	if err != nil {
 		return compareDryWetResult{}, fmt.Errorf("cub unit get: %w", err)
 	}
 	// Best-effort only: trust hints should degrade gracefully if the unit-get
 	// envelope changes, while DRY/WET extraction still remains authoritative.
-	unitMeta, _ := decodeCompareUnitMetadataFromGetJSON(dryRaw)
+	unitMeta, _ := decodeCompareUnitMetadataFromGetJSON(metaRaw)
 
-	dryYAML, err := decodeCompareUnitDataFromGetJSON(dryRaw)
+	// The configuration is not part of the unit envelope; it has its own
+	// endpoint, which `cub unit data` reads. The payload is plain text.
+	dryYAML, err := runCompareCubCommand(ctx, compareUnitDataArgs(unitSlug, space))
 	if err != nil {
-		return compareDryWetResult{}, fmt.Errorf("decode unit get data: %w", err)
+		return compareDryWetResult{}, fmt.Errorf("cub unit data: %w", err)
+	}
+	dryYAML = strings.TrimSpace(dryYAML)
+	if dryYAML == "" {
+		return compareDryWetResult{}, fmt.Errorf("unit %s has no configuration data", unitSlug)
 	}
 	drySummary, dryErr := extractCompareSummaryFromManifestYAML("dry", dryYAML, target)
 	if dryErr != nil && !errors.Is(dryErr, errCompareResourceNotFoundInManifest) {
@@ -394,6 +399,14 @@ func compareUnitGetArgs(unitSlug, space string) []string {
 	return args
 }
 
+func compareUnitDataArgs(unitSlug, space string) []string {
+	args := []string{"unit", "data", unitSlug}
+	if strings.TrimSpace(space) != "" {
+		args = append(args, "--space", strings.TrimSpace(space))
+	}
+	return args
+}
+
 func compareUnitLivedataArgs(unitSlug, space string) []string {
 	args := []string{"unit", "livedata", unitSlug}
 	if strings.TrimSpace(space) != "" {
@@ -416,32 +429,6 @@ func runCompareCubCommandImpl(ctx context.Context, args []string) (string, error
 		return "", fmt.Errorf("cub %s failed: %s", strings.Join(args, " "), msg)
 	}
 	return strings.TrimSpace(stdout.String()), nil
-}
-
-func decodeCompareUnitDataFromGetJSON(raw string) (string, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return "", fmt.Errorf("empty unit get output")
-	}
-
-	var payload interface{}
-	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
-		return "", fmt.Errorf("parse unit get json: %w", err)
-	}
-
-	base64Value := findCompareUnitDataBase64(payload)
-	if base64Value == "" {
-		return "", fmt.Errorf("unit get output missing Unit.Data")
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(base64Value)
-	if err != nil {
-		decoded, err = base64.RawStdEncoding.DecodeString(base64Value)
-		if err != nil {
-			return "", fmt.Errorf("decode Unit.Data base64: %w", err)
-		}
-	}
-	return strings.TrimSpace(string(decoded)), nil
 }
 
 func decodeCompareUnitMetadataFromGetJSON(raw string) (compareUnitMetadata, error) {
@@ -498,34 +485,6 @@ func applyCompareUnitMetadata(summary *compareSideSummary, meta compareUnitMetad
 	if summary.LastAppliedRevisionNum == 0 && meta.LastAppliedRevision > 0 {
 		summary.LastAppliedRevisionNum = meta.LastAppliedRevision
 	}
-}
-
-func findCompareUnitDataBase64(payload interface{}) string {
-	switch typed := payload.(type) {
-	case map[string]interface{}:
-		for _, key := range []string{"Unit", "unit"} {
-			if nested, ok := typed[key].(map[string]interface{}); ok {
-				if value, ok := nested["Data"].(string); ok && strings.TrimSpace(value) != "" {
-					return strings.TrimSpace(value)
-				}
-				if value, ok := nested["data"].(string); ok && strings.TrimSpace(value) != "" {
-					return strings.TrimSpace(value)
-				}
-			}
-		}
-		for _, key := range []string{"Data", "data"} {
-			if value, ok := typed[key].(string); ok && strings.TrimSpace(value) != "" {
-				return strings.TrimSpace(value)
-			}
-		}
-	case []interface{}:
-		for _, item := range typed {
-			if value := findCompareUnitDataBase64(item); value != "" {
-				return value
-			}
-		}
-	}
-	return ""
 }
 
 func extractCompareSummaryFromManifestYAML(source string, manifestYAML string, target compareResourceRef) (*compareSideSummary, error) {

--- a/cmd/cub-scout/compare_resource_mode_test.go
+++ b/cmd/cub-scout/compare_resource_mode_test.go
@@ -229,17 +229,6 @@ func TestRunCombined_ResourceCompareJSONOutput(t *testing.T) {
 	}
 }
 
-func TestDecodeCompareUnitDataFromGetJSON(t *testing.T) {
-	raw := `{"Unit":{"Data":"YXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEZXBsb3ltZW50Cm1ldGFkYXRhOgogIG5hbWU6IGFwaQogIG5hbWVzcGFjZTogcHJvZAo="}}`
-	got, err := decodeCompareUnitDataFromGetJSON(raw)
-	if err != nil {
-		t.Fatalf("decodeCompareUnitDataFromGetJSON: %v", err)
-	}
-	if !strings.Contains(got, "kind: Deployment") {
-		t.Fatalf("decoded data missing expected manifest: %q", got)
-	}
-}
-
 func TestExtractCompareSummaryFromManifestYAML(t *testing.T) {
 	manifest := `
 apiVersion: apps/v1
@@ -349,7 +338,23 @@ func TestLoadCompareDryWetSnapshots(t *testing.T) {
 	restoreRun := runCompareCubCommand
 	runCompareCubCommand = func(ctx context.Context, args []string) (string, error) {
 		if reflect.DeepEqual(args, compareUnitGetArgs("checkout", "payments-prod")) {
-			return `{"Space":{"Slug":"payments-prod","SpaceID":"sp-123"},"Unit":{"Slug":"checkout","UnitID":"u-123","HeadRevisionNum":9,"LiveRevisionNum":7,"LastAppliedRevisionNum":8,"Data":"YXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEZXBsb3ltZW50Cm1ldGFkYXRhOgogIG5hbWU6IGFwaQogIG5hbWVzcGFjZTogcHJvZApzcGVjOgogIHJlcGxpY2FzOiAxCiAgdGVtcGxhdGU6CiAgICBzcGVjOgogICAgICBjb250YWluZXJzOgogICAgICAgIC0gbmFtZTogYXBpCiAgICAgICAgICBpbWFnZTogZ2hjci5pby9hY21lL2FwaTp2MQo="}}`, nil
+			return `{"Space":{"Slug":"payments-prod","SpaceID":"sp-123"},"Unit":{"Slug":"checkout","UnitID":"u-123","HeadRevisionNum":9,"LiveRevisionNum":7,"LastAppliedRevisionNum":8}}`, nil
+		}
+		if reflect.DeepEqual(args, compareUnitDataArgs("checkout", "payments-prod")) {
+			return `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/acme/api:v1
+`, nil
 		}
 		if reflect.DeepEqual(args, compareUnitLivedataArgs("checkout", "payments-prod")) {
 			return `
@@ -400,7 +405,16 @@ func TestLoadCompareDryWetSnapshots_WetLookupFailure(t *testing.T) {
 	restoreRun := runCompareCubCommand
 	runCompareCubCommand = func(ctx context.Context, args []string) (string, error) {
 		if reflect.DeepEqual(args, compareUnitGetArgs("checkout", "payments-prod")) {
-			return `{"Unit":{"Data":"YXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEZXBsb3ltZW50Cm1ldGFkYXRhOgogIG5hbWU6IGFwaQogIG5hbWVzcGFjZTogcHJvZAo="}}`, nil
+			return `{"Unit":{"Slug":"checkout"}}`, nil
+		}
+		if reflect.DeepEqual(args, compareUnitDataArgs("checkout", "payments-prod")) {
+			return `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+`, nil
 		}
 		if reflect.DeepEqual(args, compareUnitLivedataArgs("checkout", "payments-prod")) {
 			return "", fmt.Errorf("permission denied")

--- a/cmd/cub-scout/import_wizard.go
+++ b/cmd/cub-scout/import_wizard.go
@@ -1841,17 +1841,25 @@ func (m ImportWizardModel) runTestAddAnnotation() tea.Msg {
 		}
 	}
 
-	// Step 2: Extract base64 data
-	// Write JSON to temp file first to avoid shell escaping issues with embedded newlines
-	appendTestDebug("Step 2: Extracting base64 data...")
-	jsonTmpFile := filepath.Join(testDebugDir, "unit-tmp.json")
-	os.WriteFile(jsonTmpFile, unitJSON, 0644)
-	jqCmd := exec.Command("jq", "-r", ".Unit.Data", jsonTmpFile)
-	base64Data, err := jqCmd.CombinedOutput()
-	writeTestDebug("02-base64-data.txt", base64Data)
-	appendTestDebug(fmt.Sprintf("Base64 data: %d bytes, err=%v", len(base64Data), err))
-	if err != nil || strings.TrimSpace(string(base64Data)) == "" || strings.TrimSpace(string(base64Data)) == "null" {
-		appendTestDebug(fmt.Sprintf("ERROR: No data in unit, base64=%s", string(base64Data)))
+	// Step 2: Read the unit's configuration. It lives on its own endpoint, not
+	// in the unit envelope, and is plain text -- `cub unit data` prints it.
+	appendTestDebug("Step 2: Reading unit data...")
+	dataCmd := exec.Command("cub", "unit", "data", m.testUnitSlug, "--space", m.proposal.App)
+	yamlData, err := dataCmd.CombinedOutput()
+	writeTestDebug("02-original-yaml.yaml", yamlData)
+	appendTestDebug(fmt.Sprintf("Original YAML: %d bytes, err=%v", len(yamlData), err))
+	if err != nil {
+		appendTestDebug(fmt.Sprintf("ERROR reading unit data: %s", string(yamlData)))
+		return wizardTestPhaseMsg{
+			phase:     testPhaseAddAnnotation,
+			success:   false,
+			details:   string(yamlData),
+			err:       fmt.Errorf("failed to read unit data: %w", err),
+			startTime: startTime,
+		}
+	}
+	if strings.TrimSpace(string(yamlData)) == "" {
+		appendTestDebug("ERROR: No data in unit")
 		return wizardTestPhaseMsg{
 			phase:     testPhaseAddAnnotation,
 			success:   false,
@@ -1861,40 +1869,20 @@ func (m ImportWizardModel) runTestAddAnnotation() tea.Msg {
 		}
 	}
 
-	// Step 3: Decode YAML
-	appendTestDebug("Step 3: Decoding YAML...")
-	// Write base64 to file and decode to avoid shell escaping issues
-	base64TmpFile := filepath.Join(testDebugDir, "base64-tmp.txt")
-	os.WriteFile(base64TmpFile, []byte(strings.TrimSpace(string(base64Data))), 0644)
-	decodeCmd := exec.Command("base64", "-d", "-i", base64TmpFile)
-	yamlData, err := decodeCmd.CombinedOutput()
-	writeTestDebug("03-original-yaml.yaml", yamlData)
-	appendTestDebug(fmt.Sprintf("Original YAML: %d bytes, err=%v", len(yamlData), err))
-	if err != nil {
-		appendTestDebug(fmt.Sprintf("ERROR decoding YAML: %s", string(yamlData)))
-		return wizardTestPhaseMsg{
-			phase:     testPhaseAddAnnotation,
-			success:   false,
-			details:   string(yamlData),
-			err:       fmt.Errorf("failed to decode yaml: %w", err),
-			startTime: startTime,
-		}
-	}
-
-	// Step 4: Add annotation using awk
-	appendTestDebug("Step 4: Adding annotation with awk...")
+	// Step 3: Add annotation using awk
+	appendTestDebug("Step 3: Adding annotation with awk...")
 	awkScript := fmt.Sprintf(`/^  annotations:/{print; print "    %s: \"%s\""; next}1`, annotationKey, m.testAnnotation)
 	awkCmd := exec.Command("awk", awkScript)
 	awkCmd.Stdin = strings.NewReader(string(yamlData))
 	modifiedYAML, err := awkCmd.CombinedOutput()
-	writeTestDebug("04-modified-yaml.yaml", modifiedYAML)
+	writeTestDebug("03-modified-yaml.yaml", modifiedYAML)
 	appendTestDebug(fmt.Sprintf("Modified YAML: %d bytes, err=%v", len(modifiedYAML), err))
 	if err != nil || len(modifiedYAML) == 0 {
 		appendTestDebug(fmt.Sprintf("ERROR modifying YAML: %s", string(modifiedYAML)))
 		return wizardTestPhaseMsg{
 			phase:     testPhaseAddAnnotation,
 			success:   false,
-			details:   fmt.Sprintf("Failed to modify YAML. See %s/03-original-yaml.yaml", testDebugDir),
+			details:   fmt.Sprintf("Failed to modify YAML. See %s/02-original-yaml.yaml", testDebugDir),
 			err:       fmt.Errorf("failed to add annotation with awk"),
 			startTime: startTime,
 		}
@@ -1904,7 +1892,7 @@ func (m ImportWizardModel) runTestAddAnnotation() tea.Msg {
 	if !strings.Contains(string(modifiedYAML), annotationKey) {
 		appendTestDebug("ERROR: Annotation not added - possibly no annotations: section in YAML")
 		// YAML might not have annotations section, need to add it
-		writeTestDebug("04-modified-yaml-FAILED.yaml", modifiedYAML)
+		writeTestDebug("03-modified-yaml-FAILED.yaml", modifiedYAML)
 		return wizardTestPhaseMsg{
 			phase:     testPhaseAddAnnotation,
 			success:   false,
@@ -1914,12 +1902,12 @@ func (m ImportWizardModel) runTestAddAnnotation() tea.Msg {
 		}
 	}
 
-	// Step 5: Update unit
-	appendTestDebug("Step 5: Updating unit with modified YAML...")
+	// Step 4: Update unit
+	appendTestDebug("Step 4: Updating unit with modified YAML...")
 	updateCmd := exec.Command("cub", "unit", "update", "--space", m.proposal.App, m.testUnitSlug, "-", "--change-desc", "Import wizard test")
 	updateCmd.Stdin = strings.NewReader(string(modifiedYAML))
 	updateOutput, err := updateCmd.CombinedOutput()
-	writeTestDebug("05-update-result.txt", updateOutput)
+	writeTestDebug("04-update-result.txt", updateOutput)
 	appendTestDebug(fmt.Sprintf("Update result: %s, err=%v", strings.TrimSpace(string(updateOutput)), err))
 	if err != nil {
 		appendTestDebug(fmt.Sprintf("ERROR updating unit: %s", string(updateOutput)))
@@ -2259,20 +2247,15 @@ func (m ImportWizardModel) runTestVerify() tea.Msg {
 			writeTestDebug("13-unit-final-state.json", unitOutput)
 			appendTestDebug(fmt.Sprintf("Unit final state: %d bytes, err=%v", len(unitOutput), err))
 
-			// The annotation is in base64-encoded Unit.Data, need to decode and check
-			unitJsonFile := filepath.Join(testDebugDir, "unit-final-tmp.json")
-			os.WriteFile(unitJsonFile, unitOutput, 0644)
-			jqCmd := exec.Command("jq", "-r", ".Unit.Data", unitJsonFile)
-			base64Data, jqErr := jqCmd.CombinedOutput()
-			if jqErr == nil && len(base64Data) > 0 {
-				base64File := filepath.Join(testDebugDir, "unit-final-base64.txt")
-				os.WriteFile(base64File, []byte(strings.TrimSpace(string(base64Data))), 0644)
-				decodeCmd := exec.Command("base64", "-d", "-i", base64File)
-				decodedYAML, decErr := decodeCmd.CombinedOutput()
-				writeTestDebug("14-unit-final-yaml.yaml", decodedYAML)
-				appendTestDebug(fmt.Sprintf("Decoded Unit YAML: %d bytes, contains annotation: %v", len(decodedYAML), strings.Contains(string(decodedYAML), m.testAnnotation)))
+			// The annotation is in the unit's configuration, which is read from
+			// its own endpoint by `cub unit data`.
+			dataCmd := exec.Command("cub", "unit", "data", m.testUnitSlug, "--space", m.proposal.App)
+			unitYAML, dataErr := dataCmd.CombinedOutput()
+			if len(unitYAML) > 0 {
+				writeTestDebug("14-unit-final-yaml.yaml", unitYAML)
+				appendTestDebug(fmt.Sprintf("Unit YAML: %d bytes, contains annotation: %v", len(unitYAML), strings.Contains(string(unitYAML), m.testAnnotation)))
 
-				if decErr == nil && strings.Contains(string(decodedYAML), m.testAnnotation) {
+				if dataErr == nil && strings.Contains(string(unitYAML), m.testAnnotation) {
 					appendTestDebug("Phase 4 (Verify) SUCCESS - annotation in Unit data, GitOps reconciled it away")
 					return wizardTestPhaseMsg{
 						phase:   testPhaseVerify,


### PR DESCRIPTION
Retroactive review PR: this change is already on `main` as 76542a6. Base is its parent so the diff is reviewable; merging it is a no-op relative to `main`.

Server v0.2.33 takes configuration off the Unit, and the data is text rather than base64. This repo reaches ConfigHub only through the `cub` CLI, so the change is at the command level.

- `compare_resource.go` mined the DRY manifest out of `cub unit get --json` and base64-decoded `Unit.Data`. It keeps that call for metadata and reads the configuration with `cub unit data`. `decodeCompareUnitDataFromGetJSON` and `findCompareUnitDataBase64` are deleted with the encoding they existed for.
- `import_wizard.go` had two `jq -r .Unit.Data | base64 -d` pipelines, each spending two subprocesses and a scratch file on the decode. Both are one `cub unit data`.

**Follow-up, not fixed here:** the three-way compare now issues two `cub` invocations per ConfigHub-linked resource where it issued one. It was already one process per resource, so this is a constant factor rather than a new N+1, but the bulk endpoint that would fix it has no CLI surface — `cub unit data` takes a single unit, not a `--where`.