### PR TITLE
Prepare v2.10.1 freshness patch and packaged-binary proof

### DIFF
--- a/AI-README-FIRST.md
+++ b/AI-README-FIRST.md
@@ -114,18 +114,20 @@ Do not claim that `cub scout` can do SDK/renderer work locally unless the curren
 
 ## Current High-Signal Shipped Capabilities
 
-Published: **v2.10.0** bounded explorer integration and companion **v0.3.0**.
+Release target: **v2.10.1** feedback-freshness patch; publication proof is in
+`#530` and `docs/releases/v2.10.1.md`. The bounded explorer baseline is
+**v2.10.0** and companion **v0.3.0**.
 Final proof is tracked in `#525` and `docs/releases/v2.10.0.md`. `#520` remains
 open for registry access, container architecture and Go module major-version
 distribution; authenticated live ConfigHub proof requires renewed login and
 explicit test scope. These are limitations, not passing checks. Current docs
 and competitive capability review: `#527`.
-Implemented after v2.10, not yet released: `#502` live-status timestamp gating.
+The v2.10.1 correction (`#502`, merged in `#529`) gates live-status timestamps.
 Missing/invalid/zero/future timestamps now yield `INCONCLUSIVE`; stale reports,
 including old failures, yield `WATCH`. Original report fields and freshness
 omissions remain visible; activity evidence retains the original `observedAt`.
 See `examples/live-delivery-observability/#trusting-feedback-freshness` for proof.
-Published v2.10 binaries still have the disclosed gap. Producer deletion/history
+Earlier v2.10.0 binaries have the disclosed gap. Producer deletion/history
 semantics and deeper delivery joins remain open; bounded TUI contracts are unchanged.
 The first slice adds opt-in bounded `explain` reads and short-lived MCP/TUI
 session reuse; see `examples/bounded-resource-read/`. The companion panel is

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,16 +1,18 @@
 # cub-scout Handover for the Next AI Coder
 
-Last updated: 2026-09-11. Published: Scout `v2.10.0` (`f9f5512`) and separately
+Last updated: 2026-09-11. Release target: Scout `v2.10.1`; publication and
+artifact proof are tracked in `#530` and `docs/releases/v2.10.1.md`.
+Previous published baseline: Scout `v2.10.0` (`f9f5512`) and separately
 packaged Commander `v0.3.0` (`7ffc9c5`). Final CI, downloaded checksums,
 standalone/plugin/MCP/TUI/watch/bot proof and validation gaps are recorded in
 `#525`. `#520` remains open for registry access, architecture coverage and Go
 module major-version distribution. Post-release intro/docs review is `#527`.
-The `#502` timestamp correction is implemented after v2.10, not yet released:
+The v2.10.1 `#502` timestamp correction is merged in `#529` (`bc68a9a`):
 missing/invalid/zero/future timestamps become `unknown` / `INCONCLUSIVE`, and
 stale reports become `WATCH`, including old failures. Reported fields remain
 visible with freshness omissions; activity rows preserve original `observedAt`.
 Recorded parser/collector/MCP/doctor/activity/trace/receipt proof lives under
