### PR TITLE
docs: update post-v2.8 roadmap boundary

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -82,6 +82,30 @@ Important:
 - `cub gitops import` is target + render-target based
 - it is not a local `--git-path` renderer
 
+Current `cub k8s` truth from `confighub/sdk` `origin/main` as of 2026-09-11:
+- `cub k8s get` and `cub k8s types` read Kubernetes configuration stored in
+  ConfigHub Units through the Resource entity. They are ConfigHub-side
+  intended/config reads, not live-cluster reads.
+- `cub k8s get` supports kubectl-style type names, `all`, custom-resource Kind
+  fallback, `--space`, `--target`, `--where`, `--where-resource`, `--namespace`,
+  `--show list|detail|data`, and machine-readable output.
+- `cub k8s source` reads one live cluster object, resolves the
+  `confighub.com/origin` annotation or legacy SpaceID/UnitSlug annotations, and
+  opens the owning Unit in the browser. It is useful operator UX, but it is not
+  a general machine-readable reverse-source API today.
+- `cub k8s collect` reads live cluster facts and writes Target facts unless
+  `--dry-run` is set.
+- `cub k8s refresh` reads a live object and writes cluster-side drift back into
+  the owning Unit unless `--dry-run` is set.
+- `cub k8s crd-spec` reads a local CRD file and writes a resource-type spec to
+  stdout. It is present on `sdk` `origin/main`, while the installed `cub` on this
+  machine may lag and not show it yet.
+
+Boundary rule for cub scout: consume or align with the read paths (`get`,
+`types`, Resource list, origin annotations) where they avoid expensive
+ConfigHub-side re-reading. Do not wrap mutating `cub k8s refresh` or non-dry-run
+`cub k8s collect` in cub-scout read-only surfaces.
+
 ### `confighub/sdk`
 
 The SDK contains renderer and bridge implementation details used by `cub`.
@@ -197,8 +221,21 @@ Verify live state before acting. As of 2026-09-11, the receipts arc, Pilot consu
 ### Recently closed (this session's arc)
 
 - **`v2.8.0`** — delivery-evidence, freshness, MCP parity, Modelplane substrate, five-run-mode, and bot-mode release train; see `docs/releases/v2.8.0.md`
+- ~~**`#392`**~~ — Initiatives compliance overlay. Closed as deferred outside
+  cub-scout until ConfigHub exposes a stable backend/CLI Initiative primitive.
 - ~~**`#500`**~~ — live delivery observability release slice, merged 2026-07-09; see `docs/releases/v2.7.0.md`
 - Earlier closed arcs: ~~**`#446`**~~ (parent), ~~**`#444`**~~, ~~**`#448`**~~, ~~**`#449`**~~, ~~**`#451`**~~ — see HANDOVER.md § "May 2026 completions — session 2026-05-25" for the PR-by-PR breakdown
+
+### Post-v2.8 ConfigHub-native boundary
+
+- **`#505`** — highest-leverage next umbrella: evolve cub scout around the
+  OCI-pull + argobot + `cub k8s` + Resource + component/variant/target model.
+- Prefer ConfigHub-native reads (`cub k8s get/types`, Resource list,
+  `confighub.com/origin`) for intended/config and reverse-source evidence when
+  they are cheaper and more authoritative than re-reading Units.
+- Keep cub scout focused on the gaps: live-vs-desired drift, non-Argo runtimes,
+  workload/runtime evidence, cross-cluster/fleet sweeps, receipts, MCP, and
+  explanations that join ConfigHub evidence with controller/Kubernetes evidence.
 
 ### Live delivery observability follow-ups
 
@@ -214,15 +251,21 @@ Verify live state before acting. As of 2026-09-11, the receipts arc, Pilot consu
 
 ### Open tracked issues
 
+- **`#505`** — post-OCI ConfigHub-native evidence boundary: Resource entity,
+  `cub k8s`, argobot/live-status, and component/variant/target provenance.
 - **`#481`** — Helm/Kustomize provenance back-resolution for templated-source attribution.
 - **`#502`** — deepen release/event/live-status correlation beyond the initial `gitops status --with-confighub` reader; do not reuse production event-consumer cursors.
-- **`#475`** — Blog/documentation publication series for introducing cub-scout.
 - **`#432`** — Grafana collector / data-source path using existing cub-scout outputs.
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design).
 - **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up). Scopes #1 (`#414`) and #3 (`#420`) already shipped.
 - **`#421`** — Views project: CEL + JSONPath column evaluators.
-- **`#392`** — Initiatives compliance overlay; **deferred** until ConfigHub exposes Initiative as a backend primitive. Design doc at `docs/howto/initiatives-integration-when-ready.md`.
 - **`#386`** — `preferInvocationForm` lint extension to non-hint legacy string leaks.
+
+### Delayed documentation
+
+- **`#475`** — Blog/documentation publication series for introducing cub-scout.
+  Delayed until `#505` / `#502` settle so the public story reflects the
+  ConfigHub-native OCI/argobot/Resource boundary.
 
 ### Attribution-layer next-up
 
@@ -269,6 +312,9 @@ When the question crosses into ConfigHub or renderer workflows:
 cub version
 cub gitops --help
 cub gitops import --help
+cub k8s --help
+cub k8s get --help
+cub k8s types --help
 cub link --help
 cub link list --help
 ```

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -79,6 +79,35 @@ events, controller sources, and workloads without guessing; add aggregate
 controller-resource failures with generated-artifact lineage to `doctor` when
 safe.
 
+## September 2026 update — `cub k8s` and ConfigHub-native Resource boundary
+
+`confighub/sdk` `origin/main` now has a meaningful `cub k8s` surface that should
+shape the next cub-scout milestone:
+
+- `cub k8s get` and `cub k8s types` read Kubernetes configuration stored in
+  ConfigHub Units through the Resource entity. They are ConfigHub-side
+  intended/config reads, not live-cluster reads.
+- These reads support kubectl-style type names, custom-resource Kind fallback,
+  `--space`, `--target`, `--where`, `--where-resource`, namespace filtering, and
+  machine-readable output. The Resource entity makes fleet sweeps far cheaper
+  than per-Unit function reads.
+- `cub k8s source` reads one live object, resolves `confighub.com/origin` or
+  legacy SpaceID/UnitSlug annotations, and opens the owning Unit in the browser.
+  Treat it as operator UX unless or until a machine-readable reverse-source mode
+  exists.
+- `cub k8s collect` writes Target facts unless `--dry-run` is set.
+- `cub k8s refresh` writes cluster-side drift back into a Unit unless
+  `--dry-run` is set.
+- `cub k8s crd-spec` is present on `sdk` `origin/main` and emits resource-type
+  specs from local CRD files; the installed `cub` on this host may lag.
+
+Boundary for cub scout: prefer ConfigHub-native Resource / `cub k8s get` /
+`cub k8s types` evidence for intended configuration and fleet/resource sweeps;
+keep cub-scout live reads for drift, runtime/workload evidence, non-Argo
+runtimes, receipts, MCP, and safe joins across ConfigHub, controller, and
+Kubernetes evidence. Do not wrap mutating `cub k8s refresh` or non-dry-run
+`cub k8s collect` in cub-scout read-only surfaces.
+
 ## July 2026 update — live delivery observability (`#500`)
 
 `#500` is merged and is the release slice after `v2.6.0`. It adds the README user-question table, generation-aware current-change evidence on diagnostic surfaces, aggregate delivery-resource support, audited action events, and the live-delivery how-to/example fixture.
@@ -348,6 +377,20 @@ delivery-evidence and bot-mode release):
 - ~~**`#448`**~~ — Receipts v2 aggregate / chained receipts. **Closed via `#469`** (aggregate half; chained half shipped in `#463`).
 - ~~**`#449`**~~ — `watch --emit-receipt-on` event types + backpressure. **Closed via `#470`** (full 4-event-type set + per-poll cap; v1 had shipped in `#463`).
 - ~~**`#451`**~~ — `--fail-on RECEIPT_VERDICT` exit semantics. **Closed via `#463`** (Codex round-6 P2 tightened upfront parsing).