-`examples/live-delivery-observability/`. Published v2.10 binaries still have the
+`examples/live-delivery-observability/`. Earlier v2.10.0 binaries have the
 disclosed gap. Deletion/history semantics, exact release joins and connected TUI
 coverage remain open; this does not alter bounded object-read cache behavior.
 Notes: [`docs/releases/v2.10.0.md`](docs/releases/v2.10.0.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A read-only Kubernetes and GitOps explorer for people, scripts, and AI agents.**
 
-[v2.10.0 release](https://github.com/confighub/cub-scout/releases/tag/v2.10.0)
+[v2.10.1 release](https://github.com/confighub/cub-scout/releases/tag/v2.10.1)
 | [Start here](docs/getting-started/start-here.md)
 | [Command guide](CLI-GUIDE.md)
 
@@ -44,7 +44,7 @@ cub-scout gitops status   # What do delivery controllers report?
 cub-scout map             # Explore interactively
 ```
 
-Already using `cub`? Run `cub plugin install confighub/cub-scout@v2.10.0`, then
+Already using `cub`? Run `cub plugin install confighub/cub-scout@v2.10.1`, then
 `cub scout doctor`. [Installation and verified downloads](docs/getting-started/install.md)
 cover macOS, Linux, Windows, and tagged source builds.
 
@@ -84,9 +84,9 @@ Cub-scout helps users answer questions about k8s and GitOps clusters in one plac
 | Which indexed resources match a fleet-wide predicate? | MCP `confighub_resources` | Read-only ConfigHub Resource entity queries through `cub resource list`: server-side `ResourceType`, `ResourceName`, `TargetID`, `Unit.*`, `Space.*`, and `Data.*` predicates, optional views/selects/raw data, and explicit space scoping for broad explorer questions. |
 | Could a same-name application inherit another application's delivery status? | `map activity --with-confighub --format json` | Joins require an observed Application Space ID matching the reported Space ID plus a unique, exact Application name in the selected non-wildcard space. Missing/conflicting metadata and ambiguous names/statuses remain correlation omissions; the Argo-owned result is preserved. |
 | What release or event triggered this delivery attempt? | `map activity --with-confighub`, `doctor --with-confighub`, `gitops status --with-confighub`, `trace --with-confighub`, `explain --with-confighub`, `history`, MCP `confighub_releases`, MCP `confighub_unit_events` | Bounded ConfigHub release and unit-event evidence for a known space/time window, including release ids, digests, targets, unit events, timestamps, exact resource-correlation keys when available, activity timeline rows, and structured omissions when history cannot be joined safely. |
-| Did evented delivery feedback report back, and is the report fresh? | `map activity --with-confighub`, `doctor --with-confighub`, `gitops status --with-confighub`, `trace --with-confighub`, `explain --with-confighub`, MCP `confighub_live_status` | Read-only parsing of ConfigHub live-status writeback, with `observedAt`, freshness, sync status, operation phase, observed revision, delivery verdict, separate application-health verdict, scope-level rollups, timeline rows, exact joins onto matching Argo Application activity rows, and object-level matches only when exact space plus app/unit identity is present. **v2.10 limit:** unknown or future timestamps can still accompany `PASS`; inspect timestamps, not the verdict alone. [Known freshness gap](docs/reference/explorer-comparison.md#current-feedback-verdict-limit). |
+| Did evented delivery feedback report back, and is the report fresh? | `map activity --with-confighub`, `doctor --with-confighub`, `gitops status --with-confighub`, `trace --with-confighub`, `explain --with-confighub`, MCP `confighub_live_status` | Read-only parsing of ConfigHub live-status writeback, with `observedAt`, freshness, sync status, operation phase, observed revision, delivery verdict, separate application-health verdict, scope-level rollups, timeline rows, exact joins onto matching Argo Application activity rows, and object-level matches only when exact space plus app/unit identity is present. **v2.10.1:** unknown or future timestamps cannot justify `PASS`. Earlier versions have a [documented freshness gap](docs/reference/explorer-comparison.md#current-feedback-verdict-limit). |
 | Is the in-cluster event consumer present and healthy? | `map activity --with-confighub`, `doctor --with-confighub`, `gitops status --with-confighub`, `trace --with-confighub`, `explain --with-confighub`, `map deployers` | Conservative, label-selected detection of the known event-consumer Deployment shape across namespaces when allowed, with ready/desired replicas, activity timeline rows, and `doctor` top issues when an observed consumer is unhealthy; absence or RBAC narrowing becomes an omission, not a claim that no eventing exists. |
-| Can I trust a reported success or failure when its timestamp is missing, future, or old? | Connected `gitops status`, `doctor`, `map activity`, `trace`, `explain`, MCP `confighub_live_status`, single-resource receipts | **Post-v2.10.0 fix (unreleased):** missing/invalid/zero/future timestamps yield `INCONCLUSIVE`; stale reports yield `WATCH`, including old failures. The original report, timestamp and a freshness omission stay visible. Re-reading an unchanged report does not renew it; the next step is a current controller/workload read. [Cases and proof](examples/live-delivery-observability/#trusting-feedback-freshness). |
+| Can I trust a reported success or failure when its timestamp is missing, future, or old? | Connected `gitops status`, `doctor`, `map activity`, `trace`, `explain`, MCP `confighub_live_status`, single-resource receipts | **v2.10.1:** missing/invalid/zero/future timestamps yield `INCONCLUSIVE`; stale reports yield `WATCH`, including old failures. The original report, timestamp and a freshness omission stay visible. Re-reading an unchanged report does not renew it; the next step is a current controller/workload read. [Cases and proof](examples/live-delivery-observability/#trusting-feedback-freshness). |
 | Has intended configuration reached the cluster? | `compare three-way` | DRY/WET/LIVE agreement for a resource, namespace, cluster, or governed view, with states like `agreed`, `converging`, `diverged`, and `partial`. |
 | Did the controller consume the expected source revision or OCI digest? | `trace`, `trace --with-confighub`, `gitops status`, `compare source-truth`, `gitops status --with-confighub` | Controller-owned source status, revision/digest evidence, object-correlated ConfigHub release digest context when exact space+target joins exist, and proof gaps when controller/source identifiers cannot be joined safely. |
 | Did this rendered install set land as a set? | `compare object-set`, `receipt verify --file` | Set-level desired-vs-live evidence from rendered YAML: authored-field deltas, optional added/removed object closure, object-set receipts, normalization profiles, freshness TTL, and CI-gate verdicts. |
@@ -115,6 +115,10 @@ evidence when appropriate. [Request-cost proof](examples/mcp-gateway/README.md#r
 [release notes and upgrade order](docs/releases/v2.10.0.md) for Scout/companion
 compatibility, request budgets, and explicit validation limits. The companion
 is separately packaged; install Scout v2.10.0 before Commander v0.3.0.
+
+**v2.10.1 corrects feedback freshness.** Missing or future report timestamps
+cannot justify success; old success and failure reports ask for a current check.
+See [patch notes and upgrade guidance](docs/releases/v2.10.1.md).
 
 ### Who reaches for cub-scout?
 

--- a/cmd/cub-scout/gitops_delivery_packaged_test.go
+++ b/cmd/cub-scout/gitops_delivery_packaged_test.go
@@ -1,0 +1,181 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// Opt-in release smoke: the provider is an external binary, not this test's
+// implementation. Only the public startup reachability HEAD is external;
+// credentials, connected data and CLI queries are isolated fixtures.
+func TestLiveStatusFreshnessPackaged(t *testing.T) {
+	binary := os.Getenv("CUB_SCOUT_TEST_BINARY")
+	if binary == "" {
+		t.Skip("set CUB_SCOUT_TEST_BINARY to a native release binary")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix plugin smoke; Windows archives do not contain a plugin")
+	}
+	binary, err := filepath.Abs(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plugin := os.Getenv("CUB_SCOUT_TEST_PLUGIN_BINARY")
+	if plugin == "" {
+		plugin = filepath.Join(t.TempDir(), "main")
+		if err := copyExecutable(binary, plugin); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plugin, err = filepath.Abs(plugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	cases := []liveStatusFreshnessCase{
+		{Name: "fresh", ObservedAt: now.Add(-time.Minute).Format(time.RFC3339), Freshness: "fresh", Verdict: "PASS"},
+		{Name: "fresh-failure", ObservedAt: now.Add(-time.Minute).Format(time.RFC3339), Failed: true, Freshness: "fresh", Verdict: "BLOCK"},
+		{Name: "missing", Freshness: "unknown", Verdict: "INCONCLUSIVE"},
+		{Name: "invalid", ObservedAt: "not-a-time", Freshness: "unknown", Verdict: "INCONCLUSIVE"},
+		{Name: "zero", ObservedAt: "0001-01-01T00:00:00Z", Freshness: "unknown", Verdict: "INCONCLUSIVE"},
+		{Name: "future", ObservedAt: now.Add(24 * time.Hour).Format(time.RFC3339), Freshness: "unknown", Verdict: "INCONCLUSIVE"},
+		{Name: "stale", ObservedAt: now.Add(-time.Hour).Format(time.RFC3339), Freshness: "stale", Verdict: "WATCH"},
+		{Name: "stale-failure", ObservedAt: now.Add(-time.Hour).Format(time.RFC3339), Failed: true, Freshness: "stale", Verdict: "WATCH"},
+	}
+	var rows []map[string]interface{}
+	for _, tc := range cases {
+		var row []map[string]interface{}
+		if err := json.Unmarshal([]byte(liveStatusFreshnessInput(t, tc)), &row); err != nil {
+			t.Fatal(err)
+		}
+		row[0]["Slug"], row[0]["SpaceID"] = tc.Name, "space-"+tc.Name
+		rows = append(rows, row[0])
+	}
+	raw, err := json.Marshal(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []struct {
+		name, binary string
+		plugin       bool
+	}{{"standalone", binary, false}, {"plugin", plugin, true}} {
+		t.Run(mode.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.Mkdir(filepath.Join(home, ".cub-scout"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			for name, data := range map[string][]byte{
+				".cub-scout/auth.json": []byte(`{"token":"isolated-fixture-token"}`),
+				"statuses.json":        raw,
+				"cub": []byte("#!/bin/sh\nset -eu\n" +
+					"test \"$#\" -eq 6\n" +
+					"test \"$*\" = 'space list -o json --select Slug,SpaceID,Annotations,Labels'\n" +
+					"printf 'read\\n' >> \"$HOME/reads\"\n" +
+					"exec /bin/cat \"$HOME/statuses.json\"\n"),
+			} {
+				if err := os.WriteFile(filepath.Join(home, name), data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.Chmod(filepath.Join(home, "cub"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			var input bytes.Buffer
+			for id, request := range []map[string]interface{}{
+				{"method": "initialize", "params": map[string]interface{}{"protocolVersion": "2025-03-26", "capabilities": map[string]interface{}{}, "clientInfo": map[string]string{"name": "packaged-freshness-proof", "version": "1"}}},
+				{"method": "tools/call", "params": map[string]interface{}{"name": "confighub_live_status", "arguments": map[string]string{"space": "*"}}},
+			} {
+				request["jsonrpc"], request["id"] = "2.0", id+1
+				payload, err := json.Marshal(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := writeMCPFrame(&input, payload); err != nil {
+					t.Fatal(err)
+				}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, mode.binary, "mcp", "serve")
+			cmd.Env = []string{"HOME=" + home, "PATH=" + home + ":/usr/bin:/bin", "NO_COLOR=1", "TERM=dumb", "KUBECONFIG=" + filepath.Join(home, "absent-kubeconfig")}
+			if mode.plugin {
+				cmd.Env = append(cmd.Env, "CUB_PLUGIN=1", "CUB_TOKEN=isolated-fixture-token")
+			}
+			var stderr bytes.Buffer
+			cmd.Stdin, cmd.Stderr = &input, &stderr
+			output, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("provider failed: %v: %s", err, stderr.String())
+			}
+			reader := bufio.NewReader(bytes.NewReader(output))
+			for id := 1; id <= 2; id++ {
+				frame, err := readMCPFrame(reader)
+				if err != nil {
+					t.Fatalf("response %d: %v: %s", id, err, output)
+				}
+				var response struct {
+					ID     int
+					Error  json.RawMessage
+					Result struct {
+						IsError           bool
+						StructuredContent struct {
+							LiveStatuses []ConfigHubLiveStatusEvidence
+							Omissions    []GitOpsDeliveryEvidenceOmission
+						}
+					}
+				}
+				if err := json.Unmarshal(frame, &response); err != nil {
+					t.Fatal(err)
+				}
+				if response.ID != id || len(response.Error) > 0 || response.Result.IsError {
+					t.Fatalf("response failed (startup requires public health reachability): %s", frame)
+				}
+				if id == 1 {
+					continue
+				}
+				got := response.Result.StructuredContent
+				if len(got.LiveStatuses) != len(cases) || len(got.Omissions) != 6 {
+					t.Errorf("expected %d reports and 6 omissions, got %d and %d", len(cases), len(got.LiveStatuses), len(got.Omissions))
+				}
+				bySpace := map[string]ConfigHubLiveStatusEvidence{}
+				for _, status := range got.LiveStatuses {
+					bySpace[status.Space] = status
+				}
+				for _, tc := range cases {
+					status := bySpace[tc.Name]
+					if status.Freshness != tc.Freshness || status.DeliveryVerdict != tc.Verdict || status.ApplicationHealthVerdict != tc.Verdict || status.ObservedAt != tc.ObservedAt || status.SpaceID != "space-"+tc.Name || status.App != "api" || status.Revision != "sha256:abc" {
+						t.Errorf("%s: wrong report: %+v", tc.Name, status)
+					}
+					sync, health, phase := "Synced", "Healthy", "Succeeded"
+					if tc.Failed {
+						sync, health, phase = "OutOfSync", "Degraded", "Failed"
+					}
+					if status.SyncStatus != sync || status.HealthStatus != health || status.OperationPhase != phase || status.Source != "argobot" {
+						t.Errorf("%s: original status fields changed: %+v", tc.Name, status)
+					}
+				}
+				for _, omission := range got.Omissions {
+					if omission.Layer != "confighub.liveStatus.freshness" || omission.Reason == "" || omission.Impact == "" {
+						t.Errorf("unexplained omission: %+v", omission)
+					}
+				}
+			}
+			reads, err := os.ReadFile(filepath.Join(home, "reads"))
+			if err != nil || string(reads) != "read\n" {
+				t.Fatalf("expected exactly one fixture CLI read: %q, %v", reads, err)
+			}
+			t.Logf("%s: 8 timestamp cases, original fields, 6 omissions, one fixture read", mode.name)
+		})
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ The five run modes are **standalone CLI/TUI, `cub` plugin, MCP server, watch
 stream, and in-cluster bot**. [Choose a mode](../README.md#five-ways-to-run-cub-scout)
 or [start with a user question](../README.md#user-questions).
 
-Current release: [v2.10.0](releases/v2.10.0.md). Its bounded reads add exact
+Current patch: [v2.10.1](releases/v2.10.1.md), correcting feedback freshness.
+The [v2.10.0](releases/v2.10.0.md) bounded reads add exact
 scope, visible read counts, short-lived MCP/TUI reuse, origin metadata, and
 explicit omissions. [Tool comparison](reference/explorer-comparison.md) explains
 where Scout fits and where parity is still unproved.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-For v2.10.0, use Homebrew, the `cub` plugin, or the published archives below.
+For v2.10.1, use Homebrew, the `cub` plugin, or the published archives below.
 You do not need a ConfigHub account for standalone cluster observation.
 
 ## ConfigHub Plugin
@@ -8,12 +8,12 @@ You do not need a ConfigHub account for standalone cluster observation.
 With the separately installed `cub` CLI:
 
 ```sh
-cub plugin install confighub/cub-scout@v2.10.0
+cub plugin install confighub/cub-scout@v2.10.1
 cub scout version
 cub scout doctor
 ```
 
-For an existing installation: `cub plugin upgrade scout@v2.10.0`.
+For an existing installation: `cub plugin upgrade scout@v2.10.1`.
 The plugin has the same observation commands as the standalone client. ConfigHub
 authentication is needed only for connected operations. Use `--kube-context`
 for bounded Kubernetes reads; the host's `--context` selects a ConfigHub context.
@@ -33,27 +33,27 @@ kubectl cub-scout version
 
 ### Download Binary
 
-The [v2.10.0 release](https://github.com/confighub/cub-scout/releases/tag/v2.10.0)
-contains six archives and [checksums.txt](https://github.com/confighub/cub-scout/releases/download/v2.10.0/checksums.txt).
+The [v2.10.1 release](https://github.com/confighub/cub-scout/releases/tag/v2.10.1)
+contains six archives and [checksums.txt](https://github.com/confighub/cub-scout/releases/download/v2.10.1/checksums.txt).
 Archive names include the version and use underscores, not hyphens:
 
 | Platform | Archive |
 |---|---|
-| macOS Apple Silicon | [cub-scout_2.10.0_darwin_arm64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.0/cub-scout_2.10.0_darwin_arm64.tar.gz) |
-| macOS Intel | [cub-scout_2.10.0_darwin_amd64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.0/cub-scout_2.10.0_darwin_amd64.tar.gz) |
-| Linux arm64 | [cub-scout_2.10.0_linux_arm64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.0/cub-scout_2.10.0_linux_arm64.tar.gz) |
-| Linux amd64 | [cub-scout_2.10.0_linux_amd64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.0/cub-scout_2.10.0_linux_amd64.tar.gz) |
-| Windows arm64 | [cub-scout_2.10.0_windows_arm64.zip](https://github.com/confighub/cub-scout/releases/download/v2.10.0/cub-scout_2.10.0_windows_arm64.zip) |
-| Windows amd64 | [cub-scout_2.10.0_windows_amd64.zip](https://github.com/confighub/cub-scout/releases/download/v2.10.0/cub-scout_2.10.0_windows_amd64.zip) |
+| macOS Apple Silicon | [cub-scout_2.10.1_darwin_arm64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.1/cub-scout_2.10.1_darwin_arm64.tar.gz) |
+| macOS Intel | [cub-scout_2.10.1_darwin_amd64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.1/cub-scout_2.10.1_darwin_amd64.tar.gz) |
+| Linux arm64 | [cub-scout_2.10.1_linux_arm64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.1/cub-scout_2.10.1_linux_arm64.tar.gz) |
+| Linux amd64 | [cub-scout_2.10.1_linux_amd64.tar.gz](https://github.com/confighub/cub-scout/releases/download/v2.10.1/cub-scout_2.10.1_linux_amd64.tar.gz) |
+| Windows arm64 | [cub-scout_2.10.1_windows_arm64.zip](https://github.com/confighub/cub-scout/releases/download/v2.10.1/cub-scout_2.10.1_windows_arm64.zip) |
+| Windows amd64 | [cub-scout_2.10.1_windows_amd64.zip](https://github.com/confighub/cub-scout/releases/download/v2.10.1/cub-scout_2.10.1_windows_amd64.zip) |
 
 For example, on Linux amd64:
 
 ```sh
-curl -fLO https://github.com/confighub/cub-scout/releases/download/v2.10.0/cub-scout_2.10.0_linux_amd64.tar.gz
-curl -fLO https://github.com/confighub/cub-scout/releases/download/v2.10.0/checksums.txt
-sha256sum cub-scout_2.10.0_linux_amd64.tar.gz
+curl -fLO https://github.com/confighub/cub-scout/releases/download/v2.10.1/cub-scout_2.10.1_linux_amd64.tar.gz
+curl -fLO https://github.com/confighub/cub-scout/releases/download/v2.10.1/checksums.txt
+sha256sum cub-scout_2.10.1_linux_amd64.tar.gz
 # Compare with the matching entry in checksums.txt before extracting.
-tar -xzf cub-scout_2.10.0_linux_amd64.tar.gz
+tar -xzf cub-scout_2.10.1_linux_amd64.tar.gz
 ./cub-scout version
 ```
 
@@ -65,33 +65,35 @@ Unix archives include `cub-scout`, `kubectl-cub_scout`, and the plugin entry poi
 ### Go Module Version Caveat
 
 Do not use `go install github.com/confighub/cub-scout/cmd/cub-scout@latest` to
-install v2.10.0. The module path does not have a `/v2` suffix: the default resolver
+install v2.10.1. The module path does not have a `/v2` suffix: the default resolver
 returned v1.13.0 for `@latest` during release verification, and an explicit
-`@v2.10.0` query failed Go's major-version check. Use an archive or build the
-tagged checkout below. Distribution follow-up: [#520](https://github.com/confighub/cub-scout/issues/520).
+`@v2.10.0` query failed Go's major-version check. The patch keeps the same module
+path. Use an archive or build the tagged checkout below. Distribution follow-up:
+[#520](https://github.com/confighub/cub-scout/issues/520).
 
 ### Container and Bot
 
-The v2.10.0 workflow publishes a Linux amd64 image with numeric non-root UID
-65532. **Anonymous registry pulls still return 403** in release verification;
-do not treat the command below as a verified public installation route:
+The v2.10.1 workflow publishes a Linux amd64 image with numeric non-root UID
+65532. **Anonymous registry pulls returned 403** during v2.10.0 verification;
+the patch's pull check is tracked in [#530](https://github.com/confighub/cub-scout/issues/530).
+Do not treat the command below as a verified public installation route:
 
 ```bash
-docker run ghcr.io/confighub/cub-scout:v2.10.0 version
+docker run ghcr.io/confighub/cub-scout:v2.10.1 version
 ```
 
 Linux arm64 archive binaries are available, but there is no published multiarch
 container in this release. The [bot example](../../examples/bot/) describes
-ServiceAccount/RBAC and sink configuration; [release proof](../releases/v2.10.0.md)
+ServiceAccount/RBAC and sink configuration; [release proof](../releases/v2.10.1.md)
 distinguishes local-image smoke from registry access. Do not weaken permissions
 or change package visibility just to make a smoke test pass.
 
 ### Build from Source
 
 ```bash
-git clone --branch v2.10.0 --depth 1 https://github.com/confighub/cub-scout.git
+git clone --branch v2.10.1 --depth 1 https://github.com/confighub/cub-scout.git
 cd cub-scout
-go build -ldflags '-X main.BuildTag=2.10.0' -o cub-scout ./cmd/cub-scout
+go build -ldflags '-X main.BuildTag=2.10.1' -o cub-scout ./cmd/cub-scout
 ./cub-scout version
 ```
 

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -1143,7 +1143,7 @@ reason such as `forbidden`, `unauthorized`, `timeout`, or `list_failed`.
 
 `deliveryEvidence` appears only with `--with-confighub`. It is additive and
 never replaces controller or Kubernetes status. `liveStatuses[]` separates
-`deliveryVerdict` from `applicationHealthVerdict`. In the unreleased correction
+`deliveryVerdict` from `applicationHealthVerdict`. In the v2.10.1 correction
 after v2.10.0, only a valid, non-future report within the staleness threshold may
 yield `PASS` or `BLOCK`. Stale reported states become `WATCH`, including old
 failures; missing/invalid/zero/future timestamps become `unknown` freshness and

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2526,7 +2526,7 @@ Deployment reads for `app=argobot` and `app.kubernetes.io/name=argobot`; it
 searches all namespaces when allowed and reports a scope omission if RBAC forces
 fallback to the requested namespace.
 
-**Unreleased freshness correction after v2.10.0:** a reported success or failure
+**v2.10.1 freshness correction:** a reported success or failure
 needs a valid timestamp at or before the observation clock and within
 `--confighub-stale-after` to yield `PASS` or `BLOCK`. Stale reports yield `WATCH`;
 missing, invalid, zero, or future timestamps yield `INCONCLUSIVE`. Empty status

--- a/docs/reference/explorer-comparison.md
+++ b/docs/reference/explorer-comparison.md
@@ -102,12 +102,12 @@ where needed. Tightening this contract is a correctness priority under #502,
 not a fix included in this documentation update. Bounded object-read timestamps
 and cache behavior are a separate contract.
 
-**Post-v2.10 implementation, not yet released:** timestamp gating now makes
+**v2.10.1 correction:** timestamp gating now makes
 missing/invalid/zero/future reports inconclusive and stale reports `WATCH`,
 including old failures. It retains reported fields and emits an explanatory
 omission. [Recorded proof](../../examples/live-delivery-observability/#trusting-feedback-freshness)
 covers the shared reader, MCP, doctor, activity, correlation and fingerprinted
-receipts. The published v2.10 behavior above is unchanged; broader producer
+receipts. The historical v2.10.0 behavior above is unchanged; broader producer
 deletion/history and exact-release checks remain open.
 
 ## What Would Prove Leadership

--- a/docs/reference/json-contracts.md
+++ b/docs/reference/json-contracts.md
@@ -986,7 +986,7 @@ Sveltos, Modelplane, ConfigHub, or Kubernetes as the status authority.
 The command never consumes ConfigHub event cursors and never mutates ConfigHub,
 the event consumer, the delivery controller, or Kubernetes.
 
-**Unreleased correction after v2.10.0:** the freshness gate above fixes the
+**v2.10.1 correction:** the freshness gate above fixes the
 published v2.10 behavior that allowed unknown/future timestamps to accompany
 `PASS`, and kept stale failures as `BLOCK`. Non-fresh reports now also produce
 an omission with `layer: confighub.liveStatus.freshness` describing why current

--- a/docs/releases/v2.10.1.md
+++ b/docs/releases/v2.10.1.md
@@ -1,0 +1,79 @@
+# v2.10.1 - Trustworthy Feedback Freshness
+
+Previous release: v2.10.0. The timestamp correction merged in
+[#529](https://github.com/confighub/cub-scout/pull/529). Publication and final
+artifact verification are tracked in [#530](https://github.com/confighub/cub-scout/issues/530)
+and the [release](https://github.com/confighub/cub-scout/releases/tag/v2.10.1).
+This document defines the release scope, not proof that a pending check passed.
+
+## User Value
+
+"Does this report tell me what is true now, or only what was last reported?"
+An undated or future-dated positive report must not reassure an operator that
+delivery succeeded. An old failure must not be presented as a current failure.
+
+| Report timestamp | Freshness | Reported success | Reported failure |
+|---|---|---|---|
+| Valid, not future, within the freshness window | `fresh` | `PASS` | `BLOCK` |
+| Older than the freshness window | `stale` | `WATCH` | `WATCH` |
+| Missing, invalid, zero or future | `unknown` | `INCONCLUSIVE` | `INCONCLUSIVE` |
+
+Empty status remains `INCONCLUSIVE`. The default freshness window is 15 minutes.
+Exact-now and exact-threshold timestamps are valid; no implicit future-clock
+allowance is applied. Original sync, operation, health, revision and timestamp
+fields remain visible, with an explanatory freshness omission where needed.
+Re-reading an unchanged report does not renew its observation time.
+
+## Affected Surfaces
+
+- Connected `gitops status`, `doctor`, `map activity`, `trace` and `explain`.
+- MCP `confighub_live_status`, using the same timestamp and verdict logic.
+- Single-resource receipt supporting evidence, covered by its fingerprint;
+  the independent receipt predicate is unchanged.
+- Activity evidence retains the original `observedAt`, including exact
+  Application joins. Timeline fallback time is not a new report timestamp.
+
+The standalone client and plugin share the correction. Exit codes and public
+envelope shapes are preserved; `observedAt` on activity supporting evidence is
+additive. Read the verdict and omissions, not a zero exit code alone.
+
+## Upgrade
+
+```sh
+# Existing plugin installation:
+cub plugin upgrade scout@v2.10.1
+cub scout version
+# Fresh plugin installation:
+cub plugin install confighub/cub-scout@v2.10.1
+```
+
+Standalone users can upgrade through Homebrew or the checksum-verified
+[archives](../getting-started/install.md#download-binary). Restart long-running
+MCP/watch/bot processes to load the new binary. No companion release is required:
+the existing bounded Resource Evidence panel remains compatible and unchanged.
+
+## Proof And Limits
+
+The [worked example](../../examples/live-delivery-observability/#trusting-feedback-freshness)
+includes a fixed-clock fixture, parser/collector tests, scope isolation, actual
+MCP request handling, doctor/activity/trace projections and receipt fingerprint
+checks. The opt-in packaged-binary smoke exercises the real stdio servers of
+the standalone and plugin artifacts with isolated connected fixtures. It
+requires the existing public startup health HEAD, not live authentication.
+Record exact source, CI and downloaded-artifact results in #530.
+
+- Timestamp validation does not establish producer authenticity, deletion,
+  complete history or exact expected-release delivery. Those remain #502/#505.
+- The connected proof uses fixtures, not authenticated intended-state-to-cluster
+  mapping. Live proof requires renewed user authentication and explicit scope.
+- Existing standalone/companion bounded TUI panels do not consume this connected
+  writeback. No new TUI integration or cache behavior is claimed.
+- Watch/bot still poll; no additional API reads, status writes or event cursors
+  are introduced by the fix. Observation-efficiency work remains #519.
+- The container configuration is still Linux amd64 only. Public registry access
+  and the Go module major-version distribution gap remain tracked in #520.
+  Successful image publication is not proof of anonymous pull access.
+
+The README User questions table describes the correction. Historical v2.10.0
+findings remain documented; upgrading does not turn incomplete evidence into a
+complete delivery proof.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,8 +102,8 @@ These are tracked follow-ups, not claims of competitive leadership:
 - [x] First-run documentation and current-version install guidance (#527).
   Preserve the README User questions and all five run modes; distinguish live
   inspection from offline artifacts and observation from delivery automation.
-- [x] Timestamp-gated feedback verdicts (#502), implemented after v2.10 and
-  not yet released: invalid/missing/zero/future times are inconclusive; stale
+- [x] Timestamp-gated feedback verdicts (#502), merged in #529 for v2.10.1
+  (publication tracked in #530): invalid/missing/zero/future times are inconclusive; stale
   success/failure reports ask for a recheck. Original reports, timestamps and
   omissions survive MCP, activity, correlation and receipts. Recorded proof:
   [feedback freshness](../examples/live-delivery-observability/#trusting-feedback-freshness).

--- a/examples/live-delivery-observability/README.md
+++ b/examples/live-delivery-observability/README.md
@@ -82,7 +82,7 @@ and the join performs no additional Kubernetes reads beyond one Application list
 
 ## Trusting Feedback Freshness
 
-**Unreleased correction after v2.10.0.** The question is: "Does this report tell
+**v2.10.1 correction.** The question is: "Does this report tell
 me what is true now, or only what was last reported?"
 
 [`freshness-cases.json`](freshness-cases.json) fixes the observer clock at
@@ -126,3 +126,23 @@ No live authentication, production cursor or cluster writes are used by this
 proof. Authenticated intended-state mapping remains separate. The existing
 standalone/companion bounded TUI panels do not consume connected writeback, so
 this fix does not add that TUI capability or change their cache contracts.
+
+### Packaged-Binary Smoke
+
+After extracting a checksum-verified native Unix archive, test the actual
+standalone and plugin entry points from the repository root:
+
+```sh
+CUB_SCOUT_TEST_BINARY=/absolute/archive/cub-scout \
+CUB_SCOUT_TEST_PLUGIN_BINARY=/absolute/archive/main \
+go test ./cmd/cub-scout -run '^TestLiveStatusFreshnessPackaged$' -count=1 -v
+```
+
+This opt-in test starts each binary's real stdio MCP server. An isolated fake
+`cub` returns eight timestamp cases in one explicit all-spaces fixture query;
+the test checks verdicts, original fields, six omissions and exactly one data
+read. It uses a temporary home and synthetic credentials, never user auth or
+a cluster. The provider's existing public startup health HEAD still requires
+network reachability; this is not an authenticated connected end-to-end test.
+Without an explicit binary path the test skips. Exact clock boundaries remain
+covered by the fixed-clock source tests above, not this wall-clock smoke.

--- a/examples/receipts/delivery-evidence/README.md
+++ b/examples/receipts/delivery-evidence/README.md
@@ -32,7 +32,7 @@ This is supporting evidence. The selected receipt predicate still owns
 `predicate.verdict`; the delivery controller and application-health systems
 remain the authorities for their own status.
 
-The [unreleased freshness correction](../../live-delivery-observability/#trusting-feedback-freshness)
+The [v2.10.1 freshness correction](../../live-delivery-observability/#trusting-feedback-freshness)
 retains old/undated reports as supporting evidence without presenting them as
 current success or failure. The corrected nested verdict and freshness omission
 are fingerprint-covered; they do not override the selected receipt predicate.

--- a/test/unit/release_distribution_contract_test.go
+++ b/test/unit/release_distribution_contract_test.go
@@ -244,3 +244,24 @@ func TestIntroDocs_FiveModesAndEvidenceBoundaries(t *testing.T) {
 		}
 	}
 }
+
+func TestIntroDocs_FreshnessPatch(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var question string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "| Can I trust a reported success or failure") {
+			question = line
+		}
+	}
+	for _, term := range []string{"v2.10.1", "INCONCLUSIVE", "WATCH", "original report", "freshness omission", "Cases and proof"} {
+		if !strings.Contains(question, term) {
+			t.Errorf("freshness user question must explain %q", term)
+		}
+	}
+	if strings.Contains(question, "unreleased") {
+		t.Error("release README still labels the timestamp correction unreleased")
+	}
+}


### PR DESCRIPTION
Refs #530 and #502. Release preparation only; the runtime fix is already merged in #529.

- Add v2.10.1 patch notes, current-version installation paths, corrected README user questions, and versioned freshness contracts. Preserve the historical v2.10.0 finding and unchanged TUI/cache/receipt boundaries.
- Add opt-in TestLiveStatusFreshnessPackaged to exercise external standalone/plugin artifacts through real stdio MCP with isolated auth and CLI fixtures. Eight timestamp cases, original fields, six omissions and exactly one connected data read. Existing public startup HEAD needs network reachability; no production authentication or cluster access is used. This test skips without explicit artifact paths.
- Keep README coverage for five modes and the timestamp question under regression tests. No runtime code or release workflow change.

Validation: full go test ./..., build, vet, focused race tests, repeated freshness/scope tests, doc/read-only guards and diff checks passed. The external smoke reproduced the bugs in downloaded v2.10.0 standalone/plugin binaries, then passed twice on the corrected candidate. CI remains the merge gate.

After merge and main CI: tag/publish once, verify all archive checksums/contents, real plugin-host install in temporary configuration, published-binary smoke and Homebrew publication. Authenticated connected proof, anonymous registry pull, container architecture and Go module distribution remain explicit independent checks. No release tag has been created yet.