+- ~~**`#392`**~~ — Initiatives compliance overlay. **Closed** as deferred
+  outside cub-scout until ConfigHub exposes a stable backend/CLI Initiative
+  primitive.
+
+**Post-v2.8 ConfigHub-native boundary (`#505`):**
+- `#505` is the next umbrella: evolve cub-scout's evidence boundary around
+  OCI-pull delivery, argobot/live-status, `cub k8s`, the Resource entity, and
+  component/variant/target provenance.
+- Favor ConfigHub-native Resource / `cub k8s get` / `cub k8s types` reads for
+  intended Kubernetes configuration and fleet sweeps.
+- Keep cub-scout's own cluster reads for live drift, runtime/workload evidence,
+  non-Argo runtimes, receipts, MCP, and safe joined explanations.
+- Treat `cub k8s refresh` and non-dry-run `cub k8s collect` as outside the
+  cub-scout read-only boundary.
 
 **Live delivery observability follow-ups from `#500`:**
 - Aggregate controller-resource failures as top-level `doctor` findings where controller status refs expose source/generated-artifact lineage.
@@ -363,15 +406,20 @@ delivery-evidence and bot-mode release):
 - Source-truth receipt precedence edge coverage, especially `StatusBLOCK + VerdictBLOCKED`. Nice-to-have, not blocking.
 
 **Open tracked issues:**
+- **`#505`** — post-OCI ConfigHub-native evidence boundary: Resource entity,
+  `cub k8s`, argobot/live-status, and component/variant/target provenance.
 - **`#481`** — Helm/Kustomize provenance back-resolution for templated-source attribution (`gitSource.file:line` / `sourceMapRef` honesty markers).
 - **`#502`** — initial ConfigHub history/live-status/event-consumer evidence readers shipped on `gitops status --with-confighub`, `doctor --with-confighub`, timeline `map activity --with-confighub`, object-level `trace` / `explain --with-confighub`, and single-resource `receipt verify --with-confighub`; deeper release-to-controller-to-workload correlation remains.
-- **`#475`** — Blog/documentation publication series for introducing cub-scout.
 - **`#432`** — Grafana collector / data-source path using existing cub-scout JSON outputs. Design rather than code.
 - **`#427`** — Watch kstatus migration may flip `Ready=true → false` for stalled workloads in v2.1.0+ (behavior-change design needed).
 - **`#422`** — Views project: TUI Hub view integration (`#391` scope #2 follow-up).
 - **`#421`** — Views project: CEL + JSONPath column evaluators.
-- **`#392`** — Initiatives compliance overlay. **Deferred** until ConfigHub exposes Initiative as a backend primitive. Design doc at [`docs/howto/initiatives-integration-when-ready.md`](docs/howto/initiatives-integration-when-ready.md).
 - **`#386`** — `preferInvocationForm` lint extension to non-hint legacy invocation-form leaks in strings.
+
+**Delayed documentation:**
+- **`#475`** — Blog/documentation publication series for introducing cub-scout.
+  Keep open, but delayed until `#505` / `#502` settle so public docs describe
+  the current ConfigHub-native OCI/argobot/Resource shape.
 
 ### Attribution-layer next-up
 
@@ -413,13 +461,25 @@ Recent shipped capability surface:
 
 Open work, in roughly descending leverage:
 
-1. **`#481` Helm/Kustomize provenance back-resolution.** Extends raw-YAML field attribution to templated sources while preserving honesty markers when exact file:line evidence is unavailable.
-2. **`#432` Grafana collector / data-source path.** Uses existing cub-scout JSON outputs; design rather than code work.
-3. **Views project tail.** `#422` TUI Hub View column projection (`#391` scope #2 follow-up); `#421` CEL + JSONPath column evaluators. Scopes #1 (`#414`) and #3 (`#420`) already shipped.
-4. **`#427` watch kstatus migration behavior change.** Stalled workloads may flip `Ready=true → false` in v2.1.0+; needs design.
-5. **`#386` `preferInvocationForm` lint extension** to non-hint legacy string leaks.
-6. **`#392` ConfigHub Initiatives.** Deferred until ConfigHub exposes Initiative as a backend primitive — out of cub-scout's control.
-7. **`#475` publication docs.** Use the README user-question table and v2.8.0 release notes as the source of truth.
+1. **`#505` ConfigHub-native evidence boundary.** Re-center cub-scout around
+   OCI-pull delivery, argobot/live-status, Resource-backed `cub k8s` reads, and
+   component/variant/target provenance without duplicating ConfigHub-native
+   readers.
+2. **`#502` deeper release/event/live-status correlation.** Carry the v2.8
+   evidence into aggregate/object-set/workload receipts and workload-level
+   activity joins where exact identifiers make the join safe.
+3. **`#481` Helm/Kustomize provenance back-resolution.** Next value is Phase 2:
+   values-key resolution using existing Helm/Argo/Flux decoded values before
+   attempting full render-time template source maps.
+4. **`#432` Grafana collector / data-source path.** Use existing cub-scout JSON
+   outputs, but align its data boundary with `#505` first.
+5. **Views project tail.** `#422` TUI Hub View column projection (`#391` scope
+   #2 follow-up); `#421` CEL + JSONPath column evaluators. Scopes #1 (`#414`)
+   and #3 (`#420`) already shipped.
+6. **`#427` watch kstatus migration behavior change.** Likely closable after a
+   post-release issue sweep if no user reports exist.
+7. **`#386` `preferInvocationForm` lint extension** to non-hint legacy string
+   leaks.
 
 Small untracked follow-ups carried from the receipts arc:
 - **MCP `compare_source_truth` strategy-enum drift** — resolved in the post-v2.7 delivery-evidence slice; schema now tracks all CLI strategies.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,6 +23,22 @@ remains future work. Items marked "resolved" had issues filed, implemented, and 
 
 Tracking: issue **#154** is closed. This checklist is now the live tracker.
 
+### Post-v2.8 ConfigHub-Native Boundary ([#505](https://github.com/confighub/cub-scout/issues/505))
+
+- [ ] Prefer ConfigHub Resource / `cub k8s get` / `cub k8s types` for
+  intended Kubernetes configuration and fleet-resource sweeps where those
+  server-side reads are available
+- [ ] Preserve cub-scout's live-cluster role for drift, runtime/workload
+  evidence, non-Argo runtimes, receipts, MCP, and joined explanations that need
+  Kubernetes/controller evidence
+- [ ] Add component / variant / target provenance to cub-scout evidence where
+  ConfigHub exposes stable identifiers
+- [ ] Treat `cub k8s source` as operator browser UX until a machine-readable
+  reverse-source mode exists; use `confighub.com/origin` annotations directly
+  only when the join is deterministic
+- [ ] Keep mutating `cub k8s refresh` and non-dry-run `cub k8s collect` outside
+  cub-scout read-only surfaces
+
 ### Live Delivery Observability (`proposals/next-release-live-delivery-observability.md`)
 
 - [x] First-class aggregate delivery resources (`FluxInstance`, `FluxReport`, `ResourceSet`, `ResourceSetInputProvider`, `ExternalArtifact`, `ArtifactGenerator`) in controller-resource discovery, ownership, deployer/status, trace, and activity surfaces
@@ -51,6 +67,10 @@ Tracking: issue **#154** is closed. This checklist is now the live tracker.
 - [x] Workstream F: Fleet query ergonomics and provenance readability — graduated to #242, #251
 - [x] Workstream F: Impact analysis ergonomics and multi-cluster context clarity — graduated to #243, #254
 - [ ] Workstream G: Platform-only surfaces (Functions, Actions, ChangeSets, saved queries, alert triggers, dependency graphing, time-travel UX, three-state drift resolution, bulk operations)
+
+### Publication / GTM
+
+- [ ] Blog/documentation publication series ([#475](https://github.com/confighub/cub-scout/issues/475)) — delayed until [#505](https://github.com/confighub/cub-scout/issues/505) and [#502](https://github.com/confighub/cub-scout/issues/502) settle, so external docs describe the current OCI/argobot/Resource boundary
 
 ### Connected Views + Launch (`roadmap-connected-views-and-launch.md`)
 


### PR DESCRIPTION
## Summary
- record the post-v2.8 ConfigHub-native evidence boundary around Resource, cub k8s, argobot/live-status, and component/variant/target provenance
- mark #392 as closed/deferred outside cub-scout until ConfigHub has a backend/CLI Initiative primitive
- move #475 out of the near-term engineering queue and delay it until #505/#502 settle
- capture the verified cub k8s command split: read surfaces vs mutating collect/refresh surfaces

## Verification
- git diff --check
- go build ./cmd/cub-scout
- go test ./...